### PR TITLE
feat: Add SQLite support for domain audit

### DIFF
--- a/common/persistence/sql/sqlplugin/sqlite/sqlite_persistence_test.go
+++ b/common/persistence/sql/sqlplugin/sqlite/sqlite_persistence_test.go
@@ -113,5 +113,9 @@ func TestSQLiteConfigPersistence(t *testing.T) {
 }
 
 func TestSQLiteDomainAuditPersistence(t *testing.T) {
-	t.Skip("DomainAuditPersistence is only implemented for NoSQL/Cassandra in this PR")
+	s := new(pt.DomainAuditPersistenceSuite)
+	option := GetTestClusterOption()
+	s.TestBase = pt.NewTestBaseWithSQL(t, option)
+	s.TestBase.Setup()
+	suite.Run(t, s)
 }

--- a/schema/sqlite/cadence/schema.sql
+++ b/schema/sqlite/cadence/schema.sql
@@ -299,3 +299,21 @@ CREATE TABLE cluster_config
     data_encoding VARCHAR(16) NOT NULL,
     PRIMARY KEY (row_type, version)
 );
+
+CREATE TABLE domain_audit_log
+(
+    domain_id             VARCHAR(255) NOT NULL,
+    event_id              VARCHAR(255) NOT NULL,
+    --
+    state_before          BLOB         NOT NULL,
+    state_before_encoding VARCHAR(16)  NOT NULL,
+    state_after           BLOB         NOT NULL,
+    state_after_encoding  VARCHAR(16)  NOT NULL,
+    operation_type        INT          NOT NULL,
+    created_time          DATETIME(6)  NOT NULL,
+    last_updated_time     DATETIME(6)  NOT NULL,
+    identity              VARCHAR(255) NOT NULL,
+    identity_type         VARCHAR(255) NOT NULL,
+    comment               VARCHAR(255) NOT NULL DEFAULT '',
+    PRIMARY KEY (domain_id, operation_type, created_time, event_id)
+);

--- a/schema/sqlite/cadence/versioned/v0.2/domain_audit_log.sql
+++ b/schema/sqlite/cadence/versioned/v0.2/domain_audit_log.sql
@@ -1,0 +1,17 @@
+CREATE TABLE domain_audit_log
+(
+    domain_id             VARCHAR(255) NOT NULL,
+    event_id              VARCHAR(255) NOT NULL,
+    --
+    state_before          BLOB         NOT NULL,
+    state_before_encoding VARCHAR(16)  NOT NULL,
+    state_after           BLOB         NOT NULL,
+    state_after_encoding  VARCHAR(16)  NOT NULL,
+    operation_type        INT          NOT NULL,
+    created_time          DATETIME(6)  NOT NULL,
+    last_updated_time     DATETIME(6)  NOT NULL,
+    identity              VARCHAR(255) NOT NULL,
+    identity_type         VARCHAR(255) NOT NULL,
+    comment               VARCHAR(255) NOT NULL DEFAULT '',
+    PRIMARY KEY (domain_id, operation_type, created_time, event_id)
+);

--- a/schema/sqlite/cadence/versioned/v0.2/manifest.json
+++ b/schema/sqlite/cadence/versioned/v0.2/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.2",
+  "MinCompatibleVersion": "0.2",
+  "Description": "create domain_audit_log table",
+  "SchemaUpdateCqlFiles": [
+    "domain_audit_log.sql"
+  ]
+}

--- a/schema/sqlite/version.go
+++ b/schema/sqlite/version.go
@@ -23,7 +23,7 @@ package sqlite
 // NOTE: whenever there is a new data base schema update, plz update the following versions
 
 // Version is the SQLite database release version
-const Version = "0.1"
+const Version = "0.2"
 
 // VisibilityVersion is the SQLite visibility database release version
 const VisibilityVersion = "0.1"

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -142,7 +142,7 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDirFromEmbeddings() {
 	s.NoError(err)
 	ans, err = readSchemaDir(fsys, "0.1", "")
 	s.NoError(err)
-	s.Nil(ans, "no version dirs found after 0.1")
+	s.Equal([]string{"v0.2"}, ans)
 
 	fsys, err = fs.Sub(sqlite.SchemaFS, "visibility/versioned")
 	s.NoError(err)


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Added SQLite support for DomainAudit.

- Created domain_audit_log table in SQLite schema
- Updated the sql_doamin_audit_store and the domain_audit_log tables for PostgreSQL and MySQL to accept null values for Blobs

Fixes: #7604 

**Why?**
DomainAudit allows all modifications made to a domain (e.g failovers) to be stored and retrieved. This has previously only been supported by NoSQL databases (Cassandra, MongoDB, DynamoDB), MySQL and PostgreSQL. SQLite support for DomainAudit is now added.

**How did you test it?**
- Integration tests: Ran `TestSQLiteDomainAuditPersistence` on github actions

**Potential risks**
- SQLite schema is updated with a new table; it can be rolled back with SQLite database release version

**Release notes**
SQLite support is added for domain audit

**Documentation Changes**
N/A

---

**Detailed Description**
Added SQLite support for DomainAudit.

- Created domain_audit_log table in SQLite schema
- - Updated the sql_doamin_audit_store and the domain_audit_log tables for PostgreSQL and MySQL to accept null values for Blobs

**Impact Analysis**
- **Backward Compatibility**: SQLite support is integrated with existing domain audit logic
- **Forward Compatibility**: Does not change existing logic

**Testing Plan**
- **Unit Tests**: 
- **Persistence Tests**: Ran `TestSQLiteDomainAuditPersistence` on github actions
- **Integration Tests**: [Do we have integration test covering the change?]
- **Compatibility Tests**: [Have we done tests to test the backward and forward compatibility?]

**Rollout Plan**
- What is the rollout plan?
- Does the order of deployment matter?
- Is it safe to rollback? Does the order of rollback matter? MySQL schema is updated with a new table; it can be rolled back with MySQL database release version
- Is there a kill switch to mitigate the impact immediately?
---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)
