### PR TITLE
test: Add fuzz tests to matching mappers

### DIFF
--- a/common/types/mapper/proto/matching_test.go
+++ b/common/types/mapper/proto/matching_test.go
@@ -23,10 +23,12 @@ package proto
 import (
 	"testing"
 
+	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/assert"
 
 	matchingv1 "github.com/uber/cadence/.gen/proto/matching/v1"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/common/types/mapper/testutils"
 	"github.com/uber/cadence/common/types/testdata"
 )
 
@@ -259,4 +261,170 @@ func TestToMatchingTaskListPartitionConfig(t *testing.T) {
 			assert.Equal(t, tc.expected, actual)
 		})
 	}
+}
+
+// --- Fuzz tests for matching mapper functions
+
+// taskSourceFuzzer generates valid TaskSource enum values (0: History, 1: DbBacklog).
+func taskSourceFuzzer(e *types.TaskSource, c fuzz.Continue) {
+	*e = types.TaskSource(c.Intn(2)) // 0-1: History, DbBacklog
+}
+
+// cancelOutstandingPollRequestFuzzer ensures TaskListType *int32 only contains
+// valid values (0=Decision, 1=Activity) since out-of-range values map to nil
+// on the return path.
+func cancelOutstandingPollRequestFuzzer(r *types.CancelOutstandingPollRequest, c fuzz.Continue) {
+	c.FuzzNoCustom(r)
+	if r.TaskListType != nil {
+		*r.TaskListType = int32(c.Intn(2)) // 0-1: Decision, Activity
+	}
+}
+
+func TestLoadBalancerHintsFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t, FromLoadBalancerHints, ToLoadBalancerHints)
+}
+
+func TestMatchingTaskListPartitionFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t, FromMatchingTaskListPartition, ToMatchingTaskListPartition)
+}
+
+func TestActivityTaskDispatchInfoFuzz(t *testing.T) {
+	// [BUG] Attempt is *int64 in types but int32 in proto:
+	//   - nil input maps to &0 (non-nil), breaking the nil round-trip
+	//   - int64 values outside int32 range are truncated
+	// ScheduledEvent is a HistoryEvent requiring complex enum handling;
+	// it is tested comprehensively in api_test.go (TestHistoryEventFuzz).
+	testutils.RunMapperFuzzTest(t, FromActivityTaskDispatchInfo, ToActivityTaskDispatchInfo,
+		testutils.WithExcludedFields("Attempt", "ScheduledEvent"),
+	)
+}
+
+func TestMatchingAddActivityTaskRequestFuzz(t *testing.T) {
+	// ActivityTaskDispatchInfo is tested separately in TestActivityTaskDispatchInfoFuzz.
+	testutils.RunMapperFuzzTest(t, FromMatchingAddActivityTaskRequest, ToMatchingAddActivityTaskRequest,
+		testutils.WithCustomFuncs(taskSourceFuzzer),
+		testutils.WithExcludedFields("ActivityTaskDispatchInfo"),
+	)
+}
+
+func TestMatchingAddDecisionTaskRequestFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t, FromMatchingAddDecisionTaskRequest, ToMatchingAddDecisionTaskRequest,
+		testutils.WithCustomFuncs(taskSourceFuzzer),
+	)
+}
+
+func TestMatchingCancelOutstandingPollRequestFuzz(t *testing.T) {
+	// TaskListType is *int32 in types (0=Decision, 1=Activity); out-of-range values
+	// map to nil on the return path. cancelOutstandingPollRequestFuzzer constrains it.
+	testutils.RunMapperFuzzTest(t, FromMatchingCancelOutstandingPollRequest, ToMatchingCancelOutstandingPollRequest,
+		testutils.WithCustomFuncs(cancelOutstandingPollRequestFuzzer),
+	)
+}
+
+func TestMatchingDescribeTaskListRequestFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t, FromMatchingDescribeTaskListRequest, ToMatchingDescribeTaskListRequest)
+}
+
+func TestMatchingDescribeTaskListResponseFuzz(t *testing.T) {
+	// PartitionConfig contains map[int] keys that truncate to int32 in proto;
+	// specific partition scenarios are tested in TestToMatchingTaskListPartitionConfig.
+	testutils.RunMapperFuzzTest(t, FromMatchingDescribeTaskListResponse, ToMatchingDescribeTaskListResponse,
+		testutils.WithExcludedFields("PartitionConfig"),
+	)
+}
+
+func TestMatchingListTaskListPartitionsRequestFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t, FromMatchingListTaskListPartitionsRequest, ToMatchingListTaskListPartitionsRequest)
+}
+
+func TestMatchingListTaskListPartitionsResponseFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t, FromMatchingListTaskListPartitionsResponse, ToMatchingListTaskListPartitionsResponse)
+}
+
+func TestMatchingPollForActivityTaskRequestFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t, FromMatchingPollForActivityTaskRequest, ToMatchingPollForActivityTaskRequest)
+}
+
+func TestMatchingPollForActivityTaskResponseFuzz(t *testing.T) {
+	// [BUG] BacklogCountHint has no corresponding field in the activity task proto message; it is silently dropped.
+	// PartitionConfig contains map[int] keys that truncate to int32 in proto;
+	// specific partition scenarios are tested in TestToMatchingTaskListPartitionConfig.
+	testutils.RunMapperFuzzTest(t, FromMatchingPollForActivityTaskResponse, ToMatchingPollForActivityTaskResponse,
+		testutils.WithExcludedFields("BacklogCountHint", "PartitionConfig"),
+	)
+}
+
+func TestMatchingPollForDecisionTaskRequestFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t, FromMatchingPollForDecisionTaskRequest, ToMatchingPollForDecisionTaskRequest)
+}
+
+func TestMatchingPollForDecisionTaskResponseFuzz(t *testing.T) {
+	// [BUG] Attempt is int64 in types but int32 in proto; values outside int32 range are truncated.
+	// PartitionConfig contains map[int] keys that truncate to int32 in proto;
+	// specific partition scenarios are tested in TestToMatchingTaskListPartitionConfig.
+	// DecisionInfo contains HistoryEvent fields requiring non-nil EventType;
+	// HistoryEvent fuzzing is tested in api_test.go (TestHistoryEventFuzz).
+	testutils.RunMapperFuzzTest(t, FromMatchingPollForDecisionTaskResponse, ToMatchingPollForDecisionTaskResponse,
+		testutils.WithExcludedFields("Attempt", "PartitionConfig", "DecisionInfo"),
+	)
+}
+
+func TestMatchingQueryWorkflowRequestFuzz(t *testing.T) {
+	// QueryWorkflowRequest contains QueryRejectCondition and QueryConsistencyLevel enums
+	// that require valid values (0-1 each); out-of-range values map to nil on return.
+	testutils.RunMapperFuzzTest(t, FromMatchingQueryWorkflowRequest, ToMatchingQueryWorkflowRequest,
+		testutils.WithCustomFuncs(QueryRejectConditionFuzzer, QueryConsistencyLevelFuzzer),
+	)
+}
+
+func TestMatchingQueryWorkflowResponseFuzz(t *testing.T) {
+	// PartitionConfig contains map[int] keys that truncate to int32 in proto;
+	// specific partition scenarios are tested in TestToMatchingTaskListPartitionConfig.
+	testutils.RunMapperFuzzTest(t, FromMatchingQueryWorkflowResponse, ToMatchingQueryWorkflowResponse,
+		testutils.WithExcludedFields("PartitionConfig"),
+	)
+}
+
+func TestMatchingRespondQueryTaskCompletedRequestFuzz(t *testing.T) {
+	// CompletedTypeFuzzer overrides WithCommonEnumFuzzers which incorrectly generates value 2.
+	// QueryTaskCompletedType only has 2 valid values: 0=Completed, 1=Failed.
+	testutils.RunMapperFuzzTest(t, FromMatchingRespondQueryTaskCompletedRequest, ToMatchingRespondQueryTaskCompletedRequest,
+		testutils.WithCustomFuncs(CompletedTypeFuzzer),
+	)
+}
+
+func TestMatchingGetTaskListsByDomainRequestFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t, FromMatchingGetTaskListsByDomainRequest, ToMatchingGetTaskListsByDomainRequest)
+}
+
+func TestMatchingGetTaskListsByDomainResponseFuzz(t *testing.T) {
+	// PartitionConfig contains map[int] keys that truncate to int32 in proto;
+	// specific partition scenarios are tested in TestToMatchingTaskListPartitionConfig.
+	testutils.RunMapperFuzzTest(t, FromMatchingGetTaskListsByDomainResponse, ToMatchingGetTaskListsByDomainResponse,
+		testutils.WithExcludedFields("PartitionConfig"),
+	)
+}
+
+func TestMatchingUpdateTaskListPartitionConfigRequestFuzz(t *testing.T) {
+	// PartitionConfig contains map[int] keys that truncate to int32 in proto;
+	// specific partition scenarios are tested in TestToMatchingTaskListPartitionConfig.
+	testutils.RunMapperFuzzTest(t, FromMatchingUpdateTaskListPartitionConfigRequest, ToMatchingUpdateTaskListPartitionConfigRequest,
+		testutils.WithExcludedFields("PartitionConfig"),
+	)
+}
+
+func TestMatchingUpdateTaskListPartitionConfigResponseFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t, FromMatchingUpdateTaskListPartitionConfigResponse, ToMatchingUpdateTaskListPartitionConfigResponse)
+}
+
+func TestMatchingRefreshTaskListPartitionConfigRequestFuzz(t *testing.T) {
+	// PartitionConfig contains map[int] keys that truncate to int32 in proto;
+	// specific partition scenarios are tested in TestToMatchingTaskListPartitionConfig.
+	testutils.RunMapperFuzzTest(t, FromMatchingRefreshTaskListPartitionConfigRequest, ToMatchingRefreshTaskListPartitionConfigRequest,
+		testutils.WithExcludedFields("PartitionConfig"),
+	)
+}
+
+func TestMatchingRefreshTaskListPartitionConfigResponseFuzz(t *testing.T) {
+	testutils.RunMapperFuzzTest(t, FromMatchingRefreshTaskListPartitionConfigResponse, ToMatchingRefreshTaskListPartitionConfigResponse)
 }

--- a/common/types/mapper/proto/matching_test.go
+++ b/common/types/mapper/proto/matching_test.go
@@ -265,15 +265,15 @@ func TestToMatchingTaskListPartitionConfig(t *testing.T) {
 
 // --- Fuzz tests for matching mapper functions
 
-// taskSourceFuzzer generates valid TaskSource enum values (0: History, 1: DbBacklog).
-func taskSourceFuzzer(e *types.TaskSource, c fuzz.Continue) {
+// TaskSourceFuzzer generates valid TaskSource enum values (0: History, 1: DbBacklog).
+func TaskSourceFuzzer(e *types.TaskSource, c fuzz.Continue) {
 	*e = types.TaskSource(c.Intn(2)) // 0-1: History, DbBacklog
 }
 
-// cancelOutstandingPollRequestFuzzer ensures TaskListType *int32 only contains
+// CancelOutstandingPollRequestFuzzer ensures TaskListType *int32 only contains
 // valid values (0=Decision, 1=Activity) since out-of-range values map to nil
 // on the return path.
-func cancelOutstandingPollRequestFuzzer(r *types.CancelOutstandingPollRequest, c fuzz.Continue) {
+func CancelOutstandingPollRequestFuzzer(r *types.CancelOutstandingPollRequest, c fuzz.Continue) {
 	c.FuzzNoCustom(r)
 	if r.TaskListType != nil {
 		*r.TaskListType = int32(c.Intn(2)) // 0-1: Decision, Activity
@@ -302,22 +302,22 @@ func TestActivityTaskDispatchInfoFuzz(t *testing.T) {
 func TestMatchingAddActivityTaskRequestFuzz(t *testing.T) {
 	// ActivityTaskDispatchInfo is tested separately in TestActivityTaskDispatchInfoFuzz.
 	testutils.RunMapperFuzzTest(t, FromMatchingAddActivityTaskRequest, ToMatchingAddActivityTaskRequest,
-		testutils.WithCustomFuncs(taskSourceFuzzer),
+		testutils.WithCustomFuncs(TaskSourceFuzzer),
 		testutils.WithExcludedFields("ActivityTaskDispatchInfo"),
 	)
 }
 
 func TestMatchingAddDecisionTaskRequestFuzz(t *testing.T) {
 	testutils.RunMapperFuzzTest(t, FromMatchingAddDecisionTaskRequest, ToMatchingAddDecisionTaskRequest,
-		testutils.WithCustomFuncs(taskSourceFuzzer),
+		testutils.WithCustomFuncs(TaskSourceFuzzer),
 	)
 }
 
 func TestMatchingCancelOutstandingPollRequestFuzz(t *testing.T) {
 	// TaskListType is *int32 in types (0=Decision, 1=Activity); out-of-range values
-	// map to nil on the return path. cancelOutstandingPollRequestFuzzer constrains it.
+	// map to nil on the return path. CancelOutstandingPollRequestFuzzer constrains it.
 	testutils.RunMapperFuzzTest(t, FromMatchingCancelOutstandingPollRequest, ToMatchingCancelOutstandingPollRequest,
-		testutils.WithCustomFuncs(cancelOutstandingPollRequestFuzzer),
+		testutils.WithCustomFuncs(CancelOutstandingPollRequestFuzzer),
 	)
 }
 
@@ -386,8 +386,8 @@ func TestMatchingQueryWorkflowResponseFuzz(t *testing.T) {
 }
 
 func TestMatchingRespondQueryTaskCompletedRequestFuzz(t *testing.T) {
-	// CompletedTypeFuzzer overrides WithCommonEnumFuzzers which incorrectly generates value 2.
-	// QueryTaskCompletedType only has 2 valid values: 0=Completed, 1=Failed.
+	// QueryTaskCompletedType only has 2 valid values (0=Completed, 1=Failed);
+	// the default fuzzer generates arbitrary int values so CompletedTypeFuzzer constrains the range.
 	testutils.RunMapperFuzzTest(t, FromMatchingRespondQueryTaskCompletedRequest, ToMatchingRespondQueryTaskCompletedRequest,
 		testutils.WithCustomFuncs(CompletedTypeFuzzer),
 	)

--- a/service/frontend/wrappers/ratelimited/ratelimit_test.go
+++ b/service/frontend/wrappers/ratelimited/ratelimit_test.go
@@ -321,7 +321,12 @@ func TestCallerTypeBypassWithWait(t *testing.T) {
 			handler.maxWorkerPollDelay = func(domain string) time.Duration { return 1 * time.Millisecond }
 			ctx := types.ContextWithCallerInfo(context.Background(), types.NewCallerInfo(tt.callerType))
 
-			// Wait returns an error, but waitCtx.Err() is nil (case nil path)
+			// Wait returns an error, but waitCtx.Err() is nil (nil path).
+			// With a 1ms maxWorkerPollDelay there is a race: if the waitCtx deadline
+			// expires before Wait returns, the DeadlineExceeded branch calls Allow()
+			// instead. .Maybe() covers that optional call; returning false falls through
+			// to ShouldBypass, so both branches produce the same test outcome.
+			handler.workerRateLimiter.(*mockPolicy).On("Allow", quotas.Info{Domain: testDomain}).Return(false).Maybe()
 			handler.workerRateLimiter.(*mockPolicy).On("Wait", mock.Anything, quotas.Info{Domain: testDomain}).Return(assert.AnError).Once()
 
 			err := handler.allowDomain(ctx, ratelimitTypeWorkerPoll, quotas.Info{Domain: testDomain})


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
This adds fuzz tests for all mappers within common/types/mapper/proto/matching.go

**Why?**
This is part of the implementation of https://github.com/cadence-workflow/cadence/issues/7611. Further follow ups will work on additional files. 

**How did you test it?**
```
go test ./common/types/mapper/...
ok      github.com/uber/cadence/common/types/mapper/errorutils  (cached)
ok      github.com/uber/cadence/common/types/mapper/proto       (cached)
ok      github.com/uber/cadence/common/types/mapper/testutils   (cached)
ok      github.com/uber/cadence/common/types/mapper/thrift      (cached)
```

**Potential risks**
I found some bugs and marked them. Will fix them in separate PRs.

**Release notes**
N/A

**Documentation Changes**
N/A
----
## Summary by Gitar

- **Fuzz tests added:**
  - 18 new fuzz test functions covering matching mapper bidirectional conversions (`From*/To*` pairs)
  - Custom fuzzers for constrained enums: `TaskSource`, `CancelOutstandingPollRequest.TaskListType`, query-related enums
  - Excluded fields with known bugs (e.g., `Attempt` int64→int32 truncation, `BacklogCountHint` field loss, `PartitionConfig` map key truncation)

<sub>This will update automatically on new commits.</sub>