### PR TITLE
feat(domain multi-tenancy): Add metrics for history task latency at task list level

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2809,6 +2809,12 @@ const (
 	VirtualQueuePausedGauge
 	VirtualQueueRunningGauge
 
+	TaskRequestsPerTaskList
+	ExponentialTaskLatencyPerTaskList
+	ExponentialTaskProcessingLatencyPerTaskList
+	ExponentialTaskQueueLatencyPerTaskList
+	ExponentialTaskScheduleLatencyPerTaskList
+
 	NumHistoryMetrics
 )
 
@@ -3378,6 +3384,14 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 		WorkflowTerminateCounterPerDomain:         {metricName: "workflow_terminate_counter_per_domain", metricRollupName: "workflow_terminate_counter", metricType: Counter},
 		TaskSchedulerAllowedCounterPerDomain:      {metricName: "task_scheduler_allowed_counter_per_domain", metricRollupName: "task_scheduler_allowed_counter", metricType: Counter},
 		TaskSchedulerThrottledCounterPerDomain:    {metricName: "task_scheduler_throttled_counter_per_domain", metricRollupName: "task_scheduler_throttled_counter", metricType: Counter},
+
+		// per task list task metrics
+
+		TaskRequestsPerTaskList:                     {metricName: "task_requests_per_task_list", metricType: Counter},
+		ExponentialTaskLatencyPerTaskList:           {metricName: "task_latency_per_task_list_ns", metricType: Histogram, exponentialBuckets: High1ms24h},
+		ExponentialTaskProcessingLatencyPerTaskList: {metricName: "task_latency_processing_per_task_list_ns", metricType: Histogram, exponentialBuckets: High1ms24h},
+		ExponentialTaskQueueLatencyPerTaskList:      {metricName: "task_latency_queue_per_task_list_ns", metricType: Histogram, exponentialBuckets: High1ms24h},
+		ExponentialTaskScheduleLatencyPerTaskList:   {metricName: "task_latency_schedule_per_task_list_ns", metricType: Histogram, exponentialBuckets: High1ms24h},
 
 		TaskBatchCompleteCounter:                                     {metricName: "task_batch_complete_counter", metricType: Counter},
 		TaskBatchCompleteFailure:                                     {metricName: "task_batch_complete_error", metricType: Counter},

--- a/common/util.go
+++ b/common/util.go
@@ -976,19 +976,9 @@ func IntersectionStringSlice(a, b []string) []string {
 	return result
 }
 
-// NewPerTaskListScope creates a tasklist metrics scope
-func NewPerTaskListScope(
-	domainName string,
-	taskListName string,
-	taskListKind types.TaskListKind,
-	client metrics.Client,
-	scopeIdx metrics.ScopeIdx,
-) metrics.Scope {
-	domainTag := metrics.DomainUnknownTag()
+// GetTaskListTag returns the task list tag for the given task list name and kind
+func GetTaskListTag(taskListName string, taskListKind types.TaskListKind) metrics.Tag {
 	taskListTag := metrics.TaskListUnknownTag()
-	if domainName != "" {
-		domainTag = metrics.DomainTag(domainName)
-	}
 	if taskListName != "" && taskListKind == types.TaskListKindNormal {
 		taskListTag = metrics.TaskListTag(taskListName)
 	}
@@ -998,5 +988,21 @@ func NewPerTaskListScope(
 	if taskListKind == types.TaskListKindEphemeral {
 		taskListTag = ephemeralTaskListMetricTag
 	}
+	return taskListTag
+}
+
+// NewPerTaskListScope creates a tasklist metrics scope
+func NewPerTaskListScope(
+	domainName string,
+	taskListName string,
+	taskListKind types.TaskListKind,
+	client metrics.Client,
+	scopeIdx metrics.ScopeIdx,
+) metrics.Scope {
+	domainTag := metrics.DomainUnknownTag()
+	if domainName != "" {
+		domainTag = metrics.DomainTag(domainName)
+	}
+	taskListTag := GetTaskListTag(taskListName, taskListKind)
 	return client.Scope(scopeIdx, domainTag, taskListTag)
 }

--- a/service/history/task/task.go
+++ b/service/history/task/task.go
@@ -200,14 +200,22 @@ func (t *taskImpl) Execute() error {
 	}
 
 	executionStartTime := t.timeSource.Now()
+	taskListTaggedScope := metrics.NoopScope
 	defer func() {
 		t.scope.IncCounter(metrics.TaskRequestsPerDomain)
-		t.scope.RecordTimer(metrics.TaskProcessingLatencyPerDomain, time.Since(executionStartTime))
-		t.scope.ExponentialHistogram(metrics.ExponentialTaskProcessingLatencyPerDomain, time.Since(executionStartTime))
+		processingLatency := time.Since(executionStartTime)
+		t.scope.RecordTimer(metrics.TaskProcessingLatencyPerDomain, processingLatency)
+		t.scope.ExponentialHistogram(metrics.ExponentialTaskProcessingLatencyPerDomain, processingLatency)
+
+		taskListTaggedScope.IncCounter(metrics.TaskRequestsPerTaskList)
+		taskListTaggedScope.ExponentialHistogram(metrics.ExponentialTaskProcessingLatencyPerTaskList, processingLatency)
 	}()
 	executeResponse, err := t.taskExecutor.Execute(t)
 	t.scope = executeResponse.Scope
+	taskListTaggedScope = t.scope.Tagged(common.GetTaskListTag(t.GetOriginalTaskList(), t.GetOriginalTaskListKind()))
 	if t.GetAttempt() == 0 {
+		taskListTaggedScope.ExponentialHistogram(metrics.ExponentialTaskScheduleLatencyPerTaskList, scheduleLatency)
+		// TODO: replace with ExponentialHistogram
 		// domain level metrics for the duration between task being submitted to task scheduler and being executed
 		t.scope.RecordHistogramDuration(metrics.TaskScheduleLatencyPerDomain, scheduleLatency)
 	}
@@ -375,13 +383,19 @@ func (t *taskImpl) Ack() {
 	if t.shouldProcessTask {
 		// Record attempt count as duration so timer mean ≈ average attempt count.
 		t.scope.RecordTimer(metrics.TaskAttemptTimerPerDomain, time.Duration(t.attempt))
+
+		latency := time.Since(t.initialSubmitTime)
+		queueLatency := time.Since(t.GetVisibilityTimestamp())
 		// Use IntExponentialHistogram with Mid1To16k buckets (1–64k) for attempt counts
 		t.scope.IntExponentialHistogram(metrics.ExponentialTaskAttemptCountsPerDomain, t.attempt)
-		t.scope.RecordTimer(metrics.TaskLatencyPerDomain, time.Since(t.initialSubmitTime))
-		t.scope.ExponentialHistogram(metrics.ExponentialTaskLatencyPerDomain, time.Since(t.initialSubmitTime))
-		t.scope.RecordTimer(metrics.TaskQueueLatencyPerDomain, time.Since(t.GetVisibilityTimestamp()))
-		t.scope.ExponentialHistogram(metrics.ExponentialTaskQueueLatencyPerDomain, time.Since(t.GetVisibilityTimestamp()))
+		t.scope.RecordTimer(metrics.TaskLatencyPerDomain, latency)
+		t.scope.ExponentialHistogram(metrics.ExponentialTaskLatencyPerDomain, latency)
+		t.scope.RecordTimer(metrics.TaskQueueLatencyPerDomain, queueLatency)
+		t.scope.ExponentialHistogram(metrics.ExponentialTaskQueueLatencyPerDomain, queueLatency)
 
+		taskListTaggedScope := t.scope.Tagged(common.GetTaskListTag(t.GetOriginalTaskList(), t.GetOriginalTaskListKind()))
+		taskListTaggedScope.ExponentialHistogram(metrics.ExponentialTaskLatencyPerTaskList, latency)
+		taskListTaggedScope.ExponentialHistogram(metrics.ExponentialTaskQueueLatencyPerTaskList, queueLatency)
 	}
 
 	if t.eventLogger != nil && t.shouldProcessTask && t.attempt != 0 {

--- a/service/history/task/task_test.go
+++ b/service/history/task/task_test.go
@@ -85,6 +85,8 @@ func (s *taskSuite) SetupTest() {
 	s.mockTaskRedispatcher = NewMockRedispatcher(s.controller)
 	s.mockTaskInfo = persistence.NewMockTask(s.controller)
 	s.mockTaskInfo.EXPECT().GetDomainID().Return(constants.TestDomainID).AnyTimes()
+	s.mockTaskInfo.EXPECT().GetOriginalTaskList().Return("test-task-list").AnyTimes()
+	s.mockTaskInfo.EXPECT().GetOriginalTaskListKind().Return(types.TaskListKindNormal).AnyTimes()
 	s.mockShard.Resource.DomainCache.EXPECT().GetDomainName(constants.TestDomainID).Return(constants.TestDomainName, nil).AnyTimes()
 
 	s.logger = testlogger.New(s.Suite.T())


### PR DESCRIPTION

<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Add metrics for history task latency at task list level

Related to https://github.com/cadence-workflow/cadence/issues/7724
**Why?**
We want to track the latency of history task processing at task list level.

**How did you test it?**
deployed to dev2 and verified manually

**Potential risks**
No

**Release notes**
N/A

**Documentation Changes**
N/A
