### PR TITLE
fix(cadence-matching): fix deadlock in getTasksPump

### DIFF
--- a/service/matching/tasklist/task_reader.go
+++ b/service/matching/tasklist/task_reader.go
@@ -153,11 +153,7 @@ func (tr *taskReader) Start() {
 			tr.dispatchBufferedTasks(g)
 		}()
 	}
-	tr.stopWg.Add(1)
-	go func() {
-		defer tr.stopWg.Done()
-		tr.getTasksPump()
-	}()
+	go tr.getTasksPump()
 }
 
 func (tr *taskReader) Stop() {

--- a/service/matching/tasklist/task_reader_test.go
+++ b/service/matching/tasklist/task_reader_test.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -435,6 +436,27 @@ func requireCallbackInvocation(t *testing.T, msg string) func() {
 	return func() {
 		called = true
 	}
+}
+
+func TestGetTasksPumpHandleErrStopNoDeadlock(t *testing.T) {
+	controller := gomock.NewController(t)
+	c := defaultConfig()
+	c.UpdateAckInterval = dynamicproperties.GetDurationPropertyFnFilteredByTaskListInfo(10 * time.Millisecond)
+
+	tlm := createTestTaskListManagerWithConfig(t, testlogger.New(t), controller, c, clock.NewRealTimeSource())
+
+	err := tlm.taskWriter.Start()
+	require.NoError(t, err)
+
+	// Force ConditionFailedError on the next persistAckLevel -> handleErr -> Stop() path
+	tm := tlm.db.store.(*TestTaskManager)
+	tm.SetRangeID(tlm.taskListID, 999)
+
+	tlm.taskReader.Start()
+
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&tlm.stopped) == 1
+	}, 5*time.Second, 10*time.Millisecond)
 }
 
 func TestTaskReaderBatchSizeValidation(t *testing.T) {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Removed getTasksPump from the taskReader.stopWg wait group. The pump goroutine now launches as a go tr.getTasksPump() and relies on context cancellation to exit, matching the pattern used by taskWriter.taskWriterLoop.
Contributes to the issue https://github.com/cadence-workflow/cadence/issues/6862 

**Why?**
When getTasksPump gets a ConditionFailedError from persistAckLevel, the call chain is: getTasksPump -> handleErr -> taskListManagerImpl.Stop() -> taskReader.Stop() -> stopWg.Wait(). 
Because getTasksPump was tracked by stopWg, it ended up waiting for itself to call Done() - a deadlock. We have observed it in production which also affected into blocking the shard distributor heartbeat loop since shardProcessorImpl.Stop() synchronously tears down all task list managers.

The fix is safe because getTasksPump already checks <-tr.cancelCtx.Done() at the top of its event loop, and all intermediate operations also respect context cancellation. After taskReader.Stop() calls cancelFunc(), the pump exits on its next select iteration.

**How did you test it?**
go test -race -count=1 -timeout 60s ./service/matching/tasklist/...
Also added TestGetTasksPumpHandleErrStopNoDeadlock unit test

**Potential risks**
Low
The only behavioural change is that taskReader.Stop() no longer blocks waiting for getTaskPump to exit.  The pump still exits via context cancellation. Dispatcher goroutines remain tracked by stopWg and are waited on as before.

**Release notes**
Fixed a deadlock in the matching service where getTasksPump could block when handling a ConditionFailedError

**Documentation Changes**
N/A
