### PR TITLE
fix(metrics): ensure consistent Prometheus label sets for persistence metrics

### DIFF
--- a/common/persistence/wrappers/metered/base.go
+++ b/common/persistence/wrappers/metered/base.go
@@ -179,8 +179,32 @@ func (p *base) callWithoutDomainTag(scope metrics.ScopeIdx, op func() error, tag
 	return err
 }
 
+func (p *base) callWithShardScope(scope metrics.ScopeIdx, op func() error, shardIDTag metrics.Tag, shardTags ...metrics.Tag) error {
+	metricsScope := p.metricClient.Scope(scope)
+	shardOperationsMetricsScope := p.metricClient.Scope(scope, append([]metrics.Tag{shardIDTag}, shardTags...)...)
+	shardOverallMetricsScope := p.metricClient.Scope(metrics.PersistenceShardRequestCountScope, append([]metrics.Tag{shardIDTag}, shardTags...)...)
+
+	metricsScope.IncCounter(metrics.PersistenceRequests)
+	shardOperationsMetricsScope.IncCounter(metrics.PersistenceRequestsPerShard)
+	shardOverallMetricsScope.IncCounter(metrics.PersistenceRequestsPerShard)
+
+	before := time.Now()
+	err := op()
+	duration := time.Since(before)
+
+	metricsScope.RecordTimer(metrics.PersistenceLatency, duration)
+	shardOperationsMetricsScope.RecordTimer(metrics.PersistenceLatencyPerShard, duration)
+	shardOverallMetricsScope.RecordTimer(metrics.PersistenceLatencyPerShard, duration)
+	p.recordLatencyHistogram(scope, duration)
+
+	if err != nil {
+		p.updateErrorMetric(scope, err, metricsScope, p.logger.Helper())
+	}
+	return err
+}
+
 func (p *base) callWithDomainAndShardScope(scope metrics.ScopeIdx, op func() error, domainTag metrics.Tag, shardIDTag metrics.Tag, additionalTags ...metrics.Tag) error {
-	domainMetricsScope := p.metricClient.Scope(scope, append([]metrics.Tag{domainTag}, additionalTags...)...)
+	domainMetricsScope := p.metricClient.Scope(scope, domainTag)
 	shardOperationsMetricsScope := p.metricClient.Scope(scope, append([]metrics.Tag{shardIDTag}, additionalTags...)...)
 	shardOverallMetricsScope := p.metricClient.Scope(metrics.PersistenceShardRequestCountScope, append([]metrics.Tag{shardIDTag}, additionalTags...)...)
 

--- a/common/persistence/wrappers/metered/base.go
+++ b/common/persistence/wrappers/metered/base.go
@@ -182,7 +182,7 @@ func (p *base) callWithoutDomainTag(scope metrics.ScopeIdx, op func() error, tag
 func (p *base) callWithDomainAndShardScope(scope metrics.ScopeIdx, op func() error, domainTag metrics.Tag, shardIDTag metrics.Tag, additionalTags ...metrics.Tag) error {
 	domainMetricsScope := p.metricClient.Scope(scope, append([]metrics.Tag{domainTag}, additionalTags...)...)
 	shardOperationsMetricsScope := p.metricClient.Scope(scope, append([]metrics.Tag{shardIDTag}, additionalTags...)...)
-	shardOverallMetricsScope := p.metricClient.Scope(metrics.PersistenceShardRequestCountScope, shardIDTag)
+	shardOverallMetricsScope := p.metricClient.Scope(metrics.PersistenceShardRequestCountScope, append([]metrics.Tag{shardIDTag}, additionalTags...)...)
 
 	domainMetricsScope.IncCounter(metrics.PersistenceRequestsPerDomain)
 	shardOperationsMetricsScope.IncCounter(metrics.PersistenceRequestsPerShard)

--- a/common/persistence/wrappers/metered/base.go
+++ b/common/persistence/wrappers/metered/base.go
@@ -25,6 +25,7 @@ package metered
 import (
 	"context"
 	"errors"
+	"reflect"
 	"time"
 
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
@@ -352,7 +353,7 @@ type domainTaggedRequest interface {
 
 func getDomainNameFromRequest(req any) (res string, check bool) {
 	d, check := req.(domainTaggedRequest)
-	if check {
+	if check && !isNilRequest(d) {
 		res = d.GetDomainName()
 	}
 	return res, check
@@ -360,7 +361,7 @@ func getDomainNameFromRequest(req any) (res string, check bool) {
 
 func getCustomLogTags(req any) (res []tag.Tag) {
 	d, check := req.(extraLogRequest)
-	if check {
+	if check && !isNilRequest(d) {
 		res = d.GetExtraLogTags()
 	}
 	return res
@@ -368,7 +369,7 @@ func getCustomLogTags(req any) (res []tag.Tag) {
 
 func getCustomMetricTags(req any) (res []metrics.Tag) {
 	d, check := req.(taggedRequest)
-	if check {
+	if check && !isNilRequest(d) {
 		res = d.MetricTags()
 	}
 	return res
@@ -379,4 +380,18 @@ func getRetryCountFromContext(ctx context.Context) int {
 		return retryCount
 	}
 	return 0
+}
+
+func isNilRequest(v any) bool {
+	if v == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(v)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }

--- a/common/persistence/wrappers/metered/execution_generated.go
+++ b/common/persistence/wrappers/metered/execution_generated.go
@@ -56,7 +56,7 @@ func (c *meteredExecutionManager) CompleteHistoryTask(ctx context.Context, reque
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
-	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
+	shardMetricTags := []metrics.Tag{metrics.IsRetryTag(retryCount > 0)}
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence CompleteHistoryTask called", c.sampleLoggingRate(), logTags...)
@@ -85,7 +85,7 @@ func (c *meteredExecutionManager) ConflictResolveWorkflowExecution(ctx context.C
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
-	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
+	shardMetricTags := []metrics.Tag{metrics.IsRetryTag(retryCount > 0)}
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence ConflictResolveWorkflowExecution called", c.sampleLoggingRate(), logTags...)
@@ -113,7 +113,7 @@ func (c *meteredExecutionManager) CreateFailoverMarkerTasks(ctx context.Context,
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
-	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
+	shardMetricTags := []metrics.Tag{metrics.IsRetryTag(retryCount > 0)}
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence CreateFailoverMarkerTasks called", c.sampleLoggingRate(), logTags...)
@@ -142,7 +142,7 @@ func (c *meteredExecutionManager) CreateWorkflowExecution(ctx context.Context, r
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
-	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
+	shardMetricTags := []metrics.Tag{metrics.IsRetryTag(retryCount > 0)}
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence CreateWorkflowExecution called", c.sampleLoggingRate(), logTags...)
@@ -170,7 +170,7 @@ func (c *meteredExecutionManager) DeleteActiveClusterSelectionPolicy(ctx context
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
-	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
+	shardMetricTags := []metrics.Tag{metrics.IsRetryTag(retryCount > 0)}
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence DeleteActiveClusterSelectionPolicy called", c.sampleLoggingRate(), logTags...)
@@ -198,7 +198,7 @@ func (c *meteredExecutionManager) DeleteCurrentWorkflowExecution(ctx context.Con
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
-	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
+	shardMetricTags := []metrics.Tag{metrics.IsRetryTag(retryCount > 0)}
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence DeleteCurrentWorkflowExecution called", c.sampleLoggingRate(), logTags...)
@@ -226,7 +226,7 @@ func (c *meteredExecutionManager) DeleteReplicationTaskFromDLQ(ctx context.Conte
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
-	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
+	shardMetricTags := []metrics.Tag{metrics.IsRetryTag(retryCount > 0)}
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence DeleteReplicationTaskFromDLQ called", c.sampleLoggingRate(), logTags...)
@@ -254,7 +254,7 @@ func (c *meteredExecutionManager) DeleteWorkflowExecution(ctx context.Context, r
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
-	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
+	shardMetricTags := []metrics.Tag{metrics.IsRetryTag(retryCount > 0)}
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence DeleteWorkflowExecution called", c.sampleLoggingRate(), logTags...)
@@ -283,7 +283,7 @@ func (c *meteredExecutionManager) GetActiveClusterSelectionPolicy(ctx context.Co
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
-	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
+	shardMetricTags := []metrics.Tag{metrics.IsRetryTag(retryCount > 0)}
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence GetActiveClusterSelectionPolicy called", c.sampleLoggingRate(), logTags...)
@@ -312,7 +312,7 @@ func (c *meteredExecutionManager) GetCurrentExecution(ctx context.Context, reque
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
-	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
+	shardMetricTags := []metrics.Tag{metrics.IsRetryTag(retryCount > 0)}
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence GetCurrentExecution called", c.sampleLoggingRate(), logTags...)
@@ -341,7 +341,7 @@ func (c *meteredExecutionManager) GetHistoryTasks(ctx context.Context, request *
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
-	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
+	shardMetricTags := []metrics.Tag{metrics.IsRetryTag(retryCount > 0)}
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence GetHistoryTasks called", c.sampleLoggingRate(), logTags...)
@@ -374,7 +374,7 @@ func (c *meteredExecutionManager) GetReplicationDLQSize(ctx context.Context, req
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
-	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
+	shardMetricTags := []metrics.Tag{metrics.IsRetryTag(retryCount > 0)}
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence GetReplicationDLQSize called", c.sampleLoggingRate(), logTags...)
@@ -403,7 +403,7 @@ func (c *meteredExecutionManager) GetReplicationTasksFromDLQ(ctx context.Context
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
-	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
+	shardMetricTags := []metrics.Tag{metrics.IsRetryTag(retryCount > 0)}
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence GetReplicationTasksFromDLQ called", c.sampleLoggingRate(), logTags...)
@@ -436,7 +436,7 @@ func (c *meteredExecutionManager) GetWorkflowExecution(ctx context.Context, requ
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
-	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
+	shardMetricTags := []metrics.Tag{metrics.IsRetryTag(retryCount > 0)}
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence GetWorkflowExecution called", c.sampleLoggingRate(), logTags...)
@@ -465,7 +465,7 @@ func (c *meteredExecutionManager) IsWorkflowExecutionExists(ctx context.Context,
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
-	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
+	shardMetricTags := []metrics.Tag{metrics.IsRetryTag(retryCount > 0)}
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence IsWorkflowExecutionExists called", c.sampleLoggingRate(), logTags...)
@@ -494,7 +494,7 @@ func (c *meteredExecutionManager) ListConcreteExecutions(ctx context.Context, re
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
-	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
+	shardMetricTags := []metrics.Tag{metrics.IsRetryTag(retryCount > 0)}
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence ListConcreteExecutions called", c.sampleLoggingRate(), logTags...)
@@ -523,7 +523,7 @@ func (c *meteredExecutionManager) ListCurrentExecutions(ctx context.Context, req
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
-	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
+	shardMetricTags := []metrics.Tag{metrics.IsRetryTag(retryCount > 0)}
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence ListCurrentExecutions called", c.sampleLoggingRate(), logTags...)
@@ -551,7 +551,7 @@ func (c *meteredExecutionManager) PutReplicationTaskToDLQ(ctx context.Context, r
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
-	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
+	shardMetricTags := []metrics.Tag{metrics.IsRetryTag(retryCount > 0)}
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence PutReplicationTaskToDLQ called", c.sampleLoggingRate(), logTags...)
@@ -580,7 +580,7 @@ func (c *meteredExecutionManager) RangeCompleteHistoryTask(ctx context.Context, 
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
-	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
+	shardMetricTags := []metrics.Tag{metrics.IsRetryTag(retryCount > 0)}
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence RangeCompleteHistoryTask called", c.sampleLoggingRate(), logTags...)
@@ -609,7 +609,7 @@ func (c *meteredExecutionManager) RangeDeleteReplicationTaskFromDLQ(ctx context.
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
-	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
+	shardMetricTags := []metrics.Tag{metrics.IsRetryTag(retryCount > 0)}
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence RangeDeleteReplicationTaskFromDLQ called", c.sampleLoggingRate(), logTags...)
@@ -638,7 +638,7 @@ func (c *meteredExecutionManager) UpdateWorkflowExecution(ctx context.Context, r
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
-	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
+	shardMetricTags := []metrics.Tag{metrics.IsRetryTag(retryCount > 0)}
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence UpdateWorkflowExecution called", c.sampleLoggingRate(), logTags...)

--- a/common/persistence/wrappers/metered/execution_generated.go
+++ b/common/persistence/wrappers/metered/execution_generated.go
@@ -56,19 +56,23 @@ func (c *meteredExecutionManager) CompleteHistoryTask(ctx context.Context, reque
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
+	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence CompleteHistoryTask called", c.sampleLoggingRate(), logTags...)
 		if c.enableShardIDMetrics() {
 			err = c.callWithDomainAndShardScope(metrics.PersistenceCompleteHistoryTaskScope, op, metrics.DomainTag(domainName),
-				metrics.ShardIDTag(c.GetShardID()), metrics.IsRetryTag(retryCount > 0))
+				metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
 		} else {
-			err = c.call(metrics.PersistenceCompleteHistoryTaskScope, op, metrics.DomainTag(domainName), metrics.IsRetryTag(retryCount > 0))
+			err = c.call(metrics.PersistenceCompleteHistoryTaskScope, op, metrics.DomainTag(domainName))
 		}
 		return
 	}
-
-	err = c.callWithoutDomainTag(metrics.PersistenceCompleteHistoryTaskScope, op, metrics.IsRetryTag(retryCount > 0))
+	if c.enableShardIDMetrics() {
+		err = c.callWithShardScope(metrics.PersistenceCompleteHistoryTaskScope, op, metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
+		return
+	}
+	err = c.callWithoutDomainTag(metrics.PersistenceCompleteHistoryTaskScope, op)
 
 	return
 }
@@ -81,19 +85,23 @@ func (c *meteredExecutionManager) ConflictResolveWorkflowExecution(ctx context.C
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
+	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence ConflictResolveWorkflowExecution called", c.sampleLoggingRate(), logTags...)
 		if c.enableShardIDMetrics() {
 			err = c.callWithDomainAndShardScope(metrics.PersistenceConflictResolveWorkflowExecutionScope, op, metrics.DomainTag(domainName),
-				metrics.ShardIDTag(c.GetShardID()), metrics.IsRetryTag(retryCount > 0))
+				metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
 		} else {
-			err = c.call(metrics.PersistenceConflictResolveWorkflowExecutionScope, op, metrics.DomainTag(domainName), metrics.IsRetryTag(retryCount > 0))
+			err = c.call(metrics.PersistenceConflictResolveWorkflowExecutionScope, op, metrics.DomainTag(domainName))
 		}
 		return
 	}
-
-	err = c.callWithoutDomainTag(metrics.PersistenceConflictResolveWorkflowExecutionScope, op, metrics.IsRetryTag(retryCount > 0))
+	if c.enableShardIDMetrics() {
+		err = c.callWithShardScope(metrics.PersistenceConflictResolveWorkflowExecutionScope, op, metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
+		return
+	}
+	err = c.callWithoutDomainTag(metrics.PersistenceConflictResolveWorkflowExecutionScope, op)
 
 	return
 }
@@ -105,19 +113,23 @@ func (c *meteredExecutionManager) CreateFailoverMarkerTasks(ctx context.Context,
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
+	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence CreateFailoverMarkerTasks called", c.sampleLoggingRate(), logTags...)
 		if c.enableShardIDMetrics() {
 			err = c.callWithDomainAndShardScope(metrics.PersistenceCreateFailoverMarkerTasksScope, op, metrics.DomainTag(domainName),
-				metrics.ShardIDTag(c.GetShardID()), metrics.IsRetryTag(retryCount > 0))
+				metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
 		} else {
-			err = c.call(metrics.PersistenceCreateFailoverMarkerTasksScope, op, metrics.DomainTag(domainName), metrics.IsRetryTag(retryCount > 0))
+			err = c.call(metrics.PersistenceCreateFailoverMarkerTasksScope, op, metrics.DomainTag(domainName))
 		}
 		return
 	}
-
-	err = c.callWithoutDomainTag(metrics.PersistenceCreateFailoverMarkerTasksScope, op, metrics.IsRetryTag(retryCount > 0))
+	if c.enableShardIDMetrics() {
+		err = c.callWithShardScope(metrics.PersistenceCreateFailoverMarkerTasksScope, op, metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
+		return
+	}
+	err = c.callWithoutDomainTag(metrics.PersistenceCreateFailoverMarkerTasksScope, op)
 
 	return
 }
@@ -130,19 +142,23 @@ func (c *meteredExecutionManager) CreateWorkflowExecution(ctx context.Context, r
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
+	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence CreateWorkflowExecution called", c.sampleLoggingRate(), logTags...)
 		if c.enableShardIDMetrics() {
 			err = c.callWithDomainAndShardScope(metrics.PersistenceCreateWorkflowExecutionScope, op, metrics.DomainTag(domainName),
-				metrics.ShardIDTag(c.GetShardID()), metrics.IsRetryTag(retryCount > 0))
+				metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
 		} else {
-			err = c.call(metrics.PersistenceCreateWorkflowExecutionScope, op, metrics.DomainTag(domainName), metrics.IsRetryTag(retryCount > 0))
+			err = c.call(metrics.PersistenceCreateWorkflowExecutionScope, op, metrics.DomainTag(domainName))
 		}
 		return
 	}
-
-	err = c.callWithoutDomainTag(metrics.PersistenceCreateWorkflowExecutionScope, op, metrics.IsRetryTag(retryCount > 0))
+	if c.enableShardIDMetrics() {
+		err = c.callWithShardScope(metrics.PersistenceCreateWorkflowExecutionScope, op, metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
+		return
+	}
+	err = c.callWithoutDomainTag(metrics.PersistenceCreateWorkflowExecutionScope, op)
 
 	return
 }
@@ -154,19 +170,23 @@ func (c *meteredExecutionManager) DeleteActiveClusterSelectionPolicy(ctx context
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
+	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence DeleteActiveClusterSelectionPolicy called", c.sampleLoggingRate(), logTags...)
 		if c.enableShardIDMetrics() {
 			err = c.callWithDomainAndShardScope(metrics.PersistenceDeleteActiveClusterSelectionPolicyScope, op, metrics.DomainTag(domainName),
-				metrics.ShardIDTag(c.GetShardID()), metrics.IsRetryTag(retryCount > 0))
+				metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
 		} else {
-			err = c.call(metrics.PersistenceDeleteActiveClusterSelectionPolicyScope, op, metrics.DomainTag(domainName), metrics.IsRetryTag(retryCount > 0))
+			err = c.call(metrics.PersistenceDeleteActiveClusterSelectionPolicyScope, op, metrics.DomainTag(domainName))
 		}
 		return
 	}
-
-	err = c.callWithoutDomainTag(metrics.PersistenceDeleteActiveClusterSelectionPolicyScope, op, metrics.IsRetryTag(retryCount > 0))
+	if c.enableShardIDMetrics() {
+		err = c.callWithShardScope(metrics.PersistenceDeleteActiveClusterSelectionPolicyScope, op, metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
+		return
+	}
+	err = c.callWithoutDomainTag(metrics.PersistenceDeleteActiveClusterSelectionPolicyScope, op)
 
 	return
 }
@@ -178,19 +198,23 @@ func (c *meteredExecutionManager) DeleteCurrentWorkflowExecution(ctx context.Con
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
+	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence DeleteCurrentWorkflowExecution called", c.sampleLoggingRate(), logTags...)
 		if c.enableShardIDMetrics() {
 			err = c.callWithDomainAndShardScope(metrics.PersistenceDeleteCurrentWorkflowExecutionScope, op, metrics.DomainTag(domainName),
-				metrics.ShardIDTag(c.GetShardID()), metrics.IsRetryTag(retryCount > 0))
+				metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
 		} else {
-			err = c.call(metrics.PersistenceDeleteCurrentWorkflowExecutionScope, op, metrics.DomainTag(domainName), metrics.IsRetryTag(retryCount > 0))
+			err = c.call(metrics.PersistenceDeleteCurrentWorkflowExecutionScope, op, metrics.DomainTag(domainName))
 		}
 		return
 	}
-
-	err = c.callWithoutDomainTag(metrics.PersistenceDeleteCurrentWorkflowExecutionScope, op, metrics.IsRetryTag(retryCount > 0))
+	if c.enableShardIDMetrics() {
+		err = c.callWithShardScope(metrics.PersistenceDeleteCurrentWorkflowExecutionScope, op, metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
+		return
+	}
+	err = c.callWithoutDomainTag(metrics.PersistenceDeleteCurrentWorkflowExecutionScope, op)
 
 	return
 }
@@ -202,19 +226,23 @@ func (c *meteredExecutionManager) DeleteReplicationTaskFromDLQ(ctx context.Conte
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
+	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence DeleteReplicationTaskFromDLQ called", c.sampleLoggingRate(), logTags...)
 		if c.enableShardIDMetrics() {
 			err = c.callWithDomainAndShardScope(metrics.PersistenceDeleteReplicationTaskFromDLQScope, op, metrics.DomainTag(domainName),
-				metrics.ShardIDTag(c.GetShardID()), metrics.IsRetryTag(retryCount > 0))
+				metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
 		} else {
-			err = c.call(metrics.PersistenceDeleteReplicationTaskFromDLQScope, op, metrics.DomainTag(domainName), metrics.IsRetryTag(retryCount > 0))
+			err = c.call(metrics.PersistenceDeleteReplicationTaskFromDLQScope, op, metrics.DomainTag(domainName))
 		}
 		return
 	}
-
-	err = c.callWithoutDomainTag(metrics.PersistenceDeleteReplicationTaskFromDLQScope, op, metrics.IsRetryTag(retryCount > 0))
+	if c.enableShardIDMetrics() {
+		err = c.callWithShardScope(metrics.PersistenceDeleteReplicationTaskFromDLQScope, op, metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
+		return
+	}
+	err = c.callWithoutDomainTag(metrics.PersistenceDeleteReplicationTaskFromDLQScope, op)
 
 	return
 }
@@ -226,19 +254,23 @@ func (c *meteredExecutionManager) DeleteWorkflowExecution(ctx context.Context, r
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
+	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence DeleteWorkflowExecution called", c.sampleLoggingRate(), logTags...)
 		if c.enableShardIDMetrics() {
 			err = c.callWithDomainAndShardScope(metrics.PersistenceDeleteWorkflowExecutionScope, op, metrics.DomainTag(domainName),
-				metrics.ShardIDTag(c.GetShardID()), metrics.IsRetryTag(retryCount > 0))
+				metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
 		} else {
-			err = c.call(metrics.PersistenceDeleteWorkflowExecutionScope, op, metrics.DomainTag(domainName), metrics.IsRetryTag(retryCount > 0))
+			err = c.call(metrics.PersistenceDeleteWorkflowExecutionScope, op, metrics.DomainTag(domainName))
 		}
 		return
 	}
-
-	err = c.callWithoutDomainTag(metrics.PersistenceDeleteWorkflowExecutionScope, op, metrics.IsRetryTag(retryCount > 0))
+	if c.enableShardIDMetrics() {
+		err = c.callWithShardScope(metrics.PersistenceDeleteWorkflowExecutionScope, op, metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
+		return
+	}
+	err = c.callWithoutDomainTag(metrics.PersistenceDeleteWorkflowExecutionScope, op)
 
 	return
 }
@@ -251,19 +283,23 @@ func (c *meteredExecutionManager) GetActiveClusterSelectionPolicy(ctx context.Co
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
+	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence GetActiveClusterSelectionPolicy called", c.sampleLoggingRate(), logTags...)
 		if c.enableShardIDMetrics() {
 			err = c.callWithDomainAndShardScope(metrics.PersistenceGetActiveClusterSelectionPolicyScope, op, metrics.DomainTag(domainName),
-				metrics.ShardIDTag(c.GetShardID()), metrics.IsRetryTag(retryCount > 0))
+				metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
 		} else {
-			err = c.call(metrics.PersistenceGetActiveClusterSelectionPolicyScope, op, metrics.DomainTag(domainName), metrics.IsRetryTag(retryCount > 0))
+			err = c.call(metrics.PersistenceGetActiveClusterSelectionPolicyScope, op, metrics.DomainTag(domainName))
 		}
 		return
 	}
-
-	err = c.callWithoutDomainTag(metrics.PersistenceGetActiveClusterSelectionPolicyScope, op, metrics.IsRetryTag(retryCount > 0))
+	if c.enableShardIDMetrics() {
+		err = c.callWithShardScope(metrics.PersistenceGetActiveClusterSelectionPolicyScope, op, metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
+		return
+	}
+	err = c.callWithoutDomainTag(metrics.PersistenceGetActiveClusterSelectionPolicyScope, op)
 
 	return
 }
@@ -276,19 +312,23 @@ func (c *meteredExecutionManager) GetCurrentExecution(ctx context.Context, reque
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
+	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence GetCurrentExecution called", c.sampleLoggingRate(), logTags...)
 		if c.enableShardIDMetrics() {
 			err = c.callWithDomainAndShardScope(metrics.PersistenceGetCurrentExecutionScope, op, metrics.DomainTag(domainName),
-				metrics.ShardIDTag(c.GetShardID()), metrics.IsRetryTag(retryCount > 0))
+				metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
 		} else {
-			err = c.call(metrics.PersistenceGetCurrentExecutionScope, op, metrics.DomainTag(domainName), metrics.IsRetryTag(retryCount > 0))
+			err = c.call(metrics.PersistenceGetCurrentExecutionScope, op, metrics.DomainTag(domainName))
 		}
 		return
 	}
-
-	err = c.callWithoutDomainTag(metrics.PersistenceGetCurrentExecutionScope, op, metrics.IsRetryTag(retryCount > 0))
+	if c.enableShardIDMetrics() {
+		err = c.callWithShardScope(metrics.PersistenceGetCurrentExecutionScope, op, metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
+		return
+	}
+	err = c.callWithoutDomainTag(metrics.PersistenceGetCurrentExecutionScope, op)
 
 	return
 }
@@ -301,19 +341,23 @@ func (c *meteredExecutionManager) GetHistoryTasks(ctx context.Context, request *
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
+	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence GetHistoryTasks called", c.sampleLoggingRate(), logTags...)
 		if c.enableShardIDMetrics() {
 			err = c.callWithDomainAndShardScope(metrics.PersistenceGetHistoryTasksScope, op, metrics.DomainTag(domainName),
-				metrics.ShardIDTag(c.GetShardID()), metrics.IsRetryTag(retryCount > 0))
+				metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
 		} else {
-			err = c.call(metrics.PersistenceGetHistoryTasksScope, op, metrics.DomainTag(domainName), metrics.IsRetryTag(retryCount > 0))
+			err = c.call(metrics.PersistenceGetHistoryTasksScope, op, metrics.DomainTag(domainName))
 		}
 		return
 	}
-
-	err = c.callWithoutDomainTag(metrics.PersistenceGetHistoryTasksScope, op, metrics.IsRetryTag(retryCount > 0))
+	if c.enableShardIDMetrics() {
+		err = c.callWithShardScope(metrics.PersistenceGetHistoryTasksScope, op, metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
+		return
+	}
+	err = c.callWithoutDomainTag(metrics.PersistenceGetHistoryTasksScope, op)
 
 	return
 }
@@ -330,19 +374,23 @@ func (c *meteredExecutionManager) GetReplicationDLQSize(ctx context.Context, req
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
+	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence GetReplicationDLQSize called", c.sampleLoggingRate(), logTags...)
 		if c.enableShardIDMetrics() {
 			err = c.callWithDomainAndShardScope(metrics.PersistenceGetReplicationDLQSizeScope, op, metrics.DomainTag(domainName),
-				metrics.ShardIDTag(c.GetShardID()), metrics.IsRetryTag(retryCount > 0))
+				metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
 		} else {
-			err = c.call(metrics.PersistenceGetReplicationDLQSizeScope, op, metrics.DomainTag(domainName), metrics.IsRetryTag(retryCount > 0))
+			err = c.call(metrics.PersistenceGetReplicationDLQSizeScope, op, metrics.DomainTag(domainName))
 		}
 		return
 	}
-
-	err = c.callWithoutDomainTag(metrics.PersistenceGetReplicationDLQSizeScope, op, metrics.IsRetryTag(retryCount > 0))
+	if c.enableShardIDMetrics() {
+		err = c.callWithShardScope(metrics.PersistenceGetReplicationDLQSizeScope, op, metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
+		return
+	}
+	err = c.callWithoutDomainTag(metrics.PersistenceGetReplicationDLQSizeScope, op)
 
 	return
 }
@@ -355,19 +403,23 @@ func (c *meteredExecutionManager) GetReplicationTasksFromDLQ(ctx context.Context
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
+	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence GetReplicationTasksFromDLQ called", c.sampleLoggingRate(), logTags...)
 		if c.enableShardIDMetrics() {
 			err = c.callWithDomainAndShardScope(metrics.PersistenceGetReplicationTasksFromDLQScope, op, metrics.DomainTag(domainName),
-				metrics.ShardIDTag(c.GetShardID()), metrics.IsRetryTag(retryCount > 0))
+				metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
 		} else {
-			err = c.call(metrics.PersistenceGetReplicationTasksFromDLQScope, op, metrics.DomainTag(domainName), metrics.IsRetryTag(retryCount > 0))
+			err = c.call(metrics.PersistenceGetReplicationTasksFromDLQScope, op, metrics.DomainTag(domainName))
 		}
 		return
 	}
-
-	err = c.callWithoutDomainTag(metrics.PersistenceGetReplicationTasksFromDLQScope, op, metrics.IsRetryTag(retryCount > 0))
+	if c.enableShardIDMetrics() {
+		err = c.callWithShardScope(metrics.PersistenceGetReplicationTasksFromDLQScope, op, metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
+		return
+	}
+	err = c.callWithoutDomainTag(metrics.PersistenceGetReplicationTasksFromDLQScope, op)
 
 	return
 }
@@ -384,19 +436,23 @@ func (c *meteredExecutionManager) GetWorkflowExecution(ctx context.Context, requ
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
+	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence GetWorkflowExecution called", c.sampleLoggingRate(), logTags...)
 		if c.enableShardIDMetrics() {
 			err = c.callWithDomainAndShardScope(metrics.PersistenceGetWorkflowExecutionScope, op, metrics.DomainTag(domainName),
-				metrics.ShardIDTag(c.GetShardID()), metrics.IsRetryTag(retryCount > 0))
+				metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
 		} else {
-			err = c.call(metrics.PersistenceGetWorkflowExecutionScope, op, metrics.DomainTag(domainName), metrics.IsRetryTag(retryCount > 0))
+			err = c.call(metrics.PersistenceGetWorkflowExecutionScope, op, metrics.DomainTag(domainName))
 		}
 		return
 	}
-
-	err = c.callWithoutDomainTag(metrics.PersistenceGetWorkflowExecutionScope, op, metrics.IsRetryTag(retryCount > 0))
+	if c.enableShardIDMetrics() {
+		err = c.callWithShardScope(metrics.PersistenceGetWorkflowExecutionScope, op, metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
+		return
+	}
+	err = c.callWithoutDomainTag(metrics.PersistenceGetWorkflowExecutionScope, op)
 
 	return
 }
@@ -409,19 +465,23 @@ func (c *meteredExecutionManager) IsWorkflowExecutionExists(ctx context.Context,
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
+	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence IsWorkflowExecutionExists called", c.sampleLoggingRate(), logTags...)
 		if c.enableShardIDMetrics() {
 			err = c.callWithDomainAndShardScope(metrics.PersistenceIsWorkflowExecutionExistsScope, op, metrics.DomainTag(domainName),
-				metrics.ShardIDTag(c.GetShardID()), metrics.IsRetryTag(retryCount > 0))
+				metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
 		} else {
-			err = c.call(metrics.PersistenceIsWorkflowExecutionExistsScope, op, metrics.DomainTag(domainName), metrics.IsRetryTag(retryCount > 0))
+			err = c.call(metrics.PersistenceIsWorkflowExecutionExistsScope, op, metrics.DomainTag(domainName))
 		}
 		return
 	}
-
-	err = c.callWithoutDomainTag(metrics.PersistenceIsWorkflowExecutionExistsScope, op, metrics.IsRetryTag(retryCount > 0))
+	if c.enableShardIDMetrics() {
+		err = c.callWithShardScope(metrics.PersistenceIsWorkflowExecutionExistsScope, op, metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
+		return
+	}
+	err = c.callWithoutDomainTag(metrics.PersistenceIsWorkflowExecutionExistsScope, op)
 
 	return
 }
@@ -434,19 +494,23 @@ func (c *meteredExecutionManager) ListConcreteExecutions(ctx context.Context, re
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
+	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence ListConcreteExecutions called", c.sampleLoggingRate(), logTags...)
 		if c.enableShardIDMetrics() {
 			err = c.callWithDomainAndShardScope(metrics.PersistenceListConcreteExecutionsScope, op, metrics.DomainTag(domainName),
-				metrics.ShardIDTag(c.GetShardID()), metrics.IsRetryTag(retryCount > 0))
+				metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
 		} else {
-			err = c.call(metrics.PersistenceListConcreteExecutionsScope, op, metrics.DomainTag(domainName), metrics.IsRetryTag(retryCount > 0))
+			err = c.call(metrics.PersistenceListConcreteExecutionsScope, op, metrics.DomainTag(domainName))
 		}
 		return
 	}
-
-	err = c.callWithoutDomainTag(metrics.PersistenceListConcreteExecutionsScope, op, metrics.IsRetryTag(retryCount > 0))
+	if c.enableShardIDMetrics() {
+		err = c.callWithShardScope(metrics.PersistenceListConcreteExecutionsScope, op, metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
+		return
+	}
+	err = c.callWithoutDomainTag(metrics.PersistenceListConcreteExecutionsScope, op)
 
 	return
 }
@@ -459,19 +523,23 @@ func (c *meteredExecutionManager) ListCurrentExecutions(ctx context.Context, req
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
+	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence ListCurrentExecutions called", c.sampleLoggingRate(), logTags...)
 		if c.enableShardIDMetrics() {
 			err = c.callWithDomainAndShardScope(metrics.PersistenceListCurrentExecutionsScope, op, metrics.DomainTag(domainName),
-				metrics.ShardIDTag(c.GetShardID()), metrics.IsRetryTag(retryCount > 0))
+				metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
 		} else {
-			err = c.call(metrics.PersistenceListCurrentExecutionsScope, op, metrics.DomainTag(domainName), metrics.IsRetryTag(retryCount > 0))
+			err = c.call(metrics.PersistenceListCurrentExecutionsScope, op, metrics.DomainTag(domainName))
 		}
 		return
 	}
-
-	err = c.callWithoutDomainTag(metrics.PersistenceListCurrentExecutionsScope, op, metrics.IsRetryTag(retryCount > 0))
+	if c.enableShardIDMetrics() {
+		err = c.callWithShardScope(metrics.PersistenceListCurrentExecutionsScope, op, metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
+		return
+	}
+	err = c.callWithoutDomainTag(metrics.PersistenceListCurrentExecutionsScope, op)
 
 	return
 }
@@ -483,19 +551,23 @@ func (c *meteredExecutionManager) PutReplicationTaskToDLQ(ctx context.Context, r
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
+	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence PutReplicationTaskToDLQ called", c.sampleLoggingRate(), logTags...)
 		if c.enableShardIDMetrics() {
 			err = c.callWithDomainAndShardScope(metrics.PersistencePutReplicationTaskToDLQScope, op, metrics.DomainTag(domainName),
-				metrics.ShardIDTag(c.GetShardID()), metrics.IsRetryTag(retryCount > 0))
+				metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
 		} else {
-			err = c.call(metrics.PersistencePutReplicationTaskToDLQScope, op, metrics.DomainTag(domainName), metrics.IsRetryTag(retryCount > 0))
+			err = c.call(metrics.PersistencePutReplicationTaskToDLQScope, op, metrics.DomainTag(domainName))
 		}
 		return
 	}
-
-	err = c.callWithoutDomainTag(metrics.PersistencePutReplicationTaskToDLQScope, op, metrics.IsRetryTag(retryCount > 0))
+	if c.enableShardIDMetrics() {
+		err = c.callWithShardScope(metrics.PersistencePutReplicationTaskToDLQScope, op, metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
+		return
+	}
+	err = c.callWithoutDomainTag(metrics.PersistencePutReplicationTaskToDLQScope, op)
 
 	return
 }
@@ -508,19 +580,23 @@ func (c *meteredExecutionManager) RangeCompleteHistoryTask(ctx context.Context, 
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
+	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence RangeCompleteHistoryTask called", c.sampleLoggingRate(), logTags...)
 		if c.enableShardIDMetrics() {
 			err = c.callWithDomainAndShardScope(metrics.PersistenceRangeCompleteHistoryTaskScope, op, metrics.DomainTag(domainName),
-				metrics.ShardIDTag(c.GetShardID()), metrics.IsRetryTag(retryCount > 0))
+				metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
 		} else {
-			err = c.call(metrics.PersistenceRangeCompleteHistoryTaskScope, op, metrics.DomainTag(domainName), metrics.IsRetryTag(retryCount > 0))
+			err = c.call(metrics.PersistenceRangeCompleteHistoryTaskScope, op, metrics.DomainTag(domainName))
 		}
 		return
 	}
-
-	err = c.callWithoutDomainTag(metrics.PersistenceRangeCompleteHistoryTaskScope, op, metrics.IsRetryTag(retryCount > 0))
+	if c.enableShardIDMetrics() {
+		err = c.callWithShardScope(metrics.PersistenceRangeCompleteHistoryTaskScope, op, metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
+		return
+	}
+	err = c.callWithoutDomainTag(metrics.PersistenceRangeCompleteHistoryTaskScope, op)
 
 	return
 }
@@ -533,19 +609,23 @@ func (c *meteredExecutionManager) RangeDeleteReplicationTaskFromDLQ(ctx context.
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
+	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence RangeDeleteReplicationTaskFromDLQ called", c.sampleLoggingRate(), logTags...)
 		if c.enableShardIDMetrics() {
 			err = c.callWithDomainAndShardScope(metrics.PersistenceRangeDeleteReplicationTaskFromDLQScope, op, metrics.DomainTag(domainName),
-				metrics.ShardIDTag(c.GetShardID()), metrics.IsRetryTag(retryCount > 0))
+				metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
 		} else {
-			err = c.call(metrics.PersistenceRangeDeleteReplicationTaskFromDLQScope, op, metrics.DomainTag(domainName), metrics.IsRetryTag(retryCount > 0))
+			err = c.call(metrics.PersistenceRangeDeleteReplicationTaskFromDLQScope, op, metrics.DomainTag(domainName))
 		}
 		return
 	}
-
-	err = c.callWithoutDomainTag(metrics.PersistenceRangeDeleteReplicationTaskFromDLQScope, op, metrics.IsRetryTag(retryCount > 0))
+	if c.enableShardIDMetrics() {
+		err = c.callWithShardScope(metrics.PersistenceRangeDeleteReplicationTaskFromDLQScope, op, metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
+		return
+	}
+	err = c.callWithoutDomainTag(metrics.PersistenceRangeDeleteReplicationTaskFromDLQScope, op)
 
 	return
 }
@@ -558,19 +638,23 @@ func (c *meteredExecutionManager) UpdateWorkflowExecution(ctx context.Context, r
 	}
 
 	retryCount := getRetryCountFromContext(ctx)
+	shardMetricTags := append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))
 	if domainName, hasDomainName := getDomainNameFromRequest(request); hasDomainName {
 		logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags(request)...)
 		c.logger.SampleInfo("Persistence UpdateWorkflowExecution called", c.sampleLoggingRate(), logTags...)
 		if c.enableShardIDMetrics() {
 			err = c.callWithDomainAndShardScope(metrics.PersistenceUpdateWorkflowExecutionScope, op, metrics.DomainTag(domainName),
-				metrics.ShardIDTag(c.GetShardID()), metrics.IsRetryTag(retryCount > 0))
+				metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
 		} else {
-			err = c.call(metrics.PersistenceUpdateWorkflowExecutionScope, op, metrics.DomainTag(domainName), metrics.IsRetryTag(retryCount > 0))
+			err = c.call(metrics.PersistenceUpdateWorkflowExecutionScope, op, metrics.DomainTag(domainName))
 		}
 		return
 	}
-
-	err = c.callWithoutDomainTag(metrics.PersistenceUpdateWorkflowExecutionScope, op, metrics.IsRetryTag(retryCount > 0))
+	if c.enableShardIDMetrics() {
+		err = c.callWithShardScope(metrics.PersistenceUpdateWorkflowExecutionScope, op, metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
+		return
+	}
+	err = c.callWithoutDomainTag(metrics.PersistenceUpdateWorkflowExecutionScope, op)
 
 	return
 }

--- a/common/persistence/wrappers/metered/execution_generated.go
+++ b/common/persistence/wrappers/metered/execution_generated.go
@@ -68,7 +68,7 @@ func (c *meteredExecutionManager) CompleteHistoryTask(ctx context.Context, reque
 		return
 	}
 
-	err = c.callWithoutDomainTag(metrics.PersistenceCompleteHistoryTaskScope, op, append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))...)
+	err = c.callWithoutDomainTag(metrics.PersistenceCompleteHistoryTaskScope, op, metrics.IsRetryTag(retryCount > 0))
 
 	return
 }
@@ -93,7 +93,7 @@ func (c *meteredExecutionManager) ConflictResolveWorkflowExecution(ctx context.C
 		return
 	}
 
-	err = c.callWithoutDomainTag(metrics.PersistenceConflictResolveWorkflowExecutionScope, op, append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))...)
+	err = c.callWithoutDomainTag(metrics.PersistenceConflictResolveWorkflowExecutionScope, op, metrics.IsRetryTag(retryCount > 0))
 
 	return
 }
@@ -117,7 +117,7 @@ func (c *meteredExecutionManager) CreateFailoverMarkerTasks(ctx context.Context,
 		return
 	}
 
-	err = c.callWithoutDomainTag(metrics.PersistenceCreateFailoverMarkerTasksScope, op, append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))...)
+	err = c.callWithoutDomainTag(metrics.PersistenceCreateFailoverMarkerTasksScope, op, metrics.IsRetryTag(retryCount > 0))
 
 	return
 }
@@ -142,7 +142,7 @@ func (c *meteredExecutionManager) CreateWorkflowExecution(ctx context.Context, r
 		return
 	}
 
-	err = c.callWithoutDomainTag(metrics.PersistenceCreateWorkflowExecutionScope, op, append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))...)
+	err = c.callWithoutDomainTag(metrics.PersistenceCreateWorkflowExecutionScope, op, metrics.IsRetryTag(retryCount > 0))
 
 	return
 }
@@ -166,7 +166,7 @@ func (c *meteredExecutionManager) DeleteActiveClusterSelectionPolicy(ctx context
 		return
 	}
 
-	err = c.callWithoutDomainTag(metrics.PersistenceDeleteActiveClusterSelectionPolicyScope, op, append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))...)
+	err = c.callWithoutDomainTag(metrics.PersistenceDeleteActiveClusterSelectionPolicyScope, op, metrics.IsRetryTag(retryCount > 0))
 
 	return
 }
@@ -190,7 +190,7 @@ func (c *meteredExecutionManager) DeleteCurrentWorkflowExecution(ctx context.Con
 		return
 	}
 
-	err = c.callWithoutDomainTag(metrics.PersistenceDeleteCurrentWorkflowExecutionScope, op, append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))...)
+	err = c.callWithoutDomainTag(metrics.PersistenceDeleteCurrentWorkflowExecutionScope, op, metrics.IsRetryTag(retryCount > 0))
 
 	return
 }
@@ -214,7 +214,7 @@ func (c *meteredExecutionManager) DeleteReplicationTaskFromDLQ(ctx context.Conte
 		return
 	}
 
-	err = c.callWithoutDomainTag(metrics.PersistenceDeleteReplicationTaskFromDLQScope, op, append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))...)
+	err = c.callWithoutDomainTag(metrics.PersistenceDeleteReplicationTaskFromDLQScope, op, metrics.IsRetryTag(retryCount > 0))
 
 	return
 }
@@ -238,7 +238,7 @@ func (c *meteredExecutionManager) DeleteWorkflowExecution(ctx context.Context, r
 		return
 	}
 
-	err = c.callWithoutDomainTag(metrics.PersistenceDeleteWorkflowExecutionScope, op, append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))...)
+	err = c.callWithoutDomainTag(metrics.PersistenceDeleteWorkflowExecutionScope, op, metrics.IsRetryTag(retryCount > 0))
 
 	return
 }
@@ -263,7 +263,7 @@ func (c *meteredExecutionManager) GetActiveClusterSelectionPolicy(ctx context.Co
 		return
 	}
 
-	err = c.callWithoutDomainTag(metrics.PersistenceGetActiveClusterSelectionPolicyScope, op, append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))...)
+	err = c.callWithoutDomainTag(metrics.PersistenceGetActiveClusterSelectionPolicyScope, op, metrics.IsRetryTag(retryCount > 0))
 
 	return
 }
@@ -288,7 +288,7 @@ func (c *meteredExecutionManager) GetCurrentExecution(ctx context.Context, reque
 		return
 	}
 
-	err = c.callWithoutDomainTag(metrics.PersistenceGetCurrentExecutionScope, op, append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))...)
+	err = c.callWithoutDomainTag(metrics.PersistenceGetCurrentExecutionScope, op, metrics.IsRetryTag(retryCount > 0))
 
 	return
 }
@@ -313,7 +313,7 @@ func (c *meteredExecutionManager) GetHistoryTasks(ctx context.Context, request *
 		return
 	}
 
-	err = c.callWithoutDomainTag(metrics.PersistenceGetHistoryTasksScope, op, append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))...)
+	err = c.callWithoutDomainTag(metrics.PersistenceGetHistoryTasksScope, op, metrics.IsRetryTag(retryCount > 0))
 
 	return
 }
@@ -342,7 +342,7 @@ func (c *meteredExecutionManager) GetReplicationDLQSize(ctx context.Context, req
 		return
 	}
 
-	err = c.callWithoutDomainTag(metrics.PersistenceGetReplicationDLQSizeScope, op, append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))...)
+	err = c.callWithoutDomainTag(metrics.PersistenceGetReplicationDLQSizeScope, op, metrics.IsRetryTag(retryCount > 0))
 
 	return
 }
@@ -367,7 +367,7 @@ func (c *meteredExecutionManager) GetReplicationTasksFromDLQ(ctx context.Context
 		return
 	}
 
-	err = c.callWithoutDomainTag(metrics.PersistenceGetReplicationTasksFromDLQScope, op, append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))...)
+	err = c.callWithoutDomainTag(metrics.PersistenceGetReplicationTasksFromDLQScope, op, metrics.IsRetryTag(retryCount > 0))
 
 	return
 }
@@ -396,7 +396,7 @@ func (c *meteredExecutionManager) GetWorkflowExecution(ctx context.Context, requ
 		return
 	}
 
-	err = c.callWithoutDomainTag(metrics.PersistenceGetWorkflowExecutionScope, op, append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))...)
+	err = c.callWithoutDomainTag(metrics.PersistenceGetWorkflowExecutionScope, op, metrics.IsRetryTag(retryCount > 0))
 
 	return
 }
@@ -421,7 +421,7 @@ func (c *meteredExecutionManager) IsWorkflowExecutionExists(ctx context.Context,
 		return
 	}
 
-	err = c.callWithoutDomainTag(metrics.PersistenceIsWorkflowExecutionExistsScope, op, append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))...)
+	err = c.callWithoutDomainTag(metrics.PersistenceIsWorkflowExecutionExistsScope, op, metrics.IsRetryTag(retryCount > 0))
 
 	return
 }
@@ -446,7 +446,7 @@ func (c *meteredExecutionManager) ListConcreteExecutions(ctx context.Context, re
 		return
 	}
 
-	err = c.callWithoutDomainTag(metrics.PersistenceListConcreteExecutionsScope, op, append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))...)
+	err = c.callWithoutDomainTag(metrics.PersistenceListConcreteExecutionsScope, op, metrics.IsRetryTag(retryCount > 0))
 
 	return
 }
@@ -471,7 +471,7 @@ func (c *meteredExecutionManager) ListCurrentExecutions(ctx context.Context, req
 		return
 	}
 
-	err = c.callWithoutDomainTag(metrics.PersistenceListCurrentExecutionsScope, op, append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))...)
+	err = c.callWithoutDomainTag(metrics.PersistenceListCurrentExecutionsScope, op, metrics.IsRetryTag(retryCount > 0))
 
 	return
 }
@@ -495,7 +495,7 @@ func (c *meteredExecutionManager) PutReplicationTaskToDLQ(ctx context.Context, r
 		return
 	}
 
-	err = c.callWithoutDomainTag(metrics.PersistencePutReplicationTaskToDLQScope, op, append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))...)
+	err = c.callWithoutDomainTag(metrics.PersistencePutReplicationTaskToDLQScope, op, metrics.IsRetryTag(retryCount > 0))
 
 	return
 }
@@ -520,7 +520,7 @@ func (c *meteredExecutionManager) RangeCompleteHistoryTask(ctx context.Context, 
 		return
 	}
 
-	err = c.callWithoutDomainTag(metrics.PersistenceRangeCompleteHistoryTaskScope, op, append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))...)
+	err = c.callWithoutDomainTag(metrics.PersistenceRangeCompleteHistoryTaskScope, op, metrics.IsRetryTag(retryCount > 0))
 
 	return
 }
@@ -545,7 +545,7 @@ func (c *meteredExecutionManager) RangeDeleteReplicationTaskFromDLQ(ctx context.
 		return
 	}
 
-	err = c.callWithoutDomainTag(metrics.PersistenceRangeDeleteReplicationTaskFromDLQScope, op, append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))...)
+	err = c.callWithoutDomainTag(metrics.PersistenceRangeDeleteReplicationTaskFromDLQScope, op, metrics.IsRetryTag(retryCount > 0))
 
 	return
 }
@@ -570,7 +570,7 @@ func (c *meteredExecutionManager) UpdateWorkflowExecution(ctx context.Context, r
 		return
 	}
 
-	err = c.callWithoutDomainTag(metrics.PersistenceUpdateWorkflowExecutionScope, op, append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))...)
+	err = c.callWithoutDomainTag(metrics.PersistenceUpdateWorkflowExecutionScope, op, metrics.IsRetryTag(retryCount > 0))
 
 	return
 }

--- a/common/persistence/wrappers/metered/metered_test.go
+++ b/common/persistence/wrappers/metered/metered_test.go
@@ -399,6 +399,31 @@ func TestExecutionManagerSharedMetricsStayTagStable(t *testing.T) {
 	})
 }
 
+func TestExecutionManagerNilRequestDoesNotPanic(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	wrapped := persistence.NewMockExecutionManager(ctrl)
+	wrapped.EXPECT().GetShardID().Return(17).AnyTimes()
+	wrapped.EXPECT().GetReplicationTasksFromDLQ(gomock.Any(), (*persistence.GetReplicationTasksFromDLQRequest)(nil)).
+		Return(&persistence.GetHistoryTasksResponse{}, nil).
+		Times(1)
+
+	metricScope := tally.NewTestScope("", nil)
+	metricsClient := metrics.NewClient(metricScope, metrics.ServiceIdx(0), metrics.MigrationConfig{})
+	logger := log.NewNoop()
+
+	wrapper := NewExecutionManager(
+		wrapped,
+		metricsClient,
+		logger,
+		&config.Persistence{EnablePersistenceLatencyHistogramMetrics: true},
+		dynamicproperties.GetIntPropertyFn(1),
+		dynamicproperties.GetBoolPropertyFn(true),
+	)
+
+	_, err := wrapper.GetReplicationTasksFromDLQ(context.Background(), nil)
+	assert.NoError(t, err)
+}
+
 func assertCounterSnapshotTags(t *testing.T, snapshot tally.Snapshot, metricName string, predicate func(tags map[string]string) bool) {
 	t.Helper()
 	for _, counter := range snapshot.Counters() {

--- a/common/persistence/wrappers/metered/metered_test.go
+++ b/common/persistence/wrappers/metered/metered_test.go
@@ -322,3 +322,108 @@ func runScenario(t *testing.T, newObj any, newLogs *observer.ObservedLogs, newMe
 		})
 	}
 }
+
+func TestExecutionManagerSharedMetricsStayTagStable(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	wrapped := persistence.NewMockExecutionManager(ctrl)
+	wrapped.EXPECT().GetShardID().Return(17).AnyTimes()
+	wrapped.EXPECT().GetHistoryTasks(gomock.Any(), gomock.Any()).Return(&persistence.GetHistoryTasksResponse{}, nil).Times(1)
+	wrapped.EXPECT().CreateWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.CreateWorkflowExecutionResponse{}, nil).Times(1)
+
+	metricScope := tally.NewTestScope("", nil)
+	metricsClient := metrics.NewClient(metricScope, metrics.ServiceIdx(0), metrics.MigrationConfig{})
+	logger := log.NewNoop()
+
+	wrapper := NewExecutionManager(
+		wrapped,
+		metricsClient,
+		logger,
+		&config.Persistence{EnablePersistenceLatencyHistogramMetrics: true},
+		dynamicproperties.GetIntPropertyFn(1),
+		dynamicproperties.GetBoolPropertyFn(true),
+	)
+
+	retryCtx := context.WithValue(context.Background(), retryCountKey, 1)
+	_, err := wrapper.GetHistoryTasks(retryCtx, &persistence.GetHistoryTasksRequest{
+		TaskCategory: persistence.HistoryTaskCategoryTransfer,
+	})
+	assert.NoError(t, err)
+
+	_, err = wrapper.CreateWorkflowExecution(retryCtx, &persistence.CreateWorkflowExecutionRequest{
+		DomainName: "test-domain",
+	})
+	assert.NoError(t, err)
+
+	snapshot := metricScope.Snapshot()
+	const (
+		persistenceRequestsName         = "persistence_requests"
+		persistenceLatencyName          = "persistence_latency"
+		persistenceRequestsPerShardName = "persistence_requests_per_shard"
+		persistenceLatencyPerShardName  = "persistence_latency_per_shard"
+	)
+
+	assertCounterSnapshotTags(t, snapshot, persistenceRequestsName, func(tags map[string]string) bool {
+		return tags["operation"] == "GetHistoryTasks" && !hasAnyMetricTag(tags, "task_category", "is_retry", "shard_id")
+	})
+	assertTimerSnapshotTags(t, snapshot, persistenceLatencyName, func(tags map[string]string) bool {
+		return tags["operation"] == "GetHistoryTasks" && !hasAnyMetricTag(tags, "task_category", "is_retry", "shard_id")
+	})
+	assertCounterSnapshotTags(t, snapshot, persistenceRequestsName, func(tags map[string]string) bool {
+		return tags["operation"] == "CreateWorkflowExecution" && !hasAnyMetricTag(tags, "is_retry", "shard_id")
+	})
+	assertTimerSnapshotTags(t, snapshot, persistenceLatencyName, func(tags map[string]string) bool {
+		return tags["operation"] == "CreateWorkflowExecution" && !hasAnyMetricTag(tags, "is_retry", "shard_id")
+	})
+
+	assertCounterSnapshotTags(t, snapshot, persistenceRequestsPerShardName, func(tags map[string]string) bool {
+		return tags["operation"] == "GetHistoryTasks" && tags["task_category"] == persistence.HistoryTaskCategoryTransfer.Name() &&
+			tags["is_retry"] == "true" && tags["shard_id"] == "17"
+	})
+	assertTimerSnapshotTags(t, snapshot, persistenceLatencyPerShardName, func(tags map[string]string) bool {
+		return tags["operation"] == "GetHistoryTasks" && tags["task_category"] == persistence.HistoryTaskCategoryTransfer.Name() &&
+			tags["is_retry"] == "true" && tags["shard_id"] == "17"
+	})
+	assertCounterSnapshotTags(t, snapshot, persistenceRequestsPerShardName, func(tags map[string]string) bool {
+		return tags["operation"] == "ShardIdPersistenceRequest" && tags["task_category"] == persistence.HistoryTaskCategoryTransfer.Name() &&
+			tags["is_retry"] == "true" && tags["shard_id"] == "17"
+	})
+	assertTimerSnapshotTags(t, snapshot, persistenceLatencyPerShardName, func(tags map[string]string) bool {
+		return tags["operation"] == "ShardIdPersistenceRequest" && tags["task_category"] == persistence.HistoryTaskCategoryTransfer.Name() &&
+			tags["is_retry"] == "true" && tags["shard_id"] == "17"
+	})
+	assertCounterSnapshotTags(t, snapshot, persistenceRequestsPerShardName, func(tags map[string]string) bool {
+		return tags["operation"] == "CreateWorkflowExecution" && tags["is_retry"] == "true" && tags["shard_id"] == "17"
+	})
+	assertTimerSnapshotTags(t, snapshot, persistenceLatencyPerShardName, func(tags map[string]string) bool {
+		return tags["operation"] == "CreateWorkflowExecution" && tags["is_retry"] == "true" && tags["shard_id"] == "17"
+	})
+}
+
+func assertCounterSnapshotTags(t *testing.T, snapshot tally.Snapshot, metricName string, predicate func(tags map[string]string) bool) {
+	t.Helper()
+	for _, counter := range snapshot.Counters() {
+		if counter.Name() == metricName && predicate(counter.Tags()) {
+			return
+		}
+	}
+	t.Fatalf("counter %q with expected tags not found", metricName)
+}
+
+func assertTimerSnapshotTags(t *testing.T, snapshot tally.Snapshot, metricName string, predicate func(tags map[string]string) bool) {
+	t.Helper()
+	for _, timer := range snapshot.Timers() {
+		if timer.Name() == metricName && predicate(timer.Tags()) {
+			return
+		}
+	}
+	t.Fatalf("timer %q with expected tags not found", metricName)
+}
+
+func hasAnyMetricTag(tags map[string]string, keys ...string) bool {
+	for _, key := range keys {
+		if _, ok := tags[key]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/common/persistence/wrappers/metered/metered_test.go
+++ b/common/persistence/wrappers/metered/metered_test.go
@@ -376,20 +376,24 @@ func TestExecutionManagerSharedMetricsStayTagStable(t *testing.T) {
 	})
 
 	assertCounterSnapshotTags(t, snapshot, persistenceRequestsPerShardName, func(tags map[string]string) bool {
-		return tags["operation"] == "GetHistoryTasks" && tags["task_category"] == persistence.HistoryTaskCategoryTransfer.Name() &&
-			tags["is_retry"] == "true" && tags["shard_id"] == "17"
+		return tags["operation"] == "GetHistoryTasks" &&
+			tags["is_retry"] == "true" && tags["shard_id"] == "17" &&
+			!hasAnyMetricTag(tags, "task_category", "domain")
 	})
 	assertTimerSnapshotTags(t, snapshot, persistenceLatencyPerShardName, func(tags map[string]string) bool {
-		return tags["operation"] == "GetHistoryTasks" && tags["task_category"] == persistence.HistoryTaskCategoryTransfer.Name() &&
-			tags["is_retry"] == "true" && tags["shard_id"] == "17"
+		return tags["operation"] == "GetHistoryTasks" &&
+			tags["is_retry"] == "true" && tags["shard_id"] == "17" &&
+			!hasAnyMetricTag(tags, "task_category", "domain")
 	})
 	assertCounterSnapshotTags(t, snapshot, persistenceRequestsPerShardName, func(tags map[string]string) bool {
-		return tags["operation"] == "ShardIdPersistenceRequest" && tags["task_category"] == persistence.HistoryTaskCategoryTransfer.Name() &&
-			tags["is_retry"] == "true" && tags["shard_id"] == "17"
+		return tags["operation"] == "ShardIdPersistenceRequest" &&
+			tags["is_retry"] == "true" && tags["shard_id"] == "17" &&
+			!hasAnyMetricTag(tags, "task_category", "domain")
 	})
 	assertTimerSnapshotTags(t, snapshot, persistenceLatencyPerShardName, func(tags map[string]string) bool {
-		return tags["operation"] == "ShardIdPersistenceRequest" && tags["task_category"] == persistence.HistoryTaskCategoryTransfer.Name() &&
-			tags["is_retry"] == "true" && tags["shard_id"] == "17"
+		return tags["operation"] == "ShardIdPersistenceRequest" &&
+			tags["is_retry"] == "true" && tags["shard_id"] == "17" &&
+			!hasAnyMetricTag(tags, "task_category", "domain")
 	})
 	assertCounterSnapshotTags(t, snapshot, persistenceRequestsPerShardName, func(tags map[string]string) bool {
 		return tags["operation"] == "CreateWorkflowExecution" && tags["is_retry"] == "true" && tags["shard_id"] == "17"

--- a/common/persistence/wrappers/templates/metered_execution.tmpl
+++ b/common/persistence/wrappers/templates/metered_execution.tmpl
@@ -55,25 +55,25 @@ func New{{.Interface.Name}}(
             {{ if gt (len $method.Params) 1 -}}
                 {{ $reqName := (index $method.Params 1).Name }}
                 retryCount := getRetryCountFromContext(ctx)
+                shardMetricTags := append(getCustomMetricTags({{$reqName}}), metrics.IsRetryTag(retryCount > 0))
                 if domainName, hasDomainName := getDomainNameFromRequest({{$reqName}}); hasDomainName {
                     logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags({{$reqName}})...)
                     c.logger.SampleInfo("Persistence {{$methodName}} called", c.sampleLoggingRate(), logTags...)
                 	if c.enableShardIDMetrics() {
                 	    err = c.callWithDomainAndShardScope({{$scopeName}}, op, metrics.DomainTag(domainName),
-                	    metrics.ShardIDTag(c.GetShardID()), metrics.IsRetryTag(retryCount > 0))
+                	    metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
                 	} else {
-                		err = c.call({{$scopeName}}, op, metrics.DomainTag(domainName), metrics.IsRetryTag(retryCount > 0))
+                		err = c.call({{$scopeName}}, op, metrics.DomainTag(domainName))
                 	}
                 	return
                 }
+                if c.enableShardIDMetrics() {
+                    err = c.callWithShardScope({{$scopeName}}, op, metrics.ShardIDTag(c.GetShardID()), shardMetricTags...)
+                    return
+                }
             {{ end -}}
 
-             {{$extraTags := ""}}
-             {{ if gt (len $method.Params) 1 -}}
-                  {{ $extraTags = ", metrics.IsRetryTag(retryCount > 0)" }}
-             {{ end -}}
-
-	        err = c.callWithoutDomainTag({{$scopeName}}, op{{$extraTags}})
+	        err = c.callWithoutDomainTag({{$scopeName}}, op)
 
 	        return
         }

--- a/common/persistence/wrappers/templates/metered_execution.tmpl
+++ b/common/persistence/wrappers/templates/metered_execution.tmpl
@@ -55,7 +55,7 @@ func New{{.Interface.Name}}(
             {{ if gt (len $method.Params) 1 -}}
                 {{ $reqName := (index $method.Params 1).Name }}
                 retryCount := getRetryCountFromContext(ctx)
-                shardMetricTags := append(getCustomMetricTags({{$reqName}}), metrics.IsRetryTag(retryCount > 0))
+                shardMetricTags := []metrics.Tag{metrics.IsRetryTag(retryCount > 0)}
                 if domainName, hasDomainName := getDomainNameFromRequest({{$reqName}}); hasDomainName {
                     logTags := append([]tag.Tag{tag.WorkflowDomainName(domainName)}, getCustomLogTags({{$reqName}})...)
                     c.logger.SampleInfo("Persistence {{$methodName}} called", c.sampleLoggingRate(), logTags...)

--- a/common/persistence/wrappers/templates/metered_execution.tmpl
+++ b/common/persistence/wrappers/templates/metered_execution.tmpl
@@ -70,8 +70,7 @@ func New{{.Interface.Name}}(
 
              {{$extraTags := ""}}
              {{ if gt (len $method.Params) 1 -}}
-                  {{ $reqName := (index $method.Params 1).Name }}
-                  {{ $extraTags = printf ", append(getCustomMetricTags(%s), metrics.IsRetryTag(retryCount > 0))..." $reqName }}
+                  {{ $extraTags = ", metrics.IsRetryTag(retryCount > 0)" }}
              {{ end -}}
 
 	        err = c.callWithoutDomainTag({{$scopeName}}, op{{$extraTags}})


### PR DESCRIPTION
**What changed?**

Fixed inconsistent label sets across scopes emitting the same Prometheus metric name, which caused the Prometheus reporter to silently drop metrics.

Fixes #7844.

**Why?**

The Prometheus `client_golang` library requires that all descriptors registered under the same metric name share the same label-name set. When Cadence emitted the same metric from scopes with different tag sets, the second registration failed and Tally returned a `noopMetric{}`, silently discarding all data from that scope.

Two specific patterns were broken:

1. **`persistence_requests_per_shard` / `persistence_latency_per_shard`** — In `callWithDomainAndShardScope`, `shardOperationsMetricsScope` included `additionalTags` (e.g., `is_retry`) but `shardOverallMetricsScope` did not. Both scopes emitted the same metric names with different label sets. Fixed by passing `additionalTags` to `shardOverallMetricsScope`.

2. **`persistence_requests` / `persistence_latency`** — Three methods (`CompleteHistoryTask`, `GetHistoryTasks`, `RangeCompleteHistoryTask`) added a `task_category` tag via `getCustomMetricTags` in the `callWithoutDomainTag` fallback path, while all other ExecutionManager methods did not. This created an inconsistent label set for the shared `persistence_requests` and `persistence_latency` metrics. Fixed by removing `getCustomMetricTags` from the `callWithoutDomainTag` path in the codegen template — the `operation` label already identifies the method uniquely.

Note: the cache metrics inconsistencies (`cache_count`, `cache_evict`, `cache_latency`) mentioned in #7844 originate in the cache layer, not the persistence metered wrapper, and are left for a follow-up.

**How did you test it?**

```bash
go test -race ./common/persistence/wrappers/metered/...
go build ./...
```

All existing tests pass. The generated file `execution_generated.go` was regenerated from the updated template via `make go-generate GEN_DIR=common/persistence`.

**Potential risks**

- The `task_category` tag is no longer emitted on `persistence_requests` / `persistence_latency` for the three history-task methods when the request has no domain. Dashboards querying these metrics by `task_category` on the no-domain path would need to switch to filtering by `operation` instead. The `operation` label already uniquely identifies these methods, so no information is lost.
- The `shardOverallMetricsScope` now carries `additionalTags` (currently `is_retry`), slightly increasing label cardinality for the `PersistenceShardRequestCountScope`. This is the intended fix — all emission paths for `persistence_requests_per_shard` must share the same label set.

**Release notes**

Fixed silent metric data loss when using the Prometheus reporter. Persistence metrics (`persistence_requests_per_shard`, `persistence_latency_per_shard`, `persistence_requests`, `persistence_latency`) were emitted with inconsistent label sets across code paths, causing Prometheus to reject the second registration and drop all data from the affected scope.

**Documentation Changes**

N/A