### PR TITLE
chore: Enable new Workflow History page for cadence-web in docker-compose files

### DIFF
--- a/docker/docker-compose-archival-filestore.yml
+++ b/docker/docker-compose-archival-filestore.yml
@@ -68,6 +68,7 @@ services:
     image: ubercadence/web:latest
     environment:
       - "CADENCE_GRPC_PEERS=cadence:7833"
+      - "CADENCE_HISTORY_PAGE_V2_ENABLED=OPT_OUT"
     ports:
       - "8088:8088"
     depends_on:

--- a/docker/docker-compose-async-wf-kafka-v4.yml
+++ b/docker/docker-compose-async-wf-kafka-v4.yml
@@ -58,6 +58,7 @@ services:
     image: ubercadence/web:latest
     environment:
       - "CADENCE_GRPC_PEERS=cadence:7833"
+      - "CADENCE_HISTORY_PAGE_V2_ENABLED=OPT_OUT"
     ports:
       - "8088:8088"
     depends_on:

--- a/docker/docker-compose-async-wf-kafka.yml
+++ b/docker/docker-compose-async-wf-kafka.yml
@@ -58,6 +58,7 @@ services:
     image: ubercadence/web:latest
     environment:
       - "CADENCE_GRPC_PEERS=cadence:7833"
+      - "CADENCE_HISTORY_PAGE_V2_ENABLED=OPT_OUT"
     ports:
       - "8088:8088"
     depends_on:

--- a/docker/docker-compose-es-v7.yml
+++ b/docker/docker-compose-es-v7.yml
@@ -80,6 +80,7 @@ services:
     image: ubercadence/web:latest
     environment:
       - "CADENCE_GRPC_PEERS=cadence:7833"
+      - "CADENCE_HISTORY_PAGE_V2_ENABLED=OPT_OUT"
     ports:
       - "8088:8088"
     depends_on:

--- a/docker/docker-compose-es.yml
+++ b/docker/docker-compose-es.yml
@@ -79,6 +79,7 @@ services:
     image: ubercadence/web:latest
     environment:
       - "CADENCE_GRPC_PEERS=cadence:7833"
+      - "CADENCE_HISTORY_PAGE_V2_ENABLED=OPT_OUT"
     ports:
       - "8088:8088"
     depends_on:

--- a/docker/docker-compose-http-api.yml
+++ b/docker/docker-compose-http-api.yml
@@ -54,6 +54,7 @@ services:
     image: ubercadence/web:latest
     environment:
       - "CADENCE_GRPC_PEERS=cadence:7833"
+      - "CADENCE_HISTORY_PAGE_V2_ENABLED=OPT_OUT"
     ports:
       - "8088:8088"
     depends_on:

--- a/docker/docker-compose-multiclusters-cass-mysql-es.yaml
+++ b/docker/docker-compose-multiclusters-cass-mysql-es.yaml
@@ -137,6 +137,7 @@ services:
       - "CADENCE_GRPC_PEERS=cadence:7833,cadence-secondary:7833"
       - "CADENCE_GRPC_SERVICES_NAMES=cadence-frontend,cadence-frontend"
       - "CADENCE_CLUSTERS_NAMES=cluster0,cluster1"
+      - "CADENCE_HISTORY_PAGE_V2_ENABLED=OPT_OUT"
     ports:
       - "8088:8088"
     depends_on:

--- a/docker/docker-compose-multiclusters-es.yml
+++ b/docker/docker-compose-multiclusters-es.yml
@@ -133,6 +133,7 @@ services:
       - "CADENCE_GRPC_PEERS=cadence:7833,cadence-secondary:7833"
       - "CADENCE_GRPC_SERVICES_NAMES=cadence-frontend,cadence-frontend"
       - "CADENCE_CLUSTERS_NAMES=cluster0,cluster1"
+      - "CADENCE_HISTORY_PAGE_V2_ENABLED=OPT_OUT"
     ports:
       - "8088:8088"
     depends_on:

--- a/docker/docker-compose-multiclusters.yml
+++ b/docker/docker-compose-multiclusters.yml
@@ -116,6 +116,7 @@ services:
       - "CADENCE_GRPC_PEERS=cadence:7833,cadence-secondary:7833"
       - "CADENCE_GRPC_SERVICES_NAMES=cadence-frontend,cadence-frontend"
       - "CADENCE_CLUSTERS_NAMES=cluster0,cluster1"
+      - "CADENCE_HISTORY_PAGE_V2_ENABLED=OPT_OUT"
     ports:
       - "8088:8088"
     depends_on:

--- a/docker/docker-compose-mysql.yml
+++ b/docker/docker-compose-mysql.yml
@@ -43,6 +43,7 @@ services:
     image: ubercadence/web:latest
     environment:
       - "CADENCE_GRPC_PEERS=cadence:7833"
+      - "CADENCE_HISTORY_PAGE_V2_ENABLED=OPT_OUT"
     ports:
       - "8088:8088"
     depends_on:

--- a/docker/docker-compose-oauth.yml
+++ b/docker/docker-compose-oauth.yml
@@ -44,6 +44,7 @@ services:
     image: ubercadence/web:latest
     environment:
       - "CADENCE_GRPC_PEERS=cadence:7833"
+      - "CADENCE_HISTORY_PAGE_V2_ENABLED=OPT_OUT"
     ports:
       - "8088:8088"
     depends_on:

--- a/docker/docker-compose-opensearch.yml
+++ b/docker/docker-compose-opensearch.yml
@@ -95,6 +95,7 @@ services:
     image: ubercadence/web:latest
     environment:
       - "CADENCE_GRPC_PEERS=cadence:7833"
+      - "CADENCE_HISTORY_PAGE_V2_ENABLED=OPT_OUT"
     ports:
       - "8088:8088"
     depends_on:

--- a/docker/docker-compose-pinot.yml
+++ b/docker/docker-compose-pinot.yml
@@ -102,6 +102,7 @@ services:
     image: ubercadence/web:latest
     environment:
       - "CADENCE_GRPC_PEERS=cadence:7833"
+      - "CADENCE_HISTORY_PAGE_V2_ENABLED=OPT_OUT"
     ports:
       - "8088:8088"
     depends_on:

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -44,6 +44,7 @@ services:
     image: ubercadence/web:latest
     environment:
       - "CADENCE_GRPC_PEERS=cadence:7833"
+      - "CADENCE_HISTORY_PAGE_V2_ENABLED=OPT_OUT"
     ports:
       - "8088:8088"
     depends_on:

--- a/docker/docker-compose-scylla.yml
+++ b/docker/docker-compose-scylla.yml
@@ -41,6 +41,7 @@ services:
     image: ubercadence/web:latest
     environment:
       - "CADENCE_GRPC_PEERS=cadence:7833"
+      - "CADENCE_HISTORY_PAGE_V2_ENABLED=OPT_OUT"
     ports:
       - "8088:8088"
     depends_on:

--- a/docker/docker-compose-statsd.yml
+++ b/docker/docker-compose-statsd.yml
@@ -39,6 +39,7 @@ services:
     image: ubercadence/web:latest
     environment:
       - "CADENCE_GRPC_PEERS=cadence:7833"
+      - "CADENCE_HISTORY_PAGE_V2_ENABLED=OPT_OUT"
     ports:
       - "8088:8088"
     depends_on:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -54,6 +54,7 @@ services:
     image: ubercadence/web:latest
     environment:
       - "CADENCE_GRPC_PEERS=cadence:7833"
+      - "CADENCE_HISTORY_PAGE_V2_ENABLED=OPT_OUT"
     ports:
       - "8088:8088"
     depends_on:

--- a/docker/github_actions/docker-compose-local-replication-simulation.yml
+++ b/docker/github_actions/docker-compose-local-replication-simulation.yml
@@ -142,6 +142,7 @@ services:
       - "CADENCE_GRPC_PEERS=cadence-cluster0:7833,cadence-cluster1:7833"
       - "CADENCE_GRPC_SERVICES_NAMES=cadence-frontend,cadence-frontend"
       - "CADENCE_CLUSTERS_NAMES=cluster0,cluster1"
+      - "CADENCE_HISTORY_PAGE_V2_ENABLED=OPT_OUT"
     ports:
       - "8088:8088"
     depends_on:


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
This PR enables the new Workflow History UI in cadence-web by setting the `CADENCE_HISTORY_PAGE_V2_ENABLED` env variable to `OPT_OUT`.

`OPT_OUT` enables the new UI by default, and gives users the option to view the workflow in the old UI if they need to.

**Why?**
The new Workflow History UI has been moved to open beta, and we want users to experience it without needing to set the configuration themselves.

**How did you test it?**
Ran `docker-compose -f docker/docker-compose-multiclusters.yml up` locally to verify.

**Potential risks**
None; users still have the option to fall back to the old UI if they need to.

**Release notes**
N/A

**Documentation Changes**
N/A
