### PR TITLE
fix: Add select block in Offer function to handle the context timeout

### DIFF
--- a/service/matching/tasklist/matcher.go
+++ b/service/matching/tasklist/matcher.go
@@ -173,17 +173,18 @@ func (tm *taskMatcherImpl) Offer(ctx context.Context, task *InternalTask) (bool,
 				select {
 				case err := <-task.ResponseC:
 					tm.scope.RecordTimer(metrics.SyncMatchLocalPollLatencyPerTaskList, time.Since(startT))
-					if err == nil {
-						e.EventName = "Offer task due to local wait"
-						e.Payload = map[string]any{
-							"TaskIsForwarded": task.IsForwarded(),
-						}
-						event.Log(e)
+					if err != nil {
+						return false, err
 					}
-					return true, err
+					e.EventName = "Offer task due to local wait"
+					e.Payload = map[string]any{
+						"TaskIsForwarded": task.IsForwarded(),
+					}
+					event.Log(e)
+					return true, nil
 				// If the context expires while waiting for the poller's response
 				case <-ctx.Done():
-					return true, fmt.Errorf("waiting for sync match response: %w", ctx.Err())
+					return false, fmt.Errorf("waiting for sync match response: %w", ctx.Err())
 				}
 			}
 			return false, nil
@@ -199,10 +200,13 @@ func (tm *taskMatcherImpl) Offer(ctx context.Context, task *InternalTask) (bool,
 			select {
 			case err := <-task.ResponseC:
 				tm.scope.RecordTimer(metrics.SyncMatchLocalPollLatencyPerTaskList, time.Since(startT))
-				return true, err
+				if err != nil {
+					return false, err
+				}
+				return true, nil
 			// If the context expires while waiting for the poller's response
 			case <-ctx.Done():
-				return true, fmt.Errorf("waiting for sync match response: %w", ctx.Err())
+				return false, fmt.Errorf("waiting for sync match response: %w", ctx.Err())
 			}
 		}
 		return false, nil

--- a/service/matching/tasklist/matcher.go
+++ b/service/matching/tasklist/matcher.go
@@ -170,16 +170,21 @@ func (tm *taskMatcherImpl) Offer(ctx context.Context, task *InternalTask) (bool,
 			if task.ResponseC != nil {
 				// if there is a response channel, block until resp is received
 				// and return error if the response contains error
-				err := <-task.ResponseC
-				tm.scope.RecordTimer(metrics.SyncMatchLocalPollLatencyPerTaskList, time.Since(startT))
-				if err == nil {
-					e.EventName = "Offer task due to local wait"
-					e.Payload = map[string]any{
-						"TaskIsForwarded": task.IsForwarded(),
+				select {
+				case err := <-task.ResponseC:
+					tm.scope.RecordTimer(metrics.SyncMatchLocalPollLatencyPerTaskList, time.Since(startT))
+					if err == nil {
+						e.EventName = "Offer task due to local wait"
+						e.Payload = map[string]any{
+							"TaskIsForwarded": task.IsForwarded(),
+						}
+						event.Log(e)
 					}
-					event.Log(e)
+					return true, err
+				// If the context expires while waiting for the poller's response
+				case <-ctx.Done():
+					return false, nil
 				}
-				return true, err
 			}
 			return false, nil
 		case <-childCtx.Done():
@@ -191,9 +196,14 @@ func (tm *taskMatcherImpl) Offer(ctx context.Context, task *InternalTask) (bool,
 		if task.ResponseC != nil {
 			// if there is a response channel, block until resp is received
 			// and return error if the response contains error
-			err := <-task.ResponseC
-			tm.scope.RecordTimer(metrics.SyncMatchLocalPollLatencyPerTaskList, time.Since(startT))
-			return true, err
+			select {
+			case err := <-task.ResponseC:
+				tm.scope.RecordTimer(metrics.SyncMatchLocalPollLatencyPerTaskList, time.Since(startT))
+				return true, err
+			// If the context expires while waiting for the poller's response
+			case <-ctx.Done():
+				return false, nil
+			}
 		}
 		return false, nil
 	default:

--- a/service/matching/tasklist/matcher.go
+++ b/service/matching/tasklist/matcher.go
@@ -183,7 +183,7 @@ func (tm *taskMatcherImpl) Offer(ctx context.Context, task *InternalTask) (bool,
 					return true, err
 				// If the context expires while waiting for the poller's response
 				case <-ctx.Done():
-					return true, fmt.Errorf("expected response from the channel but time limit exceeded, couldn't confirm the result")
+					return true, fmt.Errorf("waiting for sync match response: %w", ctx.Err())
 				}
 			}
 			return false, nil
@@ -202,7 +202,7 @@ func (tm *taskMatcherImpl) Offer(ctx context.Context, task *InternalTask) (bool,
 				return true, err
 			// If the context expires while waiting for the poller's response
 			case <-ctx.Done():
-				return true, fmt.Errorf("expected response from the channel but time limit exceeded, couldn't confirm the result")
+				return true, fmt.Errorf("waiting for sync match response: %w", ctx.Err())
 			}
 		}
 		return false, nil

--- a/service/matching/tasklist/matcher.go
+++ b/service/matching/tasklist/matcher.go
@@ -183,7 +183,7 @@ func (tm *taskMatcherImpl) Offer(ctx context.Context, task *InternalTask) (bool,
 					return true, err
 				// If the context expires while waiting for the poller's response
 				case <-ctx.Done():
-					return false, nil
+					return true, fmt.Errorf("expected response from the channel but time limit exceeded, couldn't confirm the result")
 				}
 			}
 			return false, nil
@@ -202,7 +202,7 @@ func (tm *taskMatcherImpl) Offer(ctx context.Context, task *InternalTask) (bool,
 				return true, err
 			// If the context expires while waiting for the poller's response
 			case <-ctx.Done():
-				return false, nil
+				return true, fmt.Errorf("expected response from the channel but time limit exceeded, couldn't confirm the result")
 			}
 		}
 		return false, nil

--- a/service/matching/tasklist/matcher_test.go
+++ b/service/matching/tasklist/matcher_test.go
@@ -762,7 +762,7 @@ func (t *MatcherTestSuite) TestOffer_NoTimeoutSyncMatchedError() {
 	wait()
 
 	t.Error(err)
-	t.True(syncMatched)
+	t.False(syncMatched)
 }
 
 func (t *MatcherTestSuite) TestOffer_NoTimeoutAsyncMatchedNoError() {

--- a/service/matching/tasklist/matcher_test.go
+++ b/service/matching/tasklist/matcher_test.go
@@ -136,7 +136,7 @@ func (t *MatcherTestSuite) TestLocalSyncMatchTimeout() {
 	cancel()
 	wait()
 	t.Error(err)
-	t.True(syncMatch)
+	t.False(syncMatch)
 }
 
 func (t *MatcherTestSuite) TestIsolationLocalSyncMatch() {

--- a/service/matching/tasklist/matcher_test.go
+++ b/service/matching/tasklist/matcher_test.go
@@ -117,6 +117,28 @@ func (t *MatcherTestSuite) TestLocalSyncMatch() {
 	t.True(syncMatch)
 }
 
+func (t *MatcherTestSuite) TestLocalSyncMatchTimeout() {
+	t.disableRemoteForwarding()
+
+	wait := ensureAsyncReady(5*time.Second, func(ctx context.Context) {
+		task, err := t.matcher.Poll(ctx, "")
+		if err == nil {
+			time.Sleep(500 * time.Millisecond) // Slowly poll the task
+			task.Finish(nil)
+		}
+	})
+
+	task := newInternalTask(t.newTaskInfo(), nil, types.TaskSourceHistory, "", true, nil, "")
+
+	// Set context timeout smaller than poller waiting time
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	syncMatch, err := t.matcher.Offer(ctx, task)
+	cancel()
+	wait()
+	t.NoError(err)
+	t.False(syncMatch)
+}
+
 func (t *MatcherTestSuite) TestIsolationLocalSyncMatch() {
 	const isolationGroup = "dca1"
 

--- a/service/matching/tasklist/matcher_test.go
+++ b/service/matching/tasklist/matcher_test.go
@@ -761,6 +761,7 @@ func (t *MatcherTestSuite) TestOffer_NoTimeoutSyncMatchedError() {
 	cancel()
 	wait()
 
+	// If there is an error in ResponseC, Offer should return an error with syncMatch failed
 	t.Error(err)
 	t.False(syncMatched)
 }

--- a/service/matching/tasklist/matcher_test.go
+++ b/service/matching/tasklist/matcher_test.go
@@ -135,8 +135,8 @@ func (t *MatcherTestSuite) TestLocalSyncMatchTimeout() {
 	syncMatch, err := t.matcher.Offer(ctx, task)
 	cancel()
 	wait()
-	t.NoError(err)
-	t.False(syncMatch)
+	t.Error(err)
+	t.True(syncMatch)
 }
 
 func (t *MatcherTestSuite) TestIsolationLocalSyncMatch() {

--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -836,19 +836,27 @@ func (c *taskListManagerImpl) TaskListID() *Identifier {
 	return c.taskListID
 }
 
+// trySyncMatch performs to match the domain synchronously.
 func (c *taskListManagerImpl) trySyncMatch(ctx context.Context, params AddTaskParams, isolationGroup string) (bool, error) {
+	// Create a new InternalTask struct using paramters to make the task processable in the matcher.
 	task := newInternalTask(params.TaskInfo, nil, params.Source, params.ForwardedFrom, true, params.ActivityTaskDispatchInfo, isolationGroup)
 	childCtx := ctx
 	cancel := func() {}
+
+	// Decide how long to spend the time to sync match
 	waitTime := maxSyncMatchWaitTime
 	if params.ActivityTaskDispatchInfo != nil {
 		waitTime = c.config.ActivityTaskSyncMatchWaitTime(params.ActivityTaskDispatchInfo.WorkflowDomain)
 	}
+
+	// Cap the context deadline
 	if !task.IsForwarded() {
 		// when task is forwarded from another matching host, we trust the context as is
 		// otherwise, we override to limit the amount of time we can block on sync match
 		childCtx, cancel = c.newChildContext(ctx, waitTime, time.Second)
 	}
+
+	// Route to the right matcher method
 	var matched bool
 	var err error
 	if params.ActivityTaskDispatchInfo != nil {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

- Add context timeout handle code block using `select` clause in `Offer` function
- Implemented simple unit test case to check if the `Offer` returns false if context timeout occurs
- `Offer` function returns `false` with an error message if the `ResponseC` has an error.
- `Offer` function returns `false` with an error message if the context has been timed out.
- Returning `false` with error means that task scheduler persist the failed task into backlog to match it again asynchronously which makes more efficient than `true` with an error message. Because if this returns `true`, matcher retires the sync match, that occurs more execution time than asynchronous way.
- I assume that persistence layer ensure the Idempotency when writing the backlog.

**Why?**

- PR#7709 resolved some case to respect the context time out, but not fully resolved.
- This PR solves the unresolved context timeout problem start from `appendTask`
- Reference: #7642 

**How did you test it?**

- Implemented unit test
```bash
go test -v ./service/matching/...
```

- Ran entire unit tests locally

**Potential risks**


**Release notes**


**Documentation Changes**

