### PR TITLE
feat(domain multi-tenancy): optimize IWRR node cleanup

### DIFF
--- a/common/task/iwrr_node.go
+++ b/common/task/iwrr_node.go
@@ -230,33 +230,87 @@ func (n *iwrrNode[K, V]) tryChildren() (V, bool) {
 // The method performs a depth-first traversal, cleaning up children before checking itself.
 //
 // Process:
-//  1. Recursively cleanup all children
-//  2. Remove children that return true (indicating they should be removed)
-//  3. Update the IWRR schedule if any children were removed
-//  4. If this node is now a leaf, check if its own channel should be cleaned up
+//  1. Take a snapshot of children with read lock
+//  2. Release lock and recursively cleanup all children (allows concurrent executeAtPath)
+//  3. If any children should be removed, acquire write lock and check if the child still qualifies for deletion
+//     - Child still exists and is the same instance (not replaced)
+//     - Child has no children (no descendants were added since cleanup decision)
+//     - Child's TTL channel still qualifies for cleanup (no tasks in own channel)
+//  4. Update the IWRR schedule if any children were removed
+//  5. If this node is now a leaf, check if its own channel should be cleaned up
 //
 // A leaf node is eligible for removal if its TTL channel has been idle beyond the TTL duration.
 //
+// Performance optimization: The parent lock is released during recursive cleanup of children,
+// reducing lock contention and allowing concurrent operations on the parent node.
+//
 // Returns: true if this node should be removed by its parent, false otherwise
 //
-// Concurrency: Safe for concurrent access. Acquires write lock during execution.
+// Concurrency: Safe for concurrent access. Uses read lock for snapshot, write lock only for modifications.
 func (n *iwrrNode[K, V]) cleanup(now time.Time, ttl time.Duration) bool {
-	n.Lock()
-	defer n.Unlock()
-
-	// Clean up children first and collect keys to remove
-	keysToRemove := make([]K, 0)
+	// Step 1: Take snapshot of children with read lock
+	n.RLock()
+	if len(n.children) == 0 {
+		n.RUnlock()
+		// Fast path: leaf node, check if should be cleaned up
+		shouldRemove := n.c.ShouldCleanup(now, ttl)
+		return shouldRemove
+	}
+	childrenSnapshot := make(map[K]*iwrrNode[K, V], len(n.children))
 	for key, container := range n.children {
-		if container.item.cleanup(now, ttl) {
+		childrenSnapshot[key] = container.item
+	}
+	n.RUnlock()
+
+	// Step 2: Cleanup children WITHOUT holding parent lock
+	// This allows concurrent executeAtPath operations on the parent
+	keysToRemove := make([]K, 0)
+	for key, child := range childrenSnapshot {
+		if child.cleanup(now, ttl) {
 			keysToRemove = append(keysToRemove, key)
 		}
 	}
 
-	// Remove children that should be cleaned up
+	// Step 3: Fast path if no children need removal
+	if len(keysToRemove) == 0 {
+		return false
+	}
+
+	// Step 4: Acquire write lock only when we need to modify
+	n.Lock()
+	defer n.Unlock()
+
 	needsUpdate := false
 	for _, key := range keysToRemove {
-		delete(n.children, key)
-		needsUpdate = true
+		// Verify the child still qualifies for deletion:
+		// 1. Child still exists and is the same instance (not replaced)
+		// 2. Child's TTL channel still qualifies for cleanup (no tasks in own channel, RefCount == 0)
+		//    If RefCount == 0, executeAtPath has fully returned, meaning any grandchildren it
+		//    created are already committed to child.children — making the hasNoChildren check
+		//    below accurate.
+		// 3. Child has no children (no descendants were added since cleanup decision)
+		//    If no descendants exist, childrenItemCount must be 0 by definition
+		// This protects against the race where executeAtPath adds tasks to descendants
+		// between the cleanup decision and the actual deletion.
+		container, exists := n.children[key]
+		if !exists || container.item != childrenSnapshot[key] {
+			continue
+		}
+		// Check ShouldCleanup first: if RefCount > 0, an executeAtPath is still in-flight
+		// for this child and may be creating grandchildren, so skip deletion.
+		if !container.item.c.ShouldCleanup(now, ttl) {
+			continue
+		}
+		// ShouldCleanup passed (RefCount==0, Len==0, TTL expired). Take the read lock only to
+		// guard against a concurrent cleanup goroutine removing grandchildren from this child
+		// and confirm there are truly no descendants before deleting.
+		container.item.RLock()
+		hasNoChildren := len(container.item.children) == 0
+		container.item.RUnlock()
+		if hasNoChildren {
+			delete(n.children, key)
+			needsUpdate = true
+		}
 	}
 
 	// Update schedule if children were removed
@@ -264,7 +318,7 @@ func (n *iwrrNode[K, V]) cleanup(now time.Time, ttl time.Duration) bool {
 		n.updateScheduleLocked()
 	}
 
-	// If the node is a leaf node or becomes a leaf node, check if it should be removed
+	// If the node became a leaf node, check if it should be removed
 	if len(n.children) == 0 {
 		return n.c.ShouldCleanup(now, ttl)
 	}

--- a/common/task/iwrr_node_test.go
+++ b/common/task/iwrr_node_test.go
@@ -1,6 +1,9 @@
 package task
 
 import (
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -850,4 +853,283 @@ func TestIwrrNode_Cleanup(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIwrrNode_Cleanup_ConcurrentCleanup(t *testing.T) {
+	// Test that multiple concurrent cleanup calls don't cause race conditions
+	root := newiwrrNode[string, int](10)
+
+	// Create a tree with multiple levels and old timestamps
+	// root -> level1a -> level2a
+	//      -> level1b -> level2b
+	//      -> level1c -> level2c
+	oldTime := time.Now().Add(-2 * time.Hour) // Old enough to be cleaned up
+	for i := 0; i < 3; i++ {
+		path := []WeightedKey[string]{
+			{Key: fmt.Sprintf("level1_%d", i), Weight: 1},
+			{Key: fmt.Sprintf("level2_%d", i), Weight: 1},
+		}
+		root.executeAtPath(path, 10, func(c *TTLChannel[int]) int64 {
+			c.UpdateLastWriteTime(oldTime) // Set old timestamp
+			return 0                       // Don't add items, just create the tree structure
+		})
+	}
+
+	// Verify initial state
+	require.Equal(t, 3, len(root.children))
+
+	// Run multiple concurrent cleanup operations
+	now := time.Now()
+	ttl := time.Hour
+
+	var wg sync.WaitGroup
+	numGoroutines := 10
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			root.cleanup(now, ttl)
+		}()
+	}
+
+	wg.Wait()
+
+	// Verify tree was cleaned up correctly
+	// All nodes should be removed since they're idle
+	assert.Equal(t, 0, len(root.children))
+}
+
+func TestIwrrNode_Cleanup_ConcurrentWithExecuteAtPath(t *testing.T) {
+	// Test that cleanup and executeAtPath can run concurrently without deadlock or corruption
+	// Uses multi-level hierarchy with multiple goroutines for both operations
+	root := newiwrrNode[string, int](100)
+
+	var wg sync.WaitGroup
+	stopCh := make(chan struct{})
+	var tasksAdded atomic.Int64
+
+	// Multiple goroutines running executeAtPath with multi-level paths
+	numExecuteGoroutines := 10
+	for g := 0; g < numExecuteGoroutines; g++ {
+		wg.Add(1)
+		go func(goroutineID int) {
+			defer wg.Done()
+			counter := 0
+			for {
+				select {
+				case <-stopCh:
+					return
+				default:
+					// Create multi-level paths: domain -> tasklist -> tenant
+					domainKey := fmt.Sprintf("domain_%d", (goroutineID+counter)%3)
+					tasklistKey := fmt.Sprintf("tasklist_%d", (goroutineID+counter)%5)
+					tenantKey := fmt.Sprintf("tenant_%d", (goroutineID+counter)%7)
+
+					path := []WeightedKey[string]{
+						{Key: domainKey, Weight: ((goroutineID + counter) % 3) + 1},
+						{Key: tasklistKey, Weight: ((goroutineID + counter) % 5) + 1},
+						{Key: tenantKey, Weight: ((goroutineID + counter) % 7) + 1},
+					}
+
+					taskValue := goroutineID*10000 + counter
+					root.executeAtPath(path, 10, func(c *TTLChannel[int]) int64 {
+						select {
+						case c.Chan() <- taskValue:
+							c.UpdateLastWriteTime(time.Now())
+							tasksAdded.Add(1)
+							return 1
+						default:
+							return 0
+						}
+					})
+					counter++
+				}
+			}
+		}(g)
+	}
+
+	// Multiple goroutines running cleanup
+	numCleanupGoroutines := 5
+	for g := 0; g < numCleanupGoroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stopCh:
+					return
+				default:
+					// Cleanup with a TTL that will remove idle nodes
+					now := time.Now()
+					ttl := 50 * time.Millisecond
+					root.cleanup(now, ttl)
+					time.Sleep(time.Millisecond)
+				}
+			}
+		}()
+	}
+
+	// Let them run concurrently for a short time
+	time.Sleep(50 * time.Millisecond)
+	close(stopCh)
+	wg.Wait()
+
+	// Drain all tasks and verify count
+	drainedCount := 0
+	for {
+		if _, ok := root.tryGetNextItem(); ok {
+			drainedCount++
+		} else {
+			break
+		}
+	}
+
+	// All added items should be drained
+	assert.Equal(t, int(tasksAdded.Load()), drainedCount, "All enqueued items should be dequeuable")
+}
+
+func TestIwrrNode_Cleanup_PointerEqualityCheck(t *testing.T) {
+	// Test that cleanup only removes the child it decided to remove,
+	// not a newly created child with the same key
+	root := newiwrrNode[string, int](10)
+
+	// Add an initial child that will be cleaned up
+	path := []WeightedKey[string]{
+		{Key: "child", Weight: 1},
+	}
+	root.executeAtPath(path, 10, func(c *TTLChannel[int]) int64 {
+		c.UpdateLastWriteTime(time.Now().Add(-2 * time.Hour)) // Old timestamp
+		return 0
+	})
+
+	// Start cleanup in background (it will snapshot, then recurse, then try to delete)
+	cleanupDone := make(chan bool)
+	go func() {
+		// Add a small delay to ensure executeAtPath runs during the recursive phase
+		now := time.Now()
+		ttl := time.Hour
+		root.cleanup(now, ttl)
+		cleanupDone <- true
+	}()
+
+	// While cleanup is running, add a new child with the same key
+	// This simulates the race condition the pointer equality check protects against
+	time.Sleep(time.Millisecond) // Give cleanup time to snapshot
+	path2 := []WeightedKey[string]{
+		{Key: "child", Weight: 2}, // Same key, different weight
+	}
+	root.executeAtPath(path2, 10, func(c *TTLChannel[int]) int64 {
+		c.UpdateLastWriteTime(time.Now())
+		return 0
+	})
+
+	<-cleanupDone
+
+	// Verify: the new child should still exist
+	root.RLock()
+	container, exists := root.children["child"]
+	root.RUnlock()
+
+	// The child should exist (either old or new depending on timing)
+	// If it's the new child, weight should be 2
+	// If it's the old child, weight should be 1
+	// Either way, the tree should be in a consistent state
+	if exists {
+		// If child exists, verify it's a valid node
+		assert.NotNil(t, container.item)
+		assert.Contains(t, []int{1, 2}, container.weight)
+	}
+}
+
+func TestIwrrNode_Cleanup_DeepHierarchyConcurrency(t *testing.T) {
+	// Test cleanup performance with deep hierarchy and concurrent operations
+	// Verifies all tasks can be drained even with concurrent cleanup
+	root := newiwrrNode[string, int](10)
+
+	// Track tasks added
+	var tasksAdded atomic.Int64
+
+	// Create a deep hierarchy (5 levels, 3 children per level = 243 leaf paths)
+	var createPaths func(depth int, prefix string) [][]WeightedKey[string]
+	createPaths = func(depth int, prefix string) [][]WeightedKey[string] {
+		if depth == 0 {
+			return [][]WeightedKey[string]{{}}
+		}
+		var paths [][]WeightedKey[string]
+		for i := 0; i < 3; i++ {
+			key := fmt.Sprintf("%s_L%d_C%d", prefix, 5-depth, i)
+			subPaths := createPaths(depth-1, prefix)
+			for _, subPath := range subPaths {
+				path := append([]WeightedKey[string]{{Key: key, Weight: i + 1}}, subPath...)
+				paths = append(paths, path)
+			}
+		}
+		return paths
+	}
+
+	paths := createPaths(5, "node")
+	for i, path := range paths {
+		root.executeAtPath(path, 10, func(c *TTLChannel[int]) int64 {
+			select {
+			case c.Chan() <- i:
+				c.UpdateLastWriteTime(time.Now())
+				tasksAdded.Add(1)
+				return 1
+			default:
+				return 0
+			}
+		})
+	}
+
+	// Verify tree was created
+	require.Equal(t, 3, len(root.children))
+
+	var wg sync.WaitGroup
+
+	// Start multiple cleanup operations concurrently
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			now := time.Now().Add(2 * time.Hour)
+			ttl := time.Hour
+			root.cleanup(now, ttl)
+		}()
+	}
+
+	// Also start some executeAtPath operations to add new nodes/tasks
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			path := []WeightedKey[string]{
+				{Key: fmt.Sprintf("new_L0_C%d", idx), Weight: 1},
+			}
+			root.executeAtPath(path, 10, func(c *TTLChannel[int]) int64 {
+				select {
+				case c.Chan() <- idx + 1000:
+					c.UpdateLastWriteTime(time.Now())
+					tasksAdded.Add(1)
+					return 1
+				default:
+					return 0
+				}
+			})
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Drain all remaining tasks to verify nothing was lost
+	drainedCount := 0
+	for {
+		if _, ok := root.tryGetNextItem(); ok {
+			drainedCount++
+		} else {
+			break
+		}
+	}
+
+	totalAdded := int(tasksAdded.Load())
+	assert.Equal(t, totalAdded, drainedCount, "All added tasks should be dequeuable")
 }


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Optimize cleanup performance by releasing parent lock during recursive cleanup of children, reducing lock contention in deep hierarchies.
- Add comprehensive concurrent tests to verify cleanup correctness under concurrent executeAtPath operations and verify no tasks are lost.

related to https://github.com/cadence-workflow/cadence/issues/7724

**Why?**
Reduce lock contention for cleanup method of iwrr node

**How did you test it?**
cd common/task && go test ./... -race

**Potential risks**
Tasks can be lost if a node with task is removed from the tree. 

**Release notes**
N/A

**Documentation Changes**
N/A
