### PR TITLE
ci: Automatically create issues for failed tests on master branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/test_failure.md
+++ b/.github/ISSUE_TEMPLATE/test_failure.md
@@ -1,0 +1,9 @@
+## ❌ Test Failure
+
+**Test:** {{TEST_NAME}}
+
+**Run:** {{RUN_URL}}
+
+---
+
+Please investigate this failure.

--- a/.github/workflows/codecov-on-master.yml
+++ b/.github/workflows/codecov-on-master.yml
@@ -1,7 +1,12 @@
 name: Workflow for Codecov integration
 on: push
-branches:
-  - master
+  branches:
+    - master
+
+permissions:
+  issues: write
+  contents: read
+
 
 jobs:
   codecov:

--- a/scripts/create_failed_test_issues.sh
+++ b/scripts/create_failed_test_issues.sh
@@ -3,45 +3,50 @@ set -euo pipefail
 
 failed_tests_file="${1:?usage: $0 <failed-tests-file>}"
 
+
 repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
-job_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/job/${GITHUB_JOB}"
+job_id=$(gh api repos/"${repo}"/actions/runs/"${GITHUB_RUN_ID}"/jobs \
+            --jq ".jobs[] | select(.name==\"${GITHUB_JOB}\") | .id")
+job_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/job/${job_id}"
+template=".github/ISSUE_TEMPLATE/test_failure.md"
+
 
 while IFS= read -r test; do
   [[ -n "$test" ]] || continue
 
-  body=$(cat <<EOF
-GitHub Actions job: ${job_url}
+  body=$(sed \
+    -e "s|{{TEST_NAME}}|${test//|/\|}|g" \
+    -e "s|{{RUN_URL}}|${job_url//|/\|}|g" \
+    "$template")
 
-Failed test: \`${test}\`
-EOF
-)
+  title="Failed Test: $test"
 
   matches="$(
     gh issue list \
       --repo "$repo" \
       --state all \
-      --search "\"$test\" in:title" \
+      --search "\"$title\" in:title" \
       --json number,state,title \
       --limit 100
   )"
 
   open_issue_number="$(
-    jq -r --arg title "$test" '
+    jq -r --arg title "$title" '
       .[] | select(.title == $title and .state == "OPEN") | .number
     ' <<<"$matches" | head -n1
   )"
 
   closed_issue_number="$(
-    jq -r --arg title "$test" '
+    jq -r --arg title "$title" '
       .[] | select(.title == $title and .state != "OPEN") | .number
     ' <<<"$matches" | head -n1
   )"
 
   if [[ -n "${open_issue_number:-}" ]]; then
-    gh issue comment "$open_issue_number" --repo "$repo" --body "$body"
+    gh issue comment "$open_issue_number" --repo "$repo" --body "$job_url"
   elif [[ -n "${closed_issue_number:-}" ]]; then
-    gh issue reopen "$closed_issue_number" --repo "$repo" --comment "$body"
+    gh issue reopen "$closed_issue_number" --repo "$repo" --comment "$job_url"
   else
-    gh issue create --repo "$repo" --title "$test" --body "$body"
+    gh issue create --repo "$repo" --title "$title" --body "$body"
   fi
 done < "$failed_tests_file"

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -116,7 +116,7 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDirFromEmbeddings() {
 	s.NoError(err)
 	ans, err := readSchemaDir(fsys, "0.30", "")
 	s.NoError(err)
-	s.Equal([]string{"v0.31", "v0.32", "v0.33", "v0.34", "v0.35", "v0.36", "v0.37", "v0.38", "v0.39", "v0.40", "v0.41", "v0.42", "v0.43", "v0.44", "v0.45", "v0.4"}, ans)
+	s.Equal([]string{"v0.31", "v0.32", "v0.33", "v0.34", "v0.35", "v0.36", "v0.37", "v0.38", "v0.39", "v0.40", "v0.41", "v0.42", "v0.43", "v0.44", "v0.45", "v0.46"}, ans)
 
 	fsys, err = fs.Sub(cassandra.SchemaFS, "visibility/versioned")
 	s.NoError(err)


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Add a new issue template for failed tests
- Update github workflow to create issues for failed tests on master branch

**Why?**
Catch failed tests in master branch

**How did you test it?**
manually tested, see the output of https://github.com/cadence-workflow/cadence/actions/runs/23816034383/job/69415693634?pr=7869

**Potential risks**
No

**Release notes**
N/A

**Documentation Changes**
N/A
