### PR TITLE
refactor: Convert task schedulers to use Go generics

### DIFF
--- a/common/task/fifo_task_scheduler.go
+++ b/common/task/fifo_task_scheduler.go
@@ -32,13 +32,13 @@ import (
 	"github.com/uber/cadence/common/metrics"
 )
 
-type fifoTaskSchedulerImpl struct {
+type fifoTaskSchedulerImpl[T Task] struct {
 	status       int32
 	logger       log.Logger
 	metricsScope metrics.Scope
 	options      *FIFOTaskSchedulerOptions
 	dispatcherWG sync.WaitGroup
-	taskCh       chan PriorityTask
+	taskCh       chan T
 	ctx          context.Context
 	cancel       context.CancelFunc
 
@@ -49,18 +49,18 @@ type fifoTaskSchedulerImpl struct {
 // it's an no-op implementation as it simply copy tasks from
 // one task channel to another task channel.
 // This scheduler is only for development purpose.
-func NewFIFOTaskScheduler(
+func NewFIFOTaskScheduler[T Task](
 	logger log.Logger,
 	metricsClient metrics.Client,
 	options *FIFOTaskSchedulerOptions,
-) Scheduler {
+) Scheduler[T] {
 	ctx, cancel := context.WithCancel(context.Background())
-	return &fifoTaskSchedulerImpl{
+	return &fifoTaskSchedulerImpl[T]{
 		status:       common.DaemonStatusInitialized,
 		logger:       logger,
 		metricsScope: metricsClient.Scope(metrics.TaskSchedulerScope),
 		options:      options,
-		taskCh:       make(chan PriorityTask, options.QueueSize),
+		taskCh:       make(chan T, options.QueueSize),
 		ctx:          ctx,
 		cancel:       cancel,
 		processor: NewParallelTaskProcessor(
@@ -75,7 +75,7 @@ func NewFIFOTaskScheduler(
 	}
 }
 
-func (f *fifoTaskSchedulerImpl) Start() {
+func (f *fifoTaskSchedulerImpl[T]) Start() {
 	if !atomic.CompareAndSwapInt32(&f.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
 		return
 	}
@@ -90,7 +90,7 @@ func (f *fifoTaskSchedulerImpl) Start() {
 	f.logger.Info("FIFO task scheduler started.")
 }
 
-func (f *fifoTaskSchedulerImpl) Stop() {
+func (f *fifoTaskSchedulerImpl[T]) Stop() {
 	if !atomic.CompareAndSwapInt32(&f.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
 		return
 	}
@@ -108,7 +108,7 @@ func (f *fifoTaskSchedulerImpl) Stop() {
 	f.logger.Info("FIFO task scheduler shutdown.")
 }
 
-func (f *fifoTaskSchedulerImpl) Submit(task PriorityTask) error {
+func (f *fifoTaskSchedulerImpl[T]) Submit(task T) error {
 	f.metricsScope.IncCounter(metrics.ParallelTaskSubmitRequest)
 	sw := f.metricsScope.StartTimer(metrics.ParallelTaskSubmitLatency)
 	defer sw.Stop()
@@ -128,7 +128,7 @@ func (f *fifoTaskSchedulerImpl) Submit(task PriorityTask) error {
 	}
 }
 
-func (f *fifoTaskSchedulerImpl) TrySubmit(task PriorityTask) (bool, error) {
+func (f *fifoTaskSchedulerImpl[T]) TrySubmit(task T) (bool, error) {
 	if f.isStopped() {
 		return false, ErrTaskSchedulerClosed
 	}
@@ -147,7 +147,7 @@ func (f *fifoTaskSchedulerImpl) TrySubmit(task PriorityTask) (bool, error) {
 	}
 }
 
-func (f *fifoTaskSchedulerImpl) dispatcher() {
+func (f *fifoTaskSchedulerImpl[T]) dispatcher() {
 	defer f.dispatcherWG.Done()
 
 	for {
@@ -163,11 +163,11 @@ func (f *fifoTaskSchedulerImpl) dispatcher() {
 	}
 }
 
-func (f *fifoTaskSchedulerImpl) isStopped() bool {
+func (f *fifoTaskSchedulerImpl[T]) isStopped() bool {
 	return atomic.LoadInt32(&f.status) == common.DaemonStatusStopped
 }
 
-func (f *fifoTaskSchedulerImpl) drainAndNackTasks() {
+func (f *fifoTaskSchedulerImpl[T]) drainAndNackTasks() {
 	for {
 		select {
 		case task := <-f.taskCh:

--- a/common/task/fifo_task_scheduler_test.go
+++ b/common/task/fifo_task_scheduler_test.go
@@ -46,7 +46,7 @@ type (
 
 		queueSize int
 
-		scheduler *fifoTaskSchedulerImpl
+		scheduler *fifoTaskSchedulerImpl[PriorityTask]
 	}
 )
 
@@ -62,7 +62,7 @@ func (s *fifoTaskSchedulerSuite) SetupTest() {
 	s.mockProcessor = NewMockProcessor(s.controller)
 
 	s.queueSize = 2
-	s.scheduler = NewFIFOTaskScheduler(
+	s.scheduler = NewFIFOTaskScheduler[PriorityTask](
 		testlogger.New(s.Suite.T()),
 		metrics.NewClient(tally.NoopScope, metrics.Common, metrics.HistogramMigration{}),
 		&FIFOTaskSchedulerOptions{
@@ -71,7 +71,7 @@ func (s *fifoTaskSchedulerSuite) SetupTest() {
 			DispatcherCount: 1,
 			RetryPolicy:     backoff.NewExponentialRetryPolicy(time.Millisecond),
 		},
-	).(*fifoTaskSchedulerImpl)
+	).(*fifoTaskSchedulerImpl[PriorityTask])
 }
 
 func (s *fifoTaskSchedulerSuite) TearDownTest() {

--- a/common/task/hierarchical_weighted_round_robin_task_pool.go
+++ b/common/task/hierarchical_weighted_round_robin_task_pool.go
@@ -17,19 +17,19 @@ var (
 	errWeightedKeyWeightMustBeGreaterThanZero = errors.New("weight must be greater than 0")
 )
 
-type HierarchicalWeightedRoundRobinTaskPoolOptions[K comparable] struct {
+type HierarchicalWeightedRoundRobinTaskPoolOptions[K comparable, T Task] struct {
 	BufferSize           int
-	TaskToWeightedKeysFn func(PriorityTask) []WeightedKey[K]
+	TaskToWeightedKeysFn func(T) []WeightedKey[K]
 }
 
-type hierarchicalWeightedRoundRobinTaskPoolImpl[K comparable] struct {
+type hierarchicalWeightedRoundRobinTaskPoolImpl[K comparable, T Task] struct {
 	sync.Mutex
 	status     int32
-	root       *iwrrNode[K, PriorityTask]
+	root       *iwrrNode[K, T]
 	bufferSize int
 	ctx        context.Context
 	cancel     context.CancelFunc
-	options    *HierarchicalWeightedRoundRobinTaskPoolOptions[K]
+	options    *HierarchicalWeightedRoundRobinTaskPoolOptions[K, T]
 	logger     log.Logger
 	timeSource clock.TimeSource
 	wg         sync.WaitGroup
@@ -38,17 +38,17 @@ type hierarchicalWeightedRoundRobinTaskPoolImpl[K comparable] struct {
 }
 
 // newHierarchicalWeightedRoundRobinTaskPool creates a new hierarchical WRR task pool
-func newHierarchicalWeightedRoundRobinTaskPool[K comparable](
+func newHierarchicalWeightedRoundRobinTaskPool[K comparable, T Task](
 	logger log.Logger,
 	metricsClient metrics.Client,
 	timeSource clock.TimeSource,
-	options *HierarchicalWeightedRoundRobinTaskPoolOptions[K],
-) *hierarchicalWeightedRoundRobinTaskPoolImpl[K] {
+	options *HierarchicalWeightedRoundRobinTaskPoolOptions[K, T],
+) *hierarchicalWeightedRoundRobinTaskPoolImpl[K, T] {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	pool := &hierarchicalWeightedRoundRobinTaskPoolImpl[K]{
+	pool := &hierarchicalWeightedRoundRobinTaskPoolImpl[K, T]{
 		status:     common.DaemonStatusInitialized,
-		root:       newiwrrNode[K, PriorityTask](options.BufferSize),
+		root:       newiwrrNode[K, T](options.BufferSize),
 		bufferSize: options.BufferSize,
 		ctx:        ctx,
 		cancel:     cancel,
@@ -61,7 +61,7 @@ func newHierarchicalWeightedRoundRobinTaskPool[K comparable](
 	return pool
 }
 
-func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K]) Start() {
+func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K, T]) Start() {
 	if !atomic.CompareAndSwapInt32(&p.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
 		return
 	}
@@ -72,7 +72,7 @@ func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K]) Start() {
 	p.logger.Info("Hierarchical weighted round robin task pool started.")
 }
 
-func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K]) Stop() {
+func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K, T]) Stop() {
 	if !atomic.CompareAndSwapInt32(&p.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
 		return
 	}
@@ -83,7 +83,7 @@ func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K]) Stop() {
 	p.logger.Info("Hierarchical weighted round robin task pool stopped.")
 }
 
-func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K]) cleanupLoop() {
+func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K, T]) cleanupLoop() {
 	defer p.wg.Done()
 
 	ticker := p.timeSource.NewTicker(time.Duration((defaultIdleChannelTTLInSeconds / 2)) * time.Second)
@@ -101,17 +101,17 @@ func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K]) cleanupLoop() {
 	}
 }
 
-func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K]) doCleanup(now time.Time, ttl time.Duration) {
+func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K, T]) doCleanup(now time.Time, ttl time.Duration) {
 	p.root.cleanup(now, ttl)
 }
 
-func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K]) Enqueue(task PriorityTask) error {
+func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K, T]) Enqueue(task T) error {
 	weightedKeys := p.options.TaskToWeightedKeysFn(task)
 	if err := verifyWeightedKeys(weightedKeys); err != nil {
 		return err
 	}
 	var err error
-	p.root.executeAtPath(weightedKeys, p.bufferSize, func(c *TTLChannel[PriorityTask]) int64 {
+	p.root.executeAtPath(weightedKeys, p.bufferSize, func(c *TTLChannel[T]) int64 {
 		c.IncRef()
 		defer c.DecRef()
 		select {
@@ -126,13 +126,13 @@ func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K]) Enqueue(task PriorityTas
 	return err
 }
 
-func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K]) TryEnqueue(task PriorityTask) (bool, error) {
+func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K, T]) TryEnqueue(task T) (bool, error) {
 	weightedKeys := p.options.TaskToWeightedKeysFn(task)
 	if err := verifyWeightedKeys(weightedKeys); err != nil {
 		return false, err
 	}
 	var err error
-	delta := p.root.executeAtPath(weightedKeys, p.bufferSize, func(c *TTLChannel[PriorityTask]) int64 {
+	delta := p.root.executeAtPath(weightedKeys, p.bufferSize, func(c *TTLChannel[T]) int64 {
 		c.IncRef()
 		defer c.DecRef()
 		select {
@@ -149,10 +149,11 @@ func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K]) TryEnqueue(task Priority
 	return delta > 0, err
 }
 
-func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K]) TryDequeue() (PriorityTask, bool) {
+func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K, T]) TryDequeue() (T, bool) {
+	var zero T
 	item, ok := p.root.tryGetNextItem()
 	if !ok {
-		return nil, false
+		return zero, false
 	}
 	return item, true
 }

--- a/common/task/hierarchical_weighted_round_robin_task_pool_test.go
+++ b/common/task/hierarchical_weighted_round_robin_task_pool_test.go
@@ -40,17 +40,16 @@ func TestHierarchicalWRRTaskPool_SingleLevel_IWRROrdering(t *testing.T) {
 		"domain2": 1,
 	}
 
-	pool := newHierarchicalWeightedRoundRobinTaskPool[string](
+	pool := newHierarchicalWeightedRoundRobinTaskPool[string, *testPriorityTask](
 		testlogger.New(t),
 		metrics.NoopClient,
 		clock.NewMockedTimeSource(),
-		&HierarchicalWeightedRoundRobinTaskPoolOptions[string]{
+		&HierarchicalWeightedRoundRobinTaskPoolOptions[string, *testPriorityTask]{
 			BufferSize: 20,
-			TaskToWeightedKeysFn: func(task PriorityTask) []WeightedKey[string] {
+			TaskToWeightedKeysFn: func(task *testPriorityTask) []WeightedKey[string] {
 				// Single-level hierarchy: tasks grouped by domain with different weights
-				testTask := task.(*testPriorityTask)
 				return []WeightedKey[string]{
-					{Key: testTask.domain, Weight: domainWeights[testTask.domain]},
+					{Key: task.domain, Weight: domainWeights[task.domain]},
 				}
 			},
 		},
@@ -62,7 +61,7 @@ func TestHierarchicalWRRTaskPool_SingleLevel_IWRROrdering(t *testing.T) {
 	// Domain0 (weight 5): 5 tasks
 	// Domain1 (weight 3): 3 tasks
 	// Domain2 (weight 1): 1 task
-	var tasks []PriorityTask
+	var tasks []*testPriorityTask
 	for i := 0; i < 5; i++ {
 		tasks = append(tasks, &testPriorityTask{domain: "domain0"})
 	}
@@ -75,7 +74,7 @@ func TestHierarchicalWRRTaskPool_SingleLevel_IWRROrdering(t *testing.T) {
 	var wg sync.WaitGroup
 	for _, task := range tasks {
 		wg.Add(1)
-		go func(t PriorityTask) {
+		go func(t *testPriorityTask) {
 			defer wg.Done()
 			// Randomly choose between Enqueue and TryEnqueue
 			if rand.Intn(2) == 0 {
@@ -97,8 +96,7 @@ func TestHierarchicalWRRTaskPool_SingleLevel_IWRROrdering(t *testing.T) {
 		if !ok {
 			break
 		}
-		testTask := task.(*testPriorityTask)
-		actualDomainSequence = append(actualDomainSequence, testTask.domain)
+		actualDomainSequence = append(actualDomainSequence, task.domain)
 	}
 
 	assert.Equal(t, expectedDomainPattern, actualDomainSequence)
@@ -122,18 +120,17 @@ func TestHierarchicalWRRTaskPool_TwoLevel_IWRROrdering(t *testing.T) {
 		"tasklist3B": 1,
 	}
 
-	pool := newHierarchicalWeightedRoundRobinTaskPool[string](
+	pool := newHierarchicalWeightedRoundRobinTaskPool[string, *testPriorityTask](
 		testlogger.New(t),
 		metrics.NoopClient,
 		clock.NewMockedTimeSource(),
-		&HierarchicalWeightedRoundRobinTaskPoolOptions[string]{
+		&HierarchicalWeightedRoundRobinTaskPoolOptions[string, *testPriorityTask]{
 			BufferSize: 20,
-			TaskToWeightedKeysFn: func(task PriorityTask) []WeightedKey[string] {
+			TaskToWeightedKeysFn: func(task *testPriorityTask) []WeightedKey[string] {
 				// Two-level hierarchy: domain (level 1) -> tasklist (level 2)
-				testTask := task.(*testPriorityTask)
 				return []WeightedKey[string]{
-					{Key: testTask.domain, Weight: domainWeights[testTask.domain]},
-					{Key: testTask.tasklist, Weight: tasklistWeights[testTask.tasklist]},
+					{Key: task.domain, Weight: domainWeights[task.domain]},
+					{Key: task.tasklist, Weight: tasklistWeights[task.tasklist]},
 				}
 			},
 		},
@@ -145,7 +142,7 @@ func TestHierarchicalWRRTaskPool_TwoLevel_IWRROrdering(t *testing.T) {
 	// Domain1 tasklist IWRR [2, 1]: [tasklist1A, tasklist1A, tasklist1B] = 3 tasks
 	// Domain2 tasklist IWRR [3, 1]: [tasklist2A, tasklist2A, tasklist2A, tasklist2B] = 4 tasks
 	// Domain3 tasklist IWRR [2, 1]: [tasklist3A, tasklist3A, tasklist3B] = 3 tasks
-	tasks := []PriorityTask{
+	tasks := []*testPriorityTask{
 		// Domain1 tasks (3 tasks for one complete tasklist IWRR)
 		&testPriorityTask{domain: "domain1", tasklist: "tasklist1A"},
 		&testPriorityTask{domain: "domain1", tasklist: "tasklist1A"},
@@ -165,7 +162,7 @@ func TestHierarchicalWRRTaskPool_TwoLevel_IWRROrdering(t *testing.T) {
 	var wg sync.WaitGroup
 	for _, task := range tasks {
 		wg.Add(1)
-		go func(t PriorityTask) {
+		go func(t *testPriorityTask) {
 			defer wg.Done()
 			// Randomly choose between Enqueue and TryEnqueue
 			if rand.Intn(2) == 0 {
@@ -216,10 +213,9 @@ func TestHierarchicalWRRTaskPool_TwoLevel_IWRROrdering(t *testing.T) {
 		if !ok {
 			break
 		}
-		testTask := task.(*testPriorityTask)
 		actualPattern = append(actualPattern, expectedTask{
-			domain:   testTask.domain,
-			tasklist: testTask.tasklist,
+			domain:   task.domain,
+			tasklist: task.tasklist,
 		})
 	}
 
@@ -250,17 +246,16 @@ func TestHierarchicalWRRTaskPool_TwoLevel_LargeScale_IWRROrdering(t *testing.T) 
 		"tasklist3B": 1,
 	}
 
-	pool := newHierarchicalWeightedRoundRobinTaskPool[string](
+	pool := newHierarchicalWeightedRoundRobinTaskPool[string, *testPriorityTask](
 		testlogger.New(t),
 		metrics.NoopClient,
 		clock.NewMockedTimeSource(),
-		&HierarchicalWeightedRoundRobinTaskPoolOptions[string]{
+		&HierarchicalWeightedRoundRobinTaskPoolOptions[string, *testPriorityTask]{
 			BufferSize: 100,
-			TaskToWeightedKeysFn: func(task PriorityTask) []WeightedKey[string] {
-				testTask := task.(*testPriorityTask)
+			TaskToWeightedKeysFn: func(task *testPriorityTask) []WeightedKey[string] {
 				return []WeightedKey[string]{
-					{Key: testTask.domain, Weight: domainWeights[testTask.domain]},
-					{Key: testTask.tasklist, Weight: tasklistWeights[testTask.tasklist]},
+					{Key: task.domain, Weight: domainWeights[task.domain]},
+					{Key: task.tasklist, Weight: tasklistWeights[task.tasklist]},
 				}
 			},
 		},
@@ -272,7 +267,7 @@ func TestHierarchicalWRRTaskPool_TwoLevel_LargeScale_IWRROrdering(t *testing.T) 
 	// Domain1: 30 tasks (5 cycles of tasklist IWRR: [3,2,1] = 6 tasks per cycle)
 	// Domain2: 30 tasks (5 cycles of tasklist IWRR: [4,2] = 6 tasks per cycle)
 	// Domain3: 20 tasks (5 cycles of tasklist IWRR: [3,1] = 4 tasks per cycle)
-	var tasks []PriorityTask
+	var tasks []*testPriorityTask
 
 	// Domain1: 5 cycles of [tasklist1A(3), tasklist1B(2), tasklist1C(1)]
 	for cycle := 0; cycle < 5; cycle++ {
@@ -307,7 +302,7 @@ func TestHierarchicalWRRTaskPool_TwoLevel_LargeScale_IWRROrdering(t *testing.T) 
 	var wg sync.WaitGroup
 	for _, task := range tasks {
 		wg.Add(1)
-		go func(t PriorityTask) {
+		go func(t *testPriorityTask) {
 			defer wg.Done()
 			if rand.Intn(2) == 0 {
 				_ = pool.Enqueue(t)
@@ -348,11 +343,10 @@ func TestHierarchicalWRRTaskPool_TwoLevel_LargeScale_IWRROrdering(t *testing.T) 
 		if !ok {
 			break
 		}
-		testTask := task.(*testPriorityTask)
-		dequeuedDomains = append(dequeuedDomains, testTask.domain)
-		dequeuedTasklistsByDomain[testTask.domain] = append(
-			dequeuedTasklistsByDomain[testTask.domain],
-			testTask.tasklist,
+		dequeuedDomains = append(dequeuedDomains, task.domain)
+		dequeuedTasklistsByDomain[task.domain] = append(
+			dequeuedTasklistsByDomain[task.domain],
+			task.tasklist,
 		)
 	}
 
@@ -403,18 +397,17 @@ func TestHierarchicalWRRTaskPool_ThreeLevel_LargeScale_IWRROrdering(t *testing.T
 		"tenant3": 1,
 	}
 
-	pool := newHierarchicalWeightedRoundRobinTaskPool[string](
+	pool := newHierarchicalWeightedRoundRobinTaskPool[string, *testPriorityTask](
 		testlogger.New(t),
 		metrics.NoopClient,
 		clock.NewMockedTimeSource(),
-		&HierarchicalWeightedRoundRobinTaskPoolOptions[string]{
+		&HierarchicalWeightedRoundRobinTaskPoolOptions[string, *testPriorityTask]{
 			BufferSize: 200,
-			TaskToWeightedKeysFn: func(task PriorityTask) []WeightedKey[string] {
-				testTask := task.(*testPriorityTask)
+			TaskToWeightedKeysFn: func(task *testPriorityTask) []WeightedKey[string] {
 				return []WeightedKey[string]{
-					{Key: testTask.domain, Weight: domainWeights[testTask.domain]},
-					{Key: testTask.tasklist, Weight: tasklistWeights[testTask.tasklist]},
-					{Key: testTask.tenant, Weight: tenantWeights[testTask.tenant]},
+					{Key: task.domain, Weight: domainWeights[task.domain]},
+					{Key: task.tasklist, Weight: tasklistWeights[task.tasklist]},
+					{Key: task.tenant, Weight: tenantWeights[task.tenant]},
 				}
 			},
 		},
@@ -425,7 +418,7 @@ func TestHierarchicalWRRTaskPool_ThreeLevel_LargeScale_IWRROrdering(t *testing.T
 	// Create a large number of tasks across 3 levels
 	// Each (domain, tasklist) combination gets multiple tenant cycles
 	// Tenant IWRR for weights [3, 2, 1]: 6 tasks per cycle
-	var tasks []PriorityTask
+	var tasks []*testPriorityTask
 
 	// Domain1 - tasklist1A (weight 3) - 3 tenant cycles = 18 tasks
 	for cycle := 0; cycle < 3; cycle++ {
@@ -499,7 +492,7 @@ func TestHierarchicalWRRTaskPool_ThreeLevel_LargeScale_IWRROrdering(t *testing.T
 	var wg sync.WaitGroup
 	for _, task := range tasks {
 		wg.Add(1)
-		go func(t PriorityTask) {
+		go func(t *testPriorityTask) {
 			defer wg.Done()
 			if rand.Intn(2) == 0 {
 				_ = pool.Enqueue(t)
@@ -524,16 +517,15 @@ func TestHierarchicalWRRTaskPool_ThreeLevel_LargeScale_IWRROrdering(t *testing.T
 		if !ok {
 			break
 		}
-		testTask := task.(*testPriorityTask)
-		dequeuedDomains = append(dequeuedDomains, testTask.domain)
-		dequeuedTasklistsByDomain[testTask.domain] = append(
-			dequeuedTasklistsByDomain[testTask.domain],
-			testTask.tasklist,
+		dequeuedDomains = append(dequeuedDomains, task.domain)
+		dequeuedTasklistsByDomain[task.domain] = append(
+			dequeuedTasklistsByDomain[task.domain],
+			task.tasklist,
 		)
-		key := taskKey{domain: testTask.domain, tasklist: testTask.tasklist}
+		key := taskKey{domain: task.domain, tasklist: task.tasklist}
 		dequeuedTenantsByTasklist[key] = append(
 			dequeuedTenantsByTasklist[key],
-			testTask.tenant,
+			task.tenant,
 		)
 	}
 
@@ -694,12 +686,11 @@ func TestHierarchicalWRRTaskPool_TryDequeue_Empty(t *testing.T) {
 		testlogger.New(t),
 		metrics.NoopClient,
 		clock.NewMockedTimeSource(),
-		&HierarchicalWeightedRoundRobinTaskPoolOptions[string]{
+		&HierarchicalWeightedRoundRobinTaskPoolOptions[string, *testPriorityTask]{
 			BufferSize: 10,
-			TaskToWeightedKeysFn: func(task PriorityTask) []WeightedKey[string] {
-				testTask := task.(*testPriorityTask)
+			TaskToWeightedKeysFn: func(task *testPriorityTask) []WeightedKey[string] {
 				return []WeightedKey[string]{
-					{Key: testTask.domain, Weight: domainWeights[testTask.domain]},
+					{Key: task.domain, Weight: domainWeights[task.domain]},
 				}
 			},
 		},
@@ -733,16 +724,15 @@ func TestHierarchicalWRRTaskPool_TryEnqueue_BufferFull(t *testing.T) {
 	}
 
 	// Create pool with small buffer size
-	pool := newHierarchicalWeightedRoundRobinTaskPool[string](
+	pool := newHierarchicalWeightedRoundRobinTaskPool[string, *testPriorityTask](
 		testlogger.New(t),
 		metrics.NoopClient,
 		clock.NewMockedTimeSource(),
-		&HierarchicalWeightedRoundRobinTaskPoolOptions[string]{
+		&HierarchicalWeightedRoundRobinTaskPoolOptions[string, *testPriorityTask]{
 			BufferSize: 2, // Small buffer to easily fill it
-			TaskToWeightedKeysFn: func(task PriorityTask) []WeightedKey[string] {
-				testTask := task.(*testPriorityTask)
+			TaskToWeightedKeysFn: func(task *testPriorityTask) []WeightedKey[string] {
 				return []WeightedKey[string]{
-					{Key: testTask.domain, Weight: domainWeights[testTask.domain]},
+					{Key: task.domain, Weight: domainWeights[task.domain]},
 				}
 			},
 		},
@@ -781,16 +771,15 @@ func TestHierarchicalWRRTaskPool_Enqueue_ContextCancellation(t *testing.T) {
 	}
 
 	// Create pool with small buffer size
-	pool := newHierarchicalWeightedRoundRobinTaskPool[string](
+	pool := newHierarchicalWeightedRoundRobinTaskPool[string, *testPriorityTask](
 		testlogger.New(t),
 		metrics.NoopClient,
 		clock.NewMockedTimeSource(),
-		&HierarchicalWeightedRoundRobinTaskPoolOptions[string]{
+		&HierarchicalWeightedRoundRobinTaskPoolOptions[string, *testPriorityTask]{
 			BufferSize: 1, // Very small buffer
-			TaskToWeightedKeysFn: func(task PriorityTask) []WeightedKey[string] {
-				testTask := task.(*testPriorityTask)
+			TaskToWeightedKeysFn: func(task *testPriorityTask) []WeightedKey[string] {
 				return []WeightedKey[string]{
-					{Key: testTask.domain, Weight: domainWeights[testTask.domain]},
+					{Key: task.domain, Weight: domainWeights[task.domain]},
 				}
 			},
 		},
@@ -827,16 +816,15 @@ func TestHierarchicalWRRTaskPool_CleanupLoop(t *testing.T) {
 	}
 
 	timeSource := clock.NewMockedTimeSource()
-	pool := newHierarchicalWeightedRoundRobinTaskPool[string](
+	pool := newHierarchicalWeightedRoundRobinTaskPool[string, *testPriorityTask](
 		testlogger.New(t),
 		metrics.NoopClient,
 		timeSource,
-		&HierarchicalWeightedRoundRobinTaskPoolOptions[string]{
+		&HierarchicalWeightedRoundRobinTaskPoolOptions[string, *testPriorityTask]{
 			BufferSize: 10,
-			TaskToWeightedKeysFn: func(task PriorityTask) []WeightedKey[string] {
-				testTask := task.(*testPriorityTask)
+			TaskToWeightedKeysFn: func(task *testPriorityTask) []WeightedKey[string] {
 				return []WeightedKey[string]{
-					{Key: testTask.domain, Weight: domainWeights[testTask.domain]},
+					{Key: task.domain, Weight: domainWeights[task.domain]},
 				}
 			},
 		},

--- a/common/task/hierarchical_weighted_round_robin_task_scheduler.go
+++ b/common/task/hierarchical_weighted_round_robin_task_scheduler.go
@@ -33,33 +33,33 @@ import (
 	"github.com/uber/cadence/common/metrics"
 )
 
-type hierarchicalWeightedRoundRobinTaskSchedulerImpl[K comparable] struct {
+type hierarchicalWeightedRoundRobinTaskSchedulerImpl[K comparable, T Task] struct {
 	sync.RWMutex
 
 	status       int32
-	pool         *hierarchicalWeightedRoundRobinTaskPoolImpl[K]
+	pool         *hierarchicalWeightedRoundRobinTaskPoolImpl[K, T]
 	ctx          context.Context
 	cancel       context.CancelFunc
 	notifyCh     chan struct{}
 	dispatcherWG sync.WaitGroup
 	logger       log.Logger
 	metricsScope metrics.Scope
-	options      *HierarchicalWeightedRoundRobinTaskPoolOptions[K]
+	options      *HierarchicalWeightedRoundRobinTaskPoolOptions[K, T]
 
 	processor Processor
 }
 
 // NewHierarchicalWeightedRoundRobinTaskScheduler creates a new hierarchical WRR task scheduler
-func NewHierarchicalWeightedRoundRobinTaskScheduler[K comparable](
+func NewHierarchicalWeightedRoundRobinTaskScheduler[K comparable, T Task](
 	logger log.Logger,
 	metricsClient metrics.Client,
 	timeSource clock.TimeSource,
 	processor Processor,
-	options *HierarchicalWeightedRoundRobinTaskPoolOptions[K],
-) (Scheduler, error) {
+	options *HierarchicalWeightedRoundRobinTaskPoolOptions[K, T],
+) (Scheduler[T], error) {
 	metricsScope := metricsClient.Scope(metrics.TaskSchedulerScope)
 	ctx, cancel := context.WithCancel(context.Background())
-	scheduler := &hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]{
+	scheduler := &hierarchicalWeightedRoundRobinTaskSchedulerImpl[K, T]{
 		status: common.DaemonStatusInitialized,
 		pool: newHierarchicalWeightedRoundRobinTaskPool[K](
 			logger,
@@ -79,7 +79,7 @@ func NewHierarchicalWeightedRoundRobinTaskScheduler[K comparable](
 	return scheduler, nil
 }
 
-func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) Start() {
+func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K, T]) Start() {
 	if !atomic.CompareAndSwapInt32(&w.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
 		return
 	}
@@ -90,7 +90,7 @@ func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) Start() {
 	w.logger.Info("Hierarchical weighted round robin task scheduler started.")
 }
 
-func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) Stop() {
+func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K, T]) Stop() {
 	if !atomic.CompareAndSwapInt32(&w.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
 		return
 	}
@@ -107,7 +107,7 @@ func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) Stop() {
 	w.logger.Info("Hierarchical weighted round robin task scheduler stopped.")
 }
 
-func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) Submit(task PriorityTask) error {
+func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K, T]) Submit(task T) error {
 	w.metricsScope.IncCounter(metrics.PriorityTaskSubmitRequest)
 	sw := w.metricsScope.StartTimer(metrics.PriorityTaskSubmitLatency)
 	defer sw.Stop()
@@ -123,8 +123,8 @@ func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) Submit(task Priorit
 	return nil
 }
 
-func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) TrySubmit(
-	task PriorityTask,
+func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K, T]) TrySubmit(
+	task T,
 ) (bool, error) {
 	w.metricsScope.IncCounter(metrics.PriorityTaskSubmitRequest)
 	sw := w.metricsScope.StartTimer(metrics.PriorityTaskSubmitLatency)
@@ -141,7 +141,7 @@ func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) TrySubmit(
 	return ok, err
 }
 
-func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) dispatcher() {
+func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K, T]) dispatcher() {
 	defer w.dispatcherWG.Done()
 
 	for {
@@ -154,7 +154,7 @@ func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) dispatcher() {
 	}
 }
 
-func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) dispatchTasks() {
+func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K, T]) dispatchTasks() {
 	for {
 		if w.isStopped() {
 			return
@@ -170,7 +170,7 @@ func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) dispatchTasks() {
 	}
 }
 
-func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) notifyDispatcher() {
+func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K, T]) notifyDispatcher() {
 	select {
 	case w.notifyCh <- struct{}{}:
 		// sent a notification to the dispatcher
@@ -179,11 +179,11 @@ func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) notifyDispatcher() 
 	}
 }
 
-func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) isStopped() bool {
+func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K, T]) isStopped() bool {
 	return atomic.LoadInt32(&w.status) == common.DaemonStatusStopped
 }
 
-func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K]) drainAndNackTasks() {
+func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K, T]) drainAndNackTasks() {
 	for {
 		task, ok := w.pool.TryDequeue()
 		if !ok {

--- a/common/task/hierarchical_weighted_round_robin_task_scheduler_test.go
+++ b/common/task/hierarchical_weighted_round_robin_task_scheduler_test.go
@@ -54,7 +54,7 @@ func TestHierarchicalWeightedRoundRobinTaskScheduler_SchedulerContract(t *testin
 		metrics.NewClient(tally.NoopScope, metrics.Common, metrics.HistogramMigration{}),
 		clock.NewMockedTimeSource(),
 		realProcessor,
-		&HierarchicalWeightedRoundRobinTaskPoolOptions[string]{
+		&HierarchicalWeightedRoundRobinTaskPoolOptions[string, PriorityTask]{
 			BufferSize: 1000,
 			TaskToWeightedKeysFn: func(task PriorityTask) []WeightedKey[string] {
 				priority := task.Priority()

--- a/common/task/interface.go
+++ b/common/task/interface.go
@@ -34,10 +34,10 @@ type (
 
 	// Scheduler is the generic interface for scheduling tasks with priority
 	// and processing them
-	Scheduler interface {
+	Scheduler[T Task] interface {
 		common.Daemon
-		Submit(task PriorityTask) error
-		TrySubmit(task PriorityTask) (bool, error)
+		Submit(task T) error
+		TrySubmit(task T) (bool, error)
 	}
 
 	// SchedulerType respresents the type of the task scheduler implementation

--- a/common/task/interface_mock.go
+++ b/common/task/interface_mock.go
@@ -78,55 +78,55 @@ func (mr *MockProcessorMockRecorder) Submit(task any) *gomock.Call {
 }
 
 // MockScheduler is a mock of Scheduler interface.
-type MockScheduler struct {
+type MockScheduler[T Task] struct {
 	ctrl     *gomock.Controller
-	recorder *MockSchedulerMockRecorder
+	recorder *MockSchedulerMockRecorder[T]
 	isgomock struct{}
 }
 
 // MockSchedulerMockRecorder is the mock recorder for MockScheduler.
-type MockSchedulerMockRecorder struct {
-	mock *MockScheduler
+type MockSchedulerMockRecorder[T Task] struct {
+	mock *MockScheduler[T]
 }
 
 // NewMockScheduler creates a new mock instance.
-func NewMockScheduler(ctrl *gomock.Controller) *MockScheduler {
-	mock := &MockScheduler{ctrl: ctrl}
-	mock.recorder = &MockSchedulerMockRecorder{mock}
+func NewMockScheduler[T Task](ctrl *gomock.Controller) *MockScheduler[T] {
+	mock := &MockScheduler[T]{ctrl: ctrl}
+	mock.recorder = &MockSchedulerMockRecorder[T]{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockScheduler) EXPECT() *MockSchedulerMockRecorder {
+func (m *MockScheduler[T]) EXPECT() *MockSchedulerMockRecorder[T] {
 	return m.recorder
 }
 
 // Start mocks base method.
-func (m *MockScheduler) Start() {
+func (m *MockScheduler[T]) Start() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Start")
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockSchedulerMockRecorder) Start() *gomock.Call {
+func (mr *MockSchedulerMockRecorder[T]) Start() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockScheduler)(nil).Start))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockScheduler[T])(nil).Start))
 }
 
 // Stop mocks base method.
-func (m *MockScheduler) Stop() {
+func (m *MockScheduler[T]) Stop() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Stop")
 }
 
 // Stop indicates an expected call of Stop.
-func (mr *MockSchedulerMockRecorder) Stop() *gomock.Call {
+func (mr *MockSchedulerMockRecorder[T]) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockScheduler)(nil).Stop))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockScheduler[T])(nil).Stop))
 }
 
 // Submit mocks base method.
-func (m *MockScheduler) Submit(task PriorityTask) error {
+func (m *MockScheduler[T]) Submit(task T) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Submit", task)
 	ret0, _ := ret[0].(error)
@@ -134,13 +134,13 @@ func (m *MockScheduler) Submit(task PriorityTask) error {
 }
 
 // Submit indicates an expected call of Submit.
-func (mr *MockSchedulerMockRecorder) Submit(task any) *gomock.Call {
+func (mr *MockSchedulerMockRecorder[T]) Submit(task any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Submit", reflect.TypeOf((*MockScheduler)(nil).Submit), task)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Submit", reflect.TypeOf((*MockScheduler[T])(nil).Submit), task)
 }
 
 // TrySubmit mocks base method.
-func (m *MockScheduler) TrySubmit(task PriorityTask) (bool, error) {
+func (m *MockScheduler[T]) TrySubmit(task T) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TrySubmit", task)
 	ret0, _ := ret[0].(bool)
@@ -149,9 +149,9 @@ func (m *MockScheduler) TrySubmit(task PriorityTask) (bool, error) {
 }
 
 // TrySubmit indicates an expected call of TrySubmit.
-func (mr *MockSchedulerMockRecorder) TrySubmit(task any) *gomock.Call {
+func (mr *MockSchedulerMockRecorder[T]) TrySubmit(task any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrySubmit", reflect.TypeOf((*MockScheduler)(nil).TrySubmit), task)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrySubmit", reflect.TypeOf((*MockScheduler[T])(nil).TrySubmit), task)
 }
 
 // MockTask is a mock of Task interface.

--- a/common/task/scheduler_options.go
+++ b/common/task/scheduler_options.go
@@ -27,21 +27,21 @@ import (
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 )
 
-type SchedulerOptions[K comparable] struct {
+type SchedulerOptions[K comparable, T Task] struct {
 	SchedulerType        SchedulerType
 	FIFOSchedulerOptions *FIFOTaskSchedulerOptions
-	WRRSchedulerOptions  *WeightedRoundRobinTaskSchedulerOptions[K]
+	WRRSchedulerOptions  *WeightedRoundRobinTaskSchedulerOptions[K, T]
 }
 
-func NewSchedulerOptions[K comparable](
+func NewSchedulerOptions[K comparable, T Task](
 	schedulerType int,
 	queueSize int,
 	workerCount dynamicproperties.IntPropertyFn,
 	dispatcherCount int,
-	taskToChannelKeyFn func(PriorityTask) K,
+	taskToChannelKeyFn func(T) K,
 	channelKeyToWeightFn func(K) int,
-) (*SchedulerOptions[K], error) {
-	options := &SchedulerOptions[K]{
+) (*SchedulerOptions[K, T], error) {
+	options := &SchedulerOptions[K, T]{
 		SchedulerType: SchedulerType(schedulerType),
 	}
 	switch options.SchedulerType {
@@ -53,7 +53,7 @@ func NewSchedulerOptions[K comparable](
 			RetryPolicy:     common.CreateTaskProcessingRetryPolicy(),
 		}
 	case SchedulerTypeWRR:
-		options.WRRSchedulerOptions = &WeightedRoundRobinTaskSchedulerOptions[K]{
+		options.WRRSchedulerOptions = &WeightedRoundRobinTaskSchedulerOptions[K, T]{
 			QueueSize:            queueSize,
 			DispatcherCount:      dispatcherCount,
 			TaskToChannelKeyFn:   taskToChannelKeyFn,
@@ -65,7 +65,7 @@ func NewSchedulerOptions[K comparable](
 	return options, nil
 }
 
-func (o *SchedulerOptions[K]) String() string {
+func (o *SchedulerOptions[K, T]) String() string {
 	return fmt.Sprintf("{schedulerType:%v, fifoSchedulerOptions:%s, wrrSchedulerOptions:%s}",
 		o.SchedulerType, o.FIFOSchedulerOptions, o.WRRSchedulerOptions)
 }

--- a/common/task/scheduler_options_test.go
+++ b/common/task/scheduler_options_test.go
@@ -61,7 +61,7 @@ func TestSchedulerOptionsString(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			o, err := NewSchedulerOptions[int](tc.schedulerType, tc.queueSize, tc.workerCount, tc.dispatcherCount, nil, nil)
+			o, err := NewSchedulerOptions[int, PriorityTask](tc.schedulerType, tc.queueSize, tc.workerCount, tc.dispatcherCount, nil, nil)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("Got error: %v, wantErr: %v", err, tc.wantErr)
 			}

--- a/common/task/weighted_round_robin_task_scheduler.go
+++ b/common/task/weighted_round_robin_task_scheduler.go
@@ -34,18 +34,18 @@ import (
 	"github.com/uber/cadence/common/metrics"
 )
 
-type weightedRoundRobinTaskSchedulerImpl[K comparable] struct {
+type weightedRoundRobinTaskSchedulerImpl[K comparable, T Task] struct {
 	sync.RWMutex
 
 	status       int32
-	pool         *WeightedRoundRobinChannelPool[K, PriorityTask]
+	pool         *WeightedRoundRobinChannelPool[K, T]
 	ctx          context.Context
 	cancel       context.CancelFunc
 	notifyCh     chan struct{}
 	dispatcherWG sync.WaitGroup
 	logger       log.Logger
 	metricsScope metrics.Scope
-	options      *WeightedRoundRobinTaskSchedulerOptions[K]
+	options      *WeightedRoundRobinTaskSchedulerOptions[K, T]
 
 	processor Processor
 }
@@ -61,18 +61,18 @@ var (
 )
 
 // NewWeightedRoundRobinTaskScheduler creates a new WRR task scheduler
-func NewWeightedRoundRobinTaskScheduler[K comparable](
+func NewWeightedRoundRobinTaskScheduler[K comparable, T Task](
 	logger log.Logger,
 	metricsClient metrics.Client,
 	timeSource clock.TimeSource,
 	processor Processor,
-	options *WeightedRoundRobinTaskSchedulerOptions[K],
-) (Scheduler, error) {
+	options *WeightedRoundRobinTaskSchedulerOptions[K, T],
+) (Scheduler[T], error) {
 	metricsScope := metricsClient.Scope(metrics.TaskSchedulerScope)
 	ctx, cancel := context.WithCancel(context.Background())
-	scheduler := &weightedRoundRobinTaskSchedulerImpl[K]{
+	scheduler := &weightedRoundRobinTaskSchedulerImpl[K, T]{
 		status: common.DaemonStatusInitialized,
-		pool: NewWeightedRoundRobinChannelPool[K, PriorityTask](
+		pool: NewWeightedRoundRobinChannelPool[K, T](
 			logger,
 			metricsScope,
 			timeSource,
@@ -92,7 +92,7 @@ func NewWeightedRoundRobinTaskScheduler[K comparable](
 	return scheduler, nil
 }
 
-func (w *weightedRoundRobinTaskSchedulerImpl[K]) Start() {
+func (w *weightedRoundRobinTaskSchedulerImpl[K, T]) Start() {
 	if !atomic.CompareAndSwapInt32(&w.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
 		return
 	}
@@ -104,7 +104,7 @@ func (w *weightedRoundRobinTaskSchedulerImpl[K]) Start() {
 	w.logger.Info("Weighted round robin task scheduler started.")
 }
 
-func (w *weightedRoundRobinTaskSchedulerImpl[K]) Stop() {
+func (w *weightedRoundRobinTaskSchedulerImpl[K, T]) Stop() {
 	if !atomic.CompareAndSwapInt32(&w.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
 		return
 	}
@@ -123,7 +123,7 @@ func (w *weightedRoundRobinTaskSchedulerImpl[K]) Stop() {
 	w.logger.Info("Weighted round robin task scheduler shutdown.")
 }
 
-func (w *weightedRoundRobinTaskSchedulerImpl[K]) Submit(task PriorityTask) error {
+func (w *weightedRoundRobinTaskSchedulerImpl[K, T]) Submit(task T) error {
 	w.metricsScope.IncCounter(metrics.PriorityTaskSubmitRequest)
 	sw := w.metricsScope.StartTimer(metrics.PriorityTaskSubmitLatency)
 	defer sw.Stop()
@@ -148,8 +148,8 @@ func (w *weightedRoundRobinTaskSchedulerImpl[K]) Submit(task PriorityTask) error
 	}
 }
 
-func (w *weightedRoundRobinTaskSchedulerImpl[K]) TrySubmit(
-	task PriorityTask,
+func (w *weightedRoundRobinTaskSchedulerImpl[K, T]) TrySubmit(
+	task T,
 ) (bool, error) {
 	if w.isStopped() {
 		return false, ErrTaskSchedulerClosed
@@ -176,7 +176,7 @@ func (w *weightedRoundRobinTaskSchedulerImpl[K]) TrySubmit(
 	}
 }
 
-func (w *weightedRoundRobinTaskSchedulerImpl[K]) dispatcher() {
+func (w *weightedRoundRobinTaskSchedulerImpl[K, T]) dispatcher() {
 	defer w.dispatcherWG.Done()
 
 	for {
@@ -189,7 +189,7 @@ func (w *weightedRoundRobinTaskSchedulerImpl[K]) dispatcher() {
 	}
 }
 
-func (w *weightedRoundRobinTaskSchedulerImpl[K]) dispatchTasks() {
+func (w *weightedRoundRobinTaskSchedulerImpl[K, T]) dispatchTasks() {
 	hasTask := true
 	for hasTask {
 		hasTask = false
@@ -214,7 +214,7 @@ func (w *weightedRoundRobinTaskSchedulerImpl[K]) dispatchTasks() {
 	}
 }
 
-func (w *weightedRoundRobinTaskSchedulerImpl[K]) notifyDispatcher() {
+func (w *weightedRoundRobinTaskSchedulerImpl[K, T]) notifyDispatcher() {
 	select {
 	case w.notifyCh <- struct{}{}:
 		// sent a notification to the dispatcher
@@ -223,11 +223,11 @@ func (w *weightedRoundRobinTaskSchedulerImpl[K]) notifyDispatcher() {
 	}
 }
 
-func (w *weightedRoundRobinTaskSchedulerImpl[K]) isStopped() bool {
+func (w *weightedRoundRobinTaskSchedulerImpl[K, T]) isStopped() bool {
 	return atomic.LoadInt32(&w.status) == common.DaemonStatusStopped
 }
 
-func drainAndNackPriorityTask(taskCh <-chan PriorityTask) {
+func drainAndNackPriorityTask[T Task](taskCh <-chan T) {
 	for {
 		select {
 		case task := <-taskCh:

--- a/common/task/weighted_round_robin_task_scheduler_options.go
+++ b/common/task/weighted_round_robin_task_scheduler_options.go
@@ -25,13 +25,13 @@ import (
 )
 
 // WeightedRoundRobinTaskSchedulerOptions configs WRR task scheduler
-type WeightedRoundRobinTaskSchedulerOptions[K comparable] struct {
+type WeightedRoundRobinTaskSchedulerOptions[K comparable, T Task] struct {
 	QueueSize            int
 	DispatcherCount      int
-	TaskToChannelKeyFn   func(PriorityTask) K
+	TaskToChannelKeyFn   func(T) K
 	ChannelKeyToWeightFn func(K) int
 }
 
-func (o *WeightedRoundRobinTaskSchedulerOptions[K]) String() string {
+func (o *WeightedRoundRobinTaskSchedulerOptions[K, T]) String() string {
 	return fmt.Sprintf("{QueueSize: %v, DispatcherCount: %v}", o.QueueSize, o.DispatcherCount)
 }

--- a/common/task/weighted_round_robin_task_scheduler_test.go
+++ b/common/task/weighted_round_robin_task_scheduler_test.go
@@ -52,7 +52,7 @@ type (
 
 		queueSize int
 
-		scheduler *weightedRoundRobinTaskSchedulerImpl[int]
+		scheduler *weightedRoundRobinTaskSchedulerImpl[int, PriorityTask]
 	}
 
 	mockPriorityTaskMatcher struct {
@@ -92,7 +92,7 @@ func (s *weightedRoundRobinTaskSchedulerSuite) SetupTest() {
 		},
 	)
 	s.scheduler = s.newTestWeightedRoundRobinTaskScheduler(
-		&WeightedRoundRobinTaskSchedulerOptions[int]{
+		&WeightedRoundRobinTaskSchedulerOptions[int, PriorityTask]{
 			QueueSize:       s.queueSize,
 			DispatcherCount: 3,
 			TaskToChannelKeyFn: func(task PriorityTask) int {
@@ -131,7 +131,7 @@ func (s *weightedRoundRobinTaskSchedulerSuite) TestSubmit_Success() {
 func (s *weightedRoundRobinTaskSchedulerSuite) TestSubmit_Fail_SchedulerShutDown() {
 	// create a new scheduler here with queue size 0, otherwise test is non-deterministic
 	scheduler := s.newTestWeightedRoundRobinTaskScheduler(
-		&WeightedRoundRobinTaskSchedulerOptions[int]{
+		&WeightedRoundRobinTaskSchedulerOptions[int, PriorityTask]{
 			QueueSize:       0,
 			DispatcherCount: 3,
 		},
@@ -290,8 +290,8 @@ func (s *weightedRoundRobinTaskSchedulerSuite) TestSchedulerContract() {
 }
 
 func (s *weightedRoundRobinTaskSchedulerSuite) newTestWeightedRoundRobinTaskScheduler(
-	options *WeightedRoundRobinTaskSchedulerOptions[int],
-) *weightedRoundRobinTaskSchedulerImpl[int] {
+	options *WeightedRoundRobinTaskSchedulerOptions[int, PriorityTask],
+) *weightedRoundRobinTaskSchedulerImpl[int, PriorityTask] {
 	scheduler, err := NewWeightedRoundRobinTaskScheduler(
 		testlogger.New(s.Suite.T()),
 		metrics.NewClient(tally.NoopScope, metrics.Common, metrics.HistogramMigration{}),
@@ -300,13 +300,13 @@ func (s *weightedRoundRobinTaskSchedulerSuite) newTestWeightedRoundRobinTaskSche
 		options,
 	)
 	s.NoError(err)
-	return scheduler.(*weightedRoundRobinTaskSchedulerImpl[int])
+	return scheduler.(*weightedRoundRobinTaskSchedulerImpl[int, PriorityTask])
 }
 
 func testSchedulerContract(
 	s *require.Assertions,
 	controller *gomock.Controller,
-	scheduler Scheduler,
+	scheduler Scheduler[PriorityTask],
 	processor Processor,
 ) {
 	numTasks := 10000
@@ -371,11 +371,11 @@ func testSchedulerContract(
 	}
 	s.True(common.AwaitWaitGroup(&taskWG, 10*time.Second))
 	switch schedulerImpl := scheduler.(type) {
-	case *fifoTaskSchedulerImpl:
+	case *fifoTaskSchedulerImpl[PriorityTask]:
 		<-schedulerImpl.ctx.Done()
-	case *weightedRoundRobinTaskSchedulerImpl[int]:
+	case *weightedRoundRobinTaskSchedulerImpl[int, PriorityTask]:
 		<-schedulerImpl.ctx.Done()
-	case *hierarchicalWeightedRoundRobinTaskSchedulerImpl[string]:
+	case *hierarchicalWeightedRoundRobinTaskSchedulerImpl[string, PriorityTask]:
 		<-schedulerImpl.ctx.Done()
 	default:
 		s.Fail("unknown task scheduler type")

--- a/service/history/task/processor.go
+++ b/service/history/task/processor.go
@@ -47,7 +47,7 @@ type processorImpl struct {
 
 	priorityAssigner PriorityAssigner
 	taskProcessor    task.Processor
-	scheduler        task.Scheduler
+	scheduler        task.Scheduler[Task]
 
 	status        int32
 	logger        log.Logger
@@ -81,20 +81,15 @@ func NewProcessor(
 			RetryPolicy: common.CreateTaskProcessingRetryPolicy(),
 		},
 	)
-	var scheduler task.Scheduler
+	var scheduler task.Scheduler[Task]
 	var err error
 	if config.EnableHierarchicalWeightedRoundRobinTaskScheduler() {
-		taskToWeightedKeysFn := func(t task.PriorityTask) []task.WeightedKey[any] {
+		taskToWeightedKeysFn := func(t Task) []task.WeightedKey[any] {
 			var domainID, taskList string
-			tt, ok := t.(Task)
-			if ok {
-				domainID = tt.GetDomainID()
-				taskList = tt.GetOriginalTaskList()
-				if tt.GetOriginalTaskListKind() == types.TaskListKindEphemeral {
-					taskList = ephemeralTaskListGroupKey
-				}
-			} else {
-				logger.Error("incorrect task type for task scheduler, this should not happen, there must be a bug in our code")
+			domainID = t.GetDomainID()
+			taskList = t.GetOriginalTaskList()
+			if t.GetOriginalTaskListKind() == types.TaskListKindEphemeral {
+				taskList = ephemeralTaskListGroupKey
 			}
 			key := DomainPriorityKey{
 				DomainID: domainID,
@@ -129,7 +124,7 @@ func NewProcessor(
 			metricsClient,
 			timeSource,
 			taskProcessor,
-			&task.HierarchicalWeightedRoundRobinTaskPoolOptions[any]{
+			&task.HierarchicalWeightedRoundRobinTaskPoolOptions[any, Task]{
 				BufferSize:           config.TaskSchedulerQueueSize(),
 				TaskToWeightedKeysFn: taskToWeightedKeysFn,
 			},
@@ -138,14 +133,9 @@ func NewProcessor(
 			return nil, err
 		}
 	} else {
-		taskToChannelKeyFn := func(t task.PriorityTask) DomainPriorityKey {
+		taskToChannelKeyFn := func(t Task) DomainPriorityKey {
 			var domainID string
-			tt, ok := t.(Task)
-			if ok {
-				domainID = tt.GetDomainID()
-			} else {
-				logger.Error("incorrect task type for task scheduler, this should not happen, there must be a bug in our code")
-			}
+			domainID = t.GetDomainID()
 			return DomainPriorityKey{
 				DomainID: domainID,
 				Priority: t.Priority(),
@@ -159,7 +149,7 @@ func NewProcessor(
 			metricsClient,
 			timeSource,
 			taskProcessor,
-			&task.WeightedRoundRobinTaskSchedulerOptions[DomainPriorityKey]{
+			&task.WeightedRoundRobinTaskSchedulerOptions[DomainPriorityKey, Task]{
 				QueueSize:            config.TaskSchedulerQueueSize(),
 				DispatcherCount:      config.TaskSchedulerDispatcherCount(),
 				TaskToChannelKeyFn:   taskToChannelKeyFn,

--- a/service/history/task/processor_test.go
+++ b/service/history/task/processor_test.go
@@ -79,7 +79,7 @@ func (s *queueTaskProcessorSuite) SetupTest() {
 func (s *queueTaskProcessorSuite) TearDownTest() {}
 
 func (s *queueTaskProcessorSuite) TestStartStop() {
-	mockScheduler := task.NewMockScheduler(s.controller)
+	mockScheduler := task.NewMockScheduler[Task](s.controller)
 	mockScheduler.EXPECT().Start().Times(1)
 	mockScheduler.EXPECT().Stop().Times(1)
 	s.processor.scheduler = mockScheduler
@@ -92,7 +92,7 @@ func (s *queueTaskProcessorSuite) TestSubmit() {
 	mockTask := NewMockTask(s.controller)
 	s.mockPriorityAssigner.EXPECT().Assign(NewMockTaskMatcher(mockTask)).Return(nil).Times(1)
 
-	mockScheduler := task.NewMockScheduler(s.controller)
+	mockScheduler := task.NewMockScheduler[Task](s.controller)
 	mockScheduler.EXPECT().Submit(NewMockTaskMatcher(mockTask)).Return(nil).Times(1)
 
 	s.processor.scheduler = mockScheduler
@@ -117,7 +117,7 @@ func (s *queueTaskProcessorSuite) TestTrySubmit_Fail() {
 	s.mockPriorityAssigner.EXPECT().Assign(NewMockTaskMatcher(mockTask)).Return(nil).Times(1)
 
 	errTrySubmit := errors.New("some randome error")
-	mockScheduler := task.NewMockScheduler(s.controller)
+	mockScheduler := task.NewMockScheduler[Task](s.controller)
 	mockScheduler.EXPECT().TrySubmit(NewMockTaskMatcher(mockTask)).Return(false, errTrySubmit).Times(1)
 
 	s.processor.scheduler = mockScheduler


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Replace runtime type assertions with compile-time type safety by making
  the task scheduler system generic. The Scheduler interface and all
  implementations now accept a type parameter T that implements the Task
  interface.

  Changes:
  - Make Scheduler interface generic: Scheduler[T Task]
  - Update all scheduler implementations with generic type parameters
  - Update scheduler options and supporting types with generics
  - Simplify processor task mapping functions to work with concrete types
  - Update mocks to support generic schedulers

**Why?**
  This change eliminates the need for runtime type checking in processor.go
  where tasks were previously cast from PriorityTask to Task, improving both
  type safety and removing potential runtime errors.

**How did you test it?**
cd common/task && go test ./... -race
cd service/history task && go test ./... -race

**Potential risks**
No. If the code compiles and the tests don't fail, it should cause no issue.

**Release notes**
N/A

**Documentation Changes**
N/A
