### PR TITLE
refactor(quotas): generalize LimiterFactory/Collection with type params and pass Info struct to allowDomain                                                                                                                          

### DIFF
--- a/common/dynamicconfig/quotas/dynamicratelimiterfactory.go
+++ b/common/dynamicconfig/quotas/dynamicratelimiterfactory.go
@@ -29,7 +29,7 @@ import (
 
 // NewSimpleDynamicRateLimiterFactory creates a new LimiterFactory which creates
 // a new DynamicRateLimiter for each domain, the RPS for the DynamicRateLimiter is given by the dynamic config
-func NewSimpleDynamicRateLimiterFactory(rps dynamicproperties.IntPropertyFnWithDomainFilter) quotas.LimiterFactory {
+func NewSimpleDynamicRateLimiterFactory(rps dynamicproperties.IntPropertyFnWithDomainFilter) quotas.LimiterFactory[string] {
 	return dynamicRateLimiterFactory{
 		rps: rps,
 	}

--- a/common/dynamicconfig/quotas/fallbackdynamicratelimiterfactory.go
+++ b/common/dynamicconfig/quotas/fallbackdynamicratelimiterfactory.go
@@ -33,7 +33,7 @@ import (
 func NewFallbackDynamicRateLimiterFactory(
 	primary dynamicproperties.IntPropertyFnWithDomainFilter,
 	secondary dynamicproperties.IntPropertyFn,
-) quotas.LimiterFactory {
+) quotas.LimiterFactory[string] {
 	return fallbackDynamicRateLimiterFactory{
 		primary:   primary,
 		secondary: secondary,

--- a/common/quotas/collection.go
+++ b/common/quotas/collection.go
@@ -28,36 +28,36 @@ import (
 )
 
 // LimiterFactory is used to create a Limiter for a given domain
-type LimiterFactory interface {
+type LimiterFactory[K comparable] interface {
 	// GetLimiter returns a new Limiter for the given domain
-	GetLimiter(domain string) Limiter
+	GetLimiter(key K) Limiter
 }
 
 // Collection stores a map of limiters by key
-type Collection struct {
+type Collection[K comparable] struct {
 	mu       sync.RWMutex
-	factory  LimiterFactory
-	limiters map[string]Limiter
+	factory  LimiterFactory[K]
+	limiters map[K]Limiter
 }
 
-type ICollection interface {
-	For(key string) Limiter
+type ICollection[K comparable] interface {
+	For(key K) Limiter
 }
 
-var _ ICollection = (*Collection)(nil)
+var _ ICollection[string] = (*Collection[string])(nil)
 
 // NewCollection create a new limiter collection.
 // Given factory is called to create new individual limiter.
-func NewCollection(factory LimiterFactory) *Collection {
-	return &Collection{
+func NewCollection[K comparable](factory LimiterFactory[K]) *Collection[K] {
+	return &Collection[K]{
 		factory:  factory,
-		limiters: make(map[string]Limiter),
+		limiters: make(map[K]Limiter),
 	}
 }
 
 // For retrieves limiter by a given key.
 // If limiter for such key does not exists, it creates new one with via factory.
-func (c *Collection) For(key string) Limiter {
+func (c *Collection[K]) For(key K) Limiter {
 	c.mu.RLock()
 	limiter, ok := c.limiters[key]
 	c.mu.RUnlock()

--- a/common/quotas/collection_mock.go
+++ b/common/quotas/collection_mock.go
@@ -16,31 +16,31 @@ import (
 )
 
 // MockICollection is a mock of ICollection interface.
-type MockICollection struct {
+type MockICollection[K comparable] struct {
 	ctrl     *gomock.Controller
-	recorder *MockICollectionMockRecorder
+	recorder *MockICollectionMockRecorder[K]
 	isgomock struct{}
 }
 
 // MockICollectionMockRecorder is the mock recorder for MockICollection.
-type MockICollectionMockRecorder struct {
-	mock *MockICollection
+type MockICollectionMockRecorder[K comparable] struct {
+	mock *MockICollection[K]
 }
 
 // NewMockICollection creates a new mock instance.
-func NewMockICollection(ctrl *gomock.Controller) *MockICollection {
-	mock := &MockICollection{ctrl: ctrl}
-	mock.recorder = &MockICollectionMockRecorder{mock}
+func NewMockICollection[K comparable](ctrl *gomock.Controller) *MockICollection[K] {
+	mock := &MockICollection[K]{ctrl: ctrl}
+	mock.recorder = &MockICollectionMockRecorder[K]{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockICollection) EXPECT() *MockICollectionMockRecorder {
+func (m *MockICollection[K]) EXPECT() *MockICollectionMockRecorder[K] {
 	return m.recorder
 }
 
 // For mocks base method.
-func (m *MockICollection) For(key string) Limiter {
+func (m *MockICollection[K]) For(key K) Limiter {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "For", key)
 	ret0, _ := ret[0].(Limiter)
@@ -48,7 +48,7 @@ func (m *MockICollection) For(key string) Limiter {
 }
 
 // For indicates an expected call of For.
-func (mr *MockICollectionMockRecorder) For(key any) *gomock.Call {
+func (mr *MockICollectionMockRecorder[K]) For(key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "For", reflect.TypeOf((*MockICollection)(nil).For), key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "For", reflect.TypeOf((*MockICollection[K])(nil).For), key)
 }

--- a/common/quotas/global/collection/collection.go
+++ b/common/quotas/global/collection/collection.go
@@ -92,7 +92,7 @@ type (
 
 		global   *internal.AtomicMap[shared.LocalKey, *internal.FallbackLimiter]
 		local    *internal.AtomicMap[shared.LocalKey, internal.CountedLimiter]
-		disabled quotas.ICollection
+		disabled quotas.ICollection[string]
 		km       shared.KeyMapper
 
 		ctx       context.Context // context used for background operations, canceled when stopping
@@ -161,13 +161,13 @@ func New(
 	name string,
 	// quotas for "local only" behavior.
 	// used for both "local" and "disabled" behavior, though "local" wraps the values with usage metrics.
-	local quotas.ICollection,
+	local quotas.ICollection[string],
 	// quotas for the global limiter's internal fallback.
 	//
 	// this should be configured the same as the local collection, but it
 	// MUST NOT actually be the same collection, or shadowing will double-count
 	// events on the fallback.
-	globalFallback quotas.ICollection,
+	globalFallback quotas.ICollection[string],
 	updateInterval dynamicproperties.DurationPropertyFn,
 	targetRPS dynamicproperties.IntPropertyFnWithDomainFilter,
 	keyModes dynamicproperties.StringPropertyWithRatelimitKeyFilter,

--- a/common/quotas/global/collection/collection_test.go
+++ b/common/quotas/global/collection/collection_test.go
@@ -54,8 +54,8 @@ func TestLifecycleBasics(t *testing.T) {
 	logger, logs := testlogger.NewObserved(t)
 	c, err := New(
 		"test",
-		quotas.NewCollection(quotas.NewMockLimiterFactory(ctrl)),
-		quotas.NewCollection(quotas.NewMockLimiterFactory(ctrl)),
+		quotas.NewCollection[string](quotas.NewMockLimiterFactory[string](ctrl)),
+		quotas.NewCollection[string](quotas.NewMockLimiterFactory[string](ctrl)),
 		func(opts ...dynamicproperties.FilterOption) time.Duration { return time.Second },
 		nil, // not used
 		func(globalRatelimitKey string) string { return string(modeGlobal) },

--- a/common/quotas/limiterfactory_mock.go
+++ b/common/quotas/limiterfactory_mock.go
@@ -16,39 +16,39 @@ import (
 )
 
 // MockLimiterFactory is a mock of LimiterFactory interface.
-type MockLimiterFactory struct {
+type MockLimiterFactory[K comparable] struct {
 	ctrl     *gomock.Controller
-	recorder *MockLimiterFactoryMockRecorder
+	recorder *MockLimiterFactoryMockRecorder[K]
 	isgomock struct{}
 }
 
 // MockLimiterFactoryMockRecorder is the mock recorder for MockLimiterFactory.
-type MockLimiterFactoryMockRecorder struct {
-	mock *MockLimiterFactory
+type MockLimiterFactoryMockRecorder[K comparable] struct {
+	mock *MockLimiterFactory[K]
 }
 
 // NewMockLimiterFactory creates a new mock instance.
-func NewMockLimiterFactory(ctrl *gomock.Controller) *MockLimiterFactory {
-	mock := &MockLimiterFactory{ctrl: ctrl}
-	mock.recorder = &MockLimiterFactoryMockRecorder{mock}
+func NewMockLimiterFactory[K comparable](ctrl *gomock.Controller) *MockLimiterFactory[K] {
+	mock := &MockLimiterFactory[K]{ctrl: ctrl}
+	mock.recorder = &MockLimiterFactoryMockRecorder[K]{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockLimiterFactory) EXPECT() *MockLimiterFactoryMockRecorder {
+func (m *MockLimiterFactory[K]) EXPECT() *MockLimiterFactoryMockRecorder[K] {
 	return m.recorder
 }
 
 // GetLimiter mocks base method.
-func (m *MockLimiterFactory) GetLimiter(domain string) Limiter {
+func (m *MockLimiterFactory[K]) GetLimiter(key K) Limiter {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLimiter", domain)
+	ret := m.ctrl.Call(m, "GetLimiter", key)
 	ret0, _ := ret[0].(Limiter)
 	return ret0
 }
 
 // GetLimiter indicates an expected call of GetLimiter.
-func (mr *MockLimiterFactoryMockRecorder) GetLimiter(domain any) *gomock.Call {
+func (mr *MockLimiterFactoryMockRecorder[K]) GetLimiter(key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLimiter", reflect.TypeOf((*MockLimiterFactory)(nil).GetLimiter), domain)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLimiter", reflect.TypeOf((*MockLimiterFactory[K])(nil).GetLimiter), key)
 }

--- a/common/quotas/multistageratelimiter.go
+++ b/common/quotas/multistageratelimiter.go
@@ -24,13 +24,13 @@ import "context"
 
 // MultiStageRateLimiter indicates a domain specific rate limit policy
 type MultiStageRateLimiter struct {
-	domainLimiters ICollection
+	domainLimiters ICollection[string]
 	globalLimiter  Limiter
 }
 
 // NewMultiStageRateLimiter returns a new domain quota rate limiter. This is about
 // an order of magnitude slower than
-func NewMultiStageRateLimiter(global Limiter, domainLimiters ICollection) *MultiStageRateLimiter {
+func NewMultiStageRateLimiter(global Limiter, domainLimiters ICollection[string]) *MultiStageRateLimiter {
 	return &MultiStageRateLimiter{
 		domainLimiters: domainLimiters,
 		globalLimiter:  global,

--- a/common/quotas/permember/permember.go
+++ b/common/quotas/permember/permember.go
@@ -53,7 +53,7 @@ func NewPerMemberDynamicRateLimiterFactory(
 	globalRPS dynamicproperties.IntPropertyFnWithDomainFilter,
 	instanceRPS dynamicproperties.IntPropertyFnWithDomainFilter,
 	resolver membership.Resolver,
-) quotas.LimiterFactory {
+) quotas.LimiterFactory[string] {
 	return perMemberFactory{
 		service:     service,
 		globalRPS:   globalRPS,

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -220,11 +220,11 @@ type globalRatelimiterCollections struct {
 // - "local" limits, which do not use global-load-balancing to adjust to request load
 // - fallbacks within "global" limits, for when the global-load information cannot be retrieved (startup, errors, etc)
 type ratelimiterCollections struct {
-	user, worker, visibility, async *quotas.Collection
+	user, worker, visibility, async *quotas.Collection[string]
 }
 
 func (s *Service) createGlobalQuotaCollections() (globalRatelimiterCollections, error) {
-	create := func(name string, local, global *quotas.Collection, targetRPS dynamicproperties.IntPropertyFnWithDomainFilter) (*collection.Collection, error) {
+	create := func(name string, local, global *quotas.Collection[string], targetRPS dynamicproperties.IntPropertyFnWithDomainFilter) (*collection.Collection, error) {
 		c, err := collection.New(
 			name,
 			local,
@@ -268,7 +268,7 @@ func (s *Service) createGlobalQuotaCollections() (globalRatelimiterCollections, 
 	}, combinedErr
 }
 func (s *Service) createBaseLimiters() ratelimiterCollections {
-	create := func(shared, perInstance dynamicproperties.IntPropertyFnWithDomainFilter) *quotas.Collection {
+	create := func(shared, perInstance dynamicproperties.IntPropertyFnWithDomainFilter) *quotas.Collection[string] {
 		return quotas.NewCollection(permember.NewPerMemberDynamicRateLimiterFactory(
 			service.Frontend,
 			shared,

--- a/service/frontend/templates/ratelimited.tmpl
+++ b/service/frontend/templates/ratelimited.tmpl
@@ -64,6 +64,7 @@ import (
 {{$domainIDAPIs := list "RecordActivityTaskHeartbeat" "RespondActivityTaskCanceled" "RespondActivityTaskCompleted" "RespondActivityTaskFailed" "RespondDecisionTaskCompleted" "RespondDecisionTaskFailed" "RespondQueryTaskCompleted"}}
 {{$queryTaskTokenAPIs := list "RespondQueryTaskCompleted"}}
 {{$nonBlockingAPIs := list "RecordActivityTaskHeartbeat" "RecordActivityTaskHeartbeatByID" "RespondActivityTaskCompleted" "RespondActivityTaskCompletedByID" "RespondActivityTaskFailed" "RespondActivityTaskFailedByID" "RespondActivityTaskCanceled" "RespondActivityTaskCanceledByID" "RespondDecisionTaskCompleted" "RespondDecisionTaskFailed" "RespondQueryTaskCompleted" "ResetStickyTaskList"}}
+{{$taskListAPIs := list }}
 
 {{$interfaceName := .Interface.Name}}
 {{$handlerName := (index .Vars "handler")}}
@@ -147,9 +148,9 @@ func (h *{{$decorator}}) {{$method.Declaration}} {
         {{- if has $method.Name $nonBlockingAPIs}}
             // Count the request in the host RPS,
             // but we still accept it even if RPS is exceeded
-            h.allowDomain({{(index $method.Params 0).Name}}, {{$ratelimitType}}, {{$domain}})
+            h.allowDomain({{(index $method.Params 0).Name}}, {{$ratelimitType}}, quotas.Info{Domain: {{$domain}}})
         {{- else}}
-            if limitErr := h.allowDomain({{(index $method.Params 0).Name}}, {{$ratelimitType}}, {{$domain}}); limitErr != nil {
+            if limitErr := h.allowDomain({{(index $method.Params 0).Name}}, {{$ratelimitType}}, quotas.Info{Domain: {{$domain}}{{if has $method.Name $taskListAPIs}}, TaskList: {{(index $method.Params 1).Name}}.GetTaskList().GetName(){{end}}}); limitErr != nil {
                 err = limitErr
                 return
             }

--- a/service/frontend/wrappers/ratelimited/api_generated.go
+++ b/service/frontend/wrappers/ratelimited/api_generated.go
@@ -62,7 +62,7 @@ func (h *apiHandler) CountWorkflowExecutions(ctx context.Context, cp1 *types.Cou
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeVisibility, cp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeVisibility, quotas.Info{Domain: cp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -90,7 +90,7 @@ func (h *apiHandler) DescribeTaskList(ctx context.Context, dp1 *types.DescribeTa
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, dp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, quotas.Info{Domain: dp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -106,7 +106,7 @@ func (h *apiHandler) DescribeWorkflowExecution(ctx context.Context, dp1 *types.D
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, dp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, quotas.Info{Domain: dp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -122,7 +122,7 @@ func (h *apiHandler) DiagnoseWorkflowExecution(ctx context.Context, dp1 *types.D
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, dp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, quotas.Info{Domain: dp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -138,7 +138,7 @@ func (h *apiHandler) FailoverDomain(ctx context.Context, fp1 *types.FailoverDoma
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, fp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, quotas.Info{Domain: fp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -162,7 +162,7 @@ func (h *apiHandler) GetTaskListsByDomain(ctx context.Context, gp1 *types.GetTas
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, gp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, quotas.Info{Domain: gp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -178,7 +178,7 @@ func (h *apiHandler) GetWorkflowExecutionHistory(ctx context.Context, gp1 *types
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, gp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, quotas.Info{Domain: gp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -198,7 +198,7 @@ func (h *apiHandler) ListArchivedWorkflowExecutions(ctx context.Context, lp1 *ty
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeVisibility, lp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeVisibility, quotas.Info{Domain: lp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -214,7 +214,7 @@ func (h *apiHandler) ListClosedWorkflowExecutions(ctx context.Context, lp1 *type
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeVisibility, lp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeVisibility, quotas.Info{Domain: lp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -238,7 +238,7 @@ func (h *apiHandler) ListOpenWorkflowExecutions(ctx context.Context, lp1 *types.
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeVisibility, lp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeVisibility, quotas.Info{Domain: lp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -254,7 +254,7 @@ func (h *apiHandler) ListTaskListPartitions(ctx context.Context, lp1 *types.List
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, lp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, quotas.Info{Domain: lp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -270,7 +270,7 @@ func (h *apiHandler) ListWorkflowExecutions(ctx context.Context, lp1 *types.List
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeVisibility, lp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeVisibility, quotas.Info{Domain: lp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -286,7 +286,7 @@ func (h *apiHandler) PollForActivityTask(ctx context.Context, pp1 *types.PollFor
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeWorkerPoll, pp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeWorkerPoll, quotas.Info{Domain: pp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -302,7 +302,7 @@ func (h *apiHandler) PollForDecisionTask(ctx context.Context, pp1 *types.PollFor
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeWorkerPoll, pp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeWorkerPoll, quotas.Info{Domain: pp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -318,7 +318,7 @@ func (h *apiHandler) QueryWorkflow(ctx context.Context, qp1 *types.QueryWorkflow
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, qp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, quotas.Info{Domain: qp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -348,7 +348,7 @@ func (h *apiHandler) RecordActivityTaskHeartbeat(ctx context.Context, rp1 *types
 	}
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	h.allowDomain(ctx, ratelimitTypeWorker, domainName)
+	h.allowDomain(ctx, ratelimitTypeWorker, quotas.Info{Domain: domainName})
 	return h.wrapped.RecordActivityTaskHeartbeat(ctx, rp1)
 }
 
@@ -363,7 +363,7 @@ func (h *apiHandler) RecordActivityTaskHeartbeatByID(ctx context.Context, rp1 *t
 	}
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	h.allowDomain(ctx, ratelimitTypeWorker, rp1.GetDomain())
+	h.allowDomain(ctx, ratelimitTypeWorker, quotas.Info{Domain: rp1.GetDomain()})
 	return h.wrapped.RecordActivityTaskHeartbeatByID(ctx, rp1)
 }
 
@@ -376,7 +376,7 @@ func (h *apiHandler) RefreshWorkflowTasks(ctx context.Context, rp1 *types.Refres
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, rp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, quotas.Info{Domain: rp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -396,7 +396,7 @@ func (h *apiHandler) RequestCancelWorkflowExecution(ctx context.Context, rp1 *ty
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, rp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, quotas.Info{Domain: rp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -414,7 +414,7 @@ func (h *apiHandler) ResetStickyTaskList(ctx context.Context, rp1 *types.ResetSt
 	}
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	h.allowDomain(ctx, ratelimitTypeWorker, rp1.GetDomain())
+	h.allowDomain(ctx, ratelimitTypeWorker, quotas.Info{Domain: rp1.GetDomain()})
 	return h.wrapped.ResetStickyTaskList(ctx, rp1)
 }
 
@@ -427,7 +427,7 @@ func (h *apiHandler) ResetWorkflowExecution(ctx context.Context, rp1 *types.Rese
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, rp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, quotas.Info{Domain: rp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -457,7 +457,7 @@ func (h *apiHandler) RespondActivityTaskCanceled(ctx context.Context, rp1 *types
 	}
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	h.allowDomain(ctx, ratelimitTypeWorker, domainName)
+	h.allowDomain(ctx, ratelimitTypeWorker, quotas.Info{Domain: domainName})
 	return h.wrapped.RespondActivityTaskCanceled(ctx, rp1)
 }
 
@@ -472,7 +472,7 @@ func (h *apiHandler) RespondActivityTaskCanceledByID(ctx context.Context, rp1 *t
 	}
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	h.allowDomain(ctx, ratelimitTypeWorker, rp1.GetDomain())
+	h.allowDomain(ctx, ratelimitTypeWorker, quotas.Info{Domain: rp1.GetDomain()})
 	return h.wrapped.RespondActivityTaskCanceledByID(ctx, rp1)
 }
 
@@ -499,7 +499,7 @@ func (h *apiHandler) RespondActivityTaskCompleted(ctx context.Context, rp1 *type
 	}
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	h.allowDomain(ctx, ratelimitTypeWorker, domainName)
+	h.allowDomain(ctx, ratelimitTypeWorker, quotas.Info{Domain: domainName})
 	return h.wrapped.RespondActivityTaskCompleted(ctx, rp1)
 }
 
@@ -514,7 +514,7 @@ func (h *apiHandler) RespondActivityTaskCompletedByID(ctx context.Context, rp1 *
 	}
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	h.allowDomain(ctx, ratelimitTypeWorker, rp1.GetDomain())
+	h.allowDomain(ctx, ratelimitTypeWorker, quotas.Info{Domain: rp1.GetDomain()})
 	return h.wrapped.RespondActivityTaskCompletedByID(ctx, rp1)
 }
 
@@ -541,7 +541,7 @@ func (h *apiHandler) RespondActivityTaskFailed(ctx context.Context, rp1 *types.R
 	}
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	h.allowDomain(ctx, ratelimitTypeWorker, domainName)
+	h.allowDomain(ctx, ratelimitTypeWorker, quotas.Info{Domain: domainName})
 	return h.wrapped.RespondActivityTaskFailed(ctx, rp1)
 }
 
@@ -556,7 +556,7 @@ func (h *apiHandler) RespondActivityTaskFailedByID(ctx context.Context, rp1 *typ
 	}
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	h.allowDomain(ctx, ratelimitTypeWorker, rp1.GetDomain())
+	h.allowDomain(ctx, ratelimitTypeWorker, quotas.Info{Domain: rp1.GetDomain()})
 	return h.wrapped.RespondActivityTaskFailedByID(ctx, rp1)
 }
 
@@ -583,7 +583,7 @@ func (h *apiHandler) RespondDecisionTaskCompleted(ctx context.Context, rp1 *type
 	}
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	h.allowDomain(ctx, ratelimitTypeWorker, domainName)
+	h.allowDomain(ctx, ratelimitTypeWorker, quotas.Info{Domain: domainName})
 	return h.wrapped.RespondDecisionTaskCompleted(ctx, rp1)
 }
 
@@ -610,7 +610,7 @@ func (h *apiHandler) RespondDecisionTaskFailed(ctx context.Context, rp1 *types.R
 	}
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	h.allowDomain(ctx, ratelimitTypeWorker, domainName)
+	h.allowDomain(ctx, ratelimitTypeWorker, quotas.Info{Domain: domainName})
 	return h.wrapped.RespondDecisionTaskFailed(ctx, rp1)
 }
 
@@ -637,7 +637,7 @@ func (h *apiHandler) RespondQueryTaskCompleted(ctx context.Context, rp1 *types.R
 	}
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	h.allowDomain(ctx, ratelimitTypeWorker, domainName)
+	h.allowDomain(ctx, ratelimitTypeWorker, quotas.Info{Domain: domainName})
 	return h.wrapped.RespondQueryTaskCompleted(ctx, rp1)
 }
 
@@ -650,7 +650,7 @@ func (h *apiHandler) RestartWorkflowExecution(ctx context.Context, rp1 *types.Re
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, rp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, quotas.Info{Domain: rp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -666,7 +666,7 @@ func (h *apiHandler) ScanWorkflowExecutions(ctx context.Context, lp1 *types.List
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeVisibility, lp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeVisibility, quotas.Info{Domain: lp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -682,7 +682,7 @@ func (h *apiHandler) SignalWithStartWorkflowExecution(ctx context.Context, sp1 *
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, sp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, quotas.Info{Domain: sp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -698,7 +698,7 @@ func (h *apiHandler) SignalWithStartWorkflowExecutionAsync(ctx context.Context, 
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeAsync, sp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeAsync, quotas.Info{Domain: sp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -714,7 +714,7 @@ func (h *apiHandler) SignalWorkflowExecution(ctx context.Context, sp1 *types.Sig
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, sp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, quotas.Info{Domain: sp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -730,7 +730,7 @@ func (h *apiHandler) StartWorkflowExecution(ctx context.Context, sp1 *types.Star
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, sp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, quotas.Info{Domain: sp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -746,7 +746,7 @@ func (h *apiHandler) StartWorkflowExecutionAsync(ctx context.Context, sp1 *types
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeAsync, sp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeAsync, quotas.Info{Domain: sp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}
@@ -762,7 +762,7 @@ func (h *apiHandler) TerminateWorkflowExecution(ctx context.Context, tp1 *types.
 		err = validate.ErrDomainNotSet
 		return
 	}
-	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, tp1.GetDomain()); limitErr != nil {
+	if limitErr := h.allowDomain(ctx, ratelimitTypeUser, quotas.Info{Domain: tp1.GetDomain()}); limitErr != nil {
 		err = limitErr
 		return
 	}

--- a/service/frontend/wrappers/ratelimited/ratelimit.go
+++ b/service/frontend/wrappers/ratelimited/ratelimit.go
@@ -47,7 +47,7 @@ func newErrRateLimited() error {
 	return &errRateLimited
 }
 
-func (h *apiHandler) allowDomain(ctx context.Context, requestType ratelimitType, domain string) error {
+func (h *apiHandler) allowDomain(ctx context.Context, requestType ratelimitType, info quotas.Info) error {
 	var policy quotas.Policy
 	switch requestType {
 	case ratelimitTypeUser:
@@ -65,21 +65,21 @@ func (h *apiHandler) allowDomain(ctx context.Context, requestType ratelimitType,
 	// If it is a poll request and there is a maxWorkerPollDelay configured, use Wait()
 	// to potentially wait for a token. Otherwise, use Allow() for an immediate check
 	if requestType == ratelimitTypeWorkerPoll {
-		waitTime := h.maxWorkerPollDelay(domain)
+		waitTime := h.maxWorkerPollDelay(info.Domain)
 		if waitTime > 0 {
-			return h.waitForPolicy(ctx, waitTime, policy, domain)
+			return h.waitForPolicy(ctx, waitTime, policy, info)
 		}
 	}
-	if !h.callerBypass.AllowPolicy(ctx, policy, quotas.Info{Domain: domain}) {
+	if !h.callerBypass.AllowPolicy(ctx, policy, info) {
 		return newErrRateLimited()
 	}
 	return nil
 }
 
-func (h *apiHandler) waitForPolicy(ctx context.Context, waitTime time.Duration, policy quotas.Policy, domain string) error {
+func (h *apiHandler) waitForPolicy(ctx context.Context, waitTime time.Duration, policy quotas.Policy, info quotas.Info) error {
 	waitCtx, cancel := context.WithTimeout(ctx, waitTime)
 	defer cancel()
-	err := policy.Wait(waitCtx, quotas.Info{Domain: domain})
+	err := policy.Wait(waitCtx, info)
 	if err != nil {
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -93,7 +93,7 @@ func (h *apiHandler) waitForPolicy(ctx context.Context, waitTime time.Duration, 
 			return newErrRateLimited()
 		case context.DeadlineExceeded:
 			// Race condition: context deadline hit right around wait completion
-			if !h.callerBypass.AllowPolicy(ctx, policy, quotas.Info{Domain: domain}) {
+			if !h.callerBypass.AllowPolicy(ctx, policy, info) {
 				return newErrRateLimited()
 			}
 			return nil

--- a/service/frontend/wrappers/ratelimited/ratelimit_test.go
+++ b/service/frontend/wrappers/ratelimited/ratelimit_test.go
@@ -112,7 +112,7 @@ func TestAllowDomainRequestRouting(t *testing.T) {
 			handler := setupHandler(t)
 			tc.setupMock(handler)
 
-			err := handler.allowDomain(context.Background(), tc.requestType, testDomain)
+			err := handler.allowDomain(context.Background(), tc.requestType, quotas.Info{Domain: testDomain})
 
 			if tc.expectedErr != nil {
 				assert.Error(t, err)
@@ -272,7 +272,7 @@ func TestCallerTypeBypass(t *testing.T) {
 				handler.userRateLimiter.(*mockPolicy).On("Allow", quotas.Info{Domain: testDomain}).Return(true).Once()
 			}
 
-			err := handler.allowDomain(ctx, ratelimitTypeUser, testDomain)
+			err := handler.allowDomain(ctx, ratelimitTypeUser, quotas.Info{Domain: testDomain})
 
 			if tt.expectBypass {
 				assert.NoError(t, err, "Expected bypass to allow request")
@@ -324,7 +324,7 @@ func TestCallerTypeBypassWithWait(t *testing.T) {
 			// Wait returns an error, but waitCtx.Err() is nil (case nil path)
 			handler.workerRateLimiter.(*mockPolicy).On("Wait", mock.Anything, quotas.Info{Domain: testDomain}).Return(assert.AnError).Once()
 
-			err := handler.allowDomain(ctx, ratelimitTypeWorkerPoll, testDomain)
+			err := handler.allowDomain(ctx, ratelimitTypeWorkerPoll, quotas.Info{Domain: testDomain})
 
 			if tt.expectBypass {
 				assert.NoError(t, err, "Expected bypass to allow request")

--- a/service/history/task/priority_assigner.go
+++ b/service/history/task/priority_assigner.go
@@ -50,7 +50,7 @@ type priorityAssignerImpl struct {
 	config             *config.Config
 	logger             log.Logger
 	scope              metrics.Scope
-	rateLimiters       *quotas.Collection
+	rateLimiters       *quotas.Collection[string]
 	activeClusterMgr   activecluster.Manager
 }
 

--- a/service/history/task/task_rate_limiter.go
+++ b/service/history/task/task_rate_limiter.go
@@ -48,7 +48,7 @@ type (
 		logger           log.Logger
 		metricsScope     metrics.Scope
 		domainCache      cache.DomainCache
-		limiters         quotas.ICollection
+		limiters         quotas.ICollection[string]
 		enabled          dynamicproperties.BoolPropertyFn
 		enableShadowMode dynamicproperties.BoolPropertyFnWithDomainFilter
 	}

--- a/service/history/task/task_rate_limiter_test.go
+++ b/service/history/task/task_rate_limiter_test.go
@@ -133,7 +133,7 @@ type taskRateLimiterMockDeps struct {
 	ctrl                *gomock.Controller
 	mockDomainCache     *cache.MockDomainCache
 	mockShardController *shard.MockController
-	mockICollection     *quotas.MockICollection
+	mockICollection     *quotas.MockICollection[string]
 	dynamicClient       dynamicconfig.Client
 }
 
@@ -171,7 +171,7 @@ func setupMocksForTaskRateLimiter(t *testing.T, mockQuotasCollection bool) (*tas
 	r, ok := rateLimiter.(*taskRateLimiterImpl)
 	require.True(t, ok, "rate limiter type assertion failure")
 	if mockQuotasCollection {
-		deps.mockICollection = quotas.NewMockICollection(ctrl)
+		deps.mockICollection = quotas.NewMockICollection[string](ctrl)
 		r.limiters = deps.mockICollection
 	}
 	return r, deps

--- a/service/history/workflowcache/cache.go
+++ b/service/history/workflowcache/cache.go
@@ -48,8 +48,8 @@ type WFCache interface {
 
 type wfCache struct {
 	lru                    cache.Cache
-	externalLimiterFactory quotas.LimiterFactory
-	internalLimiterFactory quotas.LimiterFactory
+	externalLimiterFactory quotas.LimiterFactory[string]
+	internalLimiterFactory quotas.LimiterFactory[string]
 	domainCache            cache.DomainCache
 	metricsClient          metrics.Client
 	logger                 log.Logger
@@ -75,8 +75,8 @@ type cacheValue struct {
 type Params struct {
 	TTL                    time.Duration
 	MaxCount               int
-	ExternalLimiterFactory quotas.LimiterFactory
-	InternalLimiterFactory quotas.LimiterFactory
+	ExternalLimiterFactory quotas.LimiterFactory[string]
+	InternalLimiterFactory quotas.LimiterFactory[string]
 	DomainCache            cache.DomainCache
 	MetricsClient          metrics.Client
 	Logger                 log.Logger

--- a/service/history/workflowcache/cache_test.go
+++ b/service/history/workflowcache/cache_test.go
@@ -55,7 +55,7 @@ func TestWfCache_AllowSingleWorkflow(t *testing.T) {
 	externalLimiter.EXPECT().Allow().Return(true).Times(1)
 	externalLimiter.EXPECT().Allow().Return(false).Times(1)
 
-	externalLimiterFactory := quotas.NewMockLimiterFactory(ctrl)
+	externalLimiterFactory := quotas.NewMockLimiterFactory[string](ctrl)
 	externalLimiterFactory.EXPECT().GetLimiter(testDomainName).Return(externalLimiter).Times(1)
 
 	// The internal rate limiter will allow the second request, but not the first.
@@ -63,7 +63,7 @@ func TestWfCache_AllowSingleWorkflow(t *testing.T) {
 	internalLimiter.EXPECT().Allow().Return(false).Times(1)
 	internalLimiter.EXPECT().Allow().Return(true).Times(1)
 
-	internalLimiterFactory := quotas.NewMockLimiterFactory(ctrl)
+	internalLimiterFactory := quotas.NewMockLimiterFactory[string](ctrl)
 	internalLimiterFactory.EXPECT().GetLimiter(testDomainName).Return(internalLimiter).Times(1)
 
 	wfCache := New(Params{
@@ -101,7 +101,7 @@ func TestWfCache_AllowMultipleWorkflow(t *testing.T) {
 	externalLimiterWf2.EXPECT().Allow().Return(false).Times(1)
 	externalLimiterWf2.EXPECT().Allow().Return(true).Times(1)
 
-	externalLimiterFactory := quotas.NewMockLimiterFactory(ctrl)
+	externalLimiterFactory := quotas.NewMockLimiterFactory[string](ctrl)
 	externalLimiterFactory.EXPECT().GetLimiter(testDomainName).Return(externalLimiterWf1).Times(1)
 	externalLimiterFactory.EXPECT().GetLimiter(testDomainName).Return(externalLimiterWf2).Times(1)
 
@@ -109,7 +109,7 @@ func TestWfCache_AllowMultipleWorkflow(t *testing.T) {
 	internalLimiterWf1 := quotas.NewMockLimiter(ctrl)
 	internalLimiterWf2 := quotas.NewMockLimiter(ctrl)
 
-	internalLimiterFactory := quotas.NewMockLimiterFactory(ctrl)
+	internalLimiterFactory := quotas.NewMockLimiterFactory[string](ctrl)
 	internalLimiterFactory.EXPECT().GetLimiter(testDomainName).Return(internalLimiterWf1).Times(1)
 	internalLimiterFactory.EXPECT().GetLimiter(testDomainName).Return(internalLimiterWf2).Times(1)
 
@@ -235,14 +235,14 @@ func TestWfCache_RejectLog(t *testing.T) {
 	externalLimiter := quotas.NewMockLimiter(ctrl)
 	externalLimiter.EXPECT().Allow().Return(false).Times(1)
 
-	externalLimiterFactory := quotas.NewMockLimiterFactory(ctrl)
+	externalLimiterFactory := quotas.NewMockLimiterFactory[string](ctrl)
 	externalLimiterFactory.EXPECT().GetLimiter(testDomainName).Return(externalLimiter).Times(1)
 
 	// The internal rate limiter will reject
 	internalLimiter := quotas.NewMockLimiter(ctrl)
 	internalLimiter.EXPECT().Allow().Return(false).Times(1)
 
-	internalLimiterFactory := quotas.NewMockLimiterFactory(ctrl)
+	internalLimiterFactory := quotas.NewMockLimiterFactory[string](ctrl)
 	internalLimiterFactory.EXPECT().GetLimiter(testDomainName).Return(internalLimiter).Times(1)
 
 	// Setup the mock logger


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
  Make `LimiterFactory` and `Collection` (and their mocks) generic over                                                                                                                                                                
  a comparable key type `K` instead of hardcoding `string`. This allows                                                                                                                                                                
  future rate limiting keyed by non-domain values (e.g. task list names,                                                                                                                                                               
  workflow IDs) without duplicating the collection infrastructure.                                                                                                                                                                     
                                                                                                                                                                                                                                       
  Change the frontend `allowDomain` / `waitForPolicy` helpers to accept                                                                                                                                                                
  `quotas.Info` directly instead of a plain domain string. The struct is                                                                                                                                                               
  constructed at each call site, eliminating the redundant wrapping that                                                                                                                                                               
  previously happened inside those helpers. The template also wires up an                                                                                                                                                              
  (initially empty) `$taskListAPIs` list so per-task-list rate limiting                                                                                                                                                                
  can be enabled for specific APIs by adding their names to that list                                                                                                                                                                  
  without further plumbing changes.    

**Why?**
1. Generic Collection[K] — decouples the collection from string keys so rate limiters can be keyed by something other than a domain name (e.g. task list, workflow ID) without reimplementing the whole collection. Right now        
  everything still passes string, but the type system no longer forces that.                                                                                                                                                           
  2. quotas.Info struct in allowDomain — the template adds a $taskListAPIs list (currently empty) that conditionally includes TaskList: ... in the Info. The goal is per-task-list rate limiting: once you add an API name to          
  $taskListAPIs, the generated code automatically passes the task list name through to the rate limiter. Without the struct, you'd need to change the method signature again to add that second dimension.             

**How did you test it?**
go test -v ./service/frontend/... 

go test ./service/history/...

go test ./common/quotas/...
**Potential risks**
No.

**Release notes**
N/A

**Documentation Changes**
N/A