### PR TITLE
test: Add fuzz tests to schedule mappers

### DIFF
--- a/common/types/mapper/proto/schedule_test.go
+++ b/common/types/mapper/proto/schedule_test.go
@@ -314,3 +314,64 @@ func TestBackfillScheduleRequestFuzz(t *testing.T) {
 		WithScheduleEnumFuzzers(),
 	)
 }
+
+func TestCreateScheduleResponseFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t, FromCreateScheduleResponse, ToCreateScheduleResponse,
+		WithScheduleEnumFuzzers(),
+	)
+}
+
+func TestDeleteScheduleResponseFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t, FromDeleteScheduleResponse, ToDeleteScheduleResponse,
+		WithScheduleEnumFuzzers(),
+	)
+}
+
+func TestScheduleCatchUpPolicyFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t, FromScheduleCatchUpPolicy, ToScheduleCatchUpPolicy,
+		WithScheduleEnumFuzzers(),
+	)
+}
+
+func TestScheduleOverlapPolicyFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t,
+		FromScheduleOverlapPolicy, ToScheduleOverlapPolicy,
+		WithScheduleEnumFuzzers(),
+	)
+}
+
+func TestScheduleListEntryArrayFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t, FromScheduleListEntryArray, ToScheduleListEntryArray,
+		WithScheduleEnumFuzzers(),
+	)
+}
+
+func TestUpdateScheduleResponseFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t, FromUpdateScheduleResponse, ToUpdateScheduleResponse,
+		WithScheduleEnumFuzzers(),
+	)
+}
+
+func TestBackfillScheduleResponseFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t, FromBackfillScheduleResponse, ToBackfillScheduleResponse,
+		WithScheduleEnumFuzzers(),
+	)
+}
+
+func TestPauseScheduleResponseFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t, FromPauseScheduleResponse, ToPauseScheduleResponse,
+		WithScheduleEnumFuzzers(),
+	)
+}
+
+func TestUnpauseScheduleResponseFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t, FromUnpauseScheduleResponse, ToUnpauseScheduleResponse,
+		WithScheduleEnumFuzzers(),
+	)
+}
+
+func TestBackfillInfoArrayFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t, FromBackfillInfoArray, ToBackfillInfoArray,
+		WithScheduleEnumFuzzers(),
+	)
+}


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

This adds fuzz tests for additional mappers within common/types/mapper/proto/schedule.go

**Why?**

This is part of the implementation of https://github.com/cadence-workflow/cadence/issues/7611. Further follow ups will work on additional files. 

**How did you test it?**

```bash
go test ./common/types/mapper/...
ok      github.com/uber/cadence/common/types/mapper/errorutils  (cached)
ok      github.com/uber/cadence/common/types/mapper/proto       (cached)
ok      github.com/uber/cadence/common/types/mapper/testutils   (cached)
ok      github.com/uber/cadence/common/types/mapper/thrift      (cached)
```

**Potential risks**

N/A

**Release notes**

N/A

**Documentation Changes**

N/A