### PR TITLE
test: Handle map struct values in clearFieldsIf for fuzz mapper

### DIFF
--- a/common/types/mapper/proto/api_test.go
+++ b/common/types/mapper/proto/api_test.go
@@ -2035,10 +2035,10 @@ func TestListOpenWorkflowExecutionsRequestFuzz(t *testing.T) {
 }
 
 func TestGetTaskListsByDomainResponseFuzz(t *testing.T) {
-	// SKIPPED: PartitionConfig is nested inside map values (map[string]*DescribeTaskListResponse)
-	// clearFieldsIf cannot modify fields inside map values due to Go reflection limitations
-	// TODO(c-warren): Implement map rebuilding in clearFieldsIf to support this pattern
-	t.Skip("Map value field exclusion not yet supported")
+	// SKIPPED: TaskListPartitionConfig uses map[int]*TaskListPartition internally but the proto
+	// mapper converts int keys to int32, making the round trip lossy for fuzzed int values.
+	// This is a known limitation of the proto mapper, not a clearFieldsIf issue.
+	t.Skip("Proto mapper truncates map[int] keys to int32, causing lossy round trip")
 	testutils.RunMapperFuzzTest(t, FromGetTaskListsByDomainResponse, ToGetTaskListsByDomainResponse)
 }
 

--- a/common/types/mapper/testutils/fuzz_mapper.go
+++ b/common/types/mapper/testutils/fuzz_mapper.go
@@ -252,12 +252,47 @@ func clearFieldsIf(obj interface{}, shouldClear func(fieldName string) bool) {
 					}
 				}
 			case reflect.Map:
-				// Map values cannot be modified through reflection in Go.
-				// Calling clearFieldsIf on map values would operate on copies that are discarded.
-				// To properly handle maps with struct values, the map would need to be rebuilt
-				// with cleared values, which is beyond the scope of this utility.
-				// Since Cadence types primarily use slices and pointers rather than maps of structs,
-				// this limitation has minimal practical impact.
+				clearMapValues(field, shouldClear)
+			}
+		}
+	}
+}
+
+// clearMapValues rebuilds a map, recursively clearing fields in struct or pointer-to-struct values.
+// In Go, map values retrieved via reflection are copies and cannot be modified in place.
+// This function rebuilds the map with cleared values to work around that limitation.
+func clearMapValues(m reflect.Value, shouldClear func(string) bool) {
+	if m.IsNil() {
+		return
+	}
+
+	valType := m.Type().Elem()
+	needsClear := false
+
+	switch valType.Kind() {
+	case reflect.Struct:
+		needsClear = true
+	case reflect.Ptr:
+		needsClear = valType.Elem().Kind() == reflect.Struct
+	}
+
+	if !needsClear {
+		return
+	}
+
+	for _, key := range m.MapKeys() {
+		val := m.MapIndex(key)
+
+		switch valType.Kind() {
+		case reflect.Struct:
+			// Create a new addressable copy, clear it, and set it back
+			cp := reflect.New(valType).Elem()
+			cp.Set(val)
+			clearFieldsIf(cp.Addr().Interface(), shouldClear)
+			m.SetMapIndex(key, cp)
+		case reflect.Ptr:
+			if !val.IsNil() {
+				clearFieldsIf(val.Interface(), shouldClear)
 			}
 		}
 	}

--- a/common/types/mapper/testutils/fuzz_mapper_test.go
+++ b/common/types/mapper/testutils/fuzz_mapper_test.go
@@ -196,6 +196,123 @@ func TestClearFieldsIf_TriplePointer(t *testing.T) {
 	assert.Equal(t, "", level1.XXX_ClearMe, "Should clear through triple pointer")
 }
 
+func TestClearFieldsIf_MapWithStructValues(t *testing.T) {
+	type innerStruct struct {
+		KeepMe      string
+		XXX_ClearMe string // revive:disable-line:var-naming Protobuf internal field pattern (XXX_ prefix)
+		AlsoClearMe string
+	}
+	type outerStruct struct {
+		StructMap map[string]innerStruct
+	}
+
+	obj := &outerStruct{
+		StructMap: map[string]innerStruct{
+			"a": {KeepMe: "keep1", XXX_ClearMe: "clear1", AlsoClearMe: "clear1"},
+			"b": {KeepMe: "keep2", XXX_ClearMe: "clear2", AlsoClearMe: "clear2"},
+		},
+	}
+
+	clearExcludedFields(obj, []string{"AlsoClearMe"})
+
+	// Map values should have their excluded fields cleared via map rebuild
+	assert.Equal(t, "keep1", obj.StructMap["a"].KeepMe, "KeepMe should not be cleared in map value")
+	assert.Equal(t, "", obj.StructMap["a"].XXX_ClearMe, "XXX_ClearMe should be cleared in map struct value")
+	assert.Equal(t, "", obj.StructMap["a"].AlsoClearMe, "AlsoClearMe should be cleared in map struct value")
+
+	assert.Equal(t, "keep2", obj.StructMap["b"].KeepMe, "KeepMe should not be cleared in map value")
+	assert.Equal(t, "", obj.StructMap["b"].XXX_ClearMe, "XXX_ClearMe should be cleared in map struct value")
+	assert.Equal(t, "", obj.StructMap["b"].AlsoClearMe, "AlsoClearMe should be cleared in map struct value")
+}
+
+func TestClearFieldsIf_MapWithPointerValues(t *testing.T) {
+	type innerStruct struct {
+		KeepMe      string
+		XXX_ClearMe string // revive:disable-line:var-naming Protobuf internal field pattern (XXX_ prefix)
+		AlsoClearMe string
+	}
+	type outerStruct struct {
+		PtrMap map[string]*innerStruct
+	}
+
+	obj := &outerStruct{
+		PtrMap: map[string]*innerStruct{
+			"a": {KeepMe: "keep1", XXX_ClearMe: "clear1", AlsoClearMe: "clear1"},
+			"b": {KeepMe: "keep2", XXX_ClearMe: "clear2", AlsoClearMe: "clear2"},
+		},
+	}
+
+	clearExcludedFields(obj, []string{"AlsoClearMe"})
+
+	// Pointer map values should have their excluded fields cleared
+	assert.Equal(t, "keep1", obj.PtrMap["a"].KeepMe, "KeepMe should not be cleared in map pointer value")
+	assert.Equal(t, "", obj.PtrMap["a"].XXX_ClearMe, "XXX_ClearMe should be cleared in map pointer value")
+	assert.Equal(t, "", obj.PtrMap["a"].AlsoClearMe, "AlsoClearMe should be cleared in map pointer value")
+
+	assert.Equal(t, "keep2", obj.PtrMap["b"].KeepMe, "KeepMe should not be cleared in map pointer value")
+	assert.Equal(t, "", obj.PtrMap["b"].XXX_ClearMe, "XXX_ClearMe should be cleared in map pointer value")
+	assert.Equal(t, "", obj.PtrMap["b"].AlsoClearMe, "AlsoClearMe should be cleared in map pointer value")
+}
+
+func TestClearFieldsIf_MapWithNilPointerValues(t *testing.T) {
+	type innerStruct struct {
+		XXX_ClearMe string // revive:disable-line:var-naming Protobuf internal field pattern (XXX_ prefix)
+	}
+	type outerStruct struct {
+		PtrMap map[string]*innerStruct
+	}
+
+	obj := &outerStruct{
+		PtrMap: map[string]*innerStruct{
+			"a": {XXX_ClearMe: "clear"},
+			"b": nil,
+		},
+	}
+
+	clearExcludedFields(obj, nil)
+
+	assert.Equal(t, "", obj.PtrMap["a"].XXX_ClearMe, "XXX_ClearMe should be cleared")
+	assert.Nil(t, obj.PtrMap["b"], "nil pointer value should remain nil")
+}
+
+func TestClearFieldsIf_NilMap(t *testing.T) {
+	type innerStruct struct {
+		XXX_ClearMe string // revive:disable-line:var-naming Protobuf internal field pattern (XXX_ prefix)
+	}
+	type outerStruct struct {
+		StructMap map[string]innerStruct
+	}
+
+	obj := &outerStruct{
+		StructMap: nil,
+	}
+
+	// Should not panic on nil map
+	clearExcludedFields(obj, nil)
+
+	assert.Nil(t, obj.StructMap, "nil map should remain nil")
+}
+
+func TestClearFieldsIf_MapWithPrimitiveValues(t *testing.T) {
+	type outerStruct struct {
+		StringMap map[string]string
+		IntMap    map[string]int
+	}
+
+	obj := &outerStruct{
+		StringMap: map[string]string{"a": "val1", "b": "val2"},
+		IntMap:    map[string]int{"x": 1, "y": 2},
+	}
+
+	clearExcludedFields(obj, nil)
+
+	// Primitive map values should not be modified
+	assert.Equal(t, "val1", obj.StringMap["a"], "string map value should not be modified")
+	assert.Equal(t, "val2", obj.StringMap["b"], "string map value should not be modified")
+	assert.Equal(t, 1, obj.IntMap["x"], "int map value should not be modified")
+	assert.Equal(t, 2, obj.IntMap["y"], "int map value should not be modified")
+}
+
 func TestClearFieldsIf_WithExcludedFields(t *testing.T) {
 	// This test verifies that WithExcludedFields works correctly with pointer types
 	// Previously, this would silently do nothing due to the double-pointer bug


### PR DESCRIPTION
**What changed?**
Implemented map value handling in `clearFieldsIf` (`common/types/mapper/testutils/fuzz_mapper.go`). The function now recursively clears fields inside map values that are structs or pointers to structs, instead of silently skipping them. Also updated the skip reason for `TestGetTaskListsByDomainResponseFuzz` to accurately reflect the remaining issue (proto mapper int key truncation). #7788

**Why?**
Go reflection returns copies of map values, so modifying them in place has no effect on the original map. The previous code documented this limitation with an empty `case reflect.Map:` branch. This meant `clearFieldsIf` could not clear excluded fields (like protobuf internal `XXX_` fields) nested inside map values, which prevented fuzz testing of types containing maps of structs. The new `clearMapValues` helper works around this by rebuilding maps: for struct-valued maps it creates addressable copies, clears them, and sets them back; for pointer-valued maps it recurses into the pointed-to struct directly.

**How did you test it?**
```bash
# Run all clearFieldsIf unit tests (including 5 new map-specific tests)
go test -race -v -run "TestClearFieldsIf" ./common/types/mapper/testutils/...

# Run all fuzz tests in proto mapper to verify no regressions
go test -race -run "Fuzz" ./common/types/mapper/proto/... -count 1

# Run all fuzz tests in thrift mapper
go test -race -run "Fuzz" ./common/types/mapper/thrift/... -count 1
```

**Potential risks**
N/A — test-only change with no impact on production code.

**Release notes**
N/A

**Documentation Changes**
N/A