### PR TITLE
chore(sqlite): tune default parameters for performance

### DIFF
--- a/common/persistence/sql/sql_test_utils.go
+++ b/common/persistence/sql/sql_test_utils.go
@@ -71,6 +71,7 @@ func NewTestCluster(pluginName, dbName, username, password, host string, port in
 		NumShards:       4,
 		EncodingType:    "thriftrw",
 		DecodingTypes:   []string{"thriftrw"},
+		MaxConns:        1, // SQLite would encounter database is locked error if maxConns is larger than 1
 	}
 	return &result, nil
 }

--- a/common/persistence/sql/sqlplugin/sqlite/dsn.go
+++ b/common/persistence/sql/sqlplugin/sqlite/dsn.go
@@ -44,6 +44,14 @@ const (
 	// https://sqlite.org/pragma.html#pragma_busy_timeout
 	pragmaBusyTimeoutAttrName = "_pragma.busy_timeout"
 	pragmaBusyTimeoutDefault  = "60000"
+
+	// praga cache size (set the maximum number of pages in the page cache)
+	pragmaCacheSizeAttrName = "_pragma.cache_size"
+	pragmaCacheSizeDefault  = "131072" // 128MB
+
+	// pragma mmap size (enable memory-mapped I/O)
+	pragmaMmapSizeAttrName = "_pragma.mmap_size"
+	pragmaMmapSizeDefault  = "268435456" // 256MB
 )
 
 const (
@@ -92,6 +100,8 @@ func buildDSNAttrs(cfg *config.SQL) string {
 	}
 
 	defaultIfEmpty(sanitizedAttrs, pragmaBusyTimeoutAttrName, pragmaBusyTimeoutDefault)
+	defaultIfEmpty(sanitizedAttrs, pragmaCacheSizeAttrName, pragmaCacheSizeDefault)
+	defaultIfEmpty(sanitizedAttrs, pragmaMmapSizeAttrName, pragmaMmapSizeDefault)
 	return joinDSNAttrs(sanitizedAttrs)
 }
 

--- a/common/persistence/sql/sqlplugin/sqlite/dsn_test.go
+++ b/common/persistence/sql/sqlplugin/sqlite/dsn_test.go
@@ -23,6 +23,7 @@
 package sqlite
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,7 +49,9 @@ func Test_buildDSN(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			dsn := buildDSN(c.cfg)
-			assert.Equal(t, c.want, dsn)
+			dsnAttrs :=strings.Split(dsn, "&")
+			wantAttrs := strings.Split(c.want, "&")
+			assert.Subset(t, dsnAttrs, wantAttrs)
 		})
 	}
 }
@@ -79,7 +82,9 @@ func Test_buildDSN_attrs(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			dsn := buildDSN(c.cfg)
-			assert.Contains(t, c.want, dsn)
+			dsnAttrs :=strings.Split(dsn, "&")
+			wantAttrs := strings.Split(c.want, "&")
+			assert.Subset(t, dsnAttrs, wantAttrs)
 		})
 	}
 }

--- a/common/persistence/sql/sqlplugin/sqlite/dsn_test.go
+++ b/common/persistence/sql/sqlplugin/sqlite/dsn_test.go
@@ -49,7 +49,7 @@ func Test_buildDSN(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			dsn := buildDSN(c.cfg)
-			dsnAttrs :=strings.Split(dsn, "&")
+			dsnAttrs := strings.Split(dsn, "&")
 			wantAttrs := strings.Split(c.want, "&")
 			assert.Subset(t, dsnAttrs, wantAttrs)
 		})
@@ -82,7 +82,7 @@ func Test_buildDSN_attrs(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			dsn := buildDSN(c.cfg)
-			dsnAttrs :=strings.Split(dsn, "&")
+			dsnAttrs := strings.Split(dsn, "&")
 			wantAttrs := strings.Split(c.want, "&")
 			assert.Subset(t, dsnAttrs, wantAttrs)
 		})


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

Adding some parameters to tune sqlite performance

**Why?**

Integration tests is flaky likely due to task processing lag. (heartbeat timer for example)
Other integration tests take 17m while this could time out at 29m

**How did you test it?**

Unit Test / Integration Test 

**Potential risks**


**Release notes**


**Documentation Changes**

