### PR TITLE
docs: Add KubeStellar Console guided install reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Try out the sample recipes for [Go](https://github.com/cadence-workflow/cadence-
 Visit http://localhost:8088 to check workflow histories and detailed traces.
 
 
+### Kubernetes Deployment
+
+For a guided Kubernetes installation experience, [KubeStellar Console](https://console.kubestellar.io/missions/install-cadence-workflow) provides a step-by-step mission that deploys Cadence using the official Helm chart from [cadence-charts](https://github.com/cadence-workflow/cadence-charts). The mission includes pre-flight checks, validation, troubleshooting, and rollback support.
+
 ### Client Libraries
 You can implement your workflows with one of our client libraries:
 - [Official Cadence Go SDK](https://github.com/cadence-workflow/cadence-go-client)


### PR DESCRIPTION
## What changed?

Added a **Kubernetes Deployment** subsection to the Getting Started area of the README, referencing the [KubeStellar Console guided installation mission for Cadence](https://console.kubestellar.io/missions/install-cadence-workflow).

## Why?

Following up on #7830 where maintainer @shijiesheng helped rebuild the mission using the official Helm chart from [cadence-workflow/cadence-charts](https://github.com/cadence-workflow/cadence-charts), and @demirkayaender expressed interest in a demo. This gives Cadence users a guided Kubernetes deployment path with pre-flight checks, validation, troubleshooting, and rollback support.

## How did you test it?

- Verified README renders correctly with the new section
- Confirmed all links resolve (console mission, cadence-charts repo)
- Checked placement is between Getting Started steps and Client Libraries

## Potential risks

None — documentation-only change adding a single subsection to the README.

## Release notes

N/A — docs only.

## Documentation Changes

Added a "Kubernetes Deployment" section to README.md linking to the KubeStellar Console guided install mission.