### PR TITLE
fix(test): flaky TestRegisterDomainRequestFuzz

### DIFF
--- a/common/types/mapper/thrift/shared_test.go
+++ b/common/types/mapper/thrift/shared_test.go
@@ -2288,6 +2288,13 @@ func TestRegisterDomainRequestFuzz(t *testing.T) {
 				func(e *types.ArchivalStatus, c fuzz.Continue) {
 					*e = types.ArchivalStatus(c.Intn(2)) // 0-1 are valid values (Disabled=0, Enabled=1)
 				},
+				func(s *string, c fuzz.Continue) {
+					if c.RandBool() {
+						*s = ""
+					} else {
+						c.Fuzz(s)
+					}
+				},
 			).NilChance(0.3)
 
 			var orig *types.RegisterDomainRequest


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Added a func(s *string, c fuzz.Continue) custom funcs entry to the fuzzer in TestRegisterDomainRequestFuzz, which generates "" with 50% probability and a random string otherwise.

**Why?**
The "empty" coverage label requires Name == "" && ActiveClusterName == "" && ActiveClusters == nil simultaneously. With default gofuzz string generation, strings are almost never empty, so the probability of hitting all three conditions at once was effectively zero — causing the test to fail intermittently
  (actually deterministically fail, just rarely triggered in CI depending on seed). The custom string funcer gives P("empty") ≈ 7.5% per iteration, guaranteeing coverage within ~10 attempts on average, well within the 10,000 limit.

**How did you test it?**
go test -count=10 -run TestRegisterDomainRequestFuzz ./common/types/mapper/thrift/

**Potential risks**
N/A

**Release notes**
N/A flaky test fix

**Documentation Changes**
N/A flaky test fix
