### PR TITLE
fix(test): skip SQLite persistence tests under race detector

### DIFF
--- a/common/persistence/sql/sqlplugin/sqlite/sqlite_persistence_test.go
+++ b/common/persistence/sql/sqlplugin/sqlite/sqlite_persistence_test.go
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build !race
+
 package sqlite
 
 import (


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Added //go:build !race to common/persistence/sql/sqlplugin/sqlite/sqlite_persistence_test.go to exclude SQLite persistence tests when running with the race detector.

**Why?**
SQLite uses CGO, and the race detector's instrumentation significantly increases stack usage per goroutine. This causes a fatal split stack overflow in SQLite's native memmove during large history event writes in TestSQLiteHistoryV2PersistenceSuite. Since the crash kills the entire test binary, all SQLite tests fail. This follows the existing pattern used in other packages in this repo (e.g., cmd/server/cadence/server_test.go).

**How did you test it?**
go test -race ./common/persistence/sql/sqlplugin/sqlite/

**Potential risks**
N/A

**Release notes**
N/A flaky test fix

**Documentation Changes**
N/A flaky test fix
