### PR TITLE
feat(schedules): implement Schedule API handlers

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -22,12 +22,27 @@ package api
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/frontend/validate"
+	"github.com/uber/cadence/service/worker/scheduler"
 )
 
-var errScheduleNotImplemented = &types.BadRequestError{Message: "Schedule APIs are not yet implemented."}
+const (
+	scheduleWorkflowIDPrefix          = "cadence-scheduler:"
+	schedulerWorkflowExecutionTimeout = 10 * 365 * 24 * time.Hour // ~10 years
+	schedulerWorkflowDecisionTimeout  = 10 * time.Second
+)
+
+func scheduleWorkflowID(scheduleID string) string {
+	return scheduleWorkflowIDPrefix + scheduleID
+}
 
 func (wh *WorkflowHandler) CreateSchedule(
 	ctx context.Context,
@@ -39,7 +54,71 @@ func (wh *WorkflowHandler) CreateSchedule(
 	if request == nil {
 		return nil, validate.ErrRequestNotSet
 	}
-	return nil, errScheduleNotImplemented
+
+	domainName := request.GetDomain()
+	if domainName == "" {
+		return nil, validate.ErrDomainNotSet
+	}
+	scheduleID := request.GetScheduleID()
+	if scheduleID == "" {
+		return nil, &types.BadRequestError{Message: "ScheduleID is not set on request."}
+	}
+	if request.GetSpec() == nil {
+		return nil, &types.BadRequestError{Message: "Spec is not set on request."}
+	}
+	if request.GetSpec().GetCronExpression() == "" {
+		return nil, &types.BadRequestError{Message: "CronExpression is not set on request."}
+	}
+	if request.GetAction() == nil || request.GetAction().GetStartWorkflow() == nil {
+		return nil, &types.BadRequestError{Message: "Action.StartWorkflow is not set on request."}
+	}
+
+	workflowInput := scheduler.SchedulerWorkflowInput{
+		Domain:     domainName,
+		ScheduleID: scheduleID,
+		Spec:       *request.GetSpec(),
+		Action:     *request.GetAction(),
+	}
+	if request.GetPolicies() != nil {
+		workflowInput.Policies = *request.GetPolicies()
+	}
+
+	inputBytes, err := json.Marshal(workflowInput)
+	if err != nil {
+		return nil, &types.InternalServiceError{Message: fmt.Sprintf("failed to serialize scheduler workflow input: %v", err)}
+	}
+
+	wfID := scheduleWorkflowID(scheduleID)
+	requestID := uuid.New().String()
+	reusePolicy := types.WorkflowIDReusePolicyRejectDuplicate
+	executionTimeout := int32(schedulerWorkflowExecutionTimeout.Seconds())
+	decisionTimeout := int32(schedulerWorkflowDecisionTimeout.Seconds())
+
+	_, err = wh.StartWorkflowExecution(ctx, &types.StartWorkflowExecutionRequest{
+		Domain:                              domainName,
+		WorkflowID:                          wfID,
+		WorkflowType:                        &types.WorkflowType{Name: scheduler.WorkflowTypeName},
+		TaskList:                            &types.TaskList{Name: scheduler.TaskListName},
+		Input:                               inputBytes,
+		ExecutionStartToCloseTimeoutSeconds: &executionTimeout,
+		TaskStartToCloseTimeoutSeconds:      &decisionTimeout,
+		RequestID:                           requestID,
+		WorkflowIDReusePolicy:               &reusePolicy,
+		Memo:                                request.GetMemo(),
+		SearchAttributes:                    request.GetSearchAttributes(),
+	})
+	if err != nil {
+		var alreadyStarted *types.WorkflowExecutionAlreadyStartedError
+		if errors.As(err, &alreadyStarted) {
+			return nil, &types.BadRequestError{
+				Message: fmt.Sprintf("schedule %q already exists in domain %q", scheduleID, domainName),
+			}
+		}
+		return nil, err
+	}
+
+	// TODO: return ScheduleID in the response once the IDL CreateScheduleResponse has the field
+	return &types.CreateScheduleResponse{}, nil
 }
 
 func (wh *WorkflowHandler) DescribeSchedule(
@@ -52,7 +131,61 @@ func (wh *WorkflowHandler) DescribeSchedule(
 	if request == nil {
 		return nil, validate.ErrRequestNotSet
 	}
-	return nil, errScheduleNotImplemented
+
+	domainName := request.GetDomain()
+	if domainName == "" {
+		return nil, validate.ErrDomainNotSet
+	}
+	scheduleID := request.GetScheduleID()
+	if scheduleID == "" {
+		return nil, &types.BadRequestError{Message: "ScheduleID is not set on request."}
+	}
+
+	wfID := scheduleWorkflowID(scheduleID)
+	queryResp, err := wh.QueryWorkflow(ctx, &types.QueryWorkflowRequest{
+		Domain: domainName,
+		Execution: &types.WorkflowExecution{
+			WorkflowID: wfID,
+		},
+		Query: &types.WorkflowQuery{
+			QueryType: scheduler.QueryTypeDescribe,
+		},
+	})
+	if err != nil {
+		return nil, normalizeScheduleError(err, scheduleID, domainName)
+	}
+
+	if queryResp == nil || queryResp.GetQueryResult() == nil {
+		return nil, &types.InternalServiceError{Message: "empty query result from scheduler workflow"}
+	}
+
+	var desc scheduler.ScheduleDescription
+	if err := json.Unmarshal(queryResp.GetQueryResult(), &desc); err != nil {
+		return nil, &types.InternalServiceError{Message: fmt.Sprintf("failed to deserialize scheduler describe response: %v", err)}
+	}
+
+	return &types.DescribeScheduleResponse{
+		Spec:     &desc.Spec,
+		Action:   &desc.Action,
+		Policies: &desc.Policies,
+		State: &types.ScheduleState{
+			Paused: desc.Paused,
+			PauseInfo: func() *types.SchedulePauseInfo {
+				if !desc.Paused {
+					return nil
+				}
+				return &types.SchedulePauseInfo{
+					Reason:   desc.PauseReason,
+					PausedBy: desc.PausedBy,
+				}
+			}(),
+		},
+		Info: &types.ScheduleInfo{
+			LastRunTime: desc.LastRunTime,
+			NextRunTime: desc.NextRunTime,
+			TotalRuns:   desc.TotalRuns,
+		},
+	}, nil
 }
 
 func (wh *WorkflowHandler) UpdateSchedule(
@@ -65,7 +198,29 @@ func (wh *WorkflowHandler) UpdateSchedule(
 	if request == nil {
 		return nil, validate.ErrRequestNotSet
 	}
-	return nil, errScheduleNotImplemented
+
+	domainName := request.GetDomain()
+	if domainName == "" {
+		return nil, validate.ErrDomainNotSet
+	}
+	scheduleID := request.GetScheduleID()
+	if scheduleID == "" {
+		return nil, &types.BadRequestError{Message: "ScheduleID is not set on request."}
+	}
+	if request.GetSpec() == nil && request.GetAction() == nil && request.GetPolicies() == nil {
+		return nil, &types.BadRequestError{Message: "At least one of Spec, Action, or Policies must be set on request."}
+	}
+
+	signal := scheduler.UpdateSignal{
+		Spec:     request.GetSpec(),
+		Action:   request.GetAction(),
+		Policies: request.GetPolicies(),
+	}
+
+	if err := wh.signalScheduleWorkflow(ctx, domainName, scheduleID, scheduler.SignalNameUpdate, signal); err != nil {
+		return nil, err
+	}
+	return &types.UpdateScheduleResponse{}, nil
 }
 
 func (wh *WorkflowHandler) DeleteSchedule(
@@ -78,7 +233,20 @@ func (wh *WorkflowHandler) DeleteSchedule(
 	if request == nil {
 		return nil, validate.ErrRequestNotSet
 	}
-	return nil, errScheduleNotImplemented
+
+	domainName := request.GetDomain()
+	if domainName == "" {
+		return nil, validate.ErrDomainNotSet
+	}
+	scheduleID := request.GetScheduleID()
+	if scheduleID == "" {
+		return nil, &types.BadRequestError{Message: "ScheduleID is not set on request."}
+	}
+
+	if err := wh.signalScheduleWorkflow(ctx, domainName, scheduleID, scheduler.SignalNameDelete, nil); err != nil {
+		return nil, err
+	}
+	return &types.DeleteScheduleResponse{}, nil
 }
 
 func (wh *WorkflowHandler) PauseSchedule(
@@ -91,7 +259,25 @@ func (wh *WorkflowHandler) PauseSchedule(
 	if request == nil {
 		return nil, validate.ErrRequestNotSet
 	}
-	return nil, errScheduleNotImplemented
+
+	domainName := request.GetDomain()
+	if domainName == "" {
+		return nil, validate.ErrDomainNotSet
+	}
+	scheduleID := request.GetScheduleID()
+	if scheduleID == "" {
+		return nil, &types.BadRequestError{Message: "ScheduleID is not set on request."}
+	}
+
+	// TODO: populate PausedBy once PauseScheduleRequest has an Identity field in the IDL
+	signal := scheduler.PauseSignal{
+		Reason: request.GetReason(),
+	}
+
+	if err := wh.signalScheduleWorkflow(ctx, domainName, scheduleID, scheduler.SignalNamePause, signal); err != nil {
+		return nil, err
+	}
+	return &types.PauseScheduleResponse{}, nil
 }
 
 func (wh *WorkflowHandler) UnpauseSchedule(
@@ -104,7 +290,25 @@ func (wh *WorkflowHandler) UnpauseSchedule(
 	if request == nil {
 		return nil, validate.ErrRequestNotSet
 	}
-	return nil, errScheduleNotImplemented
+
+	domainName := request.GetDomain()
+	if domainName == "" {
+		return nil, validate.ErrDomainNotSet
+	}
+	scheduleID := request.GetScheduleID()
+	if scheduleID == "" {
+		return nil, &types.BadRequestError{Message: "ScheduleID is not set on request."}
+	}
+
+	signal := scheduler.UnpauseSignal{
+		Reason:        request.GetReason(),
+		CatchUpPolicy: request.GetCatchUpPolicy(),
+	}
+
+	if err := wh.signalScheduleWorkflow(ctx, domainName, scheduleID, scheduler.SignalNameUnpause, signal); err != nil {
+		return nil, err
+	}
+	return &types.UnpauseScheduleResponse{}, nil
 }
 
 func (wh *WorkflowHandler) BackfillSchedule(
@@ -117,7 +321,36 @@ func (wh *WorkflowHandler) BackfillSchedule(
 	if request == nil {
 		return nil, validate.ErrRequestNotSet
 	}
-	return nil, errScheduleNotImplemented
+
+	domainName := request.GetDomain()
+	if domainName == "" {
+		return nil, validate.ErrDomainNotSet
+	}
+	scheduleID := request.GetScheduleID()
+	if scheduleID == "" {
+		return nil, &types.BadRequestError{Message: "ScheduleID is not set on request."}
+	}
+	if request.GetStartTime().IsZero() {
+		return nil, &types.BadRequestError{Message: "StartTime is not set on request."}
+	}
+	if request.GetEndTime().IsZero() {
+		return nil, &types.BadRequestError{Message: "EndTime is not set on request."}
+	}
+	if !request.GetEndTime().After(request.GetStartTime()) {
+		return nil, &types.BadRequestError{Message: "EndTime must be after StartTime."}
+	}
+
+	signal := scheduler.BackfillSignal{
+		StartTime:     request.GetStartTime(),
+		EndTime:       request.GetEndTime(),
+		OverlapPolicy: request.GetOverlapPolicy(),
+		BackfillID:    request.GetBackfillID(),
+	}
+
+	if err := wh.signalScheduleWorkflow(ctx, domainName, scheduleID, scheduler.SignalNameBackfill, signal); err != nil {
+		return nil, err
+	}
+	return &types.BackfillScheduleResponse{}, nil
 }
 
 func (wh *WorkflowHandler) ListSchedules(
@@ -130,5 +363,53 @@ func (wh *WorkflowHandler) ListSchedules(
 	if request == nil {
 		return nil, validate.ErrRequestNotSet
 	}
-	return nil, errScheduleNotImplemented
+
+	domainName := request.GetDomain()
+	if domainName == "" {
+		return nil, validate.ErrDomainNotSet
+	}
+
+	return nil, &types.BadRequestError{Message: "ListSchedules is not yet implemented."}
+}
+
+func (wh *WorkflowHandler) signalScheduleWorkflow(
+	ctx context.Context,
+	domainName string,
+	scheduleID string,
+	signalName string,
+	signalInput interface{},
+) error {
+	var inputBytes []byte
+	var err error
+	if signalInput != nil {
+		inputBytes, err = json.Marshal(signalInput)
+		if err != nil {
+			return &types.InternalServiceError{Message: fmt.Sprintf("failed to serialize signal input: %v", err)}
+		}
+	}
+
+	wfID := scheduleWorkflowID(scheduleID)
+	err = wh.SignalWorkflowExecution(ctx, &types.SignalWorkflowExecutionRequest{
+		Domain: domainName,
+		WorkflowExecution: &types.WorkflowExecution{
+			WorkflowID: wfID,
+		},
+		SignalName: signalName,
+		Input:      inputBytes,
+		RequestID:  uuid.New().String(),
+	})
+	if err != nil {
+		return normalizeScheduleError(err, scheduleID, domainName)
+	}
+	return nil
+}
+
+func normalizeScheduleError(err error, scheduleID, domainName string) error {
+	var notFound *types.EntityNotExistsError
+	if errors.As(err, &notFound) {
+		return &types.EntityNotExistsError{
+			Message: fmt.Sprintf("schedule %q not found in domain %q", scheduleID, domainName),
+		}
+	}
+	return err
 }

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -1,0 +1,725 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/yarpc"
+
+	"github.com/uber/cadence/client/history"
+	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/client"
+	dc "github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/resource"
+	"github.com/uber/cadence/common/service"
+	"github.com/uber/cadence/common/types"
+	frontendcfg "github.com/uber/cadence/service/frontend/config"
+	"github.com/uber/cadence/service/frontend/validate"
+	"github.com/uber/cadence/service/worker/scheduler"
+)
+
+type scheduleTestFixture struct {
+	t              *testing.T
+	ctrl           *gomock.Controller
+	mockResource   *resource.Test
+	domainCache    *cache.MockDomainCache
+	historyClient  *history.MockClient
+	versionChecker *client.MockVersionChecker
+	handler        *WorkflowHandler
+}
+
+func newScheduleTestFixture(t *testing.T) *scheduleTestFixture {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	mockResource := resource.NewTest(t, ctrl, metrics.Frontend)
+
+	versionChecker := client.NewMockVersionChecker(ctrl)
+	versionChecker.EXPECT().ClientSupported(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockResource.MembershipResolver.EXPECT().MemberCount(service.Frontend).Return(5, nil).AnyTimes()
+
+	config := frontendcfg.NewConfig(
+		dc.NewCollection(dc.NewInMemoryClient(), mockResource.Logger),
+		10, false, "hostname", mockResource.Logger,
+	)
+	config.EmitSignalNameMetricsTag = dynamicproperties.GetBoolPropertyFnFilteredByDomain(true)
+
+	handler := NewWorkflowHandler(mockResource, config, versionChecker, nil)
+
+	return &scheduleTestFixture{
+		t:              t,
+		ctrl:           ctrl,
+		mockResource:   mockResource,
+		domainCache:    mockResource.DomainCache,
+		historyClient:  mockResource.HistoryClient,
+		versionChecker: versionChecker,
+		handler:        handler,
+	}
+}
+
+func (f *scheduleTestFixture) finish() {
+	f.ctrl.Finish()
+	f.mockResource.Finish(f.t)
+}
+
+func TestCreateSchedule(t *testing.T) {
+	validRequest := &types.CreateScheduleRequest{
+		Domain:     testDomain,
+		ScheduleID: "my-schedule",
+		Spec:       &types.ScheduleSpec{CronExpression: "*/5 * * * *"},
+		Action: &types.ScheduleAction{
+			StartWorkflow: &types.StartWorkflowAction{
+				WorkflowType: &types.WorkflowType{Name: "my-workflow"},
+				TaskList:     &types.TaskList{Name: "my-tasklist"},
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		request     *types.CreateScheduleRequest
+		mockFn      func(*scheduleTestFixture)
+		wantErr     bool
+		wantErrType interface{}
+	}{
+		"nil request": {
+			request: nil,
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"empty domain": {
+			request: &types.CreateScheduleRequest{},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"empty schedule ID": {
+			request: &types.CreateScheduleRequest{Domain: testDomain},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"nil spec": {
+			request: &types.CreateScheduleRequest{Domain: testDomain, ScheduleID: "s1"},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"empty cron expression": {
+			request: &types.CreateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Spec:       &types.ScheduleSpec{},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"nil action": {
+			request: &types.CreateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Spec:       &types.ScheduleSpec{CronExpression: "* * * * *"},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"domain not found": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return("", errors.New("not found")).AnyTimes()
+			},
+			wantErr: true,
+		},
+		"already exists": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(nil, &types.WorkflowExecutionAlreadyStartedError{Message: "already started"})
+			},
+			wantErr: true,
+		},
+		"history error": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("internal error"))
+			},
+			wantErr: true,
+		},
+		"success": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.HistoryStartWorkflowExecutionRequest, _ ...yarpc.CallOption) (*types.StartWorkflowExecutionResponse, error) {
+						assert.Equal(t, testDomainID, req.DomainUUID)
+						assert.Equal(t, "cadence-scheduler:my-schedule", req.StartRequest.WorkflowID)
+						assert.Equal(t, scheduler.WorkflowTypeName, req.StartRequest.WorkflowType.Name)
+						assert.Equal(t, scheduler.TaskListName, req.StartRequest.TaskList.Name)
+
+						var input scheduler.SchedulerWorkflowInput
+						require.NoError(t, json.Unmarshal(req.StartRequest.Input, &input))
+						assert.Equal(t, testDomain, input.Domain)
+						assert.Equal(t, "my-schedule", input.ScheduleID)
+						assert.Equal(t, "*/5 * * * *", input.Spec.CronExpression)
+
+						return &types.StartWorkflowExecutionResponse{RunID: "test-run-id"}, nil
+					})
+			},
+			wantErr: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			f := newScheduleTestFixture(t)
+			defer f.finish()
+			tt.mockFn(f)
+
+			resp, err := f.handler.CreateSchedule(context.Background(), tt.request)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, resp)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, resp)
+			}
+		})
+	}
+}
+
+func TestDescribeSchedule(t *testing.T) {
+	descResult := scheduler.ScheduleDescription{
+		ScheduleID:  "my-schedule",
+		Domain:      testDomain,
+		Spec:        types.ScheduleSpec{CronExpression: "*/10 * * * *"},
+		Action:      types.ScheduleAction{StartWorkflow: &types.StartWorkflowAction{WorkflowType: &types.WorkflowType{Name: "wf"}}},
+		Policies:    types.SchedulePolicies{OverlapPolicy: types.ScheduleOverlapPolicySkipNew},
+		Paused:      true,
+		PauseReason: "maintenance",
+		PausedBy:    "admin",
+		TotalRuns:   42,
+	}
+	descBytes, _ := json.Marshal(descResult)
+
+	validRequest := &types.DescribeScheduleRequest{
+		Domain:     testDomain,
+		ScheduleID: "my-schedule",
+	}
+
+	tests := map[string]struct {
+		request *types.DescribeScheduleRequest
+		mockFn  func(*scheduleTestFixture)
+		wantErr bool
+		check   func(*testing.T, *types.DescribeScheduleResponse)
+	}{
+		"nil request": {
+			request: nil,
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"empty domain": {
+			request: &types.DescribeScheduleRequest{},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"empty schedule ID": {
+			request: &types.DescribeScheduleRequest{Domain: testDomain},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"domain not found": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return("", errors.New("not found")).AnyTimes().AnyTimes()
+			},
+			wantErr: true,
+		},
+		"query error": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("query failed"))
+			},
+			wantErr: true,
+		},
+		"schedule not found": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+					Return(nil, &types.EntityNotExistsError{Message: "workflow not found"})
+			},
+			wantErr: true,
+		},
+		"success": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.HistoryQueryWorkflowRequest, _ ...yarpc.CallOption) (*types.HistoryQueryWorkflowResponse, error) {
+						assert.Equal(t, testDomainID, req.DomainUUID)
+						assert.Equal(t, "cadence-scheduler:my-schedule", req.Request.Execution.WorkflowID)
+						assert.Equal(t, scheduler.QueryTypeDescribe, req.Request.Query.QueryType)
+
+						return &types.HistoryQueryWorkflowResponse{
+							Response: &types.QueryWorkflowResponse{
+								QueryResult: descBytes,
+							},
+						}, nil
+					})
+			},
+			wantErr: false,
+			check: func(t *testing.T, resp *types.DescribeScheduleResponse) {
+				assert.Equal(t, "*/10 * * * *", resp.Spec.CronExpression)
+				assert.True(t, resp.State.Paused)
+				assert.Equal(t, "maintenance", resp.State.PauseInfo.Reason)
+				assert.Equal(t, "admin", resp.State.PauseInfo.PausedBy)
+				assert.Equal(t, int64(42), resp.Info.TotalRuns)
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			f := newScheduleTestFixture(t)
+			defer f.finish()
+			tt.mockFn(f)
+
+			resp, err := f.handler.DescribeSchedule(context.Background(), tt.request)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				if tt.check != nil {
+					tt.check(t, resp)
+				}
+			}
+		})
+	}
+}
+
+func TestPauseSchedule(t *testing.T) {
+	tests := map[string]struct {
+		request *types.PauseScheduleRequest
+		mockFn  func(*scheduleTestFixture)
+		wantErr bool
+	}{
+		"nil request": {
+			request: nil,
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"empty domain": {
+			request: &types.PauseScheduleRequest{},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"empty schedule ID": {
+			request: &types.PauseScheduleRequest{Domain: testDomain},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"signal error": {
+			request: &types.PauseScheduleRequest{Domain: testDomain, ScheduleID: "s1", Reason: "maintenance"},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(errors.New("signal failed"))
+			},
+			wantErr: true,
+		},
+		"success": {
+			request: &types.PauseScheduleRequest{Domain: testDomain, ScheduleID: "s1", Reason: "maintenance"},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.HistorySignalWorkflowExecutionRequest, _ ...yarpc.CallOption) error {
+						assert.Equal(t, testDomainID, req.DomainUUID)
+						assert.Equal(t, "cadence-scheduler:s1", req.SignalRequest.WorkflowExecution.WorkflowID)
+						assert.Equal(t, scheduler.SignalNamePause, req.SignalRequest.SignalName)
+
+						var signal scheduler.PauseSignal
+						require.NoError(t, json.Unmarshal(req.SignalRequest.Input, &signal))
+						assert.Equal(t, "maintenance", signal.Reason)
+						return nil
+					})
+			},
+			wantErr: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			f := newScheduleTestFixture(t)
+			defer f.finish()
+			tt.mockFn(f)
+
+			resp, err := f.handler.PauseSchedule(context.Background(), tt.request)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, resp)
+			}
+		})
+	}
+}
+
+func TestUnpauseSchedule(t *testing.T) {
+	tests := map[string]struct {
+		request *types.UnpauseScheduleRequest
+		mockFn  func(*scheduleTestFixture)
+		wantErr bool
+	}{
+		"nil request": {
+			request: nil,
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"success": {
+			request: &types.UnpauseScheduleRequest{
+				Domain:        testDomain,
+				ScheduleID:    "s1",
+				CatchUpPolicy: types.ScheduleCatchUpPolicyOne,
+			},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.HistorySignalWorkflowExecutionRequest, _ ...yarpc.CallOption) error {
+						assert.Equal(t, scheduler.SignalNameUnpause, req.SignalRequest.SignalName)
+						var signal scheduler.UnpauseSignal
+						require.NoError(t, json.Unmarshal(req.SignalRequest.Input, &signal))
+						assert.Equal(t, types.ScheduleCatchUpPolicyOne, signal.CatchUpPolicy)
+						return nil
+					})
+			},
+			wantErr: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			f := newScheduleTestFixture(t)
+			defer f.finish()
+			tt.mockFn(f)
+
+			resp, err := f.handler.UnpauseSchedule(context.Background(), tt.request)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, resp)
+			}
+		})
+	}
+}
+
+func TestUpdateSchedule(t *testing.T) {
+	tests := map[string]struct {
+		request *types.UpdateScheduleRequest
+		mockFn  func(*scheduleTestFixture)
+		wantErr bool
+	}{
+		"nil request": {
+			request: nil,
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"nothing to update": {
+			request: &types.UpdateScheduleRequest{Domain: testDomain, ScheduleID: "s1"},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"success with spec update": {
+			request: &types.UpdateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Spec:       &types.ScheduleSpec{CronExpression: "0 * * * *"},
+			},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.HistorySignalWorkflowExecutionRequest, _ ...yarpc.CallOption) error {
+						assert.Equal(t, scheduler.SignalNameUpdate, req.SignalRequest.SignalName)
+						var signal scheduler.UpdateSignal
+						require.NoError(t, json.Unmarshal(req.SignalRequest.Input, &signal))
+						assert.Equal(t, "0 * * * *", signal.Spec.CronExpression)
+						assert.Nil(t, signal.Action)
+						assert.Nil(t, signal.Policies)
+						return nil
+					})
+			},
+			wantErr: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			f := newScheduleTestFixture(t)
+			defer f.finish()
+			tt.mockFn(f)
+
+			resp, err := f.handler.UpdateSchedule(context.Background(), tt.request)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, resp)
+			}
+		})
+	}
+}
+
+func TestDeleteSchedule(t *testing.T) {
+	tests := map[string]struct {
+		request *types.DeleteScheduleRequest
+		mockFn  func(*scheduleTestFixture)
+		wantErr bool
+	}{
+		"nil request": {
+			request: nil,
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"success": {
+			request: &types.DeleteScheduleRequest{Domain: testDomain, ScheduleID: "s1"},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.HistorySignalWorkflowExecutionRequest, _ ...yarpc.CallOption) error {
+						assert.Equal(t, scheduler.SignalNameDelete, req.SignalRequest.SignalName)
+						assert.Nil(t, req.SignalRequest.Input)
+						return nil
+					})
+			},
+			wantErr: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			f := newScheduleTestFixture(t)
+			defer f.finish()
+			tt.mockFn(f)
+
+			resp, err := f.handler.DeleteSchedule(context.Background(), tt.request)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, resp)
+			}
+		})
+	}
+}
+
+func TestBackfillSchedule(t *testing.T) {
+	now := time.Now()
+	tests := map[string]struct {
+		request *types.BackfillScheduleRequest
+		mockFn  func(*scheduleTestFixture)
+		wantErr bool
+	}{
+		"nil request": {
+			request: nil,
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"missing start time": {
+			request: &types.BackfillScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				EndTime:    now,
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"missing end time": {
+			request: &types.BackfillScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				StartTime:  now.Add(-time.Hour),
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"end before start": {
+			request: &types.BackfillScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				StartTime:  now,
+				EndTime:    now.Add(-time.Hour),
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"success": {
+			request: &types.BackfillScheduleRequest{
+				Domain:        testDomain,
+				ScheduleID:    "s1",
+				StartTime:     now.Add(-time.Hour),
+				EndTime:       now,
+				OverlapPolicy: types.ScheduleOverlapPolicyConcurrent,
+				BackfillID:    "bf-1",
+			},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.HistorySignalWorkflowExecutionRequest, _ ...yarpc.CallOption) error {
+						assert.Equal(t, scheduler.SignalNameBackfill, req.SignalRequest.SignalName)
+						var signal scheduler.BackfillSignal
+						require.NoError(t, json.Unmarshal(req.SignalRequest.Input, &signal))
+						assert.Equal(t, types.ScheduleOverlapPolicyConcurrent, signal.OverlapPolicy)
+						assert.Equal(t, "bf-1", signal.BackfillID)
+						return nil
+					})
+			},
+			wantErr: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			f := newScheduleTestFixture(t)
+			defer f.finish()
+			tt.mockFn(f)
+
+			resp, err := f.handler.BackfillSchedule(context.Background(), tt.request)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, resp)
+			}
+		})
+	}
+}
+
+func TestListSchedules(t *testing.T) {
+	tests := map[string]struct {
+		request *types.ListSchedulesRequest
+		mockFn  func(*scheduleTestFixture)
+		wantErr bool
+	}{
+		"nil request": {
+			request: nil,
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"unimplemented": {
+			request: &types.ListSchedulesRequest{Domain: testDomain},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			f := newScheduleTestFixture(t)
+			defer f.finish()
+			tt.mockFn(f)
+
+			resp, err := f.handler.ListSchedules(context.Background(), tt.request)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, resp)
+			}
+		})
+	}
+}
+
+func TestNormalizeScheduleError(t *testing.T) {
+	t.Run("describe not found returns friendly message", func(t *testing.T) {
+		f := newScheduleTestFixture(t)
+		defer f.finish()
+
+		f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+		f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+			Return(nil, &types.EntityNotExistsError{Message: "workflow cadence-scheduler:s1 not found"})
+
+		_, err := f.handler.DescribeSchedule(context.Background(), &types.DescribeScheduleRequest{
+			Domain:     testDomain,
+			ScheduleID: "s1",
+		})
+
+		var notFound *types.EntityNotExistsError
+		require.True(t, errors.As(err, &notFound))
+		assert.Contains(t, notFound.Message, `schedule "s1" not found in domain`)
+	})
+
+	t.Run("delete not found returns friendly message", func(t *testing.T) {
+		f := newScheduleTestFixture(t)
+		defer f.finish()
+
+		f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+		f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+			Return(&types.EntityNotExistsError{Message: "workflow cadence-scheduler:s1 not found"})
+
+		_, err := f.handler.DeleteSchedule(context.Background(), &types.DeleteScheduleRequest{
+			Domain:     testDomain,
+			ScheduleID: "s1",
+		})
+
+		var notFound *types.EntityNotExistsError
+		require.True(t, errors.As(err, &notFound))
+		assert.Contains(t, notFound.Message, `schedule "s1" not found in domain`)
+	})
+
+	t.Run("non-EntityNotExistsError passes through unchanged", func(t *testing.T) {
+		f := newScheduleTestFixture(t)
+		defer f.finish()
+
+		origErr := errors.New("some internal error")
+		f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+		f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+			Return(origErr)
+
+		_, err := f.handler.DeleteSchedule(context.Background(), &types.DeleteScheduleRequest{
+			Domain:     testDomain,
+			ScheduleID: "s1",
+		})
+
+		assert.Equal(t, origErr, err)
+	})
+}
+
+func TestScheduleWorkflowID(t *testing.T) {
+	assert.Equal(t, "cadence-scheduler:my-schedule", scheduleWorkflowID("my-schedule"))
+	assert.Equal(t, "cadence-scheduler:", scheduleWorkflowID(""))
+}
+
+func TestCreateSchedule_ShuttingDown(t *testing.T) {
+	f := newScheduleTestFixture(t)
+	defer f.finish()
+	f.handler.shuttingDown = 1
+
+	_, err := f.handler.CreateSchedule(context.Background(), &types.CreateScheduleRequest{})
+	assert.Equal(t, validate.ErrShuttingDown, err)
+}

--- a/service/frontend/wrappers/grpc/share.go
+++ b/service/frontend/wrappers/grpc/share.go
@@ -42,6 +42,7 @@ func (g APIHandler) Register(dispatcher *yarpc.Dispatcher) {
 	dispatcher.Register(apiv1.BuildWorkerAPIYARPCProcedures(g))
 	dispatcher.Register(apiv1.BuildVisibilityAPIYARPCProcedures(g))
 	dispatcher.Register(apiv1.BuildMetaAPIYARPCProcedures(g))
+	dispatcher.Register(apiv1.BuildScheduleAPIYARPCProcedures(g))
 }
 
 func (g APIHandler) Health(ctx context.Context, request *apiv1.HealthRequest) (*apiv1.HealthResponse, error) {


### PR DESCRIPTION
## What changed?

Replaces the 8 stub Schedule API handlers with full implementations that delegate to the scheduler workflow via the history client. Relates to #7664.

## Why?

PR #7902 wired the Schedule API plumbing (interface, middleware layers, stubs). This PR fills in the actual handler logic so that schedule CRUD operations work end-to-end: `CreateSchedule` starts a scheduler workflow, `DescribeSchedule` queries it, and the remaining mutation APIs (Update, Delete, Pause, Unpause, Backfill) send signals. `ListSchedules` remains a stub pending visibility integration.

## How did you test it?

```
make .idl-status   # IDL submodule check — passed
make pr            # tidy, go-generate, fmt, lint — passed, no files changed
make build         # full compile check including test files — passed
make test          # full unit test suite — passed
```

Comprehensive table-driven tests in `handler_schedule_test.go` cover: nil requests, missing required fields, domain resolution failures, already-exists errors, history client errors, empty query results, and successful payloads with detailed gomock DoAndReturn assertions on workflow IDs, signal names, and serialized inputs.

## Potential risks

- Schedule API behavior change: handlers now start real scheduler workflows and send signals instead of returning "not implemented". This is gated by the fact that no CLI or client code invokes these APIs yet.
- `ListSchedules` still returns `BadRequestError("not yet implemented")` — this will be filled in when visibility integration lands.

## Release notes

N/A: schedule APIs are not yet exposed through CLI or client SDKs.

## Documentation Changes

N/A
