### PR TITLE
test(domain multi-tenancy): Run integration tests with new history scheduler

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -1,5 +1,5 @@
 name: CI Checks
-on: 
+on:
   push:
   pull_request:
 
@@ -7,7 +7,7 @@ jobs:
   idl-submodule-points-to-master:
     name: IDL submodule points to master
     runs-on: ubuntu-latest # uses ubuntu as runner
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,7 +21,7 @@ jobs:
   golang-unit-test:
     name: Golang unit test
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.23.4'
-      
+
       - name: Run unit test
         uses: nick-fields/retry@v3
         with:
@@ -133,8 +133,8 @@ jobs:
           name: go-cassandra-running-history-queue-v2-integration-coverage
           path: .build/coverage/*.out
 
-  golang-integration-test-with-cassandra-running-history-queue-v2-alert:
-    name: Golang integration test with running history queue v2 with alert
+  golang-integration-test-with-cassandra-new-features:
+    name: Golang integration test for new features with cassandra
     runs-on: ubuntu-latest
     continue-on-error: true
 
@@ -149,19 +149,19 @@ jobs:
         with:
           go-version: '1.23.4'
 
-      - name: Run integration profile for cassandra running history queue v2 with alert
+      - name: Run integration profile for new features with cassandra
         uses: nick-fields/retry@v3
         with:
           max_attempts: 2
           timeout_minutes: 30
           command: |
-            docker compose -f docker/github_actions/docker-compose.yml run integration-test-cassandra-queue-v2-alert bash -c "make .just-build && make cover_integration_profile"
+            docker compose -f docker/github_actions/docker-compose.yml run integration-test-cassandra-new-features bash -c "make .just-build && make cover_integration_profile"
 
       - name: Upload coverage artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: go-cassandra-running-history-queue-v2-alert-integration-coverage
+          name: go-cassandra-new-features-integration-coverage
           path: .build/coverage/*.out
 
 
@@ -323,7 +323,7 @@ jobs:
         with:
           name: go-mysql-integration-coverage
           path: .build/coverage/*.out
-          
+
 
   golang-integration-ndc-test-with-mysql:
     name: Golang integration ndc test with mysql
@@ -348,7 +348,7 @@ jobs:
           timeout_minutes: 30
           command: |
             docker compose -f docker/github_actions/docker-compose.yml run integration-test-ndc-mysql bash -c "make .just-build && make cover_ndc_profile"
-      
+
       - name: Upload coverage artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -387,7 +387,7 @@ jobs:
         with:
           name: go-postgres-integration-coverage
           path: .build/coverage/*.out
-             
+
 
   golang-integration-test-with-sqlite:
     name: Golang integration test with sqlite

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ dockerize
 # SQLite databases
 cadence.db*
 cadence_visibility.db*
+
+.claude/
+.mcp.json
+.mcp.json.bak

--- a/docker/github_actions/docker-compose.yml
+++ b/docker/github_actions/docker-compose.yml
@@ -159,7 +159,7 @@ services:
         aliases:
           - integration-test
 
-  integration-test-cassandra-queue-v2-alert:
+  integration-test-cassandra-new-features:
     build:
       context: ../../
       dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
@@ -169,8 +169,7 @@ services:
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"
       - "TEST_TAG=esintegration"
-      - "ENABLE_QUEUE_V2=true"
-      - "ENABLE_QUEUE_V2_ALERT=true"
+      - "ENABLE_NEW_FEATURES=true"
     depends_on:
       cassandra:
         condition: service_healthy

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -53,9 +53,9 @@ func TestIntegrationSuite(t *testing.T) {
 	// TODO: remove this logic once we deprecate history queue v1
 	if os.Getenv("ENABLE_QUEUE_V2") == "true" {
 		configPath = "testdata/integration_queuev2_cluster.yaml"
-		if os.Getenv("ENABLE_QUEUE_V2_ALERT") == "true" {
-			configPath = "testdata/integration_queuev2_with_alert_cluster.yaml"
-		}
+	}
+	if os.Getenv("ENABLE_NEW_FEATURES") == "true" {
+		configPath = "testdata/integration_new_features_cluster.yaml"
 	}
 	clusterConfig, err := GetTestClusterConfig(configPath)
 	if err != nil {

--- a/host/testdata/dynamicconfig/integration_new_features_test.yaml
+++ b/host/testdata/dynamicconfig/integration_new_features_test.yaml
@@ -57,3 +57,9 @@ history.queueMaxPendingTaskCount:
 history.queueCriticalPendingTaskCount:
 - value: 18
   constraints: {}
+history.enableHierarchicalWeightedRoundRobinTaskScheduler:
+- value: true
+  constraints: {}
+history.enableTaskListAwareTaskSchedulerByDomain:
+- value: true
+  constraints: {}

--- a/host/testdata/integration_new_features_cluster.yaml
+++ b/host/testdata/integration_new_features_cluster.yaml
@@ -12,5 +12,5 @@ workerconfig:
   enablereplicator: true
   enableindexer: false
 dynamicclientconfig:
-  filepath: "testdata/dynamicconfig/integration_queuev2_with_alert_test.yaml"
+  filepath: "testdata/dynamicconfig/integration_new_features_test.yaml"
   pollInterval: "10s"


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Repurpose existing history queue v2 with alert integration tests to be a generic integration tests for new features
- Update the integration tests for new features to test new history scheduler
Related to https://github.com/cadence-workflow/cadence/issues/7724

**Why?**
- Test new history scheduler which was introduced in https://github.com/cadence-workflow/cadence/pull/7807 in integration test
- Also provide an easy way to run integration tests for new features behind feature flags

**How did you test it?**
make pr

**Potential risks**
No.

**Release notes**
N/A

**Documentation Changes**
N/A
