### PR TITLE
fix(test): Stop grpc.Transport in DirectChooser tests to prevent goroutine leak

### DIFF
--- a/common/rpc/direct_peer_chooser_test.go
+++ b/common/rpc/direct_peer_chooser_test.go
@@ -42,6 +42,7 @@ func TestDirectChooser_PeerUpdates(t *testing.T) {
 	serviceName := "service"
 	directConnRetainFn := func(opts ...dynamicproperties.FilterOption) bool { return true }
 	grpcTransport := grpc.NewTransport()
+	defer grpcTransport.Stop()
 	chooser := newDirectChooser(serviceName, grpcTransport, logger, metricCl, directConnRetainFn)
 
 	choosePeers := func(peers ...string) {
@@ -184,6 +185,7 @@ func TestDirectChooser_StartStop(t *testing.T) {
 			serviceName := "service"
 			directConnRetainFn := func(opts ...dynamicproperties.FilterOption) bool { return tc.retainConn }
 			grpcTransport := grpc.NewTransport()
+			defer grpcTransport.Stop()
 
 			chooser := newDirectChooser(serviceName, grpcTransport, logger, metricCl, directConnRetainFn)
 


### PR DESCRIPTION
**What changed?**
Added `defer grpcTransport.Stop()` in both `TestDirectChooser_StartStop` and `TestDirectChooser_PeerUpdates` to properly clean up the gRPC transport after each test. #7779

**Why?**
`TestDirectChooser_StartStop` uses `goleak.VerifyNone(t)` to detect leaked goroutines. The test creates a `grpc.Transport` via `grpc.NewTransport()` but never calls `Stop()` on it. The transport spawns internal goroutines for connection management that outlive the test, causing `goleak.VerifyNone` to intermittently fail depending on goroutine scheduling. This is the same pattern used in other tests in the same package (e.g., `factory_test.go` which stops transports before goleak checks). The `TestDirectChooser_PeerUpdates` test had the same missing cleanup, so it was fixed proactively even though it does not currently use goleak.

**How did you test it?**
```bash
# Run the previously flaky test 5 times to verify reliability
go test -race -run "TestDirectChooser_StartStop" ./common/rpc/... -v -count 5

# Run all DirectChooser tests to verify no regressions
go test -race -run "TestDirectChooser" ./common/rpc/... -v -count 1
```

**Potential risks**
N/A — test-only change with no impact on production code.

**Release notes**
N/A

**Documentation Changes**
N/A