### PR TITLE
fix(kafka): raise default protocol version from 0.10.2.0 to 2.1.0

### DIFF
--- a/common/messaging/kafka/client_impl.go
+++ b/common/messaging/kafka/client_impl.go
@@ -95,13 +95,8 @@ func NewKafkaClient(
 // NewConsumer is used to create a Kafka consumer
 func (c *clientImpl) NewConsumer(app, consumerName string) (messaging.Consumer, error) {
 	topics := c.config.GetTopicsForApplication(app)
-	// All default values are copied from uber/kafka-clientImpl to keep the same behavior
-	kafkaVersion := c.config.Version
-	if kafkaVersion == "" {
-		kafkaVersion = defaultKafkaVersion
-	}
-
-	version, err := sarama.ParseKafkaVersion(kafkaVersion)
+	// All default values are copied from uber-go/kafka-client to keep the same behavior
+	version, err := c.resolveKafkaVersion()
 	if err != nil {
 		return nil, err
 	}
@@ -139,12 +134,7 @@ func (c *clientImpl) newProducerByTopic(topic string) (messaging.Producer, error
 	kafkaClusterName := c.config.GetKafkaClusterForTopic(topic)
 	brokers := c.config.GetBrokersForKafkaCluster(kafkaClusterName)
 
-	kafkaVersion := c.config.Version
-	if kafkaVersion == "" {
-		kafkaVersion = defaultKafkaVersion
-	}
-
-	version, err := sarama.ParseKafkaVersion(kafkaVersion)
+	version, err := c.resolveKafkaVersion()
 	if err != nil {
 		return nil, err
 	}
@@ -168,6 +158,16 @@ func (c *clientImpl) newProducerByTopic(topic string) (messaging.Producer, error
 		return messaging.NewMetricProducer(NewKafkaProducer(topic, producer, c.logger), c.metricsClient, withMetricsOpt), nil
 	}
 	return NewKafkaProducer(topic, producer, c.logger), nil
+}
+
+// resolveKafkaVersion returns the parsed Kafka version from config,
+// falling back to defaultKafkaVersion when none is configured.
+func (c *clientImpl) resolveKafkaVersion() (sarama.KafkaVersion, error) {
+	v := c.config.Version
+	if v == "" {
+		v = defaultKafkaVersion
+	}
+	return sarama.ParseKafkaVersion(v)
 }
 
 func (c *clientImpl) initAuth(saramaConfig *sarama.Config) error {

--- a/common/messaging/kafka/client_impl.go
+++ b/common/messaging/kafka/client_impl.go
@@ -35,6 +35,18 @@ import (
 	"github.com/uber/cadence/common/metrics"
 )
 
+const (
+	// defaultKafkaVersion is the Kafka protocol version used when the user does not
+	// specify one in the configuration. The previous default ("0.10.2.0") is too low
+	// for Sarama ≥ v1.45 which performs API-version negotiation: modern brokers
+	// (Kafka ≥ 1.0) may refuse the handshake when the client advertises such an
+	// old version, causing "client has run out of available brokers" errors.
+	// Version 2.1.0 (released Nov 2018) is old enough to be universally supported
+	// by any Kafka cluster still in production, yet new enough for Sarama's API
+	// negotiation to succeed.
+	defaultKafkaVersion = "2.1.0"
+)
+
 type (
 	// This is a default implementation of Client interface which makes use of uber-go/kafka-client as consumer
 	clientImpl struct {
@@ -83,10 +95,10 @@ func NewKafkaClient(
 // NewConsumer is used to create a Kafka consumer
 func (c *clientImpl) NewConsumer(app, consumerName string) (messaging.Consumer, error) {
 	topics := c.config.GetTopicsForApplication(app)
-	// All defaut values are copied from uber/kafka-clientImpl bo keep the same behavior
+	// All default values are copied from uber/kafka-clientImpl to keep the same behavior
 	kafkaVersion := c.config.Version
 	if kafkaVersion == "" {
-		kafkaVersion = "0.10.2.0"
+		kafkaVersion = defaultKafkaVersion
 	}
 
 	version, err := sarama.ParseKafkaVersion(kafkaVersion)
@@ -127,9 +139,20 @@ func (c *clientImpl) newProducerByTopic(topic string) (messaging.Producer, error
 	kafkaClusterName := c.config.GetKafkaClusterForTopic(topic)
 	brokers := c.config.GetBrokersForKafkaCluster(kafkaClusterName)
 
+	kafkaVersion := c.config.Version
+	if kafkaVersion == "" {
+		kafkaVersion = defaultKafkaVersion
+	}
+
+	version, err := sarama.ParseKafkaVersion(kafkaVersion)
+	if err != nil {
+		return nil, err
+	}
+
 	config := sarama.NewConfig()
+	config.Version = version
 	config.Producer.Return.Successes = true
-	err := c.initAuth(config)
+	err = c.initAuth(config)
 	if err != nil {
 		return nil, err
 	}

--- a/common/messaging/kafka/client_impl_test.go
+++ b/common/messaging/kafka/client_impl_test.go
@@ -25,6 +25,7 @@ package kafka
 import (
 	"testing"
 
+	"github.com/IBM/sarama"
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/tally"
 
@@ -32,6 +33,12 @@ import (
 	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/metrics"
 )
+
+func TestDefaultKafkaVersion(t *testing.T) {
+	// Verify the default Kafka version constant is a valid, parseable version.
+	_, err := sarama.ParseKafkaVersion(defaultKafkaVersion)
+	assert.NoError(t, err, "defaultKafkaVersion %q must be parseable by sarama", defaultKafkaVersion)
+}
 
 func TestNewKafkaClient(t *testing.T) {
 	metricsClient := metrics.NewClient(tally.NoopScope, metrics.History, metrics.MigrationConfig{})


### PR DESCRIPTION
**What changed?**

Raised the default Kafka protocol version from `0.10.2.0` to `2.1.0` and applied consistent version configuration to the producer path. Closes #7757.

**Why?**

Sarama ≥ v1.45 performs API-version negotiation when connecting to Kafka brokers. When the client advertises protocol version `0.10.2.0` (the previous hard-coded default), the handshake with modern brokers (Kafka ≥ 2.x) can fail, crashing the Cadence server on startup with `kafka: client has run out of available brokers to talk to`.

Additionally, the producer creation path (`newProducerByTopic`) was not setting `Config.Version` at all, leaving it at Sarama's internal minimum. This meant producers and consumers could negotiate using different protocol versions, leading to inconsistent behavior.

The new default `2.1.0` (released November 2018) is old enough to be universally compatible with any Kafka cluster still in production, yet new enough for Sarama's API negotiation to succeed. Existing deployments that explicitly set the `kafka.version` config are unaffected — the default only applies when no version is specified.

**How did you test it?**

```
go build ./common/messaging/kafka/...
go test -v -run TestDefaultKafkaVersion -count=1 ./common/messaging/kafka/...
go test -v ./common/messaging/kafka/...
```

Verified that `sarama.ParseKafkaVersion("2.1.0")` succeeds (covered by the new `TestDefaultKafkaVersion` test). Both consumer and producer paths now resolve the version identically.

**Potential risks**

The default version change is backward-compatible: deployments already setting `kafka.version` in their config are unaffected. The only behavioral difference is for deployments relying on the implicit `0.10.2.0` default, and those deployments are exactly the ones that were broken by the Sarama upgrade (#7757). Kafka brokers running 2.1.0 or newer (released Nov 2018) are supported, which covers all reasonable production deployments.

**Release notes**

The default Kafka protocol version has been raised from `0.10.2.0` to `2.1.0` to fix startup failures when running Cadence with Sarama ≥ v1.45 against modern Kafka clusters (see #7757). Deployments that explicitly set `kafka.version` in their configuration are unaffected. Additionally, producers now respect the configured Kafka version (previously only consumers did).

**Documentation Changes**

No documentation changes needed. The `kafka.version` config field is set per-deployment in environment-specific config files (not in `config/base.yaml`, which only contains logging defaults).