### PR TITLE
chore(docker): add compose override for local server development

### DIFF
--- a/docker/docker-compose-local.override.yaml
+++ b/docker/docker-compose-local.override.yaml
@@ -1,0 +1,22 @@
+# Override file for running the Cadence server natively on the host machine
+# while keeping infrastructure dependencies (Cassandra, Kafka, ES, etc.) in Docker.
+#
+# Usage:
+#   docker compose -f docker/docker-compose-es-v7.yml -f docker/docker-compose-local.override.yaml up
+#
+# The cadence service is replaced with a no-op container so that only the
+# infrastructure services start. Kafka advertises on 127.0.0.1 so the
+# host-running server can reach it, and cadence-web points back to the host.
+services:
+  cadence:
+    image: busybox
+    entrypoint: ["true"]
+    ports: !reset []
+    environment: !reset []
+    depends_on: !reset {}
+  kafka:
+    environment:
+      - "KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092"
+  cadence-web:
+    environment:
+      - "CADENCE_GRPC_PEERS=host.docker.internal:7833"


### PR DESCRIPTION
**What changed?**

Added `docker/docker-compose-local-server.yml` — a docker-compose override file that stubs out the Cadence server container while keeping all infrastructure dependencies running in Docker.

**Why?**

Working on and testing the Cadence server and system workflows locally is difficult because of the heavy infrastructure requirements (Elasticsearch, Kafka, Cassandra, Prometheus, Grafana). The existing docker-compose files bundle the server with these dependencies, forcing developers to either run everything in Docker (losing native debugging, fast rebuild cycles, and IDE integration) or manually set up each dependency.

This override file lets developers run only the infrastructure in Docker while running the server natively from the local repository. It:
- Replaces the Cadence server container with a no-op `busybox` stub
- Reconfigures Kafka to advertise on `127.0.0.1` so the host-running server can connect
- Points `cadence-web` to `host.docker.internal` to reach the locally running server

Usage:
```bash
# Start infrastructure dependencies
docker compose -f docker/docker-compose-es-v7.yml -f docker/docker-compose-local-server.yml up

# Install schema (first time only)
make bins && make install-schema

# Run the server locally
./cadence-server start
```

**How did you test it?**

1. Started infrastructure with the override:
   `docker compose -f docker/docker-compose-es-v7.yml -f docker/docker-compose-local-server.yml up`
2. Installed schema: `make install-schema`
3. Built and ran the server locally: `make cadence-server && ./cadence-server start`
4. Verified `cadence-web` at `localhost:8088` connects to the local server
5. Validated merged compose config: `docker compose -f docker/docker-compose-es-v7.yml -f docker/docker-compose-local-server.yml config`

**Potential risks**

None. This is a new additive file with no changes to existing files. Requires Docker Compose v2.24+ for `!reset` directive support.

**Release notes**

N/A — developer tooling only.

**Documentation Changes**

Could add a note to CONTRIBUTING.md about this local development option, but not strictly required as the file is self-documenting with usage instructions in the header comments.