### PR TITLE
feat(scheduler): implement overlap policy enforcement with single-activity pattern

### DIFF
--- a/service/worker/scheduler/activity.go
+++ b/service/worker/scheduler/activity.go
@@ -46,17 +46,54 @@ type schedulerContext struct {
 	FrontendClient frontend.Client
 }
 
-// startWorkflowActivity starts a workflow execution as specified by the schedule's action.
-// It generates a deterministic workflow ID from the schedule ID and scheduled time
-// to ensure idempotent execution.
-func startWorkflowActivity(ctx context.Context, req StartWorkflowRequest) (*StartWorkflowResult, error) {
+// processScheduleFireActivity is the single activity that handles a schedule fire.
+// It encapsulates all side effects, checking if the previous workflow is running,
+// enforcing the overlap policy (cancel/terminate), and starting the new workflow.
+// Keeping all of this in one activity means the workflow history records a single
+// activity call per fire, so the internal logic can evolve freely without
+// introducing nondeterminism.
+func processScheduleFireActivity(ctx context.Context, req ProcessFireRequest) (*ProcessFireResult, error) {
 	sc, ok := ctx.Value(schedulerContextKey).(schedulerContext)
 	if !ok {
 		return nil, fmt.Errorf("scheduler context not found in activity context")
 	}
 
-	workflowID := generateWorkflowID(req.Action.WorkflowIDPrefix, req.ScheduleID, req.ScheduledTime)
+	result := &ProcessFireResult{}
 
+	policy := req.OverlapPolicy
+	if policy == types.ScheduleOverlapPolicyInvalid {
+		policy = types.ScheduleOverlapPolicySkipNew
+	}
+
+	if policy != types.ScheduleOverlapPolicyConcurrent && req.LastStartedWorkflow != nil {
+		running, err := isWorkflowRunning(ctx, sc.FrontendClient, req.Domain, req.LastStartedWorkflow)
+		if err != nil {
+			return nil, err
+		}
+		if running {
+			switch policy {
+			case types.ScheduleOverlapPolicySkipNew:
+				result.SkippedDelta = 1
+				result.StartedWorkflow = req.LastStartedWorkflow
+				return result, nil
+			case types.ScheduleOverlapPolicyBuffer:
+				// TODO(overlap-buffer): implement sequential buffered execution
+				result.SkippedDelta = 1
+				result.StartedWorkflow = req.LastStartedWorkflow
+				return result, nil
+			case types.ScheduleOverlapPolicyCancelPrevious:
+				if err := cancelWorkflow(ctx, sc.FrontendClient, req.Domain, req.LastStartedWorkflow); err != nil {
+					return nil, err
+				}
+			case types.ScheduleOverlapPolicyTerminatePrevious:
+				if err := terminateWorkflow(ctx, sc.FrontendClient, req.Domain, req.LastStartedWorkflow); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
+	workflowID := generateWorkflowID(req.Action.WorkflowIDPrefix, req.ScheduleID, req.ScheduledTime)
 	reusePolicy := types.WorkflowIDReusePolicyAllowDuplicate
 	startReq := &types.StartWorkflowExecutionRequest{
 		Domain:                              req.Domain,
@@ -77,20 +114,22 @@ func startWorkflowActivity(ctx context.Context, req StartWorkflowRequest) (*Star
 	if err != nil {
 		var alreadyStarted *types.WorkflowExecutionAlreadyStartedError
 		if errors.As(err, &alreadyStarted) {
-			return &StartWorkflowResult{
+			result.SkippedDelta = 1
+			result.StartedWorkflow = &RunningWorkflowInfo{
 				WorkflowID: workflowID,
 				RunID:      alreadyStarted.RunID,
-				Skipped:    true,
-			}, nil
+			}
+			return result, nil
 		}
 		return nil, fmt.Errorf("failed to start workflow: %w", err)
 	}
 
-	return &StartWorkflowResult{
+	result.TotalDelta = 1
+	result.StartedWorkflow = &RunningWorkflowInfo{
 		WorkflowID: workflowID,
 		RunID:      resp.GetRunID(),
-		Started:    true,
-	}, nil
+	}
+	return result, nil
 }
 
 // generateWorkflowID creates a deterministic workflow ID from the
@@ -112,46 +151,38 @@ func generateRequestID(scheduleID string, scheduledTimeNanos int64, source Trigg
 	return uuid.NewSHA1(schedulerRequestIDNamespace, []byte(name)).String()
 }
 
-// describeWorkflowActivity checks if a target workflow is still running.
-func describeWorkflowActivity(ctx context.Context, req DescribeWorkflowRequest) (*DescribeWorkflowResult, error) {
-	sc, ok := ctx.Value(schedulerContextKey).(schedulerContext)
-	if !ok {
-		return nil, fmt.Errorf("scheduler context not found in activity context")
-	}
-
-	resp, err := sc.FrontendClient.DescribeWorkflowExecution(ctx, &types.DescribeWorkflowExecutionRequest{
-		Domain: req.Domain,
+func isWorkflowRunning(ctx context.Context, client frontend.Client, domain string, wf *RunningWorkflowInfo) (bool, error) {
+	resp, err := client.DescribeWorkflowExecution(ctx, &types.DescribeWorkflowExecutionRequest{
+		Domain: domain,
 		Execution: &types.WorkflowExecution{
-			WorkflowID: req.WorkflowID,
-			RunID:      req.RunID,
+			WorkflowID: wf.WorkflowID,
+			RunID:      wf.RunID,
 		},
 	})
 	if err != nil {
 		if isEntityNotExistsError(err) {
-			return &DescribeWorkflowResult{IsRunning: false}, nil
+			return false, nil
 		}
-		return nil, fmt.Errorf("failed to describe workflow: %w", err)
+		return false, fmt.Errorf("failed to describe workflow: %w", err)
 	}
 
 	running := resp.WorkflowExecutionInfo != nil &&
 		resp.WorkflowExecutionInfo.CloseStatus == nil
-	return &DescribeWorkflowResult{IsRunning: running}, nil
+	return running, nil
 }
 
-// cancelWorkflowActivity sends a cancellation request to a running workflow.
-func cancelWorkflowActivity(ctx context.Context, req CancelWorkflowRequest) error {
-	sc, ok := ctx.Value(schedulerContextKey).(schedulerContext)
-	if !ok {
-		return fmt.Errorf("scheduler context not found in activity context")
-	}
-
-	err := sc.FrontendClient.RequestCancelWorkflowExecution(ctx, &types.RequestCancelWorkflowExecutionRequest{
-		Domain: req.Domain,
+// Cancel is cooperative: the previous workflow receives a cancellation signal
+// but may continue running while it handles cleanup. A brief overlap with the
+// new run is expected. Use TERMINATE_PREVIOUS for a hard guarantee of no
+// concurrent execution.
+func cancelWorkflow(ctx context.Context, client frontend.Client, domain string, wf *RunningWorkflowInfo) error {
+	err := client.RequestCancelWorkflowExecution(ctx, &types.RequestCancelWorkflowExecutionRequest{
+		Domain: domain,
 		WorkflowExecution: &types.WorkflowExecution{
-			WorkflowID: req.WorkflowID,
-			RunID:      req.RunID,
+			WorkflowID: wf.WorkflowID,
+			RunID:      wf.RunID,
 		},
-		Cause: req.Cause,
+		Cause: "schedule overlap policy: CANCEL_PREVIOUS",
 	})
 	if err != nil && !isEntityNotExistsError(err) {
 		return fmt.Errorf("failed to cancel workflow: %w", err)
@@ -159,20 +190,14 @@ func cancelWorkflowActivity(ctx context.Context, req CancelWorkflowRequest) erro
 	return nil
 }
 
-// terminateWorkflowActivity forcefully terminates a running workflow.
-func terminateWorkflowActivity(ctx context.Context, req TerminateWorkflowRequest) error {
-	sc, ok := ctx.Value(schedulerContextKey).(schedulerContext)
-	if !ok {
-		return fmt.Errorf("scheduler context not found in activity context")
-	}
-
-	err := sc.FrontendClient.TerminateWorkflowExecution(ctx, &types.TerminateWorkflowExecutionRequest{
-		Domain: req.Domain,
+func terminateWorkflow(ctx context.Context, client frontend.Client, domain string, wf *RunningWorkflowInfo) error {
+	err := client.TerminateWorkflowExecution(ctx, &types.TerminateWorkflowExecutionRequest{
+		Domain: domain,
 		WorkflowExecution: &types.WorkflowExecution{
-			WorkflowID: req.WorkflowID,
-			RunID:      req.RunID,
+			WorkflowID: wf.WorkflowID,
+			RunID:      wf.RunID,
 		},
-		Reason: req.Reason,
+		Reason: "schedule overlap policy: TERMINATE_PREVIOUS",
 	})
 	if err != nil && !isEntityNotExistsError(err) {
 		return fmt.Errorf("failed to terminate workflow: %w", err)

--- a/service/worker/scheduler/activity_test.go
+++ b/service/worker/scheduler/activity_test.go
@@ -102,10 +102,11 @@ func TestGenerateRequestID(t *testing.T) {
 	})
 }
 
-func TestStartWorkflowActivity(t *testing.T) {
+func TestProcessScheduleFireActivity(t *testing.T) {
 	scheduledTime := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 	int32Ptr := func(v int32) *int32 { return &v }
-	baseReq := StartWorkflowRequest{
+
+	baseReq := ProcessFireRequest{
 		Domain:     "test-domain",
 		ScheduleID: "sched-1",
 		Action: types.StartWorkflowAction{
@@ -118,55 +119,193 @@ func TestStartWorkflowActivity(t *testing.T) {
 		},
 		ScheduledTime: scheduledTime,
 		TriggerSource: TriggerSourceSchedule,
+		OverlapPolicy: types.ScheduleOverlapPolicySkipNew,
 	}
+
+	expectedWfID := "my-prefix-" + formatTime(scheduledTime)
 
 	tests := []struct {
 		name       string
-		req        StartWorkflowRequest
+		req        ProcessFireRequest
 		setupMock  func(m *frontend.MockClient)
-		wantResult *StartWorkflowResult
+		wantResult *ProcessFireResult
 		wantErr    bool
+		noContext  bool
 	}{
 		{
-			name: "successful start",
+			name: "successful start with no previous workflow",
 			req:  baseReq,
 			setupMock: func(m *frontend.MockClient) {
 				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
 					DoAndReturn(func(_ context.Context, req *types.StartWorkflowExecutionRequest, _ ...interface{}) (*types.StartWorkflowExecutionResponse, error) {
 						assert.Equal(t, "test-domain", req.Domain)
-						assert.Equal(t, "my-prefix-"+formatTime(scheduledTime), req.WorkflowID)
-						assert.Equal(t, "my-workflow", req.WorkflowType.Name)
-						assert.Equal(t, "my-tasklist", req.TaskList.Name)
+						assert.Equal(t, expectedWfID, req.WorkflowID)
+						assert.Equal(t, types.WorkflowIDReusePolicyAllowDuplicate, *req.WorkflowIDReusePolicy)
 						_, uuidErr := uuid.Parse(req.RequestID)
-						assert.NoError(t, uuidErr, "RequestID must be a valid UUID")
-						assert.Equal(t, generateRequestID("sched-1", scheduledTime.UnixNano(), TriggerSourceSchedule), req.RequestID, "RequestID must be deterministic")
+						assert.NoError(t, uuidErr)
 						return &types.StartWorkflowExecutionResponse{RunID: "run-abc"}, nil
 					})
 			},
-			wantResult: &StartWorkflowResult{
-				WorkflowID: "my-prefix-" + formatTime(scheduledTime),
-				RunID:      "run-abc",
-				Started:    true,
+			wantResult: &ProcessFireResult{
+				TotalDelta:      1,
+				StartedWorkflow: &RunningWorkflowInfo{WorkflowID: expectedWfID, RunID: "run-abc"},
 			},
 		},
 		{
-			name: "already started returns skipped with RunID",
+			name: "SKIP_NEW skips when previous is running",
+			req: func() ProcessFireRequest {
+				r := baseReq
+				r.OverlapPolicy = types.ScheduleOverlapPolicySkipNew
+				r.LastStartedWorkflow = &RunningWorkflowInfo{WorkflowID: "old-wf", RunID: "old-run"}
+				return r
+			}(),
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{CloseStatus: nil},
+					}, nil)
+			},
+			wantResult: &ProcessFireResult{
+				SkippedDelta:    1,
+				StartedWorkflow: &RunningWorkflowInfo{WorkflowID: "old-wf", RunID: "old-run"},
+			},
+		},
+		{
+			name: "SKIP_NEW starts when previous is closed",
+			req: func() ProcessFireRequest {
+				r := baseReq
+				r.OverlapPolicy = types.ScheduleOverlapPolicySkipNew
+				r.LastStartedWorkflow = &RunningWorkflowInfo{WorkflowID: "old-wf", RunID: "old-run"}
+				return r
+			}(),
+			setupMock: func(m *frontend.MockClient) {
+				status := types.WorkflowExecutionCloseStatusCompleted
+				m.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{CloseStatus: &status},
+					}, nil)
+				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.StartWorkflowExecutionResponse{RunID: "new-run"}, nil)
+			},
+			wantResult: &ProcessFireResult{
+				TotalDelta:      1,
+				StartedWorkflow: &RunningWorkflowInfo{WorkflowID: expectedWfID, RunID: "new-run"},
+			},
+		},
+		{
+			name: "TERMINATE_PREVIOUS terminates then starts",
+			req: func() ProcessFireRequest {
+				r := baseReq
+				r.OverlapPolicy = types.ScheduleOverlapPolicyTerminatePrevious
+				r.LastStartedWorkflow = &RunningWorkflowInfo{WorkflowID: "old-wf", RunID: "old-run"}
+				return r
+			}(),
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{CloseStatus: nil},
+					}, nil)
+				m.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.StartWorkflowExecutionResponse{RunID: "new-run"}, nil)
+			},
+			wantResult: &ProcessFireResult{
+				TotalDelta:      1,
+				StartedWorkflow: &RunningWorkflowInfo{WorkflowID: expectedWfID, RunID: "new-run"},
+			},
+		},
+		{
+			name: "CANCEL_PREVIOUS cancels then starts",
+			req: func() ProcessFireRequest {
+				r := baseReq
+				r.OverlapPolicy = types.ScheduleOverlapPolicyCancelPrevious
+				r.LastStartedWorkflow = &RunningWorkflowInfo{WorkflowID: "old-wf", RunID: "old-run"}
+				return r
+			}(),
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{CloseStatus: nil},
+					}, nil)
+				m.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.StartWorkflowExecutionResponse{RunID: "new-run"}, nil)
+			},
+			wantResult: &ProcessFireResult{
+				TotalDelta:      1,
+				StartedWorkflow: &RunningWorkflowInfo{WorkflowID: expectedWfID, RunID: "new-run"},
+			},
+		},
+		{
+			name: "TERMINATE_PREVIOUS failure returns error for retry",
+			req: func() ProcessFireRequest {
+				r := baseReq
+				r.OverlapPolicy = types.ScheduleOverlapPolicyTerminatePrevious
+				r.LastStartedWorkflow = &RunningWorkflowInfo{WorkflowID: "old-wf", RunID: "old-run"}
+				return r
+			}(),
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{CloseStatus: nil},
+					}, nil)
+				m.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(errors.New("connection refused"))
+			},
+			wantErr: true,
+		},
+		{
+			name: "CANCEL_PREVIOUS failure returns error for retry",
+			req: func() ProcessFireRequest {
+				r := baseReq
+				r.OverlapPolicy = types.ScheduleOverlapPolicyCancelPrevious
+				r.LastStartedWorkflow = &RunningWorkflowInfo{WorkflowID: "old-wf", RunID: "old-run"}
+				return r
+			}(),
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{CloseStatus: nil},
+					}, nil)
+				m.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(errors.New("connection refused"))
+			},
+			wantErr: true,
+		},
+		{
+			name: "CONCURRENT skips overlap check and starts",
+			req: func() ProcessFireRequest {
+				r := baseReq
+				r.OverlapPolicy = types.ScheduleOverlapPolicyConcurrent
+				r.LastStartedWorkflow = &RunningWorkflowInfo{WorkflowID: "old-wf", RunID: "old-run"}
+				return r
+			}(),
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.StartWorkflowExecutionResponse{RunID: "new-run"}, nil)
+			},
+			wantResult: &ProcessFireResult{
+				TotalDelta:      1,
+				StartedWorkflow: &RunningWorkflowInfo{WorkflowID: expectedWfID, RunID: "new-run"},
+			},
+		},
+		{
+			name: "AlreadyStartedError returns skipped with RunID",
 			req:  baseReq,
 			setupMock: func(m *frontend.MockClient) {
 				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
 					Return(nil, &types.WorkflowExecutionAlreadyStartedError{
 						Message: "already started",
-						RunID:   "existing-run-id",
+						RunID:   "existing-run",
 					})
 			},
-			wantResult: &StartWorkflowResult{
-				WorkflowID: "my-prefix-" + formatTime(scheduledTime),
-				RunID:      "existing-run-id",
-				Skipped:    true,
+			wantResult: &ProcessFireResult{
+				SkippedDelta:    1,
+				StartedWorkflow: &RunningWorkflowInfo{WorkflowID: expectedWfID, RunID: "existing-run"},
 			},
 		},
 		{
-			name: "transient error propagated",
+			name: "start failure returns error for retry",
 			req:  baseReq,
 			setupMock: func(m *frontend.MockClient) {
 				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
@@ -175,104 +314,26 @@ func TestStartWorkflowActivity(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "empty prefix falls back to scheduleID",
-			req: func() StartWorkflowRequest {
+			name: "describe failure returns error for retry",
+			req: func() ProcessFireRequest {
 				r := baseReq
-				r.Action.WorkflowIDPrefix = ""
+				r.OverlapPolicy = types.ScheduleOverlapPolicySkipNew
+				r.LastStartedWorkflow = &RunningWorkflowInfo{WorkflowID: "old-wf", RunID: "old-run"}
 				return r
 			}(),
-			setupMock: func(m *frontend.MockClient) {
-				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, req *types.StartWorkflowExecutionRequest, _ ...interface{}) (*types.StartWorkflowExecutionResponse, error) {
-						assert.Equal(t, "sched-1-"+formatTime(scheduledTime), req.WorkflowID)
-						return &types.StartWorkflowExecutionResponse{RunID: "run-def"}, nil
-					})
-			},
-			wantResult: &StartWorkflowResult{
-				WorkflowID: "sched-1-" + formatTime(scheduledTime),
-				RunID:      "run-def",
-				Started:    true,
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-
-			mockClient := frontend.NewMockClient(ctrl)
-			tc.setupMock(mockClient)
-
-			ctx := context.WithValue(context.Background(), schedulerContextKey, schedulerContext{
-				FrontendClient: mockClient,
-			})
-
-			result, err := startWorkflowActivity(ctx, tc.req)
-			if tc.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tc.wantResult, result)
-		})
-	}
-}
-
-func TestStartWorkflowActivity_MissingContext(t *testing.T) {
-	ctx := context.Background()
-	_, err := startWorkflowActivity(ctx, StartWorkflowRequest{})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "scheduler context not found")
-}
-
-func TestDescribeWorkflowActivity(t *testing.T) {
-	tests := []struct {
-		name       string
-		setupMock  func(m *frontend.MockClient)
-		wantResult *DescribeWorkflowResult
-		wantErr    bool
-	}{
-		{
-			name: "running workflow",
-			setupMock: func(m *frontend.MockClient) {
-				m.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
-					Return(&types.DescribeWorkflowExecutionResponse{
-						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{
-							CloseStatus: nil,
-						},
-					}, nil)
-			},
-			wantResult: &DescribeWorkflowResult{IsRunning: true},
-		},
-		{
-			name: "closed workflow",
-			setupMock: func(m *frontend.MockClient) {
-				status := types.WorkflowExecutionCloseStatusCompleted
-				m.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
-					Return(&types.DescribeWorkflowExecutionResponse{
-						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{
-							CloseStatus: &status,
-						},
-					}, nil)
-			},
-			wantResult: &DescribeWorkflowResult{IsRunning: false},
-		},
-		{
-			name: "entity not found",
-			setupMock: func(m *frontend.MockClient) {
-				m.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
-					Return(nil, &types.EntityNotExistsError{Message: "not found"})
-			},
-			wantResult: &DescribeWorkflowResult{IsRunning: false},
-		},
-		{
-			name: "transient error propagated",
 			setupMock: func(m *frontend.MockClient) {
 				m.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
 					Return(nil, errors.New("connection refused"))
 			},
 			wantErr: true,
 		},
+		{
+			name:      "missing context returns error",
+			req:       baseReq,
+			noContext: true,
+			setupMock: func(m *frontend.MockClient) {},
+			wantErr:   true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -281,134 +342,22 @@ func TestDescribeWorkflowActivity(t *testing.T) {
 			mockClient := frontend.NewMockClient(ctrl)
 			tc.setupMock(mockClient)
 
-			ctx := context.WithValue(context.Background(), schedulerContextKey, schedulerContext{
-				FrontendClient: mockClient,
-			})
+			var ctx context.Context
+			if tc.noContext {
+				ctx = context.Background()
+			} else {
+				ctx = context.WithValue(context.Background(), schedulerContextKey, schedulerContext{
+					FrontendClient: mockClient,
+				})
+			}
 
-			result, err := describeWorkflowActivity(ctx, DescribeWorkflowRequest{
-				Domain:     "test-domain",
-				WorkflowID: "wf-1",
-				RunID:      "run-1",
-			})
+			result, err := processScheduleFireActivity(ctx, tc.req)
 			if tc.wantErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tc.wantResult, result)
-		})
-	}
-}
-
-func TestCancelWorkflowActivity(t *testing.T) {
-	tests := []struct {
-		name      string
-		setupMock func(m *frontend.MockClient)
-		wantErr   bool
-	}{
-		{
-			name: "successful cancel with cause",
-			setupMock: func(m *frontend.MockClient) {
-				m.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, req *types.RequestCancelWorkflowExecutionRequest, _ ...interface{}) error {
-						assert.Equal(t, "schedule overlap policy: CANCEL_PREVIOUS", req.Cause)
-						assert.Equal(t, "wf-1", req.WorkflowExecution.WorkflowID)
-						return nil
-					})
-			},
-		},
-		{
-			name: "entity not found is not an error",
-			setupMock: func(m *frontend.MockClient) {
-				m.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), gomock.Any()).
-					Return(&types.EntityNotExistsError{Message: "not found"})
-			},
-		},
-		{
-			name: "transient error propagated",
-			setupMock: func(m *frontend.MockClient) {
-				m.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), gomock.Any()).
-					Return(errors.New("connection refused"))
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			mockClient := frontend.NewMockClient(ctrl)
-			tc.setupMock(mockClient)
-
-			ctx := context.WithValue(context.Background(), schedulerContextKey, schedulerContext{
-				FrontendClient: mockClient,
-			})
-
-			err := cancelWorkflowActivity(ctx, CancelWorkflowRequest{
-				Domain:     "test-domain",
-				WorkflowID: "wf-1",
-				RunID:      "run-1",
-				Cause:      "schedule overlap policy: CANCEL_PREVIOUS",
-			})
-			if tc.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-		})
-	}
-}
-
-func TestTerminateWorkflowActivity(t *testing.T) {
-	tests := []struct {
-		name      string
-		setupMock func(m *frontend.MockClient)
-		wantErr   bool
-	}{
-		{
-			name: "successful terminate",
-			setupMock: func(m *frontend.MockClient) {
-				m.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil)
-			},
-		},
-		{
-			name: "entity not found is not an error",
-			setupMock: func(m *frontend.MockClient) {
-				m.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).
-					Return(&types.EntityNotExistsError{Message: "not found"})
-			},
-		},
-		{
-			name: "transient error propagated",
-			setupMock: func(m *frontend.MockClient) {
-				m.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).
-					Return(errors.New("connection refused"))
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			mockClient := frontend.NewMockClient(ctrl)
-			tc.setupMock(mockClient)
-
-			ctx := context.WithValue(context.Background(), schedulerContextKey, schedulerContext{
-				FrontendClient: mockClient,
-			})
-
-			err := terminateWorkflowActivity(ctx, TerminateWorkflowRequest{
-				Domain:     "test-domain",
-				WorkflowID: "wf-1",
-				RunID:      "run-1",
-				Reason:     "overlap",
-			})
-			if tc.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
 		})
 	}
 }

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -151,47 +151,25 @@ const (
 	TriggerSourceBackfill TriggerSource = "backfill"
 )
 
-// StartWorkflowRequest is the input to the start-workflow activity.
-type StartWorkflowRequest struct {
-	Domain        string                    `json:"domain"`
-	ScheduleID    string                    `json:"scheduleId"`
-	Action        types.StartWorkflowAction `json:"action"`
-	ScheduledTime time.Time                 `json:"scheduledTime"`
-	TriggerSource TriggerSource             `json:"triggerSource"`
+// ProcessFireRequest is the input to processScheduleFireActivity. It contains
+// everything the activity needs to resolve the overlap policy and start the
+// target workflow. All side effects (describe, cancel, terminate, start) happen
+// inside this single activity so the workflow history stays stable when the
+// overlap logic evolves.
+type ProcessFireRequest struct {
+	Domain              string                      `json:"domain"`
+	ScheduleID          string                      `json:"scheduleId"`
+	Action              types.StartWorkflowAction   `json:"action"`
+	ScheduledTime       time.Time                   `json:"scheduledTime"`
+	TriggerSource       TriggerSource               `json:"triggerSource"`
+	OverlapPolicy       types.ScheduleOverlapPolicy `json:"overlapPolicy"`
+	LastStartedWorkflow *RunningWorkflowInfo        `json:"lastStartedWorkflow,omitempty"`
 }
 
-// StartWorkflowResult is the output of the start-workflow activity.
-type StartWorkflowResult struct {
-	WorkflowID string `json:"workflowId"`
-	RunID      string `json:"runId"`
-	Started    bool   `json:"started"`
-	Skipped    bool   `json:"skipped"`
-}
-
-// DescribeWorkflowRequest is the input to the describe-workflow activity.
-type DescribeWorkflowRequest struct {
-	Domain     string `json:"domain"`
-	WorkflowID string `json:"workflowId"`
-	RunID      string `json:"runId"`
-}
-
-// DescribeWorkflowResult is the output of the describe-workflow activity.
-type DescribeWorkflowResult struct {
-	IsRunning bool `json:"isRunning"`
-}
-
-// CancelWorkflowRequest is the input to the cancel workflow activity.
-type CancelWorkflowRequest struct {
-	Domain     string `json:"domain"`
-	WorkflowID string `json:"workflowId"`
-	RunID      string `json:"runId"`
-	Cause      string `json:"cause"`
-}
-
-// TerminateWorkflowRequest is the input to the terminate workflow activity.
-type TerminateWorkflowRequest struct {
-	Domain     string `json:"domain"`
-	WorkflowID string `json:"workflowId"`
-	RunID      string `json:"runId"`
-	Reason     string `json:"reason"`
+// ProcessFireResult is the output of processScheduleFireActivity. The workflow
+// applies these counters and tracking info to its state after the activity returns.
+type ProcessFireResult struct {
+	StartedWorkflow *RunningWorkflowInfo `json:"startedWorkflow,omitempty"`
+	TotalDelta      int64                `json:"totalDelta"`
+	SkippedDelta    int64                `json:"skippedDelta"`
 }

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -366,9 +366,10 @@ func handleBackfill(logger *zap.Logger, sig BackfillSignal, state *SchedulerWork
 	return true
 }
 
-// processScheduleFire executes the configured action for a single schedule fire,
-// enforcing the overlap policy when a previous target workflow is still running.
-// Activity failures do not terminate the schedule; they are logged and counted as missed runs.
+// processScheduleFire executes the configured action for a single schedule fire.
+// All side effects (overlap check, cancel/terminate, start) are encapsulated in
+// a single activity so that the overlap logic can evolve without introducing
+// nondeterminism in the workflow history.
 func processScheduleFire(ctx workflow.Context, logger *zap.Logger, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource) {
 	state.LastRunTime = scheduledTime
 
@@ -376,146 +377,50 @@ func processScheduleFire(ctx workflow.Context, logger *zap.Logger, input *Schedu
 		zap.Time("scheduledTime", scheduledTime),
 	)
 
-	actCtx := workflow.WithLocalActivityOptions(ctx, defaultActivityOptions())
-
 	if input.Action.StartWorkflow == nil {
 		state.MissedRuns++
 		logger.Error("schedule action has no StartWorkflow configuration")
 		return
 	}
 
-	policy := input.Policies.OverlapPolicy
-	if policy == types.ScheduleOverlapPolicyInvalid {
-		policy = types.ScheduleOverlapPolicySkipNew
+	actCtx := workflow.WithLocalActivityOptions(ctx, defaultActivityOptions())
+
+	req := ProcessFireRequest{
+		Domain:              input.Domain,
+		ScheduleID:          input.ScheduleID,
+		Action:              *input.Action.StartWorkflow,
+		ScheduledTime:       scheduledTime,
+		TriggerSource:       trigger,
+		OverlapPolicy:       input.Policies.OverlapPolicy,
+		LastStartedWorkflow: state.LastStartedWorkflow,
 	}
 
-	if policy != types.ScheduleOverlapPolicyConcurrent && state.LastStartedWorkflow != nil {
-		running := isPreviousRunning(ctx, actCtx, logger, input.Domain, state)
-		if running {
-			switch policy {
-			case types.ScheduleOverlapPolicySkipNew:
-				state.SkippedRuns++
-				logger.Info("skipping fire due to overlap policy SKIP_NEW",
-					zap.Time("scheduledTime", scheduledTime),
-					zap.String("runningWorkflowId", state.LastStartedWorkflow.WorkflowID),
-				)
-				return
-			case types.ScheduleOverlapPolicyBuffer:
-				state.SkippedRuns++
-				logger.Info("skipping fire: BUFFER policy not yet implemented, treating as SKIP_NEW",
-					zap.Time("scheduledTime", scheduledTime),
-					zap.String("runningWorkflowId", state.LastStartedWorkflow.WorkflowID),
-				)
-				// TODO(overlap-buffer): implement sequential buffered execution
-				return
-			case types.ScheduleOverlapPolicyCancelPrevious:
-				// Cancel is cooperative: the previous workflow receives a cancellation
-				// signal but may continue running while it handles cleanup. A brief
-				// overlap with the new run is expected. Use TERMINATE_PREVIOUS for a
-				// hard guarantee of no concurrent execution.
-				logger.Info("cancelling previous workflow due to overlap policy",
-					zap.String("workflowId", state.LastStartedWorkflow.WorkflowID),
-				)
-				if err := workflow.ExecuteLocalActivity(actCtx, cancelWorkflowActivity, CancelWorkflowRequest{
-					Domain:     input.Domain,
-					WorkflowID: state.LastStartedWorkflow.WorkflowID,
-					RunID:      state.LastStartedWorkflow.RunID,
-					Cause:      "schedule overlap policy: CANCEL_PREVIOUS",
-				}).Get(ctx, nil); err != nil {
-					logger.Error("failed to cancel previous workflow, skipping new fire",
-						zap.String("workflowId", state.LastStartedWorkflow.WorkflowID),
-						zap.Error(err),
-					)
-					state.MissedRuns++
-					return
-				}
-			case types.ScheduleOverlapPolicyTerminatePrevious:
-				logger.Info("terminating previous workflow due to overlap policy",
-					zap.String("workflowId", state.LastStartedWorkflow.WorkflowID),
-				)
-				if err := workflow.ExecuteLocalActivity(actCtx, terminateWorkflowActivity, TerminateWorkflowRequest{
-					Domain:     input.Domain,
-					WorkflowID: state.LastStartedWorkflow.WorkflowID,
-					RunID:      state.LastStartedWorkflow.RunID,
-					Reason:     "schedule overlap policy: TERMINATE_PREVIOUS",
-				}).Get(ctx, nil); err != nil {
-					logger.Error("failed to terminate previous workflow, skipping new fire",
-						zap.String("workflowId", state.LastStartedWorkflow.WorkflowID),
-						zap.Error(err),
-					)
-					state.MissedRuns++
-					return
-				}
-			}
-		}
-	}
-
-	req := StartWorkflowRequest{
-		Domain:        input.Domain,
-		ScheduleID:    input.ScheduleID,
-		Action:        *input.Action.StartWorkflow,
-		ScheduledTime: scheduledTime,
-		TriggerSource: trigger,
-	}
-
-	var result StartWorkflowResult
-	err := workflow.ExecuteLocalActivity(actCtx, startWorkflowActivity, req).Get(ctx, &result)
-	if err != nil {
+	var result ProcessFireResult
+	if err := workflow.ExecuteLocalActivity(actCtx, processScheduleFireActivity, req).Get(ctx, &result); err != nil {
 		state.MissedRuns++
-		logger.Error("scheduled action failed",
+		logger.Error("processScheduleFireActivity failed",
 			zap.Time("scheduledTime", scheduledTime),
 			zap.Error(err),
 		)
 		return
 	}
 
-	if result.Skipped {
-		state.SkippedRuns++
-		// The workflow exists and is running (AlreadyStartedError), so update
-		// tracking to point at it for future overlap checks.
-		state.LastStartedWorkflow = &RunningWorkflowInfo{
-			WorkflowID: result.WorkflowID,
-			RunID:      result.RunID,
-		}
-		logger.Info("scheduled action skipped (already started error)",
-			zap.String("workflowId", result.WorkflowID),
-			zap.String("runId", result.RunID),
+	state.TotalRuns += result.TotalDelta
+	state.SkippedRuns += result.SkippedDelta
+	if result.StartedWorkflow != nil {
+		state.LastStartedWorkflow = result.StartedWorkflow
+	}
+
+	if result.TotalDelta > 0 && result.StartedWorkflow != nil {
+		logger.Info("scheduled workflow started",
+			zap.String("workflowId", result.StartedWorkflow.WorkflowID),
+			zap.String("runId", result.StartedWorkflow.RunID),
 		)
-		return
-	}
-
-	state.TotalRuns++
-	state.LastStartedWorkflow = &RunningWorkflowInfo{
-		WorkflowID: result.WorkflowID,
-		RunID:      result.RunID,
-	}
-
-	logger.Info("scheduled workflow started",
-		zap.String("workflowId", result.WorkflowID),
-		zap.String("runId", result.RunID),
-		zap.Int64("totalRuns", state.TotalRuns),
-	)
-}
-
-// isPreviousRunning checks if the last started target workflow is still running.
-func isPreviousRunning(ctx workflow.Context, actCtx workflow.Context, logger *zap.Logger, domain string, state *SchedulerWorkflowState) bool {
-	if state.LastStartedWorkflow == nil {
-		return false
-	}
-	var descResult DescribeWorkflowResult
-	err := workflow.ExecuteLocalActivity(actCtx, describeWorkflowActivity, DescribeWorkflowRequest{
-		Domain:     domain,
-		WorkflowID: state.LastStartedWorkflow.WorkflowID,
-		RunID:      state.LastStartedWorkflow.RunID,
-	}).Get(ctx, &descResult)
-	if err != nil {
-		logger.Warn("failed to check previous workflow status, assuming not running",
-			zap.String("workflowId", state.LastStartedWorkflow.WorkflowID),
-			zap.Error(err),
+	} else if result.SkippedDelta > 0 {
+		logger.Info("schedule fire skipped",
+			zap.Time("scheduledTime", scheduledTime),
 		)
-		return false
 	}
-	return descResult.IsRunning
 }
 
 // defaultActivityOptions returns the standard local activity options used by


### PR DESCRIPTION
## What changed?

Implements overlap policy enforcement for the scheduler workflow. When a schedule fires and a previous target workflow is still running, the configured overlap policy (SKIP_NEW, BUFFER, CANCEL_PREVIOUS, TERMINATE_PREVIOUS, CONCURRENT) determines what happens. All overlap resolution logic is encapsulated in a single `processScheduleFireActivity` to avoid nondeterminism concerns as the logic evolves.

Relates to #7664

## Why?

Without overlap policies, every schedule fire unconditionally starts a new workflow regardless of whether the previous run is still active. This can lead to resource contention, duplicate processing, or unexpected concurrency. The single-activity pattern was chosen (per reviewer feedback) because the overlap logic will need to change significantly for BUFFER and CONCURRENT support — keeping all side effects (describe, cancel/terminate, start) in one activity means the workflow history stays stable when that logic evolves.

## How did you test it?

- `go build ./service/worker/scheduler/...` — compiles cleanly
- `go test ./service/worker/scheduler/... -count=1 -v` — all 48 tests pass
- `TestProcessScheduleFireActivity` covers 11 cases: successful start, all 5 overlap policies, AlreadyStartedError extraction, transient error retry propagation, missing context

## Potential risks

None — isolated change within the scheduler package with no API, schema, or feature flag impact. The scheduler feature is not yet deployed.

## Release notes

N/A — internal change to scheduler workflow (not yet released).

## Documentation Changes

N/A