### PR TITLE
fix(matching): add timeout to notifyPartitionConfig during startup

### DIFF
--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -63,6 +63,8 @@ const (
 	returnEmptyTaskTimeBudget = time.Second
 	noIsolationTimeout        = time.Duration(0)
 	minimumIsolationDuration  = time.Millisecond * 50
+
+	notifyPartitionConfigTimeout = 5 * time.Second
 )
 
 var (
@@ -295,7 +297,9 @@ func (c *taskListManagerImpl) Start(ctx context.Context) error {
 			c.stopWG.Add(1)
 			go func() {
 				defer c.stopWG.Done()
-				c.notifyPartitionConfig(context.Background(), nil, startConfig)
+				ctx, cancel := context.WithTimeout(context.Background(), notifyPartitionConfigTimeout)
+				defer cancel()
+				c.notifyPartitionConfig(ctx, nil, startConfig)
 			}()
 		}
 	}


### PR DESCRIPTION
**What changed?**

Added a 5-second timeout to the `notifyPartitionConfig` call in the task list manager `Start()` goroutine. Previously this used `context.Background()` which has no timeout.

**Why?**

When inter-partition RPCs hang (e.g., during DB unavailability), the goroutine blocks indefinitely. Since `Stop()` waits on `stopWG` which includes this goroutine, `Stop()` also blocks forever. This cascades to block heartbeats to shard-distributor, causing executors to be marked stale.

Root cause: https://github.com/uber/cadence/blob/master/service/matching/tasklist/task_list_manager.go#L297

**How did you test it?**

Existing unit tests pass. The change is minimal - adds a timeout wrapper around an existing context.

**Potential risks**

Low. If the notification RPC takes longer than 5 seconds, it will be cancelled. This is preferable to blocking forever.

**Release notes**

Fixed a deadlock in matching service where task list manager `Stop()` could block indefinitely if partition config notification RPCs hung.

**Documentation Changes**

None required.