### PR TITLE
feat(schedules): Implement overlap policy enforcement for scheduler workflow

### DIFF
--- a/service/worker/scheduler/activity.go
+++ b/service/worker/scheduler/activity.go
@@ -139,7 +139,7 @@ func describeWorkflowActivity(ctx context.Context, req DescribeWorkflowRequest) 
 }
 
 // cancelWorkflowActivity sends a cancellation request to a running workflow.
-func cancelWorkflowActivity(ctx context.Context, req TerminateWorkflowRequest) error {
+func cancelWorkflowActivity(ctx context.Context, req CancelWorkflowRequest) error {
 	sc, ok := ctx.Value(schedulerContextKey).(schedulerContext)
 	if !ok {
 		return fmt.Errorf("scheduler context not found in activity context")
@@ -151,6 +151,7 @@ func cancelWorkflowActivity(ctx context.Context, req TerminateWorkflowRequest) e
 			WorkflowID: req.WorkflowID,
 			RunID:      req.RunID,
 		},
+		Cause: req.Cause,
 	})
 	if err != nil && !isEntityNotExistsError(err) {
 		return fmt.Errorf("failed to cancel workflow: %w", err)

--- a/service/worker/scheduler/activity_test.go
+++ b/service/worker/scheduler/activity_test.go
@@ -307,9 +307,14 @@ func TestCancelWorkflowActivity(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			name: "successful cancel",
+			name: "successful cancel with cause",
 			setupMock: func(m *frontend.MockClient) {
-				m.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.RequestCancelWorkflowExecutionRequest, _ ...interface{}) error {
+						assert.Equal(t, "schedule overlap policy: CANCEL_PREVIOUS", req.Cause)
+						assert.Equal(t, "wf-1", req.WorkflowExecution.WorkflowID)
+						return nil
+					})
 			},
 		},
 		{
@@ -339,11 +344,11 @@ func TestCancelWorkflowActivity(t *testing.T) {
 				FrontendClient: mockClient,
 			})
 
-			err := cancelWorkflowActivity(ctx, TerminateWorkflowRequest{
+			err := cancelWorkflowActivity(ctx, CancelWorkflowRequest{
 				Domain:     "test-domain",
 				WorkflowID: "wf-1",
 				RunID:      "run-1",
-				Reason:     "overlap",
+				Cause:      "schedule overlap policy: CANCEL_PREVIOUS",
 			})
 			if tc.wantErr {
 				require.Error(t, err)

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -180,7 +180,15 @@ type DescribeWorkflowResult struct {
 	IsRunning bool `json:"isRunning"`
 }
 
-// TerminateWorkflowRequest is the input to the terminate/cancel workflow activity.
+// CancelWorkflowRequest is the input to the cancel workflow activity.
+type CancelWorkflowRequest struct {
+	Domain     string `json:"domain"`
+	WorkflowID string `json:"workflowId"`
+	RunID      string `json:"runId"`
+	Cause      string `json:"cause"`
+}
+
+// TerminateWorkflowRequest is the input to the terminate workflow activity.
 type TerminateWorkflowRequest struct {
 	Domain     string `json:"domain"`
 	WorkflowID string `json:"workflowId"`

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -409,14 +409,18 @@ func processScheduleFire(ctx workflow.Context, logger *zap.Logger, input *Schedu
 				// TODO(overlap-buffer): implement sequential buffered execution
 				return
 			case types.ScheduleOverlapPolicyCancelPrevious:
+				// Cancel is cooperative: the previous workflow receives a cancellation
+				// signal but may continue running while it handles cleanup. A brief
+				// overlap with the new run is expected. Use TERMINATE_PREVIOUS for a
+				// hard guarantee of no concurrent execution.
 				logger.Info("cancelling previous workflow due to overlap policy",
 					zap.String("workflowId", state.LastStartedWorkflow.WorkflowID),
 				)
-				if err := workflow.ExecuteLocalActivity(actCtx, cancelWorkflowActivity, TerminateWorkflowRequest{
+				if err := workflow.ExecuteLocalActivity(actCtx, cancelWorkflowActivity, CancelWorkflowRequest{
 					Domain:     input.Domain,
 					WorkflowID: state.LastStartedWorkflow.WorkflowID,
 					RunID:      state.LastStartedWorkflow.RunID,
-					Reason:     "schedule overlap policy: CANCEL_PREVIOUS",
+					Cause:      "schedule overlap policy: CANCEL_PREVIOUS",
 				}).Get(ctx, nil); err != nil {
 					logger.Error("failed to cancel previous workflow, skipping new fire",
 						zap.String("workflowId", state.LastStartedWorkflow.WorkflowID),


### PR DESCRIPTION
**What changed?**
- types.go: Added RunningWorkflowInfo struct and LastStartedWorkflow field to SchedulerWorkflowState for tracking the most recently started target workflow. 
- activity.go: Added three new activities: 
describeWorkflowActivity: calls DescribeWorkflowExecution to check if a target workflow is still running
- cancelWorkflowActivity: calls RequestCancelWorkflowExecution for graceful cancellation
- terminateWorkflowActivity: calls TerminateWorkflowExecution for forceful termination

- workflow.go: Rewrote processScheduleFire to enforce overlap policies before starting a new workflow:

**SKIP_NEW** (default when unset): if previous workflow is still running, skip and count as SkippedRuns
**BUFFER:** currently behaves like SKIP_NEW with a TODO for full sequential execution
**CANCEL_PREVIOUS:** cancels the running workflow, then starts the new one; if cancel fails, counts as MissedRuns and does not start
**TERMINATE_PREVIOUS:** terminates the running workflow, then starts the new one; same failure handling as cancel
**CONCURRENT:** skips the overlap check entirely, always starts

- Fixed TotalRuns to only increment on actual successful starts, not on skips or failures
- Fixed LastStartedWorkflow to update on AlreadyStartedError so future overlap checks target the correct workflow

**Why?**
Without them, every schedule fire unconditionally starts a new workflow regardless of whether the previous one is still running. This causes resource waste, data duplication, and violates the contract users expect when configuring SKIP_NEW or CANCEL_PREVIOUS.

**How did you test it?**
go test ./service/worker/scheduler/... -v -count=1

**Potential risks**
- Extra RPC per fire: For policies other than CONCURRENT, each fire now does a DescribeWorkflowExecution call before starting. This is a lightweight read but adds ~1 RPC round trip of latency per fire.
- Race between describe and start: A workflow could complete between the describe check and the start call. This is safe: the new workflow starts normally, and the deterministic RequestID prevents duplicates. At worst we start a workflow we could have skipped, which is the conservative choice.

**Release notes**
implementation phase

**Documentation Changes**
N/A
