### PR TITLE
refactor(sharddistributor): remove migration passthrough modes from executor client

### DIFF
--- a/service/sharddistributor/client/executorclient/client.go
+++ b/service/sharddistributor/client/executorclient/client.go
@@ -63,11 +63,6 @@ type Executor[SP ShardProcessor] interface {
 	// Get the current metadata of the executor
 	GetMetadata() map[string]string
 
-	// AssignShardsFromLocalLogic is used for the migration during local-passthrough, local-passthrough-shadow, distributed-passthrough
-	AssignShardsFromLocalLogic(ctx context.Context, shardAssignment map[string]*types.ShardAssignment) error
-	// RemoveShardsFromLocalLogic is used for the migration during local-passthrough, local-passthrough-shadow, distributed-passthrough
-	RemoveShardsFromLocalLogic(shardIDs []string) error
-
 	// IsOnboardedToSD is returning true if the executor relies on SD for distribution
 	IsOnboardedToSD() bool
 }

--- a/service/sharddistributor/client/executorclient/clientimpl.go
+++ b/service/sharddistributor/client/executorclient/clientimpl.go
@@ -24,10 +24,6 @@ import (
 var (
 	// ErrLocalPassthroughMode indicates that the heartbeat loop should stop due to local passthrough mode
 	ErrLocalPassthroughMode = errors.New("local passthrough mode: stopping heartbeat loop")
-	// ErrAssignmentDivergenceLocalShard indicates that the local shard is not reported back from the heartbeat
-	ErrAssignmentDivergenceLocalShard = errors.New("assignment divergence: local shard not in heartbeat or not ready")
-	// ErrAssignmentDivergenceHeartbeatShard indicates that the shard in the heartbeat is not present in the local assignment
-	ErrAssignmentDivergenceHeartbeatShard = errors.New("assignment divergence: heartbeat shard not in local")
 )
 
 type processorState int32
@@ -174,33 +170,6 @@ func (e *executorImpl[SP]) IsOnboardedToSD() bool {
 	return e.getMigrationMode() == types.MigrationModeONBOARDED
 }
 
-func (e *executorImpl[SP]) AssignShardsFromLocalLogic(ctx context.Context, shardAssignment map[string]*types.ShardAssignment) error {
-	e.assignmentMutex.Lock()
-	defer e.assignmentMutex.Unlock()
-	if e.getMigrationMode() == types.MigrationModeONBOARDED {
-		return fmt.Errorf("migration mode is onborded, no local assignemnt allowed")
-	}
-	e.logger.Info("Executing external shard assignment")
-	e.addNewShards(ctx, shardAssignment)
-	return nil
-}
-
-func (e *executorImpl[SP]) RemoveShardsFromLocalLogic(shardIDs []string) error {
-	if e.getMigrationMode() == types.MigrationModeONBOARDED {
-		return fmt.Errorf("migration mode is onborded, no local assignemnt allowed")
-	}
-
-	return e.removeShards(shardIDs)
-}
-
-func (e *executorImpl[SP]) removeShards(shardIDs []string) error {
-	e.assignmentMutex.Lock()
-	defer e.assignmentMutex.Unlock()
-	e.logger.Info("Executing external shard deletion assignment")
-	e.deleteShards(shardIDs)
-	return nil
-}
-
 // drainChannel returns the drain signal channel, or nil if no observer is configured.
 func (e *executorImpl[SP]) drainChannel() <-chan struct{} {
 	if e.drainObserver != nil {
@@ -303,30 +272,14 @@ func (e *executorImpl[SP]) heartbeatAndHandleMigrationMode(ctx context.Context) 
 		return nil, fmt.Errorf("failed to heartbeat: %w", err)
 	}
 
-	// Handle migration mode logic
 	switch migrationMode {
 	case types.MigrationModeLOCALPASSTHROUGH:
 		// LOCAL_PASSTHROUGH: statically assigned, stop heartbeating
 		return nil, ErrLocalPassthroughMode
 
-	case types.MigrationModeLOCALPASSTHROUGHSHADOW:
-		// LOCAL_PASSTHROUGH_SHADOW: check response but don't apply it
-		err = e.compareAssignments(shardAssignment)
-		return nil, err
-
-	case types.MigrationModeDISTRIBUTEDPASSTHROUGH:
-		// DISTRIBUTED_PASSTHROUGH: validate then apply the assignment
-		err = e.compareAssignments(shardAssignment)
-		if err != nil {
-			return nil, err
-		}
-		return shardAssignment, nil
-		// Continue with applying the assignment from heartbeat
-
 	case types.MigrationModeONBOARDED:
 		// ONBOARDED: normal flow, apply the assignment from heartbeat
 		return shardAssignment, nil
-		// Continue with normal assignment logic below
 
 	default:
 		e.logger.Warn("unknown migration mode, skipping assignment",
@@ -416,14 +369,6 @@ func (e *executorImpl[SP]) updateShardAssignment(ctx context.Context, shardAssig
 
 	// Start newly assigned shards. Each call fires 2 goroutines: one for the
 	// Start() call and one per-shard timeout watcher.
-	for shardID, assignment := range shardAssignments {
-		if assignment.Status == types.AssignmentStatusREADY {
-			e.addManagerProcessor(ctx, shardID)
-		}
-	}
-}
-
-func (e *executorImpl[SP]) addNewShards(ctx context.Context, shardAssignments map[string]*types.ShardAssignment) {
 	for shardID, assignment := range shardAssignments {
 		if assignment.Status == types.AssignmentStatusREADY {
 			e.addManagerProcessor(ctx, shardID)
@@ -565,53 +510,6 @@ func (e *executorImpl[SP]) shardCleanUpLoop(ctx context.Context) {
 				return true
 			})
 		}
-	}
-}
-
-// compareAssignments compares the local assignments with the heartbeat response assignments
-// return error if the assignment are not the same and emits convergence or divergence metrics
-func (e *executorImpl[SP]) compareAssignments(heartbeatAssignments map[string]*types.ShardAssignment) error {
-	// Get current local assignments
-	localAssignments := make(map[string]bool)
-	e.managedProcessors.Range(func(shardID string, managedProcessor *managedProcessor[SP]) bool {
-		if managedProcessor.getState() == processorStateStarted {
-			localAssignments[shardID] = true
-		}
-		return true
-	})
-
-	// Check if all local assignments are in heartbeat assignments with READY status
-	for shardID := range localAssignments {
-		assignment, exists := heartbeatAssignments[shardID]
-		if !exists || assignment.Status != types.AssignmentStatusREADY {
-			e.logger.Warn("assignment divergence: local shard not in heartbeat or not ready",
-				tag.ShardKey(shardID))
-			e.emitMetricsConvergence(false)
-			return ErrAssignmentDivergenceLocalShard
-		}
-	}
-
-	// Check if all heartbeat READY assignments are in local assignments
-	for shardID, assignment := range heartbeatAssignments {
-		if assignment.Status == types.AssignmentStatusREADY {
-			if !localAssignments[shardID] {
-				e.logger.Warn("assignment divergence: heartbeat shard not in local",
-					tag.ShardKey(shardID))
-				e.emitMetricsConvergence(false)
-				return ErrAssignmentDivergenceHeartbeatShard
-			}
-		}
-	}
-
-	e.emitMetricsConvergence(true)
-	return nil
-}
-
-func (e *executorImpl[SP]) emitMetricsConvergence(converged bool) {
-	if converged {
-		e.metrics.Counter(metricsconstants.ShardDistributorExecutorAssignmentConvergence).Inc(1)
-	} else {
-		e.metrics.Counter(metricsconstants.ShardDistributorExecutorAssignmentDivergence).Inc(1)
 	}
 }
 

--- a/service/sharddistributor/client/executorclient/clientimpl_test.go
+++ b/service/sharddistributor/client/executorclient/clientimpl_test.go
@@ -256,190 +256,6 @@ func TestHeartBeatLoop_ShardAssignmentChange(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestAssignShardsFromLocalLogic(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	tests := []struct {
-		name   string
-		params map[string]*types.ShardAssignment
-		setup  func() *executorImpl[*MockShardProcessor]
-		assert func(err error, executor *executorImpl[*MockShardProcessor])
-	}{
-		{
-			name:   "AssignShardsFromLocalLogic fails if the namespace is onboarded",
-			params: map[string]*types.ShardAssignment{},
-			setup: func() *executorImpl[*MockShardProcessor] {
-				executor := newTestExecutor(nil, nil, nil)
-				executor.setMigrationMode(types.MigrationModeONBOARDED)
-				return executor
-			},
-			assert: func(err error, executor *executorImpl[*MockShardProcessor]) {},
-		},
-		{
-			name: "AssignShardsFromLocalLogic succeed with only logs if it is not possible to create a new shard processor",
-			params: map[string]*types.ShardAssignment{
-				"test-shard-id2": {Status: types.AssignmentStatusREADY},
-				"test-shard-id3": {Status: types.AssignmentStatusREADY}},
-			setup: func() *executorImpl[*MockShardProcessor] {
-				shardProcessorMock1 := NewMockShardProcessor(ctrl)
-				shardProcessorMock2 := NewMockShardProcessor(ctrl)
-
-				shardProcessorFactory := NewMockShardProcessorFactory[*MockShardProcessor](ctrl)
-
-				// Setup mocks
-				shardProcessorFactory.EXPECT().NewShardProcessor(gomock.Any()).Return(nil, assert.AnError)
-
-				executor := newTestExecutor(nil, shardProcessorFactory, nil)
-				executor.managedProcessors.Store("test-shard-id1", newManagedProcessor(shardProcessorMock1, processorStateStarted))
-				executor.managedProcessors.Store("test-shard-id2", newManagedProcessor(shardProcessorMock2, processorStateStarted))
-
-				return executor
-			},
-			assert: func(err error, executor *executorImpl[*MockShardProcessor]) {
-				assert.NoError(t, err)
-			},
-		},
-		{
-			name: "AssignShardsFromLocalLogic succeed ",
-			params: map[string]*types.ShardAssignment{
-				"test-shard-id2": {Status: types.AssignmentStatusREADY},
-				"test-shard-id3": {Status: types.AssignmentStatusREADY}},
-			setup: func() *executorImpl[*MockShardProcessor] {
-				shardProcessorMock1 := NewMockShardProcessor(ctrl)
-				shardProcessorMock2 := NewMockShardProcessor(ctrl)
-				shardProcessorMock3 := NewMockShardProcessor(ctrl)
-
-				shardProcessorFactory := NewMockShardProcessorFactory[*MockShardProcessor](ctrl)
-
-				shardProcessorFactory.EXPECT().NewShardProcessor(gomock.Any()).Return(shardProcessorMock3, nil)
-
-				executor := newTestExecutor(nil, shardProcessorFactory, nil)
-
-				executor.managedProcessors.Store("test-shard-id1", newManagedProcessor(shardProcessorMock1, processorStateStarted))
-				executor.managedProcessors.Store("test-shard-id2", newManagedProcessor(shardProcessorMock2, processorStateStarted))
-
-				// With the new assignment, shardProcessorMock3 should be started
-				shardProcessorMock3.EXPECT().Start(gomock.Any()).Return(nil)
-				shardProcessorMock1.EXPECT().GetShardReport().Return(ShardReport{Status: types.ShardStatusREADY})
-				shardProcessorMock2.EXPECT().GetShardReport().Return(ShardReport{Status: types.ShardStatusREADY})
-				shardProcessorMock3.EXPECT().GetShardReport().Return(ShardReport{Status: types.ShardStatusREADY})
-				return executor
-			},
-			assert: func(_ error, executor *executorImpl[*MockShardProcessor]) {
-				// Assert that we now have the 3 shards in the assignment
-				processor1, err := executor.GetShardProcess(context.Background(), "test-shard-id1")
-				assert.NoError(t, err)
-				assert.Equal(t, types.ShardStatusREADY, processor1.GetShardReport().Status)
-
-				processor2, err := executor.GetShardProcess(context.Background(), "test-shard-id2")
-				assert.NoError(t, err)
-				assert.Equal(t, types.ShardStatusREADY, processor2.GetShardReport().Status)
-
-				processor3, err := executor.GetShardProcess(context.Background(), "test-shard-id3")
-				assert.NoError(t, err)
-				assert.Equal(t, types.ShardStatusREADY, processor3.GetShardReport().Status)
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			executor := test.setup()
-			err := executor.AssignShardsFromLocalLogic(context.Background(), test.params)
-			time.Sleep(10 * time.Millisecond) // Force the updateShardAssignment goroutines to run
-			test.assert(err, executor)
-		})
-	}
-}
-
-func TestRemoveShardsFromLocalLogic(t *testing.T) {
-	ctrl := gomock.NewController(t)
-
-	tests := []struct {
-		name   string
-		params []string
-		setup  func() *executorImpl[*MockShardProcessor]
-		assert func(err error, executor *executorImpl[*MockShardProcessor])
-	}{
-		{
-			name:   "RemoveShardsFromLocalLogic fails if the namespace is onboarded",
-			params: []string{},
-			setup: func() *executorImpl[*MockShardProcessor] {
-				executor := newTestExecutor(nil, nil, nil)
-				executor.setMigrationMode(types.MigrationModeONBOARDED)
-				return executor
-			},
-			assert: func(err error, executor *executorImpl[*MockShardProcessor]) {},
-		},
-		{
-			name: "RemoveShardsFromLocalLogic succeed ",
-			params: []string{
-				"test-shard-id2",
-				"test-shard-id3"},
-			setup: func() *executorImpl[*MockShardProcessor] {
-				shardProcessorMock1 := NewMockShardProcessor(ctrl)
-				shardProcessorMock2 := NewMockShardProcessor(ctrl)
-				executor := newTestExecutor(nil, nil, nil)
-
-				executor.managedProcessors.Store("test-shard-id1", newManagedProcessor(shardProcessorMock1, processorStateStarted))
-				executor.managedProcessors.Store("test-shard-id2", newManagedProcessor(shardProcessorMock2, processorStateStarted))
-
-				// With the new assignment, shardProcessorMock2 should be stopped
-				shardProcessorMock2.EXPECT().Stop()
-				shardProcessorMock1.EXPECT().GetShardReport().Return(ShardReport{Status: types.ShardStatusREADY})
-				return executor
-			},
-			assert: func(_ error, executor *executorImpl[*MockShardProcessor]) {
-				// Assert that we now have the 1 shard in the assignment
-				processor1, err := executor.GetShardProcess(context.Background(), "test-shard-id1")
-				assert.NoError(t, err)
-				assert.Equal(t, types.ShardStatusREADY, processor1.GetShardReport().Status)
-
-				// Check that we do not have shard "test-shard-id2" in the local cache
-				// we lookup directly since we don't want to trigger a heartbeat
-				_, ok := executor.managedProcessors.Load("test-shard-id2")
-				assert.False(t, ok)
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			executor := test.setup()
-			err := executor.RemoveShardsFromLocalLogic(test.params)
-			time.Sleep(10 * time.Millisecond) // Force the updateShardAssignment goroutines to run
-			test.assert(err, executor)
-		})
-	}
-}
-
-func TestHeartbeat_WithMigrationMode(t *testing.T) {
-	ctrl := gomock.NewController(t)
-
-	// Test that heartbeat returns migration mode correctly
-	shardDistributorClient := sharddistributorexecutor.NewMockClient(ctrl)
-	shardDistributorClient.EXPECT().Heartbeat(gomock.Any(),
-		&types.ExecutorHeartbeatRequest{
-			Namespace:          "test-namespace",
-			ExecutorID:         "test-executor-id",
-			Status:             types.ExecutorStatusACTIVE,
-			ShardStatusReports: map[string]*types.ShardStatusReport{},
-			Metadata:           make(map[string]string),
-		}, gomock.Any()).Return(&types.ExecutorHeartbeatResponse{
-		ShardAssignments: map[string]*types.ShardAssignment{
-			"test-shard-id1": {Status: types.AssignmentStatusREADY},
-		},
-		MigrationMode: types.MigrationModeDISTRIBUTEDPASSTHROUGH,
-	}, nil)
-
-	executor := newTestExecutor(shardDistributorClient, nil, nil)
-	executor.setMigrationMode(types.MigrationModeINVALID)
-
-	shardAssignments, migrationMode, err := executor.heartbeat(context.Background())
-
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(shardAssignments))
-	assert.Equal(t, types.MigrationModeDISTRIBUTEDPASSTHROUGH, migrationMode)
-	assert.Equal(t, types.MigrationModeDISTRIBUTEDPASSTHROUGH, executor.getMigrationMode())
-}
-
 func TestHeartbeat_MigrationModeTransition(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
@@ -450,7 +266,7 @@ func TestHeartbeat_MigrationModeTransition(t *testing.T) {
 	}, nil)
 
 	executor := newTestExecutor(shardDistributorClient, nil, nil)
-	executor.setMigrationMode(types.MigrationModeDISTRIBUTEDPASSTHROUGH)
+	executor.setMigrationMode(types.MigrationModeLOCALPASSTHROUGH)
 
 	_, migrationMode, err := executor.heartbeat(context.Background())
 
@@ -478,86 +294,6 @@ func TestHeartbeatLoop_LocalPassthrough_SkipsHeartbeat(t *testing.T) {
 
 	// Give some time for the heartbeat loop to potentially run (it shouldn't)
 	time.Sleep(10 * time.Millisecond)
-}
-
-func TestHeartbeatLoop_LocalPassthroughShadow_SkipsAssignment(t *testing.T) {
-	defer goleak.VerifyNone(t)
-
-	ctrl := gomock.NewController(t)
-	mockShardDistributorClient := sharddistributorexecutor.NewMockClient(ctrl)
-
-	// Heartbeat should be called but assignment should not be applied
-	mockShardDistributorClient.EXPECT().Heartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&types.ExecutorHeartbeatResponse{
-			ShardAssignments: map[string]*types.ShardAssignment{
-				"test-shard-id1": {Status: types.AssignmentStatusREADY},
-			},
-			MigrationMode: types.MigrationModeLOCALPASSTHROUGHSHADOW,
-		}, nil)
-	expectDrainingHeartbeat(t, mockShardDistributorClient)
-
-	mockShardProcessorFactory := NewMockShardProcessorFactory[*MockShardProcessor](ctrl)
-	// No shard processor should be created
-	mockShardProcessorFactory.EXPECT().NewShardProcessor(gomock.Any()).Times(0)
-
-	mockTimeSource := clock.NewMockedTimeSource()
-
-	executor := newTestExecutor(mockShardDistributorClient, mockShardProcessorFactory, mockTimeSource)
-	executor.setMigrationMode(types.MigrationModeONBOARDED)
-
-	executor.Start(context.Background())
-	defer executor.Stop()
-
-	mockTimeSource.BlockUntil(1)
-	mockTimeSource.Advance(15 * time.Second)
-	time.Sleep(10 * time.Millisecond)
-	mockTimeSource.BlockUntil(1)
-
-	// Assert that no shards were assigned, we check directly since we don't want to trigger a heartbeat
-	_, ok := executor.managedProcessors.Load("test-shard-id1")
-	assert.False(t, ok)
-}
-
-func TestHeartbeatLoop_DistributedPassthrough_AppliesAssignment(t *testing.T) {
-	defer goleak.VerifyNone(t)
-
-	ctrl := gomock.NewController(t)
-	mockShardDistributorClient := sharddistributorexecutor.NewMockClient(ctrl)
-
-	mockShardProcessor := NewMockShardProcessor(ctrl)
-	mockShardProcessor.EXPECT().GetShardReport().Return(ShardReport{Status: types.ShardStatusREADY}).AnyTimes()
-	mockShardProcessor.EXPECT().Stop()
-
-	mockShardDistributorClient.EXPECT().Heartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&types.ExecutorHeartbeatResponse{
-			ShardAssignments: map[string]*types.ShardAssignment{
-				"test-shard-id1": {Status: types.AssignmentStatusREADY},
-			},
-			MigrationMode: types.MigrationModeDISTRIBUTEDPASSTHROUGH,
-		}, nil)
-	expectDrainingHeartbeat(t, mockShardDistributorClient)
-
-	mockShardProcessorFactory := NewMockShardProcessorFactory[*MockShardProcessor](ctrl)
-
-	mockTimeSource := clock.NewMockedTimeSource()
-
-	executor := newTestExecutor(mockShardDistributorClient, mockShardProcessorFactory, mockTimeSource)
-	executor.setMigrationMode(types.MigrationModeONBOARDED)
-	// Pre-populate the executor with the shard to ensure convergence
-	executor.managedProcessors.Store("test-shard-id1", newManagedProcessor(mockShardProcessor, processorStateStarted))
-
-	executor.Start(context.Background())
-	defer executor.Stop()
-
-	mockTimeSource.BlockUntil(1)
-	mockTimeSource.Advance(15 * time.Second)
-	time.Sleep(10 * time.Millisecond)
-	mockTimeSource.BlockUntil(1)
-
-	// Assert that the shard was assigned
-	processor, err := executor.GetShardProcess(context.Background(), "test-shard-id1")
-	assert.NoError(t, err)
-	assert.Equal(t, mockShardProcessor, processor)
 }
 
 func TestHeartbeatLoop_StopSignalSendsDrainingHeartbeat(t *testing.T) {
@@ -599,115 +335,6 @@ func TestHeartbeatLoop_ContextCancelSendsDrainingHeartbeat(t *testing.T) {
 	cancel() // cancelling the context
 
 	executor.heartbeatloop(ctx)
-}
-
-func TestCompareAssignments_Converged(t *testing.T) {
-	ctrl := gomock.NewController(t)
-
-	shardProcessorMock1 := NewMockShardProcessor(ctrl)
-	shardProcessorMock2 := NewMockShardProcessor(ctrl)
-
-	testScope := tally.NewTestScope("test", nil)
-	executor := newTestExecutor(nil, nil, nil)
-	executor.metrics = testScope
-
-	executor.managedProcessors.Store("test-shard-id1", newManagedProcessor(shardProcessorMock1, processorStateStarted))
-	executor.managedProcessors.Store("test-shard-id2", newManagedProcessor(shardProcessorMock2, processorStateStarted))
-
-	heartbeatAssignments := map[string]*types.ShardAssignment{
-		"test-shard-id1": {Status: types.AssignmentStatusREADY},
-		"test-shard-id2": {Status: types.AssignmentStatusREADY},
-	}
-
-	err := executor.compareAssignments(heartbeatAssignments)
-
-	// Verify no error is returned when assignments converge
-	assert.NoError(t, err)
-
-	// Verify convergence metric was emitted
-	snapshot := testScope.Snapshot()
-	assert.Equal(t, int64(1), snapshot.Counters()["test.shard_distributor_executor_assignment_convergence+"].Value())
-}
-
-func TestCompareAssignments_Diverged_MissingShard(t *testing.T) {
-	ctrl := gomock.NewController(t)
-
-	shardProcessorMock1 := NewMockShardProcessor(ctrl)
-	shardProcessorMock2 := NewMockShardProcessor(ctrl)
-
-	testScope := tally.NewTestScope("test", nil)
-	executor := newTestExecutor(nil, nil, nil)
-	executor.metrics = testScope
-
-	executor.managedProcessors.Store("test-shard-id1", newManagedProcessor(shardProcessorMock1, processorStateStarted))
-	executor.managedProcessors.Store("test-shard-id2", newManagedProcessor(shardProcessorMock2, processorStateStarted))
-
-	// Heartbeat only has shard 1, local has both 1 and 2
-	heartbeatAssignments := map[string]*types.ShardAssignment{
-		"test-shard-id1": {Status: types.AssignmentStatusREADY},
-	}
-
-	err := executor.compareAssignments(heartbeatAssignments)
-
-	// Verify error is returned when local shard is missing from heartbeat
-	assert.ErrorIs(t, err, ErrAssignmentDivergenceLocalShard)
-
-	// Verify divergence metric was emitted
-	snapshot := testScope.Snapshot()
-	assert.Equal(t, int64(1), snapshot.Counters()["test.shard_distributor_executor_assignment_divergence+"].Value())
-}
-
-func TestCompareAssignments_Diverged_ExtraShard(t *testing.T) {
-	ctrl := gomock.NewController(t)
-
-	shardProcessorMock1 := NewMockShardProcessor(ctrl)
-
-	testScope := tally.NewTestScope("test", nil)
-	executor := newTestExecutor(nil, nil, nil)
-	executor.metrics = testScope
-
-	executor.managedProcessors.Store("test-shard-id1", newManagedProcessor(shardProcessorMock1, processorStateStarted))
-
-	// Heartbeat has shards 1 and 2, local only has 1
-	heartbeatAssignments := map[string]*types.ShardAssignment{
-		"test-shard-id1": {Status: types.AssignmentStatusREADY},
-		"test-shard-id2": {Status: types.AssignmentStatusREADY},
-	}
-
-	err := executor.compareAssignments(heartbeatAssignments)
-
-	// Verify error is returned when heartbeat has extra shard not in local
-	assert.ErrorIs(t, err, ErrAssignmentDivergenceHeartbeatShard)
-
-	// Verify divergence metric was emitted
-	snapshot := testScope.Snapshot()
-	assert.Equal(t, int64(1), snapshot.Counters()["test.shard_distributor_executor_assignment_divergence+"].Value())
-}
-
-func TestCompareAssignments_Diverged_WrongStatus(t *testing.T) {
-	ctrl := gomock.NewController(t)
-
-	shardProcessorMock1 := NewMockShardProcessor(ctrl)
-
-	testScope := tally.NewTestScope("test", nil)
-	executor := newTestExecutor(nil, nil, nil)
-	executor.metrics = testScope
-
-	executor.managedProcessors.Store("test-shard-id1", newManagedProcessor(shardProcessorMock1, processorStateStarted))
-
-	// Heartbeat has shard 1 but with INVALID status
-	heartbeatAssignments := map[string]*types.ShardAssignment{
-		"test-shard-id1": {Status: types.AssignmentStatusINVALID},
-	}
-
-	err := executor.compareAssignments(heartbeatAssignments)
-
-	// Verify error is returned when local shard has wrong status in heartbeat
-	assert.ErrorIs(t, err, ErrAssignmentDivergenceLocalShard)
-
-	// Verify divergence metric was emitted
-	snapshot := testScope.Snapshot()
-	assert.Equal(t, int64(1), snapshot.Counters()["test.shard_distributor_executor_assignment_divergence+"].Value())
 }
 
 func TestGetShardProcess_NonOwnedShard_Fails(t *testing.T) {
@@ -1036,6 +663,7 @@ func TestShardCleanupLoop(t *testing.T) {
 		name                  string
 		ttlShard              time.Duration
 		migrationMode         types.MigrationMode
+		setMigrationMode      bool
 		setupProcessors       func(executor *executorImpl[*MockShardProcessor], ctrl *gomock.Controller) []*MockShardProcessor
 		advanceTime           time.Duration
 		expectedShardsDeleted []string
@@ -1068,9 +696,10 @@ func TestShardCleanupLoop(t *testing.T) {
 			expectedShardsKept:    []string{"shard-1"},
 		},
 		{
-			name:          "cleanup removes expired shard in non-onboarded mode",
-			ttlShard:      5 * time.Second,
-			migrationMode: types.MigrationModeLOCALPASSTHROUGH,
+			name:             "cleanup removes expired shard in non-onboarded mode",
+			ttlShard:         5 * time.Second,
+			migrationMode:    types.MigrationModeLOCALPASSTHROUGH,
+			setMigrationMode: true,
 			setupProcessors: func(executor *executorImpl[*MockShardProcessor], ctrl *gomock.Controller) []*MockShardProcessor {
 				processor := NewMockShardProcessor(ctrl)
 				processor.EXPECT().Stop()
@@ -1083,9 +712,10 @@ func TestShardCleanupLoop(t *testing.T) {
 			expectedShardsKept:    []string{},
 		},
 		{
-			name:          "cleanup does not remove non-expired shard",
-			ttlShard:      10 * time.Second,
-			migrationMode: types.MigrationModeLOCALPASSTHROUGH,
+			name:             "cleanup does not remove non-expired shard",
+			ttlShard:         10 * time.Second,
+			migrationMode:    types.MigrationModeLOCALPASSTHROUGH,
+			setMigrationMode: true,
 			setupProcessors: func(executor *executorImpl[*MockShardProcessor], ctrl *gomock.Controller) []*MockShardProcessor {
 				processor := NewMockShardProcessor(ctrl)
 				executor.managedProcessors.Store("shard-1", newManagedProcessor(processor, processorStateStarted))
@@ -1097,9 +727,10 @@ func TestShardCleanupLoop(t *testing.T) {
 			expectedShardsKept:    []string{"shard-1"},
 		},
 		{
-			name:          "cleanup sets shard status to DONE and removes from processorsToLastUse in onboarded mode",
-			ttlShard:      5 * time.Second,
-			migrationMode: types.MigrationModeONBOARDED,
+			name:             "cleanup sets shard status to DONE and removes from processorsToLastUse in onboarded mode",
+			ttlShard:         5 * time.Second,
+			migrationMode:    types.MigrationModeONBOARDED,
+			setMigrationMode: true,
 			setupProcessors: func(executor *executorImpl[*MockShardProcessor], ctrl *gomock.Controller) []*MockShardProcessor {
 				processor := NewMockShardProcessor(ctrl)
 				processor.EXPECT().SetShardStatus(types.ShardStatusDONE)
@@ -1112,9 +743,10 @@ func TestShardCleanupLoop(t *testing.T) {
 			expectedShardsKept:    []string{"shard-1"},
 		},
 		{
-			name:          "cleanup removes multiple expired shards in non-onboarded mode",
-			ttlShard:      5 * time.Second,
-			migrationMode: types.MigrationModeLOCALPASSTHROUGH,
+			name:             "cleanup removes multiple expired shards in non-onboarded mode",
+			ttlShard:         5 * time.Second,
+			migrationMode:    types.MigrationModeLOCALPASSTHROUGH,
+			setMigrationMode: true,
 			setupProcessors: func(executor *executorImpl[*MockShardProcessor], ctrl *gomock.Controller) []*MockShardProcessor {
 				processor1 := NewMockShardProcessor(ctrl)
 				processor1.EXPECT().Stop()
@@ -1138,24 +770,10 @@ func TestShardCleanupLoop(t *testing.T) {
 			expectedShardsKept:    []string{"shard-3"},
 		},
 		{
-			name:          "cleanup in distributed passthrough mode removes expired shards",
-			ttlShard:      5 * time.Second,
-			migrationMode: types.MigrationModeDISTRIBUTEDPASSTHROUGH,
-			setupProcessors: func(executor *executorImpl[*MockShardProcessor], ctrl *gomock.Controller) []*MockShardProcessor {
-				processor := NewMockShardProcessor(ctrl)
-				processor.EXPECT().Stop()
-				executor.managedProcessors.Store("shard-1", newManagedProcessor(processor, processorStateStarted))
-				executor.processorsToLastUse.Store("shard-1", executor.timeSource.Now())
-				return []*MockShardProcessor{processor}
-			},
-			advanceTime:           6 * time.Second,
-			expectedShardsDeleted: []string{"shard-1"},
-			expectedShardsKept:    []string{},
-		},
-		{
-			name:          "cleanup removes shard from processorsToLastUse map even if not in managedProcessors",
-			ttlShard:      5 * time.Second,
-			migrationMode: types.MigrationModeLOCALPASSTHROUGH,
+			name:             "cleanup removes shard from processorsToLastUse map even if not in managedProcessors",
+			ttlShard:         5 * time.Second,
+			migrationMode:    types.MigrationModeLOCALPASSTHROUGH,
+			setMigrationMode: true,
 			setupProcessors: func(executor *executorImpl[*MockShardProcessor], ctrl *gomock.Controller) []*MockShardProcessor {
 				// Add to processorsToLastUse but not to managedProcessors
 				executor.processorsToLastUse.Store("shard-orphan", executor.timeSource.Now())
@@ -1176,7 +794,7 @@ func TestShardCleanupLoop(t *testing.T) {
 			mockTimeSource := clock.NewMockedTimeSource()
 			executor := newTestExecutor(nil, nil, mockTimeSource)
 			executor.ttlShard = tt.ttlShard
-			if tt.migrationMode != types.MigrationModeINVALID {
+			if tt.setMigrationMode {
 				executor.setMigrationMode(tt.migrationMode)
 			}
 

--- a/service/sharddistributor/client/executorclient/interface_mock.go
+++ b/service/sharddistributor/client/executorclient/interface_mock.go
@@ -202,20 +202,6 @@ func (m *MockExecutor[SP]) EXPECT() *MockExecutorMockRecorder[SP] {
 	return m.recorder
 }
 
-// AssignShardsFromLocalLogic mocks base method.
-func (m *MockExecutor[SP]) AssignShardsFromLocalLogic(ctx context.Context, shardAssignment map[string]*types.ShardAssignment) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AssignShardsFromLocalLogic", ctx, shardAssignment)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AssignShardsFromLocalLogic indicates an expected call of AssignShardsFromLocalLogic.
-func (mr *MockExecutorMockRecorder[SP]) AssignShardsFromLocalLogic(ctx, shardAssignment any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignShardsFromLocalLogic", reflect.TypeOf((*MockExecutor[SP])(nil).AssignShardsFromLocalLogic), ctx, shardAssignment)
-}
-
 // GetMetadata mocks base method.
 func (m *MockExecutor[SP]) GetMetadata() map[string]string {
 	m.ctrl.T.Helper()
@@ -271,20 +257,6 @@ func (m *MockExecutor[SP]) IsOnboardedToSD() bool {
 func (mr *MockExecutorMockRecorder[SP]) IsOnboardedToSD() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOnboardedToSD", reflect.TypeOf((*MockExecutor[SP])(nil).IsOnboardedToSD))
-}
-
-// RemoveShardsFromLocalLogic mocks base method.
-func (m *MockExecutor[SP]) RemoveShardsFromLocalLogic(shardIDs []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveShardsFromLocalLogic", shardIDs)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoveShardsFromLocalLogic indicates an expected call of RemoveShardsFromLocalLogic.
-func (mr *MockExecutorMockRecorder[SP]) RemoveShardsFromLocalLogic(shardIDs any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveShardsFromLocalLogic", reflect.TypeOf((*MockExecutor[SP])(nil).RemoveShardsFromLocalLogic), shardIDs)
 }
 
 // SetMetadata mocks base method.

--- a/service/sharddistributor/client/executorclient/metricsconstants/metrics.go
+++ b/service/sharddistributor/client/executorclient/metricsconstants/metrics.go
@@ -18,8 +18,6 @@ const (
 	ShardDistributorExecutorProcessorCreationFailures = "shard_distributor_executor_processor_creation_failures"
 	ShardDistributorExecutorClientRequests            = "shard_distributor_executor_client_requests"
 	ShardDistributorExecutorClientFailures            = "shard_distributor_executor_client_failures"
-	ShardDistributorExecutorAssignmentDivergence      = "shard_distributor_executor_assignment_divergence"
-	ShardDistributorExecutorAssignmentConvergence     = "shard_distributor_executor_assignment_convergence"
 	ShardDistributorExecutorProcessorStartTimeout     = "shard_distributor_executor_processor_start_timeout"
 	ShardDistributorExecutorProcessorStopTimeout      = "shard_distributor_executor_processor_stop_timeout"
 

--- a/service/sharddistributor/client/executorclient/noop.go
+++ b/service/sharddistributor/client/executorclient/noop.go
@@ -22,8 +22,6 @@ package executorclient
 
 import (
 	"context"
-
-	"github.com/uber/cadence/common/types"
 )
 
 // noopExecutor is an Executor implementation used when no shard-distributor
@@ -51,16 +49,4 @@ func (e *noopExecutor[SP]) GetMetadata() map[string]string  { return nil }
 func (e *noopExecutor[SP]) GetShardProcess(_ context.Context, _ string) (SP, error) {
 	var zero SP
 	return zero, ErrShardProcessNotFound
-}
-
-// AssignShardsFromLocalLogic is a no-op: without SD there is no shard
-// assignment to manage.
-func (e *noopExecutor[SP]) AssignShardsFromLocalLogic(_ context.Context, _ map[string]*types.ShardAssignment) error {
-	return nil
-}
-
-// RemoveShardsFromLocalLogic is a no-op: without SD there is no shard
-// assignment to manage.
-func (e *noopExecutor[SP]) RemoveShardsFromLocalLogic(_ []string) error {
-	return nil
 }

--- a/service/sharddistributor/client/executorclient/noop_test.go
+++ b/service/sharddistributor/client/executorclient/noop_test.go
@@ -25,8 +25,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/uber/cadence/common/types"
 )
 
 func TestNoopExecutor(t *testing.T) {
@@ -55,17 +53,5 @@ func TestNoopExecutor(t *testing.T) {
 		sp, err := exec.GetShardProcess(context.Background(), "any-shard")
 		assert.Nil(t, sp)
 		assert.ErrorIs(t, err, ErrShardProcessNotFound)
-	})
-
-	t.Run("AssignShardsFromLocalLogic is a no-op", func(t *testing.T) {
-		err := exec.AssignShardsFromLocalLogic(context.Background(), map[string]*types.ShardAssignment{
-			"shard-1": {},
-		})
-		assert.NoError(t, err)
-	})
-
-	t.Run("RemoveShardsFromLocalLogic is a no-op", func(t *testing.T) {
-		err := exec.RemoveShardsFromLocalLogic([]string{"shard-1"})
-		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
 Removed the `LOCAL_PASSTHROUGH_SHADOW` and `DISTRIBUTED_PASSTHROUGH` migration modes from the executor client, along with the `AssignShardsFromLocalLogic` and
  `RemoveShardsFromLocalLogic` interface methods and their implementations. Also removed the `compareAssignments`/`emitMetricsConvergence` helpers and the associated
  convergence/divergence metrics. Relates to #6862.

**Why?**
 These migration modes and the external-assignment methods were part of a non used migration path for onboarding namespaces to shard distributor. The
  `LOCAL_PASSTHROUGH_SHADOW` and `DISTRIBUTED_PASSTHROUGH` modes acted as intermediate steps that are no longer needed since we rely on fully onboarded mode and percentage base onboarding(`ONBOARDED` mode).
  Keeping dead code around increases cognitive load and leaves error-prone paths.

**How did you test it?**
 make pr GEN_DIR=service/sharddistributor/client/executorclient

  Package unit tests (race detector enabled)

  go test -race -count=1 ./service/sharddistributor/client/executorclient/...
  Result: ok  github.com/uber/cadence/service/sharddistributor/client/executorclient  3.714s

  Full build check

  make build


**Potential risks**
  None — the removed methods were only called from code already cleaned up in prior PRs. No API/IDL, schema, or feature flag changes.

**Release notes**
  N/A — internal change.

**Documentation Changes**
  N/A

