### PR TITLE
fix(domain multi-tenancy): hold root ref during enqueue to prevent cleanup race

### DIFF
--- a/common/task/hierarchical_weighted_round_robin_task_pool.go
+++ b/common/task/hierarchical_weighted_round_robin_task_pool.go
@@ -111,9 +111,9 @@ func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K, T]) Enqueue(task T) error
 		return err
 	}
 	var err error
+	p.root.c.IncRef()
+	defer p.root.c.DecRef()
 	p.root.executeAtPath(weightedKeys, p.bufferSize, func(c *TTLChannel[T]) int64 {
-		c.IncRef()
-		defer c.DecRef()
 		select {
 		case c.Chan() <- task:
 			c.UpdateLastWriteTime(p.timeSource.Now())
@@ -132,9 +132,9 @@ func (p *hierarchicalWeightedRoundRobinTaskPoolImpl[K, T]) TryEnqueue(task T) (b
 		return false, err
 	}
 	var err error
+	p.root.c.IncRef()
+	defer p.root.c.DecRef()
 	delta := p.root.executeAtPath(weightedKeys, p.bufferSize, func(c *TTLChannel[T]) int64 {
-		c.IncRef()
-		defer c.DecRef()
 		select {
 		case c.Chan() <- task:
 			c.UpdateLastWriteTime(p.timeSource.Now())

--- a/common/task/iwrr_node.go
+++ b/common/task/iwrr_node.go
@@ -58,6 +58,9 @@ func newiwrrNode[K comparable, V any](bufferSize int) *iwrrNode[K, V] {
 // After executing the callback, the drainSelfFirst flag is set to indicate children should
 // be drained first, and the childrenItemCount is updated with the delta from the callback.
 //
+// Note: The parent node is responsible for incrementing the reference count of the child node's channel,
+// so that the subtree is not cleaned up while the parent is trying to change the subtree structure.
+//
 // Parameters:
 //   - path: slice of WeightedKey representing the hierarchical path to the target node
 //   - bufferSize: buffer size for any newly created nodes


### PR DESCRIPTION


<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Remove IncRef/DecRef from the callback
- Change the reference count of root node for executeAtPath method
- Add comments explaining the contract of executeAtPath method
Related to https://github.com/cadence-workflow/cadence/issues/7724

The change moves IncRef/DecRef from the leaf channel to the root node before executeAtPath, ensuring the subtree cannot be cleaned up between path traversal and channel write. Also adds a doc comment explaining this contract.

**Why?**
We want to prevent a subtree from being cleaned up by the cleanup method while another thread is expanding the subtree. The contract is that each node's reference count should be incremented by 1 when the parent is trying to call the child's executeAtPath method, otherwise the child node's cleanup method may return true even though the parent is still trying to modify the child's subtree through the recursive calls of executeAtPath method.

Even though we never removes the root node when cleanup returns true, this change makes the root node's cleanup behavior consistent with other nodes while some goroutine is calling executeAtPath method on root node.

The reference count change in the callback is also unnecessary because it's changed in the parent node.

**How did you test it?**
cd common/task && go test ./...

**Potential risks**
No.

**Release notes**
N/A

**Documentation Changes**
N/A
