### PR TITLE
feat(domain multi-tenancy): Implement hierarchical weighted round robin scheduler

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -2294,6 +2294,20 @@ const (
 	// Allowed filters: N/A
 	MatchingExcludeShortLivedTaskListsFromShardManager
 
+	// EnableHierarchicalWeightedRoundRobinTaskScheduler is to enable hierarchical weighted round robin task scheduler
+	// KeyName: history.enableHierarchicalWeightedRoundRobinTaskScheduler
+	// Value type: Bool
+	// Default value: false
+	// Allowed filters: N/A
+	EnableHierarchicalWeightedRoundRobinTaskScheduler
+
+	// EnableTaskListAwareTaskSchedulerByDomain is to enable task list aware task scheduler by domain
+	// KeyName: history.enableTaskListAwareTaskSchedulerByDomain
+	// Value type: Bool
+	// Default value: false
+	// Allowed filters: DomainName
+	EnableTaskListAwareTaskSchedulerByDomain
+
 	// LastBoolKey must be the last one in this const group
 	LastBoolKey
 )
@@ -4984,6 +4998,17 @@ var BoolKeys = map[BoolKey]DynamicBool{
 		KeyName:      "matching.excludeShortLivedTaskListsFromShardManager",
 		Description:  "MatchingExcludeShortLivedTaskListsFromShardManager excludes short-lived task lists (e.g. bits task lists and sticky task lists) from the shard manager",
 		DefaultValue: true,
+	},
+	EnableHierarchicalWeightedRoundRobinTaskScheduler: {
+		KeyName:      "history.enableHierarchicalWeightedRoundRobinTaskScheduler",
+		Description:  "EnableHierarchicalWeightedRoundRobinTaskScheduler is to enable hierarchical weighted round robin task scheduler",
+		DefaultValue: false,
+	},
+	EnableTaskListAwareTaskSchedulerByDomain: {
+		KeyName:      "history.enableTaskListAwareTaskSchedulerByDomain",
+		Description:  "EnableTaskListAwareTaskSchedulerByDomain is to enable task list aware task scheduler by domain",
+		Filters:      []Filter{DomainName},
+		DefaultValue: false,
 	},
 }
 

--- a/common/task/hierarchical_weighted_round_robin_task_pool.go
+++ b/common/task/hierarchical_weighted_round_robin_task_pool.go
@@ -1,0 +1,167 @@
+package task
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
+)
+
+var (
+	errWeightedKeyWeightMustBeGreaterThanZero = errors.New("weight must be greater than 0")
+)
+
+type HierarchicalWeightedRoundRobinTaskPoolOptions[K comparable] struct {
+	BufferSize           int
+	TaskToWeightedKeysFn func(PriorityTask) []WeightedKey[K]
+}
+
+type hierarchicalWeightedRoundRobinTaskPoolImpl[K comparable] struct {
+	sync.Mutex
+	status     int32
+	root       *iwrrNode[K, PriorityTask]
+	bufferSize int
+	ctx        context.Context
+	cancel     context.CancelFunc
+	options    *HierarchicalWeightedRoundRobinTaskPoolOptions[K]
+	logger     log.Logger
+	timeSource clock.TimeSource
+	wg         sync.WaitGroup
+
+	doCleanupFn func(now time.Time, ttl time.Duration)
+}
+
+// newHierarchicalWeightedRoundRobinTaskPool creates a new hierarchical WRR task pool
+func newHierarchicalWeightedRoundRobinTaskPool[K comparable](
+	logger log.Logger,
+	metricsClient metrics.Client,
+	timeSource clock.TimeSource,
+	options *HierarchicalWeightedRoundRobinTaskPoolOptions[K],
+) *hierarchicalWeightedRoundRobinTaskPoolImpl[K] {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	pool := &hierarchicalWeightedRoundRobinTaskPoolImpl[K]{
+		status:     common.DaemonStatusInitialized,
+		root:       newiwrrNode[K, PriorityTask](options.BufferSize),
+		bufferSize: options.BufferSize,
+		ctx:        ctx,
+		cancel:     cancel,
+		options:    options,
+		logger:     logger,
+		timeSource: timeSource,
+	}
+	pool.doCleanupFn = pool.doCleanup
+
+	return pool
+}
+
+func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K]) Start() {
+	if !atomic.CompareAndSwapInt32(&p.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
+		return
+	}
+
+	p.wg.Add(1)
+	go p.cleanupLoop()
+
+	p.logger.Info("Hierarchical weighted round robin task pool started.")
+}
+
+func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K]) Stop() {
+	if !atomic.CompareAndSwapInt32(&p.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
+		return
+	}
+
+	p.cancel()
+	p.wg.Wait()
+
+	p.logger.Info("Hierarchical weighted round robin task pool stopped.")
+}
+
+func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K]) cleanupLoop() {
+	defer p.wg.Done()
+
+	ticker := p.timeSource.NewTicker(time.Duration((defaultIdleChannelTTLInSeconds / 2)) * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.Chan():
+			now := p.timeSource.Now()
+			ttl := time.Duration(defaultIdleChannelTTLInSeconds) * time.Second
+			p.doCleanupFn(now, ttl)
+		case <-p.ctx.Done():
+			return
+		}
+	}
+}
+
+func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K]) doCleanup(now time.Time, ttl time.Duration) {
+	p.root.cleanup(now, ttl)
+}
+
+func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K]) Enqueue(task PriorityTask) error {
+	weightedKeys := p.options.TaskToWeightedKeysFn(task)
+	if err := verifyWeightedKeys(weightedKeys); err != nil {
+		return err
+	}
+	var err error
+	p.root.executeAtPath(weightedKeys, p.bufferSize, func(c *TTLChannel[PriorityTask]) int64 {
+		c.IncRef()
+		defer c.DecRef()
+		select {
+		case c.Chan() <- task:
+			c.UpdateLastWriteTime(p.timeSource.Now())
+			return 1
+		case <-p.ctx.Done():
+			err = p.ctx.Err()
+			return 0
+		}
+	})
+	return err
+}
+
+func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K]) TryEnqueue(task PriorityTask) (bool, error) {
+	weightedKeys := p.options.TaskToWeightedKeysFn(task)
+	if err := verifyWeightedKeys(weightedKeys); err != nil {
+		return false, err
+	}
+	var err error
+	delta := p.root.executeAtPath(weightedKeys, p.bufferSize, func(c *TTLChannel[PriorityTask]) int64 {
+		c.IncRef()
+		defer c.DecRef()
+		select {
+		case c.Chan() <- task:
+			c.UpdateLastWriteTime(p.timeSource.Now())
+			return 1
+		case <-p.ctx.Done():
+			err = p.ctx.Err()
+			return 0
+		default:
+			return 0
+		}
+	})
+	return delta > 0, err
+}
+
+func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K]) TryDequeue() (PriorityTask, bool) {
+	item, ok := p.root.tryGetNextItem()
+	if !ok {
+		return nil, false
+	}
+	return item, true
+}
+
+func verifyWeightedKeys[K comparable](weightedKeys []WeightedKey[K]) error {
+	for _, weightedKey := range weightedKeys {
+		if weightedKey.Weight <= 0 {
+			return errWeightedKeyWeightMustBeGreaterThanZero
+		}
+	}
+	return nil
+}

--- a/common/task/hierarchical_weighted_round_robin_task_pool_test.go
+++ b/common/task/hierarchical_weighted_round_robin_task_pool_test.go
@@ -1,0 +1,887 @@
+package task
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/log/testlogger"
+	"github.com/uber/cadence/common/metrics"
+)
+
+// testPriorityTask is a simple test implementation of PriorityTask
+type testPriorityTask struct {
+	domain   string
+	tasklist string
+	tenant   string
+	state    State
+}
+
+func (t *testPriorityTask) Execute() error            { return nil }
+func (t *testPriorityTask) HandleErr(err error) error { return err }
+func (t *testPriorityTask) RetryErr(err error) bool   { return false }
+func (t *testPriorityTask) Ack()                      { t.state = TaskStateAcked }
+func (t *testPriorityTask) Nack(err error)            { t.state = TaskStatePending }
+func (t *testPriorityTask) Cancel()                   { t.state = TaskStateCanceled }
+func (t *testPriorityTask) State() State              { return t.state }
+func (t *testPriorityTask) Priority() int             { return 0 }
+func (t *testPriorityTask) SetPriority(p int)         {}
+
+func TestHierarchicalWRRTaskPool_SingleLevel_IWRROrdering(t *testing.T) {
+	// Define domain to weight mapping
+	domainWeights := map[string]int{
+		"domain0": 5,
+		"domain1": 3,
+		"domain2": 1,
+	}
+
+	pool := newHierarchicalWeightedRoundRobinTaskPool[string](
+		testlogger.New(t),
+		metrics.NoopClient,
+		clock.NewMockedTimeSource(),
+		&HierarchicalWeightedRoundRobinTaskPoolOptions[string]{
+			BufferSize: 20,
+			TaskToWeightedKeysFn: func(task PriorityTask) []WeightedKey[string] {
+				// Single-level hierarchy: tasks grouped by domain with different weights
+				testTask := task.(*testPriorityTask)
+				return []WeightedKey[string]{
+					{Key: testTask.domain, Weight: domainWeights[testTask.domain]},
+				}
+			},
+		},
+	)
+	pool.Start()
+	defer pool.Stop()
+
+	// Create tasks with weights [5, 3, 1]
+	// Domain0 (weight 5): 5 tasks
+	// Domain1 (weight 3): 3 tasks
+	// Domain2 (weight 1): 1 task
+	var tasks []PriorityTask
+	for i := 0; i < 5; i++ {
+		tasks = append(tasks, &testPriorityTask{domain: "domain0"})
+	}
+	for i := 0; i < 3; i++ {
+		tasks = append(tasks, &testPriorityTask{domain: "domain1"})
+	}
+	tasks = append(tasks, &testPriorityTask{domain: "domain2"})
+
+	// Enqueue tasks in parallel using randomly chosen Enqueue or TryEnqueue
+	var wg sync.WaitGroup
+	for _, task := range tasks {
+		wg.Add(1)
+		go func(t PriorityTask) {
+			defer wg.Done()
+			// Randomly choose between Enqueue and TryEnqueue
+			if rand.Intn(2) == 0 {
+				_ = pool.Enqueue(t)
+			} else {
+				_, _ = pool.TryEnqueue(t)
+			}
+		}(task)
+	}
+	wg.Wait()
+
+	// IWRR pattern for weights [5, 3, 1]: domain0, domain0, domain0, domain1, domain0, domain1, domain0, domain1, domain2
+	// Expected domain sequence: [0, 0, 0, 1, 0, 1, 0, 1, 2]
+	expectedDomainPattern := []string{"domain0", "domain0", "domain0", "domain1", "domain0", "domain1", "domain0", "domain1", "domain2"}
+
+	var actualDomainSequence []string
+	for {
+		task, ok := pool.TryDequeue()
+		if !ok {
+			break
+		}
+		testTask := task.(*testPriorityTask)
+		actualDomainSequence = append(actualDomainSequence, testTask.domain)
+	}
+
+	assert.Equal(t, expectedDomainPattern, actualDomainSequence)
+}
+
+func TestHierarchicalWRRTaskPool_TwoLevel_IWRROrdering(t *testing.T) {
+	// Define domain to weight mapping - different weights
+	domainWeights := map[string]int{
+		"domain1": 3,
+		"domain2": 2,
+		"domain3": 1,
+	}
+
+	// Define tasklist to weight mapping
+	tasklistWeights := map[string]int{
+		"tasklist1A": 2,
+		"tasklist1B": 1,
+		"tasklist2A": 3,
+		"tasklist2B": 1,
+		"tasklist3A": 2,
+		"tasklist3B": 1,
+	}
+
+	pool := newHierarchicalWeightedRoundRobinTaskPool[string](
+		testlogger.New(t),
+		metrics.NoopClient,
+		clock.NewMockedTimeSource(),
+		&HierarchicalWeightedRoundRobinTaskPoolOptions[string]{
+			BufferSize: 20,
+			TaskToWeightedKeysFn: func(task PriorityTask) []WeightedKey[string] {
+				// Two-level hierarchy: domain (level 1) -> tasklist (level 2)
+				testTask := task.(*testPriorityTask)
+				return []WeightedKey[string]{
+					{Key: testTask.domain, Weight: domainWeights[testTask.domain]},
+					{Key: testTask.tasklist, Weight: tasklistWeights[testTask.tasklist]},
+				}
+			},
+		},
+	)
+	pool.Start()
+	defer pool.Stop()
+
+	// Create enough tasks for each domain to complete at least one full tasklist IWRR cycle
+	// Domain1 tasklist IWRR [2, 1]: [tasklist1A, tasklist1A, tasklist1B] = 3 tasks
+	// Domain2 tasklist IWRR [3, 1]: [tasklist2A, tasklist2A, tasklist2A, tasklist2B] = 4 tasks
+	// Domain3 tasklist IWRR [2, 1]: [tasklist3A, tasklist3A, tasklist3B] = 3 tasks
+	tasks := []PriorityTask{
+		// Domain1 tasks (3 tasks for one complete tasklist IWRR)
+		&testPriorityTask{domain: "domain1", tasklist: "tasklist1A"},
+		&testPriorityTask{domain: "domain1", tasklist: "tasklist1A"},
+		&testPriorityTask{domain: "domain1", tasklist: "tasklist1B"},
+		// Domain2 tasks (4 tasks for one complete tasklist IWRR)
+		&testPriorityTask{domain: "domain2", tasklist: "tasklist2A"},
+		&testPriorityTask{domain: "domain2", tasklist: "tasklist2A"},
+		&testPriorityTask{domain: "domain2", tasklist: "tasklist2A"},
+		&testPriorityTask{domain: "domain2", tasklist: "tasklist2B"},
+		// Domain3 tasks (3 tasks for one complete tasklist IWRR)
+		&testPriorityTask{domain: "domain3", tasklist: "tasklist3A"},
+		&testPriorityTask{domain: "domain3", tasklist: "tasklist3A"},
+		&testPriorityTask{domain: "domain3", tasklist: "tasklist3B"},
+	}
+
+	// Enqueue all tasks in parallel using randomly chosen Enqueue or TryEnqueue
+	var wg sync.WaitGroup
+	for _, task := range tasks {
+		wg.Add(1)
+		go func(t PriorityTask) {
+			defer wg.Done()
+			// Randomly choose between Enqueue and TryEnqueue
+			if rand.Intn(2) == 0 {
+				_ = pool.Enqueue(t)
+			} else {
+				_, _ = pool.TryEnqueue(t)
+			}
+		}(task)
+	}
+	wg.Wait()
+
+	// Domain IWRR pattern for weights [3, 2, 1]: [domain1, domain1, domain2, domain1, domain2, domain3]
+	// When we dequeue, we follow this domain pattern, and within each domain we follow its tasklist IWRR
+	//
+	// Expected dequeue pattern:
+	// 1. domain1 (1st visit) -> tasklist1A (position 0 in tasklist IWRR)
+	// 2. domain1 (2nd visit) -> tasklist1A (position 1 in tasklist IWRR)
+	// 3. domain2 (1st visit) -> tasklist2A (position 0 in tasklist IWRR)
+	// 4. domain1 (3rd visit) -> tasklist1B (position 2 in tasklist IWRR)
+	// 5. domain2 (2nd visit) -> tasklist2A (position 1 in tasklist IWRR)
+	// 6. domain3 (1st visit) -> tasklist3A (position 0 in tasklist IWRR)
+	// Now we loop back to domain1, but it's exhausted, so we skip it
+	// 7. domain2 (3rd visit) -> tasklist2A (position 2 in tasklist IWRR)
+	// 8. domain2 (4th visit) -> tasklist2B (position 3 in tasklist IWRR)
+	// 9. domain3 (2nd visit) -> tasklist3A (position 1 in tasklist IWRR)
+	// 10. domain3 (3rd visit) -> tasklist3B (position 2 in tasklist IWRR)
+	type expectedTask struct {
+		domain   string
+		tasklist string
+	}
+	expectedPattern := []expectedTask{
+		{"domain1", "tasklist1A"}, // domain IWRR pos 0, tasklist IWRR pos 0
+		{"domain1", "tasklist1A"}, // domain IWRR pos 1, tasklist IWRR pos 1
+		{"domain2", "tasklist2A"}, // domain IWRR pos 2, tasklist IWRR pos 0
+		{"domain1", "tasklist1B"}, // domain IWRR pos 3, tasklist IWRR pos 2
+		{"domain2", "tasklist2A"}, // domain IWRR pos 4, tasklist IWRR pos 1
+		{"domain3", "tasklist3A"}, // domain IWRR pos 5, tasklist IWRR pos 0
+		{"domain2", "tasklist2A"}, // domain1 exhausted, skip to domain2, tasklist IWRR pos 2
+		{"domain2", "tasklist2B"}, // continue domain2, tasklist IWRR pos 3
+		{"domain3", "tasklist3A"}, // domain3, tasklist IWRR pos 1
+		{"domain3", "tasklist3B"}, // domain3, tasklist IWRR pos 2
+	}
+
+	// Dequeue all tasks and verify the order
+	var actualPattern []expectedTask
+	for {
+		task, ok := pool.TryDequeue()
+		if !ok {
+			break
+		}
+		testTask := task.(*testPriorityTask)
+		actualPattern = append(actualPattern, expectedTask{
+			domain:   testTask.domain,
+			tasklist: testTask.tasklist,
+		})
+	}
+
+	// Verify exact ordering
+	require.Equal(t, len(expectedPattern), len(actualPattern), "should dequeue all tasks")
+	for i, expected := range expectedPattern {
+		assert.Equal(t, expected.domain, actualPattern[i].domain, "task %d domain mismatch", i)
+		assert.Equal(t, expected.tasklist, actualPattern[i].tasklist, "task %d tasklist mismatch", i)
+	}
+}
+
+func TestHierarchicalWRRTaskPool_TwoLevel_LargeScale_IWRROrdering(t *testing.T) {
+	// Define domain to weight mapping
+	domainWeights := map[string]int{
+		"domain1": 5,
+		"domain2": 3,
+		"domain3": 2,
+	}
+
+	// Define tasklist to weight mapping
+	tasklistWeights := map[string]int{
+		"tasklist1A": 3,
+		"tasklist1B": 2,
+		"tasklist1C": 1,
+		"tasklist2A": 4,
+		"tasklist2B": 2,
+		"tasklist3A": 3,
+		"tasklist3B": 1,
+	}
+
+	pool := newHierarchicalWeightedRoundRobinTaskPool[string](
+		testlogger.New(t),
+		metrics.NoopClient,
+		clock.NewMockedTimeSource(),
+		&HierarchicalWeightedRoundRobinTaskPoolOptions[string]{
+			BufferSize: 100,
+			TaskToWeightedKeysFn: func(task PriorityTask) []WeightedKey[string] {
+				testTask := task.(*testPriorityTask)
+				return []WeightedKey[string]{
+					{Key: testTask.domain, Weight: domainWeights[testTask.domain]},
+					{Key: testTask.tasklist, Weight: tasklistWeights[testTask.tasklist]},
+				}
+			},
+		},
+	)
+	pool.Start()
+	defer pool.Stop()
+
+	// Create a large number of tasks
+	// Domain1: 30 tasks (5 cycles of tasklist IWRR: [3,2,1] = 6 tasks per cycle)
+	// Domain2: 30 tasks (5 cycles of tasklist IWRR: [4,2] = 6 tasks per cycle)
+	// Domain3: 20 tasks (5 cycles of tasklist IWRR: [3,1] = 4 tasks per cycle)
+	var tasks []PriorityTask
+
+	// Domain1: 5 cycles of [tasklist1A(3), tasklist1B(2), tasklist1C(1)]
+	for cycle := 0; cycle < 5; cycle++ {
+		for i := 0; i < 3; i++ {
+			tasks = append(tasks, &testPriorityTask{domain: "domain1", tasklist: "tasklist1A"})
+		}
+		for i := 0; i < 2; i++ {
+			tasks = append(tasks, &testPriorityTask{domain: "domain1", tasklist: "tasklist1B"})
+		}
+		tasks = append(tasks, &testPriorityTask{domain: "domain1", tasklist: "tasklist1C"})
+	}
+
+	// Domain2: 5 cycles of [tasklist2A(4), tasklist2B(2)]
+	for cycle := 0; cycle < 5; cycle++ {
+		for i := 0; i < 4; i++ {
+			tasks = append(tasks, &testPriorityTask{domain: "domain2", tasklist: "tasklist2A"})
+		}
+		for i := 0; i < 2; i++ {
+			tasks = append(tasks, &testPriorityTask{domain: "domain2", tasklist: "tasklist2B"})
+		}
+	}
+
+	// Domain3: 5 cycles of [tasklist3A(3), tasklist3B(1)]
+	for cycle := 0; cycle < 5; cycle++ {
+		for i := 0; i < 3; i++ {
+			tasks = append(tasks, &testPriorityTask{domain: "domain3", tasklist: "tasklist3A"})
+		}
+		tasks = append(tasks, &testPriorityTask{domain: "domain3", tasklist: "tasklist3B"})
+	}
+
+	// Enqueue all tasks in parallel using randomly chosen Enqueue or TryEnqueue
+	var wg sync.WaitGroup
+	for _, task := range tasks {
+		wg.Add(1)
+		go func(t PriorityTask) {
+			defer wg.Done()
+			if rand.Intn(2) == 0 {
+				_ = pool.Enqueue(t)
+			} else {
+				_, _ = pool.TryEnqueue(t)
+			}
+		}(task)
+	}
+	wg.Wait()
+
+	// Generate expected patterns by level
+	// Level 1 (domain): IWRR for weights [5, 3, 2]
+	// Round 4: domain1 (weight 5 > 4)
+	// Round 3: domain1 (weight 5 > 3)
+	// Round 2: domain1, domain2 (weights 5,3 > 2)
+	// Round 1: domain1, domain2, domain3 (weights 5,3,2 > 1)
+	// Round 0: domain1, domain2, domain3 (weights 5,3,2 > 0)
+	// Pattern: [domain1, domain1, domain1, domain2, domain1, domain2, domain3, domain1, domain2, domain3]
+	expectedDomainPattern := []string{
+		"domain1", "domain1", "domain1", "domain2", "domain1", "domain2", "domain3", "domain1", "domain2", "domain3",
+	}
+
+	// Level 2 (tasklist per domain):
+	// domain1 with weights [3, 2, 1]: [tasklist1A, tasklist1A, tasklist1B, tasklist1A, tasklist1B, tasklist1C]
+	// domain2 with weights [4, 2]: [tasklist2A, tasklist2A, tasklist2A, tasklist2B, tasklist2A, tasklist2B]
+	// domain3 with weights [3, 1]: [tasklist3A, tasklist3A, tasklist3A, tasklist3B]
+	expectedTasklistPatterns := map[string][]string{
+		"domain1": {"tasklist1A", "tasklist1A", "tasklist1B", "tasklist1A", "tasklist1B", "tasklist1C"},
+		"domain2": {"tasklist2A", "tasklist2A", "tasklist2A", "tasklist2B", "tasklist2A", "tasklist2B"},
+		"domain3": {"tasklist3A", "tasklist3A", "tasklist3A", "tasklist3B"},
+	}
+
+	// Dequeue all tasks
+	var dequeuedDomains []string
+	dequeuedTasklistsByDomain := make(map[string][]string)
+	for {
+		task, ok := pool.TryDequeue()
+		if !ok {
+			break
+		}
+		testTask := task.(*testPriorityTask)
+		dequeuedDomains = append(dequeuedDomains, testTask.domain)
+		dequeuedTasklistsByDomain[testTask.domain] = append(
+			dequeuedTasklistsByDomain[testTask.domain],
+			testTask.tasklist,
+		)
+	}
+
+	// Verify we got all 80 tasks
+	require.Equal(t, 80, len(dequeuedDomains), "should dequeue all 80 tasks")
+
+	// Verify level 1 (domain) pattern for the first cycle (first 10 tasks)
+	// After that, domains may exhaust at different rates, so we only verify the first full cycle
+	for i := 0; i < len(expectedDomainPattern) && i < len(dequeuedDomains); i++ {
+		assert.Equal(t, expectedDomainPattern[i], dequeuedDomains[i],
+			"domain mismatch at position %d in first cycle", i)
+	}
+
+	// Verify level 2 (tasklist) pattern for each domain
+	// Each domain should follow its own tasklist IWRR pattern consistently
+	for domain, dequeuedTasklists := range dequeuedTasklistsByDomain {
+		expectedPattern := expectedTasklistPatterns[domain]
+		for i := 0; i < len(dequeuedTasklists); i++ {
+			expectedTasklist := expectedPattern[i%len(expectedPattern)]
+			assert.Equal(t, expectedTasklist, dequeuedTasklists[i],
+				"tasklist mismatch for domain %s at position %d", domain, i)
+		}
+	}
+}
+
+func TestHierarchicalWRRTaskPool_ThreeLevel_LargeScale_IWRROrdering(t *testing.T) {
+	// Define domain to weight mapping
+	domainWeights := map[string]int{
+		"domain1": 3,
+		"domain2": 2,
+		"domain3": 1,
+	}
+
+	// Define tasklist to weight mapping
+	tasklistWeights := map[string]int{
+		"tasklist1A": 3,
+		"tasklist1B": 1,
+		"tasklist2A": 2,
+		"tasklist2B": 1,
+		"tasklist3A": 2,
+		"tasklist3B": 1,
+	}
+
+	// Define tenant to weight mapping
+	tenantWeights := map[string]int{
+		"tenant1": 3,
+		"tenant2": 2,
+		"tenant3": 1,
+	}
+
+	pool := newHierarchicalWeightedRoundRobinTaskPool[string](
+		testlogger.New(t),
+		metrics.NoopClient,
+		clock.NewMockedTimeSource(),
+		&HierarchicalWeightedRoundRobinTaskPoolOptions[string]{
+			BufferSize: 200,
+			TaskToWeightedKeysFn: func(task PriorityTask) []WeightedKey[string] {
+				testTask := task.(*testPriorityTask)
+				return []WeightedKey[string]{
+					{Key: testTask.domain, Weight: domainWeights[testTask.domain]},
+					{Key: testTask.tasklist, Weight: tasklistWeights[testTask.tasklist]},
+					{Key: testTask.tenant, Weight: tenantWeights[testTask.tenant]},
+				}
+			},
+		},
+	)
+	pool.Start()
+	defer pool.Stop()
+
+	// Create a large number of tasks across 3 levels
+	// Each (domain, tasklist) combination gets multiple tenant cycles
+	// Tenant IWRR for weights [3, 2, 1]: 6 tasks per cycle
+	var tasks []PriorityTask
+
+	// Domain1 - tasklist1A (weight 3) - 3 tenant cycles = 18 tasks
+	for cycle := 0; cycle < 3; cycle++ {
+		for i := 0; i < 3; i++ {
+			tasks = append(tasks, &testPriorityTask{domain: "domain1", tasklist: "tasklist1A", tenant: "tenant1"})
+		}
+		for i := 0; i < 2; i++ {
+			tasks = append(tasks, &testPriorityTask{domain: "domain1", tasklist: "tasklist1A", tenant: "tenant2"})
+		}
+		tasks = append(tasks, &testPriorityTask{domain: "domain1", tasklist: "tasklist1A", tenant: "tenant3"})
+	}
+
+	// Domain1 - tasklist1B (weight 1) - 3 tenant cycles = 18 tasks
+	for cycle := 0; cycle < 3; cycle++ {
+		for i := 0; i < 3; i++ {
+			tasks = append(tasks, &testPriorityTask{domain: "domain1", tasklist: "tasklist1B", tenant: "tenant1"})
+		}
+		for i := 0; i < 2; i++ {
+			tasks = append(tasks, &testPriorityTask{domain: "domain1", tasklist: "tasklist1B", tenant: "tenant2"})
+		}
+		tasks = append(tasks, &testPriorityTask{domain: "domain1", tasklist: "tasklist1B", tenant: "tenant3"})
+	}
+
+	// Domain2 - tasklist2A (weight 2) - 2 tenant cycles = 12 tasks
+	for cycle := 0; cycle < 2; cycle++ {
+		for i := 0; i < 3; i++ {
+			tasks = append(tasks, &testPriorityTask{domain: "domain2", tasklist: "tasklist2A", tenant: "tenant1"})
+		}
+		for i := 0; i < 2; i++ {
+			tasks = append(tasks, &testPriorityTask{domain: "domain2", tasklist: "tasklist2A", tenant: "tenant2"})
+		}
+		tasks = append(tasks, &testPriorityTask{domain: "domain2", tasklist: "tasklist2A", tenant: "tenant3"})
+	}
+
+	// Domain2 - tasklist2B (weight 1) - 2 tenant cycles = 12 tasks
+	for cycle := 0; cycle < 2; cycle++ {
+		for i := 0; i < 3; i++ {
+			tasks = append(tasks, &testPriorityTask{domain: "domain2", tasklist: "tasklist2B", tenant: "tenant1"})
+		}
+		for i := 0; i < 2; i++ {
+			tasks = append(tasks, &testPriorityTask{domain: "domain2", tasklist: "tasklist2B", tenant: "tenant2"})
+		}
+		tasks = append(tasks, &testPriorityTask{domain: "domain2", tasklist: "tasklist2B", tenant: "tenant3"})
+	}
+
+	// Domain3 - tasklist3A (weight 2) - 2 tenant cycles = 12 tasks
+	for cycle := 0; cycle < 2; cycle++ {
+		for i := 0; i < 3; i++ {
+			tasks = append(tasks, &testPriorityTask{domain: "domain3", tasklist: "tasklist3A", tenant: "tenant1"})
+		}
+		for i := 0; i < 2; i++ {
+			tasks = append(tasks, &testPriorityTask{domain: "domain3", tasklist: "tasklist3A", tenant: "tenant2"})
+		}
+		tasks = append(tasks, &testPriorityTask{domain: "domain3", tasklist: "tasklist3A", tenant: "tenant3"})
+	}
+
+	// Domain3 - tasklist3B (weight 1) - 2 tenant cycles = 12 tasks
+	for cycle := 0; cycle < 2; cycle++ {
+		for i := 0; i < 3; i++ {
+			tasks = append(tasks, &testPriorityTask{domain: "domain3", tasklist: "tasklist3B", tenant: "tenant1"})
+		}
+		for i := 0; i < 2; i++ {
+			tasks = append(tasks, &testPriorityTask{domain: "domain3", tasklist: "tasklist3B", tenant: "tenant2"})
+		}
+		tasks = append(tasks, &testPriorityTask{domain: "domain3", tasklist: "tasklist3B", tenant: "tenant3"})
+	}
+
+	// Total: 18+18+12+12+12+12 = 84 tasks
+
+	// Enqueue all tasks in parallel using randomly chosen Enqueue or TryEnqueue
+	var wg sync.WaitGroup
+	for _, task := range tasks {
+		wg.Add(1)
+		go func(t PriorityTask) {
+			defer wg.Done()
+			if rand.Intn(2) == 0 {
+				_ = pool.Enqueue(t)
+			} else {
+				_, _ = pool.TryEnqueue(t)
+			}
+		}(task)
+	}
+	wg.Wait()
+
+	// Dequeue all tasks
+	type taskKey struct {
+		domain   string
+		tasklist string
+	}
+	var dequeuedDomains []string
+	dequeuedTasklistsByDomain := make(map[string][]string)
+	dequeuedTenantsByTasklist := make(map[taskKey][]string)
+
+	for {
+		task, ok := pool.TryDequeue()
+		if !ok {
+			break
+		}
+		testTask := task.(*testPriorityTask)
+		dequeuedDomains = append(dequeuedDomains, testTask.domain)
+		dequeuedTasklistsByDomain[testTask.domain] = append(
+			dequeuedTasklistsByDomain[testTask.domain],
+			testTask.tasklist,
+		)
+		key := taskKey{domain: testTask.domain, tasklist: testTask.tasklist}
+		dequeuedTenantsByTasklist[key] = append(
+			dequeuedTenantsByTasklist[key],
+			testTask.tenant,
+		)
+	}
+
+	// Verify we got all 84 tasks
+	require.Equal(t, 84, len(dequeuedDomains), "should dequeue all 84 tasks")
+
+	// Build expected domain sequence manually with exhaustion tracking
+	// Domain task counts: domain1=36, domain2=24, domain3=24
+	// Pattern: [domain1, domain1, domain2, domain1, domain2, domain3] repeats 12 times (72 tasks)
+	// After 12 cycles: domain1=36 (exhausted), domain2=24 (exhausted), domain3=12
+	// Then domain3 continues for 12 more tasks
+	expectedDomainSequence := []string{
+		// 12 full cycles
+		"domain1", "domain1", "domain2", "domain1", "domain2", "domain3",
+		"domain1", "domain1", "domain2", "domain1", "domain2", "domain3",
+		"domain1", "domain1", "domain2", "domain1", "domain2", "domain3",
+		"domain1", "domain1", "domain2", "domain1", "domain2", "domain3",
+		"domain1", "domain1", "domain2", "domain1", "domain2", "domain3",
+		"domain1", "domain1", "domain2", "domain1", "domain2", "domain3",
+		"domain1", "domain1", "domain2", "domain1", "domain2", "domain3",
+		"domain1", "domain1", "domain2", "domain1", "domain2", "domain3",
+		"domain1", "domain1", "domain2", "domain1", "domain2", "domain3",
+		"domain1", "domain1", "domain2", "domain1", "domain2", "domain3",
+		"domain1", "domain1", "domain2", "domain1", "domain2", "domain3",
+		"domain1", "domain1", "domain2", "domain1", "domain2", "domain3",
+		// domain1 and domain2 exhausted, domain3 continues for 12 more
+		"domain3", "domain3", "domain3", "domain3", "domain3", "domain3",
+		"domain3", "domain3", "domain3", "domain3", "domain3", "domain3",
+	}
+
+	// Verify full domain sequence
+	require.Equal(t, 84, len(expectedDomainSequence), "expected domain sequence length")
+	require.Equal(t, len(expectedDomainSequence), len(dequeuedDomains),
+		"domain sequence length mismatch")
+	for i := 0; i < len(expectedDomainSequence); i++ {
+		assert.Equal(t, expectedDomainSequence[i], dequeuedDomains[i],
+			"domain mismatch at position %d", i)
+	}
+
+	// Build expected tasklist sequences manually for each domain
+	expectedTasklistSequences := map[string][]string{
+		// Domain1: tasklist1A=18, tasklist1B=18
+		// Pattern: [tasklist1A, tasklist1A, tasklist1A, tasklist1B] repeats 6 times (24 tasks)
+		// After 6 cycles: tasklist1A=18 (exhausted), tasklist1B=6
+		// Then tasklist1B continues for 12 more tasks
+		"domain1": {
+			// 6 full cycles
+			"tasklist1A", "tasklist1A", "tasklist1A", "tasklist1B",
+			"tasklist1A", "tasklist1A", "tasklist1A", "tasklist1B",
+			"tasklist1A", "tasklist1A", "tasklist1A", "tasklist1B",
+			"tasklist1A", "tasklist1A", "tasklist1A", "tasklist1B",
+			"tasklist1A", "tasklist1A", "tasklist1A", "tasklist1B",
+			"tasklist1A", "tasklist1A", "tasklist1A", "tasklist1B",
+			// tasklist1A exhausted, tasklist1B continues for 12 more
+			"tasklist1B", "tasklist1B", "tasklist1B", "tasklist1B",
+			"tasklist1B", "tasklist1B", "tasklist1B", "tasklist1B",
+			"tasklist1B", "tasklist1B", "tasklist1B", "tasklist1B",
+		},
+		// Domain2: tasklist2A=12, tasklist2B=12
+		// Pattern: [tasklist2A, tasklist2A, tasklist2B] repeats 6 times (18 tasks)
+		// After 6 cycles: tasklist2A=12 (exhausted), tasklist2B=6
+		// Then tasklist2B continues for 6 more tasks
+		"domain2": {
+			// 6 full cycles
+			"tasklist2A", "tasklist2A", "tasklist2B",
+			"tasklist2A", "tasklist2A", "tasklist2B",
+			"tasklist2A", "tasklist2A", "tasklist2B",
+			"tasklist2A", "tasklist2A", "tasklist2B",
+			"tasklist2A", "tasklist2A", "tasklist2B",
+			"tasklist2A", "tasklist2A", "tasklist2B",
+			// tasklist2A exhausted, tasklist2B continues for 6 more
+			"tasklist2B", "tasklist2B", "tasklist2B",
+			"tasklist2B", "tasklist2B", "tasklist2B",
+		},
+		// Domain3: tasklist3A=12, tasklist3B=12
+		// Pattern: [tasklist3A, tasklist3A, tasklist3B] repeats 6 times (18 tasks)
+		// After 6 cycles: tasklist3A=12 (exhausted), tasklist3B=6
+		// Then tasklist3B continues for 6 more tasks
+		"domain3": {
+			// 6 full cycles
+			"tasklist3A", "tasklist3A", "tasklist3B",
+			"tasklist3A", "tasklist3A", "tasklist3B",
+			"tasklist3A", "tasklist3A", "tasklist3B",
+			"tasklist3A", "tasklist3A", "tasklist3B",
+			"tasklist3A", "tasklist3A", "tasklist3B",
+			"tasklist3A", "tasklist3A", "tasklist3B",
+			// tasklist3A exhausted, tasklist3B continues for 6 more
+			"tasklist3B", "tasklist3B", "tasklist3B",
+			"tasklist3B", "tasklist3B", "tasklist3B",
+		},
+	}
+
+	// Verify full tasklist sequence for each domain
+	for domain, expectedSequence := range expectedTasklistSequences {
+		dequeuedTasklists := dequeuedTasklistsByDomain[domain]
+		require.Equal(t, len(expectedSequence), len(dequeuedTasklists),
+			"tasklist sequence length mismatch for domain %s", domain)
+		for i := 0; i < len(expectedSequence); i++ {
+			assert.Equal(t, expectedSequence[i], dequeuedTasklists[i],
+				"tasklist mismatch for domain %s at position %d", domain, i)
+		}
+	}
+
+	// Verify level 3 (tenant) pattern for each (domain, tasklist) combination
+	// Build expected tenant sequences manually
+	// Pattern: [tenant1, tenant1, tenant2, tenant1, tenant2, tenant3] - 6 tasks per cycle
+	expectedTenantSequences := map[taskKey][]string{
+		// Domain1 tasklists: 3 cycles each = 18 tasks
+		{domain: "domain1", tasklist: "tasklist1A"}: {
+			"tenant1", "tenant1", "tenant2", "tenant1", "tenant2", "tenant3",
+			"tenant1", "tenant1", "tenant2", "tenant1", "tenant2", "tenant3",
+			"tenant1", "tenant1", "tenant2", "tenant1", "tenant2", "tenant3",
+		},
+		{domain: "domain1", tasklist: "tasklist1B"}: {
+			"tenant1", "tenant1", "tenant2", "tenant1", "tenant2", "tenant3",
+			"tenant1", "tenant1", "tenant2", "tenant1", "tenant2", "tenant3",
+			"tenant1", "tenant1", "tenant2", "tenant1", "tenant2", "tenant3",
+		},
+		// Domain2 tasklists: 2 cycles each = 12 tasks
+		{domain: "domain2", tasklist: "tasklist2A"}: {
+			"tenant1", "tenant1", "tenant2", "tenant1", "tenant2", "tenant3",
+			"tenant1", "tenant1", "tenant2", "tenant1", "tenant2", "tenant3",
+		},
+		{domain: "domain2", tasklist: "tasklist2B"}: {
+			"tenant1", "tenant1", "tenant2", "tenant1", "tenant2", "tenant3",
+			"tenant1", "tenant1", "tenant2", "tenant1", "tenant2", "tenant3",
+		},
+		// Domain3 tasklists: 2 cycles each = 12 tasks
+		{domain: "domain3", tasklist: "tasklist3A"}: {
+			"tenant1", "tenant1", "tenant2", "tenant1", "tenant2", "tenant3",
+			"tenant1", "tenant1", "tenant2", "tenant1", "tenant2", "tenant3",
+		},
+		{domain: "domain3", tasklist: "tasklist3B"}: {
+			"tenant1", "tenant1", "tenant2", "tenant1", "tenant2", "tenant3",
+			"tenant1", "tenant1", "tenant2", "tenant1", "tenant2", "tenant3",
+		},
+	}
+
+	for key, expectedSequence := range expectedTenantSequences {
+		dequeuedTenants := dequeuedTenantsByTasklist[key]
+		require.Equal(t, len(expectedSequence), len(dequeuedTenants),
+			"tenant sequence length mismatch for domain=%s, tasklist=%s",
+			key.domain, key.tasklist)
+		for i := 0; i < len(expectedSequence); i++ {
+			assert.Equal(t, expectedSequence[i], dequeuedTenants[i],
+				"tenant mismatch for domain=%s, tasklist=%s at position %d",
+				key.domain, key.tasklist, i)
+		}
+	}
+}
+
+func TestHierarchicalWRRTaskPool_TryDequeue_Empty(t *testing.T) {
+	domainWeights := map[string]int{
+		"domain1": 3,
+	}
+
+	pool := newHierarchicalWeightedRoundRobinTaskPool[string](
+		testlogger.New(t),
+		metrics.NoopClient,
+		clock.NewMockedTimeSource(),
+		&HierarchicalWeightedRoundRobinTaskPoolOptions[string]{
+			BufferSize: 10,
+			TaskToWeightedKeysFn: func(task PriorityTask) []WeightedKey[string] {
+				testTask := task.(*testPriorityTask)
+				return []WeightedKey[string]{
+					{Key: testTask.domain, Weight: domainWeights[testTask.domain]},
+				}
+			},
+		},
+	)
+	pool.Start()
+	defer pool.Stop()
+
+	// Try to dequeue from empty pool
+	task, ok := pool.TryDequeue()
+	assert.False(t, ok, "TryDequeue should return false on empty pool")
+	assert.Nil(t, task, "task should be nil when dequeue fails")
+
+	// Enqueue one task and dequeue it
+	testTask := &testPriorityTask{domain: "domain1"}
+	err := pool.Enqueue(testTask)
+	require.NoError(t, err)
+
+	task, ok = pool.TryDequeue()
+	assert.True(t, ok, "TryDequeue should return true when task exists")
+	assert.NotNil(t, task, "task should not be nil")
+
+	// Try to dequeue again from now-empty pool
+	task, ok = pool.TryDequeue()
+	assert.False(t, ok, "TryDequeue should return false after pool is emptied")
+	assert.Nil(t, task, "task should be nil when dequeue fails")
+}
+
+func TestHierarchicalWRRTaskPool_TryEnqueue_BufferFull(t *testing.T) {
+	domainWeights := map[string]int{
+		"domain1": 3,
+	}
+
+	// Create pool with small buffer size
+	pool := newHierarchicalWeightedRoundRobinTaskPool[string](
+		testlogger.New(t),
+		metrics.NoopClient,
+		clock.NewMockedTimeSource(),
+		&HierarchicalWeightedRoundRobinTaskPoolOptions[string]{
+			BufferSize: 2, // Small buffer to easily fill it
+			TaskToWeightedKeysFn: func(task PriorityTask) []WeightedKey[string] {
+				testTask := task.(*testPriorityTask)
+				return []WeightedKey[string]{
+					{Key: testTask.domain, Weight: domainWeights[testTask.domain]},
+				}
+			},
+		},
+	)
+	pool.Start()
+	defer pool.Stop()
+
+	// Fill the buffer completely
+	success1, err1 := pool.TryEnqueue(&testPriorityTask{domain: "domain1"})
+	assert.True(t, success1, "first TryEnqueue should succeed")
+	assert.NoError(t, err1)
+
+	success2, err2 := pool.TryEnqueue(&testPriorityTask{domain: "domain1"})
+	assert.True(t, success2, "second TryEnqueue should succeed")
+	assert.NoError(t, err2)
+
+	// Try to enqueue when buffer is full
+	success3, err3 := pool.TryEnqueue(&testPriorityTask{domain: "domain1"})
+	assert.False(t, success3, "TryEnqueue should return false when buffer is full")
+	assert.NoError(t, err3, "TryEnqueue should not return error even when buffer is full")
+
+	// Dequeue one task to free space
+	task, ok := pool.TryDequeue()
+	assert.True(t, ok, "TryDequeue should succeed")
+	assert.NotNil(t, task)
+
+	// Now TryEnqueue should succeed again
+	success4, err4 := pool.TryEnqueue(&testPriorityTask{domain: "domain1"})
+	assert.True(t, success4, "TryEnqueue should succeed after freeing space")
+	assert.NoError(t, err4)
+}
+
+func TestHierarchicalWRRTaskPool_Enqueue_ContextCancellation(t *testing.T) {
+	domainWeights := map[string]int{
+		"domain1": 3,
+	}
+
+	// Create pool with small buffer size
+	pool := newHierarchicalWeightedRoundRobinTaskPool[string](
+		testlogger.New(t),
+		metrics.NoopClient,
+		clock.NewMockedTimeSource(),
+		&HierarchicalWeightedRoundRobinTaskPoolOptions[string]{
+			BufferSize: 1, // Very small buffer
+			TaskToWeightedKeysFn: func(task PriorityTask) []WeightedKey[string] {
+				testTask := task.(*testPriorityTask)
+				return []WeightedKey[string]{
+					{Key: testTask.domain, Weight: domainWeights[testTask.domain]},
+				}
+			},
+		},
+	)
+	pool.Start()
+
+	// Fill the buffer
+	err := pool.Enqueue(&testPriorityTask{domain: "domain1"})
+	require.NoError(t, err)
+
+	// Start a goroutine that will block on Enqueue
+	enqueueDone := make(chan error, 1)
+	go func() {
+		err := pool.Enqueue(&testPriorityTask{domain: "domain1"})
+		enqueueDone <- err
+	}()
+
+	// Stop the pool, which cancels the context
+	pool.Stop()
+
+	// The blocked Enqueue should return with context error
+	select {
+	case err := <-enqueueDone:
+		assert.Error(t, err, "Enqueue should return error when context is cancelled")
+		assert.Equal(t, pool.ctx.Err(), err, "error should be context cancellation error")
+	case <-time.After(1 * time.Second):
+		t.Fatal("Enqueue did not unblock after context cancellation")
+	}
+}
+
+func TestHierarchicalWRRTaskPool_CleanupLoop(t *testing.T) {
+	domainWeights := map[string]int{
+		"domain1": 3,
+	}
+
+	timeSource := clock.NewMockedTimeSource()
+	pool := newHierarchicalWeightedRoundRobinTaskPool[string](
+		testlogger.New(t),
+		metrics.NoopClient,
+		timeSource,
+		&HierarchicalWeightedRoundRobinTaskPoolOptions[string]{
+			BufferSize: 10,
+			TaskToWeightedKeysFn: func(task PriorityTask) []WeightedKey[string] {
+				testTask := task.(*testPriorityTask)
+				return []WeightedKey[string]{
+					{Key: testTask.domain, Weight: domainWeights[testTask.domain]},
+				}
+			},
+		},
+	)
+
+	// Replace doCleanupFn with a fake that tracks calls
+	cleanupCalls := make(chan struct {
+		now time.Time
+		ttl time.Duration
+	}, 10)
+	pool.doCleanupFn = func(now time.Time, ttl time.Duration) {
+		cleanupCalls <- struct {
+			now time.Time
+			ttl time.Duration
+		}{now: now, ttl: ttl}
+	}
+
+	pool.Start()
+
+	// Advance time by cleanup interval (1800 seconds = TTL/2)
+	timeSource.BlockUntil(1)
+	timeSource.Advance(1800 * time.Second)
+
+	// Wait for first cleanup call
+	call1 := <-cleanupCalls
+	expectedTTL := 3600 * time.Second
+	require.Equal(t, expectedTTL, call1.ttl, "TTL should be 3600 seconds")
+	require.NotZero(t, call1.now, "now should be set")
+
+	// Advance time by another interval
+	timeSource.BlockUntil(1)
+	timeSource.Advance(1800 * time.Second)
+	call2 := <-cleanupCalls
+	require.Equal(t, expectedTTL, call2.ttl, "TTL should be 3600 seconds")
+	require.True(t, call2.now.After(call1.now), "second call should have later timestamp")
+
+	// Stop the pool
+	pool.Stop()
+
+	// Advance time - should NOT trigger cleanup because loop is stopped
+	timeSource.Advance(1800 * time.Second)
+	select {
+	case <-cleanupCalls:
+		t.Fatal("cleanup should not be called after Stop()")
+	default:
+		// Expected - no cleanup call
+	}
+}

--- a/common/task/hierarchical_weighted_round_robin_task_scheduler.go
+++ b/common/task/hierarchical_weighted_round_robin_task_scheduler.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package task
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
+	"github.com/uber/cadence/common/metrics"
+)
+
+type hierarchicalWeightedRoundRobinTaskSchedulerImpl[K comparable] struct {
+	sync.RWMutex
+
+	status       int32
+	pool         *hierarchicalWeightedRoundRobinTaskPoolImpl[K]
+	ctx          context.Context
+	cancel       context.CancelFunc
+	notifyCh     chan struct{}
+	dispatcherWG sync.WaitGroup
+	logger       log.Logger
+	metricsScope metrics.Scope
+	options      *HierarchicalWeightedRoundRobinTaskPoolOptions[K]
+
+	processor Processor
+}
+
+// NewHierarchicalWeightedRoundRobinTaskScheduler creates a new hierarchical WRR task scheduler
+func NewHierarchicalWeightedRoundRobinTaskScheduler[K comparable](
+	logger log.Logger,
+	metricsClient metrics.Client,
+	timeSource clock.TimeSource,
+	processor Processor,
+	options *HierarchicalWeightedRoundRobinTaskPoolOptions[K],
+) (Scheduler, error) {
+	metricsScope := metricsClient.Scope(metrics.TaskSchedulerScope)
+	ctx, cancel := context.WithCancel(context.Background())
+	scheduler := &hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]{
+		status: common.DaemonStatusInitialized,
+		pool: newHierarchicalWeightedRoundRobinTaskPool[K](
+			logger,
+			metricsClient,
+			timeSource,
+			options,
+		),
+		ctx:          ctx,
+		cancel:       cancel,
+		notifyCh:     make(chan struct{}, 1),
+		logger:       logger,
+		metricsScope: metricsScope,
+		options:      options,
+		processor:    processor,
+	}
+
+	return scheduler, nil
+}
+
+func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) Start() {
+	if !atomic.CompareAndSwapInt32(&w.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
+		return
+	}
+	w.pool.Start()
+
+	w.dispatcherWG.Add(1)
+	go w.dispatcher()
+	w.logger.Info("Hierarchical weighted round robin task scheduler started.")
+}
+
+func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) Stop() {
+	if !atomic.CompareAndSwapInt32(&w.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
+		return
+	}
+
+	w.cancel()
+	w.pool.Stop()
+
+	if success := common.AwaitWaitGroup(&w.dispatcherWG, time.Minute); !success {
+		w.logger.Warn("Hierarchical weighted round robin task scheduler timedout on shutdown.")
+	}
+
+	w.drainAndNackTasks()
+
+	w.logger.Info("Hierarchical weighted round robin task scheduler stopped.")
+}
+
+func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) Submit(task PriorityTask) error {
+	w.metricsScope.IncCounter(metrics.PriorityTaskSubmitRequest)
+	sw := w.metricsScope.StartTimer(metrics.PriorityTaskSubmitLatency)
+	defer sw.Stop()
+
+	if w.isStopped() {
+		return ErrTaskSchedulerClosed
+	}
+
+	if err := w.pool.Enqueue(task); err != nil {
+		return err
+	}
+	w.notifyDispatcher()
+	return nil
+}
+
+func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) TrySubmit(
+	task PriorityTask,
+) (bool, error) {
+	w.metricsScope.IncCounter(metrics.PriorityTaskSubmitRequest)
+	sw := w.metricsScope.StartTimer(metrics.PriorityTaskSubmitLatency)
+	defer sw.Stop()
+
+	if w.isStopped() {
+		return false, ErrTaskSchedulerClosed
+	}
+
+	ok, err := w.pool.TryEnqueue(task)
+	if ok {
+		w.notifyDispatcher()
+	}
+	return ok, err
+}
+
+func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) dispatcher() {
+	defer w.dispatcherWG.Done()
+
+	for {
+		select {
+		case <-w.notifyCh:
+			w.dispatchTasks()
+		case <-w.ctx.Done():
+			return
+		}
+	}
+}
+
+func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) dispatchTasks() {
+	for {
+		if w.isStopped() {
+			return
+		}
+		task, ok := w.pool.TryDequeue()
+		if !ok {
+			return
+		}
+		if err := w.processor.Submit(task); err != nil {
+			w.logger.Error("fail to submit task to processor", tag.Error(err))
+			task.Nack(err)
+		}
+	}
+}
+
+func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) notifyDispatcher() {
+	select {
+	case w.notifyCh <- struct{}{}:
+		// sent a notification to the dispatcher
+	default:
+		// do not block if there's already a notification
+	}
+}
+
+func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) isStopped() bool {
+	return atomic.LoadInt32(&w.status) == common.DaemonStatusStopped
+}
+
+func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) drainAndNackTasks() {
+	for {
+		task, ok := w.pool.TryDequeue()
+		if !ok {
+			return
+		}
+		task.Nack(nil)
+	}
+}

--- a/common/task/hierarchical_weighted_round_robin_task_scheduler_test.go
+++ b/common/task/hierarchical_weighted_round_robin_task_scheduler_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package task
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	"go.uber.org/mock/gomock"
+
+	"github.com/uber/cadence/common/backoff"
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
+	"github.com/uber/cadence/common/log/testlogger"
+	"github.com/uber/cadence/common/metrics"
+)
+
+func TestHierarchicalWeightedRoundRobinTaskScheduler_SchedulerContract(t *testing.T) {
+	controller := gomock.NewController(t)
+
+	realProcessor := NewParallelTaskProcessor(
+		testlogger.New(t),
+		metrics.NewClient(tally.NoopScope, metrics.Common, metrics.HistogramMigration{}),
+		&ParallelTaskProcessorOptions{
+			QueueSize:   1,
+			WorkerCount: dynamicproperties.GetIntPropertyFn(1),
+			RetryPolicy: backoff.NewExponentialRetryPolicy(time.Millisecond),
+		},
+	)
+
+	// Create hierarchical scheduler with string keys based on priority
+	scheduler, err := NewHierarchicalWeightedRoundRobinTaskScheduler(
+		testlogger.New(t),
+		metrics.NewClient(tally.NoopScope, metrics.Common, metrics.HistogramMigration{}),
+		clock.NewMockedTimeSource(),
+		realProcessor,
+		&HierarchicalWeightedRoundRobinTaskPoolOptions[string]{
+			BufferSize: 1000,
+			TaskToWeightedKeysFn: func(task PriorityTask) []WeightedKey[string] {
+				priority := task.Priority()
+				// Create a simple hierarchy: group -> priority
+				// Groups based on priority ranges with different weights
+				var group string
+				var groupWeight int
+				if priority == 0 {
+					group = "group0"
+					groupWeight = 3
+				} else if priority == 1 {
+					group = "group1"
+					groupWeight = 2
+				} else {
+					group = "group2"
+					groupWeight = 1
+				}
+
+				// Second level: individual priority
+				priorityKey := string(rune('0' + priority))
+				priorityWeight := 3 - priority
+				if priorityWeight < 1 {
+					priorityWeight = 1
+				}
+
+				return []WeightedKey[string]{
+					{Key: group, Weight: groupWeight},
+					{Key: priorityKey, Weight: priorityWeight},
+				}
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	// Reuse the existing testSchedulerContract function
+	testSchedulerContract(require.New(t), controller, scheduler, realProcessor)
+}

--- a/common/task/iwrr_node.go
+++ b/common/task/iwrr_node.go
@@ -1,0 +1,272 @@
+package task
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type (
+	// WeightedKey represents a key-weight pair used in hierarchical IWRR scheduling.
+	// The key identifies a node at a specific level in the hierarchy, and the weight
+	// determines the relative priority of that node in the IWRR schedule.
+	WeightedKey[K comparable] struct {
+		Key    K   // the identifier for this level in the hierarchy
+		Weight int // the relative weight/priority for IWRR scheduling (higher weight = more frequent selection)
+	}
+
+	// iwrrNode represents a node in the hierarchical IWRR tree structure.
+	// Each node can contain its own TTL channel for items and/or children nodes that form a subtree.
+	// The tree structure allows for hierarchical weighted round-robin scheduling where items are
+	// distributed across multiple levels based on their key paths and weights.
+	iwrrNode[K comparable, V any] struct {
+		sync.RWMutex
+		// The following fields are protected by the node's RWMutex
+		children map[K]weightedContainer[*iwrrNode[K, V]] // child nodes with their associated weights
+
+		// The following fields are immutable after construction
+		c *TTLChannel[V] // TTL channel for storing items at this level
+
+		// The following fields are concurrency-safe atomic fields
+		childrenItemCount atomic.Int64                                  // total number of items in all children's channels (across entire subtree)
+		drainSelfFirst    atomic.Bool                                   // when true, this node's channel is drained before children; when false, children are checked first
+		iwrrSchedule      atomic.Pointer[iwrrSchedule[*iwrrNode[K, V]]] // atomic snapshot of all direct children for IWRR scheduling
+
+		// The following fields are NOT concurrency-safe and must only be accessed by the single consumer goroutine
+		iter Iterator[*iwrrNode[K, V]] // stateful iterator for traversing the IWRR schedule
+	}
+)
+
+// newiwrrNode creates a new iwrrNode with the specified buffer size for its TTL channel.
+// The node is initialized with an empty children map and an empty IWRR schedule.
+func newiwrrNode[K comparable, V any](bufferSize int) *iwrrNode[K, V] {
+	node := &iwrrNode[K, V]{
+		c:        NewTTLChannel[V](bufferSize),
+		children: make(map[K]weightedContainer[*iwrrNode[K, V]]),
+	}
+	schedule := newIWRRSchedule[K, *iwrrNode[K, V]](nil)
+	node.iwrrSchedule.Store(schedule)
+	node.iter = schedule.NewIterator()
+	return node
+}
+
+// executeAtPath recursively navigates or creates nodes along the hierarchical key path
+// and executes the callback function at the target (leaf) node.
+//
+// The method traverses the tree following the path, creating intermediate nodes as needed.
+// When a child node is created or its weight changes, the parent's IWRR schedule is updated.
+// After executing the callback, the drainSelfFirst flag is set to indicate children should
+// be drained first, and the childrenItemCount is updated with the delta from the callback.
+//
+// Parameters:
+//   - path: slice of WeightedKey representing the hierarchical path to the target node
+//   - bufferSize: buffer size for any newly created nodes
+//   - callback: function to execute on the target node's channel, returns the change in item count
+//
+// Returns: the delta in item count from the callback execution
+//
+// Concurrency: This method is safe for concurrent access from multiple producer goroutines.
+func (n *iwrrNode[K, V]) executeAtPath(path []WeightedKey[K], bufferSize int, callback func(c *TTLChannel[V]) int64) int64 {
+	if len(path) == 0 {
+		n.drainSelfFirst.Store(false)
+		delta := callback(n.c)
+		return delta
+	}
+
+	key := path[0].Key
+	weight := path[0].Weight
+	needsUpdate := false
+
+	n.RLock()
+	if container, exists := n.children[key]; exists && container.weight == weight {
+		// Increment reference count to prevent cleanup while we're using this child
+		container.item.c.IncRef()
+		defer container.item.c.DecRef()
+		n.RUnlock()
+		delta := container.item.executeAtPath(path[1:], bufferSize, callback)
+		n.drainSelfFirst.Store(true)
+		n.childrenItemCount.Add(delta)
+		return delta
+	}
+	n.RUnlock()
+
+	n.Lock()
+	container, exists := n.children[key]
+	if !exists {
+		child := newiwrrNode[K, V](bufferSize)
+		n.children[key] = weightedContainer[*iwrrNode[K, V]]{
+			item:   child,
+			weight: weight,
+		}
+		container = n.children[key]
+		needsUpdate = true
+	} else if container.weight != weight {
+		n.children[key] = weightedContainer[*iwrrNode[K, V]]{
+			item:   container.item,
+			weight: weight,
+		}
+		container = n.children[key]
+		needsUpdate = true
+	}
+	// Update this node's schedule on the way back if needed
+	if needsUpdate {
+		n.updateScheduleLocked()
+	}
+	// Increment reference count to prevent cleanup while we're using this child
+	container.item.c.IncRef()
+	defer container.item.c.DecRef()
+	n.Unlock()
+	// Recurse to execute at the leaf node
+	delta := container.item.executeAtPath(path[1:], bufferSize, callback)
+	n.drainSelfFirst.Store(true)
+	n.childrenItemCount.Add(delta)
+	return delta
+}
+
+// updateScheduleLocked updates the IWRR schedule for this node based on its current direct children.
+// The new schedule is atomically stored, allowing the consumer goroutine to pick it up when the
+// current iterator naturally exhausts and resets.
+//
+// Concurrency: Must be called with write lock held on this node.
+func (n *iwrrNode[K, V]) updateScheduleLocked() {
+	schedule := newIWRRSchedule[K, *iwrrNode[K, V]](n.children)
+	n.iwrrSchedule.Store(schedule)
+	// The iterator will pick up the new schedule when it naturally exhausts and resets
+}
+
+// tryGetNextItem attempts to retrieve the next item from this subtree using IWRR scheduling.
+// The method respects the drainSelfFirst flag to determine priority:
+//   - If drainSelfFirst is true: tries own channel first, then children
+//   - If drainSelfFirst is false: tries children first, then own channel
+//
+// When traversing children, uses the IWRR iterator to select children according to their weights.
+//
+// Returns: the item and true if an item was successfully retrieved, zero value and false otherwise
+//
+// Concurrency: NOT safe for concurrent access. Must only be called by a single consumer goroutine.
+func (n *iwrrNode[K, V]) tryGetNextItem() (V, bool) {
+	var zero V
+
+	// Read drainSelfFirst flag
+	drainSelf := n.drainSelfFirst.Load()
+
+	// Check drainSelfFirst flag to determine order
+	if drainSelf {
+		if item, ok := n.tryOwnChannel(); ok {
+			return item, true
+		}
+	}
+
+	// Try children using IWRR iterator
+	if item, ok := n.tryChildren(); ok {
+		return item, true
+	}
+
+	// Try own channel if we haven't already
+	if !drainSelf {
+		if item, ok := n.tryOwnChannel(); ok {
+			return item, true
+		}
+	}
+
+	return zero, false
+}
+
+// tryOwnChannel attempts to retrieve an item from this node's own TTL channel.
+// Uses a non-blocking select to avoid waiting if the channel is empty.
+//
+// Returns: the item and true if an item was available, zero value and false if the channel is empty
+func (n *iwrrNode[K, V]) tryOwnChannel() (V, bool) {
+	var zero V
+	select {
+	case item := <-n.c.Chan():
+		return item, true
+	default:
+		return zero, false
+	}
+}
+
+// tryChildren attempts to retrieve an item from one of the child nodes using the IWRR iterator.
+// The method loops while childrenItemCount indicates items are available in the subtree.
+// If the iterator is exhausted but items remain, it resets the iterator with a fresh schedule snapshot.
+// When a child returns an item, the childrenItemCount is decremented to reflect the removal.
+//
+// This approach ensures:
+//   - Children are selected according to their IWRR weights
+//   - Schedule updates from producers are eventually picked up
+//   - The method doesn't block indefinitely on empty children
+//
+// Returns: the item and true if an item was retrieved from a child, zero value and false otherwise
+func (n *iwrrNode[K, V]) tryChildren() (V, bool) {
+	var zero V
+	for n.childrenItemCount.Load() > 0 {
+		child, ok := n.iter.TryNext()
+		if !ok {
+			// Iterator exhausted - check if any children have items
+			if n.childrenItemCount.Load() == 0 {
+				// No children have items, give up
+				return zero, false
+			}
+
+			// Some child has items, reset iterator and try another round
+			schedule := n.iwrrSchedule.Load()
+			n.iter = schedule.NewIterator()
+			continue
+		}
+
+		// Recursively try to get item from child
+		item, ok := child.tryGetNextItem()
+		if ok {
+			// Got an item from child, decrement children count
+			n.childrenItemCount.Add(-1)
+			return item, true
+		}
+		// Child had no item, try next child
+	}
+	return zero, false
+}
+
+// cleanup recursively removes idle nodes from the tree based on the TTL.
+// The method performs a depth-first traversal, cleaning up children before checking itself.
+//
+// Process:
+//  1. Recursively cleanup all children
+//  2. Remove children that return true (indicating they should be removed)
+//  3. Update the IWRR schedule if any children were removed
+//  4. If this node is now a leaf, check if its own channel should be cleaned up
+//
+// A leaf node is eligible for removal if its TTL channel has been idle beyond the TTL duration.
+//
+// Returns: true if this node should be removed by its parent, false otherwise
+//
+// Concurrency: Safe for concurrent access. Acquires write lock during execution.
+func (n *iwrrNode[K, V]) cleanup(now time.Time, ttl time.Duration) bool {
+	n.Lock()
+	defer n.Unlock()
+
+	// Clean up children first and collect keys to remove
+	keysToRemove := make([]K, 0)
+	for key, container := range n.children {
+		if container.item.cleanup(now, ttl) {
+			keysToRemove = append(keysToRemove, key)
+		}
+	}
+
+	// Remove children that should be cleaned up
+	needsUpdate := false
+	for _, key := range keysToRemove {
+		delete(n.children, key)
+		needsUpdate = true
+	}
+
+	// Update schedule if children were removed
+	if needsUpdate {
+		n.updateScheduleLocked()
+	}
+
+	// If the node is a leaf node or becomes a leaf node, check if it should be removed
+	if len(n.children) == 0 {
+		return n.c.ShouldCleanup(now, ttl)
+	}
+	return false
+}

--- a/common/task/iwrr_node_test.go
+++ b/common/task/iwrr_node_test.go
@@ -1,0 +1,853 @@
+package task
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIwrrNode_ExecuteAtPath(t *testing.T) {
+	tests := []struct {
+		name               string
+		setupFn            func() (*iwrrNode[string, int], *iwrrNode[string, int]) // returns (root, expectedChild)
+		path               []WeightedKey[string]
+		bufferSize         int
+		callbackValue      int64
+		expectedDelta      int64
+		verifyFn           func(t *testing.T, root *iwrrNode[string, int], expectedChild *iwrrNode[string, int])
+		expectedChildCount int64
+	}{
+		{
+			name: "empty_path_executes_on_current_node",
+			setupFn: func() (*iwrrNode[string, int], *iwrrNode[string, int]) {
+				return newiwrrNode[string, int](10), nil
+			},
+			path:          []WeightedKey[string]{},
+			bufferSize:    10,
+			callbackValue: 1,
+			expectedDelta: 1,
+			verifyFn: func(t *testing.T, root *iwrrNode[string, int], _ *iwrrNode[string, int]) {
+				assert.False(t, root.drainSelfFirst.Load(), "drainSelfFirst should be false after execution on self")
+			},
+			expectedChildCount: 0,
+		},
+		{
+			name: "single_element_path_creates_child",
+			setupFn: func() (*iwrrNode[string, int], *iwrrNode[string, int]) {
+				return newiwrrNode[string, int](10), nil
+			},
+			path: []WeightedKey[string]{
+				{Key: "child1", Weight: 3},
+			},
+			bufferSize:    10,
+			callbackValue: 1,
+			expectedDelta: 1,
+			verifyFn: func(t *testing.T, root *iwrrNode[string, int], _ *iwrrNode[string, int]) {
+				container := root.children["child1"]
+				require.NotNil(t, container.item)
+				assert.Equal(t, 3, container.weight)
+				assert.True(t, root.drainSelfFirst.Load(), "root should have drainSelfFirst set")
+				assert.False(t, container.item.drainSelfFirst.Load(), "target should not have drainSelfFirst set")
+			},
+			expectedChildCount: 1,
+		},
+		{
+			name: "multi_element_path_creates_nested_children",
+			setupFn: func() (*iwrrNode[string, int], *iwrrNode[string, int]) {
+				return newiwrrNode[string, int](10), nil
+			},
+			path: []WeightedKey[string]{
+				{Key: "level1", Weight: 5},
+				{Key: "level2", Weight: 3},
+				{Key: "level3", Weight: 2},
+			},
+			bufferSize:    10,
+			callbackValue: 1,
+			expectedDelta: 1,
+			verifyFn: func(t *testing.T, root *iwrrNode[string, int], _ *iwrrNode[string, int]) {
+				level1 := root.children["level1"]
+				require.NotNil(t, level1.item)
+				assert.Equal(t, 5, level1.weight)
+
+				level2 := level1.item.children["level2"]
+				require.NotNil(t, level2.item)
+				assert.Equal(t, 3, level2.weight)
+
+				level3 := level2.item.children["level3"]
+				require.NotNil(t, level3.item)
+				assert.Equal(t, 2, level3.weight)
+
+				// Check childrenItemCount at each level
+				assert.Equal(t, int64(1), root.childrenItemCount.Load())
+				assert.Equal(t, int64(1), level1.item.childrenItemCount.Load())
+				assert.Equal(t, int64(1), level2.item.childrenItemCount.Load())
+			},
+			expectedChildCount: 1,
+		},
+		{
+			name: "existing_path_with_same_weight_reuses_nodes",
+			setupFn: func() (*iwrrNode[string, int], *iwrrNode[string, int]) {
+				root := newiwrrNode[string, int](10)
+				// Pre-create a 3-level path
+				root.Lock()
+				level1 := newiwrrNode[string, int](10)
+				root.children["level1"] = weightedContainer[*iwrrNode[string, int]]{
+					item:   level1,
+					weight: 5,
+				}
+				root.updateScheduleLocked()
+				root.Unlock()
+
+				level1.Lock()
+				level2 := newiwrrNode[string, int](10)
+				level1.children["level2"] = weightedContainer[*iwrrNode[string, int]]{
+					item:   level2,
+					weight: 3,
+				}
+				level1.updateScheduleLocked()
+				level1.Unlock()
+
+				level2.Lock()
+				level3 := newiwrrNode[string, int](10)
+				level2.children["level3"] = weightedContainer[*iwrrNode[string, int]]{
+					item:   level3,
+					weight: 2,
+				}
+				level2.updateScheduleLocked()
+				level2.Unlock()
+
+				// Store the expected nodes by writing unique IDs to their channels
+				level1.c.Chan() <- 111
+				level2.c.Chan() <- 222
+				level3.c.Chan() <- 333
+
+				return root, nil
+			},
+			path: []WeightedKey[string]{
+				{Key: "level1", Weight: 5},
+				{Key: "level2", Weight: 3},
+				{Key: "level3", Weight: 2},
+			},
+			bufferSize:    10,
+			callbackValue: 1,
+			expectedDelta: 1,
+			verifyFn: func(t *testing.T, root *iwrrNode[string, int], _ *iwrrNode[string, int]) {
+				// Verify all three levels exist and have correct weights
+				level1Container := root.children["level1"]
+				require.NotNil(t, level1Container.item)
+				assert.Equal(t, 5, level1Container.weight)
+				// Check it's the same instance by reading the unique ID we stored
+				id1, ok := <-level1Container.item.c.Chan()
+				require.True(t, ok)
+				assert.Equal(t, 111, id1, "level1 should be reused (same instance)")
+
+				level2Container := level1Container.item.children["level2"]
+				require.NotNil(t, level2Container.item)
+				assert.Equal(t, 3, level2Container.weight)
+				id2, ok := <-level2Container.item.c.Chan()
+				require.True(t, ok)
+				assert.Equal(t, 222, id2, "level2 should be reused (same instance)")
+
+				level3Container := level2Container.item.children["level3"]
+				require.NotNil(t, level3Container.item)
+				assert.Equal(t, 2, level3Container.weight)
+				id3, ok := <-level3Container.item.c.Chan()
+				require.True(t, ok)
+				assert.Equal(t, 333, id3, "level3 should be reused (same instance)")
+
+				// Verify childrenItemCount at each level
+				assert.Equal(t, int64(1), root.childrenItemCount.Load())
+				assert.Equal(t, int64(1), level1Container.item.childrenItemCount.Load())
+				assert.Equal(t, int64(1), level2Container.item.childrenItemCount.Load())
+			},
+			expectedChildCount: 1,
+		},
+		{
+			name: "existing_multi_level_path_with_weight_changes_reuses_nodes",
+			setupFn: func() (*iwrrNode[string, int], *iwrrNode[string, int]) {
+				root := newiwrrNode[string, int](10)
+				// Pre-create a 3-level path with initial weights [5, 3, 2]
+				root.Lock()
+				level1 := newiwrrNode[string, int](10)
+				root.children["level1"] = weightedContainer[*iwrrNode[string, int]]{
+					item:   level1,
+					weight: 5,
+				}
+				root.updateScheduleLocked()
+				root.Unlock()
+
+				level1.Lock()
+				level2 := newiwrrNode[string, int](10)
+				level1.children["level2"] = weightedContainer[*iwrrNode[string, int]]{
+					item:   level2,
+					weight: 3,
+				}
+				level1.updateScheduleLocked()
+				level1.Unlock()
+
+				level2.Lock()
+				level3 := newiwrrNode[string, int](10)
+				level2.children["level3"] = weightedContainer[*iwrrNode[string, int]]{
+					item:   level3,
+					weight: 2,
+				}
+				level2.updateScheduleLocked()
+				level2.Unlock()
+
+				// Store unique IDs to verify same instances
+				level1.c.Chan() <- 111
+				level2.c.Chan() <- 222
+				level3.c.Chan() <- 333
+
+				return root, nil
+			},
+			path: []WeightedKey[string]{
+				{Key: "level1", Weight: 10}, // Changed from 5 to 10
+				{Key: "level2", Weight: 7},  // Changed from 3 to 7
+				{Key: "level3", Weight: 4},  // Changed from 2 to 4
+			},
+			bufferSize:    10,
+			callbackValue: 1,
+			expectedDelta: 1,
+			verifyFn: func(t *testing.T, root *iwrrNode[string, int], _ *iwrrNode[string, int]) {
+				// Verify all three levels exist with UPDATED weights
+				level1Container := root.children["level1"]
+				require.NotNil(t, level1Container.item)
+				assert.Equal(t, 10, level1Container.weight, "level1 weight should be updated to 10")
+				// Check it's the same instance by reading the unique ID we stored
+				id1, ok := <-level1Container.item.c.Chan()
+				require.True(t, ok)
+				assert.Equal(t, 111, id1, "level1 should be reused (same instance)")
+
+				level2Container := level1Container.item.children["level2"]
+				require.NotNil(t, level2Container.item)
+				assert.Equal(t, 7, level2Container.weight, "level2 weight should be updated to 7")
+				id2, ok := <-level2Container.item.c.Chan()
+				require.True(t, ok)
+				assert.Equal(t, 222, id2, "level2 should be reused (same instance)")
+
+				level3Container := level2Container.item.children["level3"]
+				require.NotNil(t, level3Container.item)
+				assert.Equal(t, 4, level3Container.weight, "level3 weight should be updated to 4")
+				id3, ok := <-level3Container.item.c.Chan()
+				require.True(t, ok)
+				assert.Equal(t, 333, id3, "level3 should be reused (same instance)")
+
+				// Verify childrenItemCount at each level
+				assert.Equal(t, int64(1), root.childrenItemCount.Load())
+				assert.Equal(t, int64(1), level1Container.item.childrenItemCount.Load())
+				assert.Equal(t, int64(1), level2Container.item.childrenItemCount.Load())
+			},
+			expectedChildCount: 1,
+		},
+		{
+			name: "weight_change_triggers_schedule_update",
+			setupFn: func() (*iwrrNode[string, int], *iwrrNode[string, int]) {
+				root := newiwrrNode[string, int](10)
+				// Pre-create a child with weight 5
+				root.Lock()
+				child := newiwrrNode[string, int](10)
+				root.children["child1"] = weightedContainer[*iwrrNode[string, int]]{
+					item:   child,
+					weight: 5,
+				}
+				root.updateScheduleLocked()
+				root.Unlock()
+				return root, child
+			},
+			path: []WeightedKey[string]{
+				{Key: "child1", Weight: 10}, // Different weight
+			},
+			bufferSize:    10,
+			callbackValue: 1,
+			expectedDelta: 1,
+			verifyFn: func(t *testing.T, root *iwrrNode[string, int], expectedChild *iwrrNode[string, int]) {
+				container := root.children["child1"]
+				require.NotNil(t, container.item)
+				assert.Equal(t, 10, container.weight, "weight should be updated")
+				// Should reuse the same child node even though weight changed
+				assert.Same(t, expectedChild, container.item, "should reuse the same node instance")
+
+				// Verify schedule was updated with new weight
+				schedule := root.iwrrSchedule.Load()
+				require.NotNil(t, schedule)
+				// Schedule length should reflect the updated weight (10, not 5)
+				assert.Equal(t, 10, schedule.Len(), "schedule length should reflect updated weight")
+			},
+			expectedChildCount: 1,
+		},
+		{
+			name: "partial_path_exists_reuses_top_creates_bottom",
+			setupFn: func() (*iwrrNode[string, int], *iwrrNode[string, int]) {
+				root := newiwrrNode[string, int](10)
+				// Only create level1, but not level2 or level3
+				root.Lock()
+				level1 := newiwrrNode[string, int](10)
+				root.children["level1"] = weightedContainer[*iwrrNode[string, int]]{
+					item:   level1,
+					weight: 5,
+				}
+				root.updateScheduleLocked()
+				root.Unlock()
+
+				// Store unique ID in level1 to verify it's reused
+				level1.c.Chan() <- 111
+
+				return root, nil
+			},
+			path: []WeightedKey[string]{
+				{Key: "level1", Weight: 5}, // Exists - should reuse
+				{Key: "level2", Weight: 3}, // Doesn't exist - should create
+				{Key: "level3", Weight: 2}, // Doesn't exist - should create
+			},
+			bufferSize:    10,
+			callbackValue: 1,
+			expectedDelta: 1,
+			verifyFn: func(t *testing.T, root *iwrrNode[string, int], _ *iwrrNode[string, int]) {
+				// Verify level1 was reused
+				level1Container := root.children["level1"]
+				require.NotNil(t, level1Container.item)
+				assert.Equal(t, 5, level1Container.weight)
+				id1, ok := <-level1Container.item.c.Chan()
+				require.True(t, ok)
+				assert.Equal(t, 111, id1, "level1 should be reused (same instance)")
+
+				// Verify level2 was created
+				level2Container := level1Container.item.children["level2"]
+				require.NotNil(t, level2Container.item)
+				assert.Equal(t, 3, level2Container.weight)
+
+				// Verify level3 was created
+				level3Container := level2Container.item.children["level3"]
+				require.NotNil(t, level3Container.item)
+				assert.Equal(t, 2, level3Container.weight)
+
+				// Verify childrenItemCount propagated correctly
+				assert.Equal(t, int64(1), root.childrenItemCount.Load())
+				assert.Equal(t, int64(1), level1Container.item.childrenItemCount.Load())
+				assert.Equal(t, int64(1), level2Container.item.childrenItemCount.Load())
+			},
+			expectedChildCount: 1,
+		},
+		{
+			name: "partial_path_exists_with_weight_change",
+			setupFn: func() (*iwrrNode[string, int], *iwrrNode[string, int]) {
+				root := newiwrrNode[string, int](10)
+				// Create level1 and level2, but not level3
+				root.Lock()
+				level1 := newiwrrNode[string, int](10)
+				root.children["level1"] = weightedContainer[*iwrrNode[string, int]]{
+					item:   level1,
+					weight: 5,
+				}
+				root.updateScheduleLocked()
+				root.Unlock()
+
+				level1.Lock()
+				level2 := newiwrrNode[string, int](10)
+				level1.children["level2"] = weightedContainer[*iwrrNode[string, int]]{
+					item:   level2,
+					weight: 3,
+				}
+				level1.updateScheduleLocked()
+				level1.Unlock()
+
+				// Store unique IDs to verify reuse
+				level1.c.Chan() <- 111
+				level2.c.Chan() <- 222
+
+				return root, nil
+			},
+			path: []WeightedKey[string]{
+				{Key: "level1", Weight: 10}, // Exists - reuse with updated weight
+				{Key: "level2", Weight: 3},  // Exists - reuse with same weight
+				{Key: "level3", Weight: 2},  // Doesn't exist - create
+			},
+			bufferSize:    10,
+			callbackValue: 1,
+			expectedDelta: 1,
+			verifyFn: func(t *testing.T, root *iwrrNode[string, int], _ *iwrrNode[string, int]) {
+				// Verify level1 was reused with updated weight
+				level1Container := root.children["level1"]
+				require.NotNil(t, level1Container.item)
+				assert.Equal(t, 10, level1Container.weight, "level1 weight should be updated")
+				id1, ok := <-level1Container.item.c.Chan()
+				require.True(t, ok)
+				assert.Equal(t, 111, id1, "level1 should be reused (same instance)")
+
+				// Verify level2 was reused with same weight
+				level2Container := level1Container.item.children["level2"]
+				require.NotNil(t, level2Container.item)
+				assert.Equal(t, 3, level2Container.weight)
+				id2, ok := <-level2Container.item.c.Chan()
+				require.True(t, ok)
+				assert.Equal(t, 222, id2, "level2 should be reused (same instance)")
+
+				// Verify level3 was newly created
+				level3Container := level2Container.item.children["level3"]
+				require.NotNil(t, level3Container.item)
+				assert.Equal(t, 2, level3Container.weight)
+
+				// Verify childrenItemCount propagated correctly
+				assert.Equal(t, int64(1), root.childrenItemCount.Load())
+				assert.Equal(t, int64(1), level1Container.item.childrenItemCount.Load())
+				assert.Equal(t, int64(1), level2Container.item.childrenItemCount.Load())
+			},
+			expectedChildCount: 1,
+		},
+		{
+			name: "multiple_children_at_same_level",
+			setupFn: func() (*iwrrNode[string, int], *iwrrNode[string, int]) {
+				return newiwrrNode[string, int](10), nil
+			},
+			path: []WeightedKey[string]{
+				{Key: "child1", Weight: 3},
+			},
+			bufferSize:    10,
+			callbackValue: 1,
+			expectedDelta: 1,
+			verifyFn: func(t *testing.T, root *iwrrNode[string, int], _ *iwrrNode[string, int]) {
+				// Execute on another child to verify multiple children work
+				delta2 := root.executeAtPath([]WeightedKey[string]{
+					{Key: "child2", Weight: 7},
+				}, 10, func(c *TTLChannel[int]) int64 {
+					return 2
+				})
+				assert.Equal(t, int64(2), delta2)
+				assert.Len(t, root.children, 2)
+				assert.Equal(t, 3, root.children["child1"].weight)
+				assert.Equal(t, 7, root.children["child2"].weight)
+				assert.Equal(t, int64(3), root.childrenItemCount.Load(), "should have sum of deltas")
+			},
+			expectedChildCount: 1,
+		},
+		{
+			name: "callback_delta_propagates_up",
+			setupFn: func() (*iwrrNode[string, int], *iwrrNode[string, int]) {
+				return newiwrrNode[string, int](10), nil
+			},
+			path: []WeightedKey[string]{
+				{Key: "level1", Weight: 5},
+				{Key: "level2", Weight: 3},
+			},
+			bufferSize:    10,
+			callbackValue: 42,
+			expectedDelta: 42,
+			verifyFn: func(t *testing.T, root *iwrrNode[string, int], _ *iwrrNode[string, int]) {
+				assert.Equal(t, int64(42), root.childrenItemCount.Load())
+				assert.Equal(t, int64(42), root.children["level1"].item.childrenItemCount.Load())
+			},
+			expectedChildCount: 42,
+		},
+		{
+			name: "zero_delta_from_callback",
+			setupFn: func() (*iwrrNode[string, int], *iwrrNode[string, int]) {
+				return newiwrrNode[string, int](10), nil
+			},
+			path: []WeightedKey[string]{
+				{Key: "child1", Weight: 3},
+			},
+			bufferSize:    10,
+			callbackValue: 0,
+			expectedDelta: 0,
+			verifyFn: func(t *testing.T, root *iwrrNode[string, int], _ *iwrrNode[string, int]) {
+				assert.Equal(t, int64(0), root.childrenItemCount.Load())
+			},
+			expectedChildCount: 0,
+		},
+		{
+			name: "negative_delta_from_callback",
+			setupFn: func() (*iwrrNode[string, int], *iwrrNode[string, int]) {
+				root := newiwrrNode[string, int](10)
+				// Pre-populate some count
+				root.childrenItemCount.Store(10)
+				return root, nil
+			},
+			path: []WeightedKey[string]{
+				{Key: "child1", Weight: 3},
+			},
+			bufferSize:    10,
+			callbackValue: -5,
+			expectedDelta: -5,
+			verifyFn: func(t *testing.T, root *iwrrNode[string, int], _ *iwrrNode[string, int]) {
+				assert.Equal(t, int64(5), root.childrenItemCount.Load(), "should subtract from existing count")
+			},
+			expectedChildCount: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root, expectedChild := tt.setupFn()
+
+			// Create callback that returns the expected value
+			delta := root.executeAtPath(tt.path, tt.bufferSize, func(c *TTLChannel[int]) int64 {
+				return tt.callbackValue
+			})
+
+			assert.Equal(t, tt.expectedDelta, delta, "delta mismatch")
+			assert.Equal(t, tt.expectedChildCount, root.childrenItemCount.Load(), "childrenItemCount mismatch")
+
+			if tt.verifyFn != nil {
+				tt.verifyFn(t, root, expectedChild)
+			}
+		})
+	}
+}
+
+func TestIwrrNode_ExecuteAtPath_ConcurrentAccess(t *testing.T) {
+	root := newiwrrNode[int, int](100)
+
+	// Concurrently execute on multi-level paths
+	done := make(chan bool)
+	for i := 0; i < 10; i++ {
+		go func(id int) {
+			for j := 0; j < 100; j++ {
+				// Create 3-level paths with varying structures
+				path := []WeightedKey[int]{
+					{Key: id % 3, Weight: (id % 3) + 1}, // level1: 3 different keys
+					{Key: id % 5, Weight: (id % 5) + 1}, // level2: 5 different keys
+					{Key: id, Weight: id + 1},           // level3: 10 different keys
+				}
+				root.executeAtPath(path, 10, func(c *TTLChannel[int]) int64 {
+					// Just return delta without writing to channel
+					// to avoid blocking when channel is full
+					return 1
+				})
+			}
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	// Verify tree structure
+	level1Count := len(root.children)
+	assert.LessOrEqual(t, level1Count, 3, "should have at most 3 level1 children")
+	assert.GreaterOrEqual(t, level1Count, 1, "should have at least 1 level1 child")
+
+	// Verify level2 and level3 exist
+	for key1, container1 := range root.children {
+		require.NotNil(t, container1.item, "level1 child %d should not be nil", key1)
+
+		level2Count := len(container1.item.children)
+		assert.LessOrEqual(t, level2Count, 5, "level1[%d] should have at most 5 level2 children", key1)
+		assert.GreaterOrEqual(t, level2Count, 1, "level1[%d] should have at least 1 level2 child", key1)
+
+		for key2, container2 := range container1.item.children {
+			require.NotNil(t, container2.item, "level2 child %d->%d should not be nil", key1, key2)
+
+			level3Count := len(container2.item.children)
+			assert.GreaterOrEqual(t, level3Count, 1, "level2[%d][%d] should have at least 1 level3 child", key1, key2)
+		}
+	}
+
+	// Total items should be 10 * 100 = 1000
+	assert.Equal(t, int64(1000), root.childrenItemCount.Load())
+}
+
+func TestIwrrNode_Cleanup(t *testing.T) {
+	baseTime := time.Unix(1000, 0)
+	ttl := 10 * time.Second
+
+	tests := []struct {
+		name           string
+		setupFn        func() *iwrrNode[string, int]
+		now            time.Time
+		ttl            time.Duration
+		expectedReturn bool
+		verifyFn       func(t *testing.T, root *iwrrNode[string, int])
+	}{
+		{
+			name: "leaf_node_should_be_cleaned_up",
+			setupFn: func() *iwrrNode[string, int] {
+				node := newiwrrNode[string, int](10)
+				// Set last write time to old time
+				node.c.UpdateLastWriteTime(baseTime)
+				// Ensure refCount is 0 and channel is empty
+				return node
+			},
+			now:            baseTime.Add(ttl + time.Second), // Past TTL
+			ttl:            ttl,
+			expectedReturn: true,
+			verifyFn: func(t *testing.T, root *iwrrNode[string, int]) {
+				assert.Empty(t, root.children, "should have no children")
+			},
+		},
+		{
+			name: "leaf_node_should_not_be_cleaned_up_not_expired",
+			setupFn: func() *iwrrNode[string, int] {
+				node := newiwrrNode[string, int](10)
+				node.c.UpdateLastWriteTime(baseTime)
+				return node
+			},
+			now:            baseTime.Add(ttl - time.Second), // Before TTL
+			ttl:            ttl,
+			expectedReturn: false,
+			verifyFn: func(t *testing.T, root *iwrrNode[string, int]) {
+				assert.Empty(t, root.children, "should have no children")
+			},
+		},
+		{
+			name: "leaf_node_should_not_be_cleaned_up_has_refs",
+			setupFn: func() *iwrrNode[string, int] {
+				node := newiwrrNode[string, int](10)
+				node.c.UpdateLastWriteTime(baseTime)
+				node.c.IncRef() // Add reference
+				return node
+			},
+			now:            baseTime.Add(ttl + time.Second), // Past TTL
+			ttl:            ttl,
+			expectedReturn: false,
+			verifyFn: func(t *testing.T, root *iwrrNode[string, int]) {
+				assert.Equal(t, int32(1), root.c.RefCount())
+			},
+		},
+		{
+			name: "leaf_node_should_not_be_cleaned_up_has_data",
+			setupFn: func() *iwrrNode[string, int] {
+				node := newiwrrNode[string, int](10)
+				node.c.UpdateLastWriteTime(baseTime)
+				node.c.Chan() <- 42 // Add data to channel
+				return node
+			},
+			now:            baseTime.Add(ttl + time.Second), // Past TTL
+			ttl:            ttl,
+			expectedReturn: false,
+			verifyFn: func(t *testing.T, root *iwrrNode[string, int]) {
+				assert.Equal(t, 1, root.c.Len())
+			},
+		},
+		{
+			name: "internal_node_with_active_children_should_not_be_cleaned_up",
+			setupFn: func() *iwrrNode[string, int] {
+				root := newiwrrNode[string, int](10)
+				root.Lock()
+				child := newiwrrNode[string, int](10)
+				child.c.UpdateLastWriteTime(baseTime) // Recent write
+				root.children["child1"] = weightedContainer[*iwrrNode[string, int]]{
+					item:   child,
+					weight: 5,
+				}
+				root.updateScheduleLocked()
+				root.Unlock()
+				return root
+			},
+			now:            baseTime.Add(ttl - time.Second), // Before TTL
+			ttl:            ttl,
+			expectedReturn: false,
+			verifyFn: func(t *testing.T, root *iwrrNode[string, int]) {
+				assert.Len(t, root.children, 1, "child should not be removed")
+				_, exists := root.children["child1"]
+				assert.True(t, exists, "child should remain")
+			},
+		},
+		{
+			name: "internal_node_removes_expired_children",
+			setupFn: func() *iwrrNode[string, int] {
+				root := newiwrrNode[string, int](10)
+				root.Lock()
+				// Add two children: one expired, one active
+				expiredChild := newiwrrNode[string, int](10)
+				expiredChild.c.UpdateLastWriteTime(baseTime.Add(-2 * ttl)) // Way past TTL
+				root.children["expired"] = weightedContainer[*iwrrNode[string, int]]{
+					item:   expiredChild,
+					weight: 3,
+				}
+
+				activeChild := newiwrrNode[string, int](10)
+				activeChild.c.UpdateLastWriteTime(baseTime.Add(ttl + time.Second)) // Before TTL
+				root.children["active"] = weightedContainer[*iwrrNode[string, int]]{
+					item:   activeChild,
+					weight: 5,
+				}
+				root.updateScheduleLocked()
+				root.Unlock()
+				return root
+			},
+			now:            baseTime.Add(ttl + time.Second),
+			ttl:            ttl,
+			expectedReturn: false,
+			verifyFn: func(t *testing.T, root *iwrrNode[string, int]) {
+				assert.Len(t, root.children, 1, "should have 1 child remaining")
+				_, exists := root.children["active"]
+				assert.True(t, exists, "active child should remain")
+				_, exists = root.children["expired"]
+				assert.False(t, exists, "expired child should be removed")
+			},
+		},
+		{
+			name: "internal_node_removes_all_expired_children",
+			setupFn: func() *iwrrNode[string, int] {
+				root := newiwrrNode[string, int](10)
+				root.Lock()
+				// Add multiple expired children
+				for i := 1; i <= 3; i++ {
+					child := newiwrrNode[string, int](10)
+					child.c.UpdateLastWriteTime(baseTime.Add(-ttl - time.Second))
+					root.children[string(rune('a'+i-1))] = weightedContainer[*iwrrNode[string, int]]{
+						item:   child,
+						weight: i,
+					}
+				}
+				root.updateScheduleLocked()
+				root.Unlock()
+				return root
+			},
+			now:            baseTime.Add(ttl + time.Second),
+			ttl:            ttl,
+			expectedReturn: true, // All children removed, so node should be removed
+			verifyFn: func(t *testing.T, root *iwrrNode[string, int]) {
+				assert.Empty(t, root.children, "all children should be removed")
+			},
+		},
+		{
+			name: "schedule_updated_when_children_removed",
+			setupFn: func() *iwrrNode[string, int] {
+				root := newiwrrNode[string, int](10)
+				root.Lock()
+				// Add two children with different weights
+				child1 := newiwrrNode[string, int](10)
+				child1.c.UpdateLastWriteTime(baseTime.Add(-ttl - time.Second)) // Expired
+				root.children["expired"] = weightedContainer[*iwrrNode[string, int]]{
+					item:   child1,
+					weight: 5,
+				}
+
+				child2 := newiwrrNode[string, int](10)
+				child2.c.UpdateLastWriteTime(baseTime.Add(ttl + time.Second)) // Active
+				root.children["active"] = weightedContainer[*iwrrNode[string, int]]{
+					item:   child2,
+					weight: 3,
+				}
+				root.updateScheduleLocked()
+				root.Unlock()
+				return root
+			},
+			now:            baseTime.Add(ttl + time.Second),
+			ttl:            ttl,
+			expectedReturn: false,
+			verifyFn: func(t *testing.T, root *iwrrNode[string, int]) {
+				assert.Len(t, root.children, 1)
+				_, exists := root.children["expired"]
+				assert.False(t, exists, "expired child should be removed")
+				_, exists = root.children["active"]
+				assert.True(t, exists, "active child should remain")
+
+				// New schedule should only have weight 3
+				newSchedule := root.iwrrSchedule.Load()
+				assert.Equal(t, 3, newSchedule.Len(), "updated schedule should only have weight 3")
+			},
+		},
+		{
+			name: "multi_level_recursive_cleanup",
+			setupFn: func() *iwrrNode[string, int] {
+				root := newiwrrNode[string, int](10)
+
+				// Create 3-level tree: root -> level1 -> level2 -> level3
+				root.Lock()
+				level1 := newiwrrNode[string, int](10)
+				level1.c.UpdateLastWriteTime(baseTime.Add(-ttl - time.Second)) // Expired
+				root.children["expired"] = weightedContainer[*iwrrNode[string, int]]{
+					item:   level1,
+					weight: 5,
+				}
+				root.updateScheduleLocked()
+				root.Unlock()
+
+				level1.Lock()
+				level2 := newiwrrNode[string, int](10)
+				level2.c.UpdateLastWriteTime(baseTime.Add(-ttl - time.Second)) // Expired
+				level1.children["expired"] = weightedContainer[*iwrrNode[string, int]]{
+					item:   level2,
+					weight: 3,
+				}
+				level1.updateScheduleLocked()
+				level1.Unlock()
+
+				level2.Lock()
+				level3 := newiwrrNode[string, int](10)
+				level3.c.UpdateLastWriteTime(baseTime.Add(-ttl - time.Second)) // Expired
+				level2.children["level3"] = weightedContainer[*iwrrNode[string, int]]{
+					item:   level3,
+					weight: 2,
+				}
+				level2.updateScheduleLocked()
+				level2.Unlock()
+
+				return root
+			},
+			now:            baseTime.Add(ttl + time.Second),
+			ttl:            ttl,
+			expectedReturn: true, // All should cascade up and be removed
+			verifyFn: func(t *testing.T, root *iwrrNode[string, int]) {
+				assert.Empty(t, root.children, "all children should be recursively removed")
+			},
+		},
+		{
+			name: "multi_level_partial_cleanup",
+			setupFn: func() *iwrrNode[string, int] {
+				root := newiwrrNode[string, int](10)
+
+				// Create tree where one branch is expired, another is active
+				root.Lock()
+				expiredBranch := newiwrrNode[string, int](10)
+				expiredBranch.c.UpdateLastWriteTime(baseTime.Add(-2 * ttl)) // Way past TTL
+				root.children["expired"] = weightedContainer[*iwrrNode[string, int]]{
+					item:   expiredBranch,
+					weight: 3,
+				}
+
+				activeBranch := newiwrrNode[string, int](10)
+				root.children["active"] = weightedContainer[*iwrrNode[string, int]]{
+					item:   activeBranch,
+					weight: 5,
+				}
+				root.updateScheduleLocked()
+				root.Unlock()
+
+				// Add active child to active branch
+				activeBranch.Lock()
+				activeLeaf := newiwrrNode[string, int](10)
+				activeLeaf.c.UpdateLastWriteTime(baseTime) // Recent write
+				activeLeaf.c.IncRef()                      // Keep it active
+				activeBranch.children["leaf"] = weightedContainer[*iwrrNode[string, int]]{
+					item:   activeLeaf,
+					weight: 2,
+				}
+				activeBranch.updateScheduleLocked()
+				activeBranch.Unlock()
+
+				return root
+			},
+			now:            baseTime.Add(ttl + time.Second),
+			ttl:            ttl,
+			expectedReturn: false,
+			verifyFn: func(t *testing.T, root *iwrrNode[string, int]) {
+				assert.Len(t, root.children, 1, "only active branch should remain")
+				_, exists := root.children["active"]
+				assert.True(t, exists, "active branch should remain")
+
+				activeBranch := root.children["active"].item
+				assert.Len(t, activeBranch.children, 1, "active leaf should remain")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := tt.setupFn()
+			shouldRemove := root.cleanup(tt.now, tt.ttl)
+			assert.Equal(t, tt.expectedReturn, shouldRemove, "cleanup return value mismatch")
+
+			if tt.verifyFn != nil {
+				tt.verifyFn(t, root)
+			}
+		})
+	}
+}

--- a/common/task/parallel_task_processor_test.go
+++ b/common/task/parallel_task_processor_test.go
@@ -166,7 +166,6 @@ func (s *parallelTaskProcessorSuite) TestExecuteTask_WorkerStopped() {
 		close(done)
 	}()
 
-	time.Sleep(100 * time.Millisecond)
 	close(workerShutdownCh)
 	<-done
 }
@@ -322,7 +321,6 @@ func (s *parallelTaskProcessorSuite) TestExecuteTask_PanicHandling() {
 		s.processor.executeTask(mockTask, workerShutdownCh)
 		close(done)
 	}()
-	time.Sleep(100 * time.Millisecond)
 	close(workerShutdownCh)
 	<-done
 }

--- a/common/task/weighted_round_robin_task_scheduler_test.go
+++ b/common/task/weighted_round_robin_task_scheduler_test.go
@@ -375,6 +375,8 @@ func testSchedulerContract(
 		<-schedulerImpl.ctx.Done()
 	case *weightedRoundRobinTaskSchedulerImpl[int]:
 		<-schedulerImpl.ctx.Done()
+	case *hierarchicalWeightedRoundRobinTaskSchedulerImpl[string]:
+		<-schedulerImpl.ctx.Done()
 	default:
 		s.Fail("unknown task scheduler type")
 	}

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -92,22 +92,24 @@ type Config struct {
 	StandbyTaskMissingEventsDiscardDelay dynamicproperties.DurationPropertyFn
 
 	// Task process settings
-	TaskProcessRPS                           dynamicproperties.IntPropertyFnWithDomainFilter
-	TaskSchedulerType                        dynamicproperties.IntPropertyFn
-	TaskSchedulerWorkerCount                 dynamicproperties.IntPropertyFn
-	TaskSchedulerQueueSize                   dynamicproperties.IntPropertyFn
-	TaskSchedulerDispatcherCount             dynamicproperties.IntPropertyFn
-	TaskSchedulerRoundRobinWeights           dynamicproperties.MapPropertyFn
-	TaskSchedulerDomainRoundRobinWeights     dynamicproperties.MapPropertyFnWithDomainFilter
-	TaskSchedulerGlobalDomainRPS             dynamicproperties.IntPropertyFnWithDomainFilter
-	TaskSchedulerEnableRateLimiter           dynamicproperties.BoolPropertyFn
-	TaskSchedulerEnableRateLimiterShadowMode dynamicproperties.BoolPropertyFnWithDomainFilter
-	TaskCriticalRetryCount                   dynamicproperties.IntPropertyFn
-	ActiveTaskRedispatchInterval             dynamicproperties.DurationPropertyFn
-	StandbyTaskRedispatchInterval            dynamicproperties.DurationPropertyFn
-	StandbyTaskReReplicationContextTimeout   dynamicproperties.DurationPropertyFnWithDomainIDFilter
-	EnableDropStuckTaskByDomainID            dynamicproperties.BoolPropertyFnWithDomainIDFilter
-	ResurrectionCheckMinDelay                dynamicproperties.DurationPropertyFnWithDomainFilter
+	TaskProcessRPS                                    dynamicproperties.IntPropertyFnWithDomainFilter
+	TaskSchedulerType                                 dynamicproperties.IntPropertyFn
+	TaskSchedulerWorkerCount                          dynamicproperties.IntPropertyFn
+	TaskSchedulerQueueSize                            dynamicproperties.IntPropertyFn
+	TaskSchedulerDispatcherCount                      dynamicproperties.IntPropertyFn
+	TaskSchedulerRoundRobinWeights                    dynamicproperties.MapPropertyFn
+	TaskSchedulerDomainRoundRobinWeights              dynamicproperties.MapPropertyFnWithDomainFilter
+	TaskSchedulerGlobalDomainRPS                      dynamicproperties.IntPropertyFnWithDomainFilter
+	TaskSchedulerEnableRateLimiter                    dynamicproperties.BoolPropertyFn
+	TaskSchedulerEnableRateLimiterShadowMode          dynamicproperties.BoolPropertyFnWithDomainFilter
+	TaskCriticalRetryCount                            dynamicproperties.IntPropertyFn
+	ActiveTaskRedispatchInterval                      dynamicproperties.DurationPropertyFn
+	StandbyTaskRedispatchInterval                     dynamicproperties.DurationPropertyFn
+	StandbyTaskReReplicationContextTimeout            dynamicproperties.DurationPropertyFnWithDomainIDFilter
+	EnableDropStuckTaskByDomainID                     dynamicproperties.BoolPropertyFnWithDomainIDFilter
+	ResurrectionCheckMinDelay                         dynamicproperties.DurationPropertyFnWithDomainFilter
+	EnableHierarchicalWeightedRoundRobinTaskScheduler dynamicproperties.BoolPropertyFn
+	EnableTaskListAwareTaskSchedulerByDomain          dynamicproperties.BoolPropertyFnWithDomainFilter
 
 	// History Queue (v2) settings
 	EnableTimerQueueV2                         dynamicproperties.BoolPropertyFnWithShardIDFilter
@@ -397,22 +399,24 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		DeleteHistoryEventContextTimeout:     dc.GetIntProperty(dynamicproperties.DeleteHistoryEventContextTimeout),
 		MaxResponseSize:                      maxMessageSize,
 
-		TaskProcessRPS:                           dc.GetIntPropertyFilteredByDomain(dynamicproperties.TaskProcessRPS),
-		TaskSchedulerType:                        dc.GetIntProperty(dynamicproperties.TaskSchedulerType),
-		TaskSchedulerWorkerCount:                 dc.GetIntProperty(dynamicproperties.TaskSchedulerWorkerCount),
-		TaskSchedulerQueueSize:                   dc.GetIntProperty(dynamicproperties.TaskSchedulerQueueSize),
-		TaskSchedulerDispatcherCount:             dc.GetIntProperty(dynamicproperties.TaskSchedulerDispatcherCount),
-		TaskSchedulerRoundRobinWeights:           dc.GetMapProperty(dynamicproperties.TaskSchedulerRoundRobinWeights),
-		TaskSchedulerDomainRoundRobinWeights:     dc.GetMapPropertyFilteredByDomain(dynamicproperties.TaskSchedulerDomainRoundRobinWeights),
-		TaskSchedulerGlobalDomainRPS:             dc.GetIntPropertyFilteredByDomain(dynamicproperties.TaskSchedulerGlobalDomainRPS),
-		TaskSchedulerEnableRateLimiter:           dc.GetBoolProperty(dynamicproperties.TaskSchedulerEnableRateLimiter),
-		TaskSchedulerEnableRateLimiterShadowMode: dc.GetBoolPropertyFilteredByDomain(dynamicproperties.TaskSchedulerEnableRateLimiterShadowMode),
-		TaskCriticalRetryCount:                   dc.GetIntProperty(dynamicproperties.TaskCriticalRetryCount),
-		ActiveTaskRedispatchInterval:             dc.GetDurationProperty(dynamicproperties.ActiveTaskRedispatchInterval),
-		StandbyTaskRedispatchInterval:            dc.GetDurationProperty(dynamicproperties.StandbyTaskRedispatchInterval),
-		StandbyTaskReReplicationContextTimeout:   dc.GetDurationPropertyFilteredByDomainID(dynamicproperties.StandbyTaskReReplicationContextTimeout),
-		EnableDropStuckTaskByDomainID:            dc.GetBoolPropertyFilteredByDomainID(dynamicproperties.EnableDropStuckTaskByDomainID),
-		ResurrectionCheckMinDelay:                dc.GetDurationPropertyFilteredByDomain(dynamicproperties.ResurrectionCheckMinDelay),
+		TaskProcessRPS:                                    dc.GetIntPropertyFilteredByDomain(dynamicproperties.TaskProcessRPS),
+		TaskSchedulerType:                                 dc.GetIntProperty(dynamicproperties.TaskSchedulerType),
+		TaskSchedulerWorkerCount:                          dc.GetIntProperty(dynamicproperties.TaskSchedulerWorkerCount),
+		TaskSchedulerQueueSize:                            dc.GetIntProperty(dynamicproperties.TaskSchedulerQueueSize),
+		TaskSchedulerDispatcherCount:                      dc.GetIntProperty(dynamicproperties.TaskSchedulerDispatcherCount),
+		TaskSchedulerRoundRobinWeights:                    dc.GetMapProperty(dynamicproperties.TaskSchedulerRoundRobinWeights),
+		TaskSchedulerDomainRoundRobinWeights:              dc.GetMapPropertyFilteredByDomain(dynamicproperties.TaskSchedulerDomainRoundRobinWeights),
+		TaskSchedulerGlobalDomainRPS:                      dc.GetIntPropertyFilteredByDomain(dynamicproperties.TaskSchedulerGlobalDomainRPS),
+		TaskSchedulerEnableRateLimiter:                    dc.GetBoolProperty(dynamicproperties.TaskSchedulerEnableRateLimiter),
+		TaskSchedulerEnableRateLimiterShadowMode:          dc.GetBoolPropertyFilteredByDomain(dynamicproperties.TaskSchedulerEnableRateLimiterShadowMode),
+		TaskCriticalRetryCount:                            dc.GetIntProperty(dynamicproperties.TaskCriticalRetryCount),
+		ActiveTaskRedispatchInterval:                      dc.GetDurationProperty(dynamicproperties.ActiveTaskRedispatchInterval),
+		StandbyTaskRedispatchInterval:                     dc.GetDurationProperty(dynamicproperties.StandbyTaskRedispatchInterval),
+		StandbyTaskReReplicationContextTimeout:            dc.GetDurationPropertyFilteredByDomainID(dynamicproperties.StandbyTaskReReplicationContextTimeout),
+		EnableDropStuckTaskByDomainID:                     dc.GetBoolPropertyFilteredByDomainID(dynamicproperties.EnableDropStuckTaskByDomainID),
+		ResurrectionCheckMinDelay:                         dc.GetDurationPropertyFilteredByDomain(dynamicproperties.ResurrectionCheckMinDelay),
+		EnableHierarchicalWeightedRoundRobinTaskScheduler: dc.GetBoolProperty(dynamicproperties.EnableHierarchicalWeightedRoundRobinTaskScheduler),
+		EnableTaskListAwareTaskSchedulerByDomain:          dc.GetBoolPropertyFilteredByDomain(dynamicproperties.EnableTaskListAwareTaskSchedulerByDomain),
 
 		EnableTimerQueueV2:                         dc.GetBoolPropertyFilteredByShardID(dynamicproperties.EnableTimerQueueV2),
 		EnableTransferQueueV2:                      dc.GetBoolPropertyFilteredByShardID(dynamicproperties.EnableTransferQueueV2),

--- a/service/history/config/config_test.go
+++ b/service/history/config/config_test.go
@@ -279,6 +279,8 @@ func TestNewConfig(t *testing.T) {
 		"VirtualSliceForceAppendInterval":                      {dynamicproperties.VirtualSliceForceAppendInterval, time.Second},
 		"ReplicationTaskProcessorLatencyLogThreshold":          {dynamicproperties.ReplicationTaskProcessorLatencyLogThreshold, time.Duration(0)},
 		"EnableCleanupOrphanedHistoryBranchOnWorkflowCreation": {dynamicproperties.EnableCleanupOrphanedHistoryBranchOnWorkflowCreation, true},
+		"EnableHierarchicalWeightedRoundRobinTaskScheduler":    {dynamicproperties.EnableHierarchicalWeightedRoundRobinTaskScheduler, true},
+		"EnableTaskListAwareTaskSchedulerByDomain":             {dynamicproperties.EnableTaskListAwareTaskSchedulerByDomain, true},
 	}
 	client := dynamicconfig.NewInMemoryClient()
 	for fieldName, expected := range fields {

--- a/service/history/task/processor.go
+++ b/service/history/task/processor.go
@@ -33,6 +33,7 @@ import (
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/task"
+	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/history/config"
 )
 
@@ -58,6 +59,10 @@ var (
 	errTaskProcessorNotRunning = errors.New("queue task processor is not running")
 )
 
+const (
+	ephemeralTaskListGroupKey = "__ephemeral__"
+)
+
 // NewProcessor creates a new task processor
 func NewProcessor(
 	priorityAssigner PriorityAssigner,
@@ -76,36 +81,94 @@ func NewProcessor(
 			RetryPolicy: common.CreateTaskProcessingRetryPolicy(),
 		},
 	)
-	taskToChannelKeyFn := func(t task.PriorityTask) DomainPriorityKey {
-		var domainID string
-		tt, ok := t.(Task)
-		if ok {
-			domainID = tt.GetDomainID()
-		} else {
-			logger.Error("incorrect task type for task scheduler, this should not happen, there must be a bug in our code")
+	var scheduler task.Scheduler
+	var err error
+	if config.EnableHierarchicalWeightedRoundRobinTaskScheduler() {
+		taskToWeightedKeysFn := func(t task.PriorityTask) []task.WeightedKey[any] {
+			var domainID, taskList string
+			tt, ok := t.(Task)
+			if ok {
+				domainID = tt.GetDomainID()
+				taskList = tt.GetOriginalTaskList()
+				if tt.GetOriginalTaskListKind() == types.TaskListKindEphemeral {
+					taskList = ephemeralTaskListGroupKey
+				}
+			} else {
+				logger.Error("incorrect task type for task scheduler, this should not happen, there must be a bug in our code")
+			}
+			key := DomainPriorityKey{
+				DomainID: domainID,
+				Priority: t.Priority(),
+			}
+			domainName, err := domainCache.GetDomainName(domainID)
+			if err != nil {
+				logger.Error("failed to get domain name from cache", tag.Error(err))
+				domainName = ""
+			}
+			if !config.EnableTaskListAwareTaskSchedulerByDomain(domainName) || t.Priority() != highTaskPriority {
+				return []task.WeightedKey[any]{
+					{
+						Key:    key,
+						Weight: getDomainPriorityWeight(logger, config, domainCache, key),
+					},
+				}
+			}
+			return []task.WeightedKey[any]{
+				{
+					Key:    key,
+					Weight: getDomainPriorityWeight(logger, config, domainCache, key),
+				},
+				{
+					Key:    taskList,
+					Weight: 1,
+				},
+			}
 		}
-		return DomainPriorityKey{
-			DomainID: domainID,
-			Priority: t.Priority(),
+		scheduler, err = task.NewHierarchicalWeightedRoundRobinTaskScheduler(
+			logger,
+			metricsClient,
+			timeSource,
+			taskProcessor,
+			&task.HierarchicalWeightedRoundRobinTaskPoolOptions[any]{
+				BufferSize:           config.TaskSchedulerQueueSize(),
+				TaskToWeightedKeysFn: taskToWeightedKeysFn,
+			},
+		)
+		if err != nil {
+			return nil, err
 		}
-	}
-	channelKeyToWeightFn := func(k DomainPriorityKey) int {
-		return getDomainPriorityWeight(logger, config, domainCache, k)
-	}
-	scheduler, err := task.NewWeightedRoundRobinTaskScheduler(
-		logger,
-		metricsClient,
-		timeSource,
-		taskProcessor,
-		&task.WeightedRoundRobinTaskSchedulerOptions[DomainPriorityKey]{
-			QueueSize:            config.TaskSchedulerQueueSize(),
-			DispatcherCount:      config.TaskSchedulerDispatcherCount(),
-			TaskToChannelKeyFn:   taskToChannelKeyFn,
-			ChannelKeyToWeightFn: channelKeyToWeightFn,
-		},
-	)
-	if err != nil {
-		return nil, err
+	} else {
+		taskToChannelKeyFn := func(t task.PriorityTask) DomainPriorityKey {
+			var domainID string
+			tt, ok := t.(Task)
+			if ok {
+				domainID = tt.GetDomainID()
+			} else {
+				logger.Error("incorrect task type for task scheduler, this should not happen, there must be a bug in our code")
+			}
+			return DomainPriorityKey{
+				DomainID: domainID,
+				Priority: t.Priority(),
+			}
+		}
+		channelKeyToWeightFn := func(k DomainPriorityKey) int {
+			return getDomainPriorityWeight(logger, config, domainCache, k)
+		}
+		scheduler, err = task.NewWeightedRoundRobinTaskScheduler(
+			logger,
+			metricsClient,
+			timeSource,
+			taskProcessor,
+			&task.WeightedRoundRobinTaskSchedulerOptions[DomainPriorityKey]{
+				QueueSize:            config.TaskSchedulerQueueSize(),
+				DispatcherCount:      config.TaskSchedulerDispatcherCount(),
+				TaskToChannelKeyFn:   taskToChannelKeyFn,
+				ChannelKeyToWeightFn: channelKeyToWeightFn,
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &processorImpl{
 		priorityAssigner: priorityAssigner,


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Related to https://github.com/cadence-workflow/cadence/issues/7724
- Implement hierarchical weighted round robin scheduler that enqueues tasks into a hierarchical structure of channels and processes tasks in hierarchical weighted round robin order at each level of the hierarchical structure
- Introduce a dynamic config property enabling hierarchical weighted round robin scheduler
    - By default, the hierarchical weighted round robin scheduler has only 1 level, which makes it the same as the weighted round robin scheduler
- Introduce a dynamic config property enabling task list aware scheduling by domain
    - If it's enabled for a certain domain, hierarchical weighted round robin task scheduler will ensure fairness of task scheduling for tasks belonging to different task lists in that domain. And the task lists will also be scheduled in a WRR order and their weights are all equal to 1 now.

**Why?**
This is the first big step to support domain multi-tenancy. With hierarchical weighted round robin scheduler, fairness of task scheduling is ensured at domain level and task list level within a domain. Users can use different task lists in a domain with some fairness guarantee on task scheduling.

**How did you test it?**
cd common/task && go test ./... -race

**Potential risks**
The change is behind a feature flag, which is safe to rollout. But to rollout the feature, we need enough test in dev and staging environments. Any bug in this PR can be a L5 incident and causing task loss or task processing being stuck.

**Release notes**
Hierarchical weighted round robin history task scheduler is introduced in this PR. This scheduler is enabled by feature flag `history.enableHierarchicalWeightedRoundRobinTaskScheduler` and is by default disabled. And task list aware scheduling feature is enabled by feature flag `history.enableTaskListAwareTaskSchedulerByDomain` at domain level. If hierarchical weighted round robin scheduler is enabled, we can ensure fairness of task scheduler at task list level by enabling this feature flag for a certain domain.

**Documentation Changes**
`history.enableHierarchicalWeightedRoundRobinTaskScheduler` and `history.enableTaskListAwareTaskSchedulerByDomain` are introduced.
