### PR TITLE
fix(test): Eliminate race condition in Test_refreshLoop_domainCacheRefreshedError

### DIFF
--- a/common/cache/domainCache_test.go
+++ b/common/cache/domainCache_test.go
@@ -890,12 +890,19 @@ func (s *domainCacheSuite) Test_refreshLoop_domainCacheRefreshedError() {
 
 	s.domainCache.timeSource = mockedTimeSource
 
-	s.metadataMgr.On("GetMetadata", mock.Anything).Return(nil, assert.AnError).Once()
+	// Send the shutdown signal from inside the GetMetadata mock callback to
+	// guarantee the timer branch is selected before shutdown. Previously,
+	// both channels could be ready simultaneously, letting Go's select
+	// randomly pick shutdown first and skip the timer entirely.
+	s.metadataMgr.On("GetMetadata", mock.Anything).Return(nil, assert.AnError).Once().Run(func(mock.Arguments) {
+		// Use a goroutine because shutdownChan is unbuffered and refreshLoop
+		// is blocked inside the timer case until refreshDomains returns.
+		go func() { s.domainCache.shutdownChan <- struct{}{} }()
+	})
 
 	go func() {
 		mockedTimeSource.BlockUntil(1)
 		mockedTimeSource.Advance(DomainCacheRefreshInterval)
-		s.domainCache.shutdownChan <- struct{}{}
 	}()
 
 	s.domainCache.refreshLoop()


### PR DESCRIPTION
**What changed?**
Restructured the `Test_refreshLoop_domainCacheRefreshedError` test so the shutdown signal is triggered from within the `GetMetadata` mock callback instead of being sent sequentially after advancing the mocked timer. #7762

**Why?**
The test was flaky because it advanced the mocked timer and sent a shutdown signal from the same goroutine in sequence. By the time `refreshLoop`'s select evaluated both channels, `timer.Chan()` and `shutdownChan` could both be ready simultaneously. Go's select randomly chooses between ready cases, so it could pick shutdown first—exiting the loop without ever calling `refreshDomains()`. The mock expected exactly one `GetMetadata` call (`.Once()`), causing `AssertExpectations` in `TearDownTest` to fail.

The fix triggers shutdown from within the `GetMetadata` mock callback via a goroutine. This guarantees the timer branch is always selected first, because shutdown only becomes ready after `refreshDomains` has already been entered. The goroutine is necessary because `shutdownChan` is unbuffered and `refreshLoop` is still inside the timer case when the callback runs.

**How did you test it?**
```bash
# Run the previously flaky test 10 times to verify reliability
go test -race -run "TestDomainCacheSuite/Test_refreshLoop_domainCacheRefreshedError" ./common/cache/... -v -count 10

# Run the full domain cache test suite to verify no regressions
go test -race -run "TestDomainCacheSuite" ./common/cache/... -count 1
```

**Potential risks**
N/A — test-only change with no impact on production code.

**Release notes**
N/A

**Documentation Changes**
N/A