### PR TITLE
revert: https://github.com/cadence-workflow/cadence/pull/4816

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -4125,7 +4125,7 @@ var IntKeys = map[IntKey]DynamicInt{
 	},
 	MaxActivityCountDispatchByDomain: {
 		KeyName:      "history.maxActivityCountDispatchByDomain",
-		Description:  "MaxActivityCountDispatchByDomain max # of activity tasks to dispatch to matching before creating transfer tasks. This is an performance optimization to skip activity scheduling efforts.",
+		Description:  "DEPRECATED: MaxActivityCountDispatchByDomain max # of activity tasks to dispatch to matching before creating transfer tasks. This is an performance optimization to skip activity scheduling efforts.",
 		DefaultValue: 0,
 	},
 	ReplicationTaskFetcherParallelism: {

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2580,8 +2580,6 @@ const (
 	AckLevelUpdateCounter
 	AckLevelUpdateFailedCounter
 	DecisionTypeScheduleActivityCounter
-	DecisionTypeScheduleActivityDispatchSucceedCounter
-	DecisionTypeScheduleActivityDispatchCounter
 	DecisionTypeCompleteWorkflowCounter
 	DecisionTypeFailWorkflowCounter
 	DecisionTypeCancelWorkflowCounter
@@ -3444,8 +3442,6 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 		AckLevelUpdateCounter:                                        {metricName: "ack_level_update", metricType: Counter},
 		AckLevelUpdateFailedCounter:                                  {metricName: "ack_level_update_failed", metricType: Counter},
 		DecisionTypeScheduleActivityCounter:                          {metricName: "schedule_activity_decision", metricType: Counter},
-		DecisionTypeScheduleActivityDispatchSucceedCounter:           {metricName: "schedule_activity_decision_sync_match_succeed", metricType: Counter},
-		DecisionTypeScheduleActivityDispatchCounter:                  {metricName: "schedule_activity_decision_try_sync_match", metricType: Counter},
 		DecisionTypeCompleteWorkflowCounter:                          {metricName: "complete_workflow_decision", metricType: Counter},
 		DecisionTypeFailWorkflowCounter:                              {metricName: "fail_workflow_decision", metricType: Counter},
 		DecisionTypeCancelWorkflowCounter:                            {metricName: "cancel_workflow_decision", metricType: Counter},

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -317,8 +317,6 @@ type Config struct {
 
 	// Allows worker to dispatch activity tasks through local tunnel after decisions are made. This is an performance optimization to skip activity scheduling efforts.
 	EnableActivityLocalDispatchByDomain dynamicproperties.BoolPropertyFnWithDomainFilter
-	// Max # of activity tasks to dispatch to matching before creating transfer tasks. This is an performance optimization to skip activity scheduling efforts.
-	MaxActivityCountDispatchByDomain dynamicproperties.IntPropertyFnWithDomainFilter
 
 	ActivityMaxScheduleToStartTimeoutForRetry dynamicproperties.DurationPropertyFnWithDomainFilter
 
@@ -586,7 +584,6 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		EnableGracefulFailover:                     dc.GetBoolProperty(dynamicproperties.EnableGracefulFailover),
 
 		EnableActivityLocalDispatchByDomain: dc.GetBoolPropertyFilteredByDomain(dynamicproperties.EnableActivityLocalDispatchByDomain),
-		MaxActivityCountDispatchByDomain:    dc.GetIntPropertyFilteredByDomain(dynamicproperties.MaxActivityCountDispatchByDomain),
 
 		ActivityMaxScheduleToStartTimeoutForRetry: dc.GetDurationPropertyFilteredByDomain(dynamicproperties.ActivityMaxScheduleToStartTimeoutForRetry),
 
@@ -636,7 +633,6 @@ func NewForTestByShardNumber(shardNumber int) *Config {
 	panicIfErr(inMem.UpdateValue(dynamicproperties.ReplicationTaskProcessorShardQPS, float64(10000)))
 	panicIfErr(inMem.UpdateValue(dynamicproperties.ReplicationTaskProcessorStartWait, time.Nanosecond))
 	panicIfErr(inMem.UpdateValue(dynamicproperties.EnableActivityLocalDispatchByDomain, true))
-	panicIfErr(inMem.UpdateValue(dynamicproperties.MaxActivityCountDispatchByDomain, 0))
 	panicIfErr(inMem.UpdateValue(dynamicproperties.EnableCrossClusterOperationsForDomain, true))
 	panicIfErr(inMem.UpdateValue(dynamicproperties.NormalDecisionScheduleToStartMaxAttempts, 3))
 	panicIfErr(inMem.UpdateValue(dynamicproperties.EnablePendingActivityValidation, true))
@@ -665,7 +661,6 @@ func NewForTestByShardNumber(shardNumber int) *Config {
 	config.ReplicationTaskProcessorShardQPS = dc.GetFloat64Property(dynamicproperties.ReplicationTaskProcessorShardQPS)
 	config.ReplicationTaskProcessorStartWait = dc.GetDurationPropertyFilteredByShardID(dynamicproperties.ReplicationTaskProcessorStartWait)
 	config.EnableActivityLocalDispatchByDomain = dc.GetBoolPropertyFilteredByDomain(dynamicproperties.EnableActivityLocalDispatchByDomain)
-	config.MaxActivityCountDispatchByDomain = dc.GetIntPropertyFilteredByDomain(dynamicproperties.MaxActivityCountDispatchByDomain)
 	config.EnableCrossClusterOperationsForDomain = dc.GetBoolPropertyFilteredByDomain(dynamicproperties.EnableCrossClusterOperationsForDomain)
 	config.NormalDecisionScheduleToStartMaxAttempts = dc.GetIntPropertyFilteredByDomain(dynamicproperties.NormalDecisionScheduleToStartMaxAttempts)
 	config.NormalDecisionScheduleToStartTimeout = dc.GetDurationPropertyFilteredByDomain(dynamicproperties.NormalDecisionScheduleToStartTimeout)

--- a/service/history/config/config_test.go
+++ b/service/history/config/config_test.go
@@ -245,7 +245,6 @@ func TestNewConfig(t *testing.T) {
 		"NotifyFailoverMarkerTimerJitterCoefficient":           {dynamicproperties.NotifyFailoverMarkerTimerJitterCoefficient, 16.0},
 		"EnableGracefulFailover":                               {dynamicproperties.EnableGracefulFailover, true},
 		"EnableActivityLocalDispatchByDomain":                  {dynamicproperties.EnableActivityLocalDispatchByDomain, true},
-		"MaxActivityCountDispatchByDomain":                     {dynamicproperties.MaxActivityCountDispatchByDomain, 92},
 		"ActivityMaxScheduleToStartTimeoutForRetry":            {dynamicproperties.ActivityMaxScheduleToStartTimeoutForRetry, time.Second},
 		"EnableDebugMode":                                      {dynamicproperties.EnableDebugMode, true},
 		"EnableTaskInfoLogByDomainID":                          {dynamicproperties.HistoryEnableTaskInfoLogByDomainID, true},

--- a/service/history/decision/handler_test.go
+++ b/service/history/decision/handler_test.go
@@ -1170,7 +1170,6 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 			shard := shard.NewMockContext(ctrl)
 			domainCache := cache.NewMockDomainCache(ctrl)
 			handlerConfig := config.NewForTest()
-			handlerConfig.MaxActivityCountDispatchByDomain = func(domain string) int { return 1 } // some value > 0
 			handlerConfig.EnableActivityLocalDispatchByDomain = func(domain string) bool { return true }
 			handlerConfig.DecisionRetryMaxAttempts = func(domain string) int { return 1 }
 			decisionHandler := &handlerImpl{

--- a/service/history/decision/task_handler.go
+++ b/service/history/decision/task_handler.go
@@ -72,8 +72,6 @@ type (
 		domainCache   cache.DomainCache
 		metricsClient metrics.Client
 		config        *config.Config
-
-		activityCountToDispatch int
 	}
 
 	decisionResult struct {
@@ -120,8 +118,6 @@ func newDecisionTaskHandler(
 		domainCache:   domainCache,
 		metricsClient: metricsClient,
 		config:        config,
-
-		activityCountToDispatch: config.MaxActivityCountDispatchByDomain(domainEntry.GetInfo().Name),
 	}
 }
 
@@ -256,19 +252,12 @@ func (handler *taskHandlerImpl) handleDecisionScheduleActivity(
 		return nil, err
 	}
 
-	event, ai, activityDispatchInfo, dispatched, started, err := handler.mutableState.AddActivityTaskScheduledEvent(
-		ctx, handler.decisionTaskCompletedID, attr, handler.activityCountToDispatch > 0)
-	if dispatched {
-		handler.activityCountToDispatch--
-	}
+	event, ai, activityDispatchInfo, err := handler.mutableState.AddActivityTaskScheduledEvent(handler.decisionTaskCompletedID, attr)
 	switch err.(type) {
 	case nil:
-		if activityDispatchInfo != nil || started {
+		if activityDispatchInfo != nil {
 			if _, err1 := handler.mutableState.AddActivityTaskStartedEvent(ai, event.ID, uuid.New(), handler.identity); err1 != nil {
 				return nil, err1
-			}
-			if started {
-				return nil, nil
 			}
 			token := &common.TaskToken{
 				DomainID:        executionInfo.DomainID,

--- a/service/history/decision/task_handler_test.go
+++ b/service/history/decision/task_handler_test.go
@@ -1308,28 +1308,13 @@ func TestHandleDecisionScheduleActivity(t *testing.T) {
 			},
 		},
 		{
-			name:       "success - activity started",
-			attributes: validAttr,
-			expectMockCalls: func(taskHandler *taskHandlerImpl, attr *types.ScheduleActivityTaskDecisionAttributes) {
-				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().GetExecutionInfo().Return(executionInfo).Times(2)
-				taskHandler.domainCache.(*cache.MockDomainCache).EXPECT().GetDomain(attr.GetDomain()).Return(domainEntry, nil)
-				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddActivityTaskScheduledEvent(context.Background(), taskHandler.decisionTaskCompletedID, attr, taskHandler.activityCountToDispatch > 0).
-					Return(&types.HistoryEvent{}, &persistence.ActivityInfo{}, &types.ActivityLocalDispatchInfo{}, true, true, nil)
-				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddActivityTaskStartedEvent(&persistence.ActivityInfo{}, int64(0), gomock.Any(), taskHandler.identity)
-			},
-			asserts: func(t *testing.T, taskHandler *taskHandlerImpl, attr *types.ScheduleActivityTaskDecisionAttributes, res *decisionResult, err error) {
-				assert.Nil(t, err)
-				assert.Nil(t, res)
-			},
-		},
-		{
 			name:       "token serialization failure",
 			attributes: validAttr,
 			expectMockCalls: func(taskHandler *taskHandlerImpl, attr *types.ScheduleActivityTaskDecisionAttributes) {
 				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().GetExecutionInfo().Return(executionInfo).Times(2)
 				taskHandler.domainCache.(*cache.MockDomainCache).EXPECT().GetDomain(attr.GetDomain()).Return(domainEntry, nil)
-				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddActivityTaskScheduledEvent(context.Background(), taskHandler.decisionTaskCompletedID, attr, taskHandler.activityCountToDispatch > 0).
-					Return(&types.HistoryEvent{}, &persistence.ActivityInfo{}, &types.ActivityLocalDispatchInfo{}, true, false, nil)
+				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddActivityTaskScheduledEvent(taskHandler.decisionTaskCompletedID, attr).
+					Return(&types.HistoryEvent{}, &persistence.ActivityInfo{}, &types.ActivityLocalDispatchInfo{}, nil)
 				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddActivityTaskStartedEvent(&persistence.ActivityInfo{}, int64(0), gomock.Any(), taskHandler.identity)
 				taskHandler.tokenSerializer.(*common.MockTaskTokenSerializer).EXPECT().Serialize(&common.TaskToken{
 					DomainID:     testdata.DomainID,
@@ -1348,8 +1333,8 @@ func TestHandleDecisionScheduleActivity(t *testing.T) {
 			expectMockCalls: func(taskHandler *taskHandlerImpl, attr *types.ScheduleActivityTaskDecisionAttributes) {
 				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().GetExecutionInfo().Return(executionInfo).Times(2)
 				taskHandler.domainCache.(*cache.MockDomainCache).EXPECT().GetDomain(attr.GetDomain()).Return(domainEntry, nil)
-				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddActivityTaskScheduledEvent(context.Background(), taskHandler.decisionTaskCompletedID, attr, taskHandler.activityCountToDispatch > 0).
-					Return(&types.HistoryEvent{}, &persistence.ActivityInfo{}, &types.ActivityLocalDispatchInfo{}, true, false, nil)
+				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddActivityTaskScheduledEvent(taskHandler.decisionTaskCompletedID, attr).
+					Return(&types.HistoryEvent{}, &persistence.ActivityInfo{}, &types.ActivityLocalDispatchInfo{}, nil)
 				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddActivityTaskStartedEvent(&persistence.ActivityInfo{}, int64(0), gomock.Any(), taskHandler.identity)
 				taskHandler.tokenSerializer.(*common.MockTaskTokenSerializer).EXPECT().Serialize(&common.TaskToken{
 					DomainID:     testdata.DomainID,
@@ -1369,8 +1354,8 @@ func TestHandleDecisionScheduleActivity(t *testing.T) {
 			expectMockCalls: func(taskHandler *taskHandlerImpl, attr *types.ScheduleActivityTaskDecisionAttributes) {
 				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().GetExecutionInfo().Return(executionInfo).Times(2)
 				taskHandler.domainCache.(*cache.MockDomainCache).EXPECT().GetDomain(attr.GetDomain()).Return(domainEntry, nil)
-				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddActivityTaskScheduledEvent(context.Background(), taskHandler.decisionTaskCompletedID, attr, taskHandler.activityCountToDispatch > 0).
-					Return(&types.HistoryEvent{}, &persistence.ActivityInfo{}, &types.ActivityLocalDispatchInfo{}, true, true, nil)
+				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddActivityTaskScheduledEvent(taskHandler.decisionTaskCompletedID, attr).
+					Return(&types.HistoryEvent{}, &persistence.ActivityInfo{}, &types.ActivityLocalDispatchInfo{}, nil)
 				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddActivityTaskStartedEvent(&persistence.ActivityInfo{}, int64(0), gomock.Any(), taskHandler.identity).Return(nil, errors.New("some error"))
 			},
 			asserts: func(t *testing.T, taskHandler *taskHandlerImpl, attr *types.ScheduleActivityTaskDecisionAttributes, res *decisionResult, err error) {
@@ -1385,8 +1370,8 @@ func TestHandleDecisionScheduleActivity(t *testing.T) {
 			expectMockCalls: func(taskHandler *taskHandlerImpl, attr *types.ScheduleActivityTaskDecisionAttributes) {
 				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().GetExecutionInfo().Return(executionInfo).Times(2)
 				taskHandler.domainCache.(*cache.MockDomainCache).EXPECT().GetDomain(attr.GetDomain()).Return(domainEntry, nil)
-				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddActivityTaskScheduledEvent(context.Background(), taskHandler.decisionTaskCompletedID, attr, taskHandler.activityCountToDispatch > 0).
-					Return(&types.HistoryEvent{}, &persistence.ActivityInfo{}, nil, true, false, nil)
+				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddActivityTaskScheduledEvent(taskHandler.decisionTaskCompletedID, attr).
+					Return(&types.HistoryEvent{}, &persistence.ActivityInfo{}, nil, nil)
 			},
 			asserts: func(t *testing.T, taskHandler *taskHandlerImpl, attr *types.ScheduleActivityTaskDecisionAttributes, res *decisionResult, err error) {
 				assert.Nil(t, err)
@@ -1399,8 +1384,8 @@ func TestHandleDecisionScheduleActivity(t *testing.T) {
 			expectMockCalls: func(taskHandler *taskHandlerImpl, attr *types.ScheduleActivityTaskDecisionAttributes) {
 				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().GetExecutionInfo().Return(executionInfo).Times(2)
 				taskHandler.domainCache.(*cache.MockDomainCache).EXPECT().GetDomain(attr.GetDomain()).Return(domainEntry, nil)
-				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddActivityTaskScheduledEvent(context.Background(), taskHandler.decisionTaskCompletedID, attr, taskHandler.activityCountToDispatch > 0).
-					Return(nil, nil, nil, false, false, &types.BadRequestError{
+				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddActivityTaskScheduledEvent(taskHandler.decisionTaskCompletedID, attr).
+					Return(nil, nil, nil, &types.BadRequestError{
 						Message: "some bad request error",
 					})
 			},
@@ -1415,8 +1400,8 @@ func TestHandleDecisionScheduleActivity(t *testing.T) {
 			expectMockCalls: func(taskHandler *taskHandlerImpl, attr *types.ScheduleActivityTaskDecisionAttributes) {
 				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().GetExecutionInfo().Return(executionInfo).Times(2)
 				taskHandler.domainCache.(*cache.MockDomainCache).EXPECT().GetDomain(attr.GetDomain()).Return(domainEntry, nil)
-				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddActivityTaskScheduledEvent(context.Background(), taskHandler.decisionTaskCompletedID, attr, taskHandler.activityCountToDispatch > 0).
-					Return(nil, nil, nil, false, false, errors.New("some default error"))
+				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddActivityTaskScheduledEvent(taskHandler.decisionTaskCompletedID, attr).
+					Return(nil, nil, nil, errors.New("some default error"))
 			},
 			asserts: func(t *testing.T, taskHandler *taskHandlerImpl, attr *types.ScheduleActivityTaskDecisionAttributes, res *decisionResult, err error) {
 				assert.NotNil(t, err)
@@ -1759,11 +1744,9 @@ func TestHandleDecisionScheduleActivityWithTooManyPendingActivities(t *testing.T
 
 				// Mock AddActivityTaskScheduledEvent to return ErrTooManyPendingActivities
 				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddActivityTaskScheduledEvent(
-					context.Background(),
 					taskHandler.decisionTaskCompletedID,
 					attr,
-					taskHandler.activityCountToDispatch > 0,
-				).Return(nil, nil, nil, false, false, execution.ErrTooManyPendingActivities)
+				).Return(nil, nil, nil, execution.ErrTooManyPendingActivities)
 
 				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddFailWorkflowEvent(
 					taskHandler.decisionTaskCompletedID,
@@ -1785,11 +1768,9 @@ func TestHandleDecisionScheduleActivityWithTooManyPendingActivities(t *testing.T
 
 				// Mock AddActivityTaskScheduledEvent to return different InternalServiceError
 				taskHandler.mutableState.(*execution.MockMutableState).EXPECT().AddActivityTaskScheduledEvent(
-					context.Background(),
 					taskHandler.decisionTaskCompletedID,
 					attr,
-					taskHandler.activityCountToDispatch > 0,
-				).Return(nil, nil, nil, false, false, &types.InternalServiceError{Message: "Some other internal service error"})
+				).Return(nil, nil, nil, &types.InternalServiceError{Message: "Some other internal service error"})
 			},
 			asserts: func(t *testing.T, taskHandler *taskHandlerImpl, attr *types.ScheduleActivityTaskDecisionAttributes, res *decisionResult, err error) {
 				assert.NotNil(t, err)

--- a/service/history/execution/history_builder_test.go
+++ b/service/history/execution/history_builder_test.go
@@ -1696,7 +1696,7 @@ func (s *historyBuilderSuite) addActivityTaskScheduledEvent(
 	retryPolicy *types.RetryPolicy,
 	requestLocalDispatch bool,
 ) (*types.HistoryEvent, *persistence.ActivityInfo, *types.ActivityLocalDispatchInfo) {
-	event, ai, activityDispatchInfo, _, _, err := s.msBuilder.AddActivityTaskScheduledEvent(nil, decisionCompletedID,
+	event, ai, activityDispatchInfo, err := s.msBuilder.AddActivityTaskScheduledEvent(decisionCompletedID,
 		&types.ScheduleActivityTaskDecisionAttributes{
 			ActivityID:                    activityID,
 			ActivityType:                  &types.ActivityType{Name: activityType},
@@ -1709,7 +1709,7 @@ func (s *historyBuilderSuite) addActivityTaskScheduledEvent(
 			StartToCloseTimeoutSeconds:    common.Int32Ptr(1),
 			RetryPolicy:                   retryPolicy,
 			RequestLocalDispatch:          requestLocalDispatch,
-		}, false,
+		},
 	)
 	s.Nil(err)
 	if domain == "" {

--- a/service/history/execution/mutable_state.go
+++ b/service/history/execution/mutable_state.go
@@ -61,7 +61,7 @@ type (
 		AddActivityTaskCanceledEvent(int64, int64, int64, []uint8, string) (*types.HistoryEvent, error)
 		AddActivityTaskCompletedEvent(int64, int64, *types.RespondActivityTaskCompletedRequest) (*types.HistoryEvent, error)
 		AddActivityTaskFailedEvent(int64, int64, *types.RespondActivityTaskFailedRequest) (*types.HistoryEvent, error)
-		AddActivityTaskScheduledEvent(context.Context, int64, *types.ScheduleActivityTaskDecisionAttributes, bool) (*types.HistoryEvent, *persistence.ActivityInfo, *types.ActivityLocalDispatchInfo, bool, bool, error)
+		AddActivityTaskScheduledEvent(int64, *types.ScheduleActivityTaskDecisionAttributes) (*types.HistoryEvent, *persistence.ActivityInfo, *types.ActivityLocalDispatchInfo, error)
 		AddActivityTaskStartedEvent(*persistence.ActivityInfo, int64, string, string) (*types.HistoryEvent, error)
 		AddActivityTaskTimedOutEvent(int64, int64, types.TimeoutType, []uint8) (*types.HistoryEvent, error)
 		AddCancelTimerFailedEvent(int64, *types.CancelTimerDecisionAttributes, string) (*types.HistoryEvent, error)

--- a/service/history/execution/mutable_state_builder_methods_activity.go
+++ b/service/history/execution/mutable_state_builder_methods_activity.go
@@ -204,15 +204,13 @@ func (e *mutableStateBuilder) GetActivityScheduledEvent(
 }
 
 func (e *mutableStateBuilder) AddActivityTaskScheduledEvent(
-	ctx context.Context,
 	decisionCompletedEventID int64,
 	attributes *types.ScheduleActivityTaskDecisionAttributes,
-	dispatch bool,
-) (*types.HistoryEvent, *persistence.ActivityInfo, *types.ActivityLocalDispatchInfo, bool, bool, error) {
+) (*types.HistoryEvent, *persistence.ActivityInfo, *types.ActivityLocalDispatchInfo, error) {
 
 	opTag := tag.WorkflowActionActivityTaskScheduled
 	if err := e.checkMutability(opTag); err != nil {
-		return nil, nil, nil, false, false, err
+		return nil, nil, nil, err
 	}
 
 	_, ok := e.GetActivityByActivityID(attributes.GetActivityID())
@@ -220,7 +218,7 @@ func (e *mutableStateBuilder) AddActivityTaskScheduledEvent(
 		e.logger.Warn(mutableStateInvalidHistoryActionMsg, opTag,
 			tag.WorkflowEventID(e.GetNextEventID()),
 			tag.ErrorTypeInvalidHistoryAction)
-		return nil, nil, nil, false, false, e.createCallerError(opTag)
+		return nil, nil, nil, e.createCallerError(opTag)
 	}
 
 	pendingActivitiesCount := len(e.pendingActivityInfoIDs)
@@ -233,7 +231,7 @@ func (e *mutableStateBuilder) AddActivityTaskScheduledEvent(
 			tag.Number(int64(pendingActivitiesCount)))
 
 		if e.config.PendingActivityValidationEnabled() {
-			return nil, nil, nil, false, false, ErrTooManyPendingActivities
+			return nil, nil, nil, ErrTooManyPendingActivities
 		}
 	} else if pendingActivitiesCount >= e.config.PendingActivitiesCountLimitWarn() && !e.pendingActivityWarningSent {
 		e.logger.Warn("Pending activity count exceeds warn limit",
@@ -258,63 +256,19 @@ func (e *mutableStateBuilder) AddActivityTaskScheduledEvent(
 
 	ai, err := e.ReplicateActivityTaskScheduledEvent(decisionCompletedEventID, event, true)
 	if err != nil {
-		return nil, nil, nil, false, false, err
+		return nil, nil, nil, err
 	}
 	activityStartedScope := e.metricsClient.Scope(metrics.HistoryRecordActivityTaskStartedScope)
 	if e.config.EnableActivityLocalDispatchByDomain(e.domainEntry.GetInfo().Name) && attributes.RequestLocalDispatch {
 		activityStartedScope.IncCounter(metrics.CadenceRequests)
-		return event, ai, &types.ActivityLocalDispatchInfo{ActivityID: ai.ActivityID}, false, false, nil
-	}
-	started := false
-	if dispatch {
-		started = e.tryDispatchActivityTask(ctx, event, ai)
-	}
-	if started {
-		activityStartedScope.IncCounter(metrics.CadenceRequests)
-		return event, ai, nil, true, true, nil
+		return event, ai, &types.ActivityLocalDispatchInfo{ActivityID: ai.ActivityID}, nil
 	}
 
 	if err := e.taskGenerator.GenerateActivityTransferTasks(event); err != nil {
-		return nil, nil, nil, dispatch, false, err
+		return nil, nil, nil, err
 	}
 
-	return event, ai, nil, dispatch, false, err
-}
-
-func (e *mutableStateBuilder) tryDispatchActivityTask(
-	ctx context.Context,
-	scheduledEvent *types.HistoryEvent,
-	ai *persistence.ActivityInfo,
-) bool {
-	taggedScope := e.metricsClient.Scope(metrics.HistoryScheduleDecisionTaskScope).Tagged(
-		metrics.DomainTag(e.domainEntry.GetInfo().Name),
-		metrics.WorkflowTypeTag(e.GetWorkflowType().Name),
-		metrics.TaskListTag(ai.TaskList))
-	taggedScope.IncCounter(metrics.DecisionTypeScheduleActivityDispatchCounter)
-	_, err := e.shard.GetService().GetMatchingClient().AddActivityTask(ctx, &types.AddActivityTaskRequest{
-		DomainUUID:       e.executionInfo.DomainID,
-		SourceDomainUUID: e.domainEntry.GetInfo().ID,
-		Execution: &types.WorkflowExecution{
-			WorkflowID: e.executionInfo.WorkflowID,
-			RunID:      e.executionInfo.RunID,
-		},
-		TaskList:                      &types.TaskList{Name: ai.TaskList},
-		ScheduleID:                    scheduledEvent.ID,
-		ScheduleToStartTimeoutSeconds: common.Int32Ptr(ai.ScheduleToStartTimeout),
-		ActivityTaskDispatchInfo: &types.ActivityTaskDispatchInfo{
-			ScheduledEvent:                  scheduledEvent,
-			StartedTimestamp:                common.Int64Ptr(e.timeSource.Now().UnixNano()),
-			WorkflowType:                    e.GetWorkflowType(),
-			WorkflowDomain:                  e.GetDomainEntry().GetInfo().Name,
-			ScheduledTimestampOfThisAttempt: common.Int64Ptr(ai.ScheduledTime.UnixNano()),
-		},
-		PartitionConfig: e.executionInfo.PartitionConfig,
-	})
-	if err == nil {
-		taggedScope.IncCounter(metrics.DecisionTypeScheduleActivityDispatchSucceedCounter)
-		return true
-	}
-	return false
+	return event, ai, nil, err
 }
 
 func (e *mutableStateBuilder) ReplicateActivityTaskScheduledEvent(

--- a/service/history/execution/mutable_state_builder_methods_activity_test.go
+++ b/service/history/execution/mutable_state_builder_methods_activity_test.go
@@ -92,8 +92,6 @@ func Test__AddActivityTaskScheduledEvent(t *testing.T) {
 		expectedAttributes *types.ActivityTaskScheduledEventAttributes
 		expectedInfo       *persistence.ActivityInfo
 		expectedDispatch   *types.ActivityLocalDispatchInfo
-		expectedDispatched bool
-		expectedStarted    bool
 		expectedError      error
 	}{
 		{
@@ -219,9 +217,7 @@ func Test__AddActivityTaskScheduledEvent(t *testing.T) {
 				mb.executionInfo.TaskListKind = tc.workflowTaskList.GetKind()
 			}
 
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-			defer cancel()
-			event, activityInfo, dispatchInfo, dispatched, started, err := mb.AddActivityTaskScheduledEvent(ctx, 0, tc.attr, tc.dispatch)
+			event, activityInfo, dispatchInfo, err := mb.AddActivityTaskScheduledEvent(0, tc.attr)
 			if tc.expectedError != nil {
 				assert.ErrorIs(t, err, tc.expectedError)
 				assert.Nil(t, event)
@@ -234,8 +230,6 @@ func Test__AddActivityTaskScheduledEvent(t *testing.T) {
 				assert.Equal(t, tc.expectedInfo, activityInfo)
 				assert.Equal(t, tc.expectedDispatch, dispatchInfo)
 			}
-			assert.Equal(t, tc.expectedDispatched, dispatched)
-			assert.Equal(t, tc.expectedStarted, started)
 		})
 	}
 }
@@ -373,14 +367,6 @@ func Test__AddActivityTaskCompletedEvent(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, int64(1), event.ActivityTaskCompletedEventAttributes.ScheduledEventID)
 	})
-}
-
-func Test__tryDispatchActivityTask(t *testing.T) {
-	mb := testMutableStateBuilder(t)
-	event := &types.HistoryEvent{}
-	ai := &persistence.ActivityInfo{}
-	result := mb.tryDispatchActivityTask(context.Background(), event, ai)
-	assert.True(t, result)
 }
 
 func Test__ReplicateActivityTaskCanceledEvent(t *testing.T) {

--- a/service/history/execution/mutable_state_builder_test.go
+++ b/service/history/execution/mutable_state_builder_test.go
@@ -130,7 +130,7 @@ func (s *mutableStateSuite) TestErrorReturnedWhenSchedulingTooManyPendingActivit
 		s.msBuilder.pendingActivityInfoIDs[int64(i)] = &persistence.ActivityInfo{}
 	}
 
-	_, _, _, _, _, err := s.msBuilder.AddActivityTaskScheduledEvent(nil, 1, &types.ScheduleActivityTaskDecisionAttributes{}, false)
+	_, _, _, err := s.msBuilder.AddActivityTaskScheduledEvent(1, &types.ScheduleActivityTaskDecisionAttributes{})
 	assert.Equal(s.T(), "Too many pending activities", err.Error())
 }
 

--- a/service/history/execution/mutable_state_mock.go
+++ b/service/history/execution/mutable_state_mock.go
@@ -109,22 +109,20 @@ func (mr *MockMutableStateMockRecorder) AddActivityTaskFailedEvent(arg0, arg1, a
 }
 
 // AddActivityTaskScheduledEvent mocks base method.
-func (m *MockMutableState) AddActivityTaskScheduledEvent(arg0 context.Context, arg1 int64, arg2 *types.ScheduleActivityTaskDecisionAttributes, arg3 bool) (*types.HistoryEvent, *persistence.ActivityInfo, *types.ActivityLocalDispatchInfo, bool, bool, error) {
+func (m *MockMutableState) AddActivityTaskScheduledEvent(arg0 int64, arg1 *types.ScheduleActivityTaskDecisionAttributes) (*types.HistoryEvent, *persistence.ActivityInfo, *types.ActivityLocalDispatchInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddActivityTaskScheduledEvent", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "AddActivityTaskScheduledEvent", arg0, arg1)
 	ret0, _ := ret[0].(*types.HistoryEvent)
 	ret1, _ := ret[1].(*persistence.ActivityInfo)
 	ret2, _ := ret[2].(*types.ActivityLocalDispatchInfo)
-	ret3, _ := ret[3].(bool)
-	ret4, _ := ret[4].(bool)
-	ret5, _ := ret[5].(error)
-	return ret0, ret1, ret2, ret3, ret4, ret5
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
 }
 
 // AddActivityTaskScheduledEvent indicates an expected call of AddActivityTaskScheduledEvent.
-func (mr *MockMutableStateMockRecorder) AddActivityTaskScheduledEvent(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockMutableStateMockRecorder) AddActivityTaskScheduledEvent(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddActivityTaskScheduledEvent", reflect.TypeOf((*MockMutableState)(nil).AddActivityTaskScheduledEvent), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddActivityTaskScheduledEvent", reflect.TypeOf((*MockMutableState)(nil).AddActivityTaskScheduledEvent), arg0, arg1)
 }
 
 // AddActivityTaskStartedEvent mocks base method.

--- a/service/history/task/transfer_active_task_executor_test.go
+++ b/service/history/task/transfer_active_task_executor_test.go
@@ -238,7 +238,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessActivityTask_EphemeralTaskL
 	workflowExecution, mutableState, decisionCompletionID, err := test.SetupWorkflowWithCompletedDecision(s.T(), s.mockShard, s.domainID)
 	s.NoError(err)
 
-	event, ai, _, _, _, _ := mutableState.AddActivityTaskScheduledEvent(nil, decisionCompletionID, &types.ScheduleActivityTaskDecisionAttributes{
+	event, ai, _, _ := mutableState.AddActivityTaskScheduledEvent(decisionCompletionID, &types.ScheduleActivityTaskDecisionAttributes{
 		ActivityID:                    "activity-1",
 		ActivityType:                  &types.ActivityType{Name: "some random activity type"},
 		TaskList:                      &types.TaskList{Name: mutableState.GetExecutionInfo().TaskList, Kind: types.TaskListKindEphemeral.Ptr()},
@@ -247,8 +247,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessActivityTask_EphemeralTaskL
 		ScheduleToStartTimeoutSeconds: common.Int32Ptr(1),
 		StartToCloseTimeoutSeconds:    common.Int32Ptr(1),
 		HeartbeatTimeoutSeconds:       common.Int32Ptr(1),
-	}, false,
-	)
+	})
 	mutableState.FlushBufferedEvents()
 
 	transferTask := s.newTransferTaskFromInfo(&persistence.ActivityTask{

--- a/service/history/task/transfer_standby_task_executor_test.go
+++ b/service/history/task/transfer_standby_task_executor_test.go
@@ -303,7 +303,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessActivityTask_Pending_TaskL
 	workflowExecution, mutableState, decisionCompletionID, err := test.SetupWorkflowWithCompletedDecision(s.T(), s.mockShard, s.domainID)
 	s.NoError(err)
 
-	event, ai, _, _, _, _ := mutableState.AddActivityTaskScheduledEvent(nil, decisionCompletionID, &types.ScheduleActivityTaskDecisionAttributes{
+	event, ai, _, _ := mutableState.AddActivityTaskScheduledEvent(decisionCompletionID, &types.ScheduleActivityTaskDecisionAttributes{
 		ActivityID:                    "activity-1",
 		ActivityType:                  &types.ActivityType{Name: "some random activity type"},
 		TaskList:                      &types.TaskList{Name: mutableState.GetExecutionInfo().TaskList, Kind: types.TaskListKindEphemeral.Ptr()},
@@ -312,8 +312,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessActivityTask_Pending_TaskL
 		ScheduleToStartTimeoutSeconds: common.Int32Ptr(1),
 		StartToCloseTimeoutSeconds:    common.Int32Ptr(1),
 		HeartbeatTimeoutSeconds:       common.Int32Ptr(1),
-	}, false,
-	)
+	})
 
 	now := time.Now()
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))

--- a/service/history/testing/events_util.go
+++ b/service/history/testing/events_util.go
@@ -149,7 +149,7 @@ func AddActivityTaskScheduledEvent(
 ) (*types.HistoryEvent,
 	*persistence.ActivityInfo) {
 
-	event, ai, _, _, _, _ := builder.AddActivityTaskScheduledEvent(nil, decisionCompletedID, &types.ScheduleActivityTaskDecisionAttributes{
+	event, ai, _, _ := builder.AddActivityTaskScheduledEvent(decisionCompletedID, &types.ScheduleActivityTaskDecisionAttributes{
 		ActivityID:                    activityID,
 		ActivityType:                  &types.ActivityType{Name: activityType},
 		TaskList:                      &types.TaskList{Name: taskList, Kind: types.TaskListKindNormal.Ptr()},
@@ -158,8 +158,7 @@ func AddActivityTaskScheduledEvent(
 		ScheduleToStartTimeoutSeconds: common.Int32Ptr(scheduleToStartTimeout),
 		StartToCloseTimeoutSeconds:    common.Int32Ptr(startToCloseTimeout),
 		HeartbeatTimeoutSeconds:       common.Int32Ptr(heartbeatTimeout),
-	}, false,
-	)
+	})
 
 	return event, ai
 }
@@ -179,7 +178,7 @@ func AddActivityTaskScheduledEventWithRetry(
 	retryPolicy *types.RetryPolicy,
 ) (*types.HistoryEvent, *persistence.ActivityInfo) {
 
-	event, ai, _, _, _, _ := builder.AddActivityTaskScheduledEvent(nil, decisionCompletedID, &types.ScheduleActivityTaskDecisionAttributes{
+	event, ai, _, _ := builder.AddActivityTaskScheduledEvent(decisionCompletedID, &types.ScheduleActivityTaskDecisionAttributes{
 		ActivityID:                    activityID,
 		ActivityType:                  &types.ActivityType{Name: activityType},
 		TaskList:                      &types.TaskList{Name: taskList},
@@ -189,8 +188,7 @@ func AddActivityTaskScheduledEventWithRetry(
 		StartToCloseTimeoutSeconds:    common.Int32Ptr(startToCloseTimeout),
 		HeartbeatTimeoutSeconds:       common.Int32Ptr(heartbeatTimeout),
 		RetryPolicy:                   retryPolicy,
-	}, false,
-	)
+	})
 
 	return event, ai
 }


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
revert: https://github.com/cadence-workflow/cadence/pull/4816

related to: https://github.com/cadence-workflow/cadence/issues/7839

**Why?**
The feature is deprecated due to its design flaw. Check details in the issue.

**How did you test it?**
cd service/history && go test ./...

**Potential risks**
No.

**Release notes**
N/A

**Documentation Changes**
N/A
