### PR TITLE
fix(history): suppress timer timestamp warnings for standby cluster tasks

### DIFF
--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1342,24 +1342,33 @@ func (s *contextImpl) allocateTimerIDsLocked(
 		// 2. current time. Otherwise the task timestamp is in the past and causes aritical load latency in queue processor metrics.
 		// Above cases can happen if shard move and new host have a time SKU,
 		// or there is db write delay, or we are simply (re-)generating tasks for an old workflow.
+		shouldLog := task.GetVersion() == constants.EmptyVersion
+		if !shouldLog {
+			clusterName, err := s.GetClusterMetadata().ClusterNameForFailoverVersion(task.GetVersion())
+			shouldLog = err == nil && clusterName == s.GetClusterMetadata().GetCurrentClusterName()
+		}
 		if ts.Before(readCursorTS) {
 			// This can happen if shard move and new host have a time SKU, or there is db write delay.
 			// We generate a new timer ID using timerMaxReadLevel.
-			s.logger.Warn("New timer generated is less than read level",
-				tag.WorkflowDomainID(domainEntry.GetInfo().ID),
-				tag.WorkflowID(workflowID),
-				tag.Timestamp(ts),
-				tag.CursorTimestamp(readCursorTS),
-				tag.ClusterName(cluster),
-				tag.ValueShardAllocateTimerBeforeRead)
+			if shouldLog {
+				s.logger.Warn("New timer generated is less than read level",
+					tag.WorkflowDomainID(domainEntry.GetInfo().ID),
+					tag.WorkflowID(workflowID),
+					tag.Timestamp(ts),
+					tag.CursorTimestamp(readCursorTS),
+					tag.ClusterName(cluster),
+					tag.ValueShardAllocateTimerBeforeRead)
+			}
 			ts = readCursorTS.Add(persistence.DBTimestampMinPrecision)
 		}
 		if ts.Before(now) {
-			s.logger.Warn("New timer generated is in the past",
-				tag.WorkflowDomainID(domainEntry.GetInfo().ID),
-				tag.WorkflowID(workflowID),
-				tag.Timestamp(ts),
-				tag.ValueShardAllocateTimerBeforeRead)
+			if shouldLog {
+				s.logger.Warn("New timer generated is in the past",
+					tag.WorkflowDomainID(domainEntry.GetInfo().ID),
+					tag.WorkflowID(workflowID),
+					tag.Timestamp(ts),
+					tag.ValueShardAllocateTimerBeforeRead)
+			}
 			ts = now.Add(persistence.DBTimestampMinPrecision)
 		}
 		task.SetVisibilityTimestamp(ts)

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1342,7 +1342,7 @@ func (s *contextImpl) allocateTimerIDsLocked(
 		// 2. current time. Otherwise the task timestamp is in the past and causes aritical load latency in queue processor metrics.
 		// Above cases can happen if shard move and new host have a time SKU,
 		// or there is db write delay, or we are simply (re-)generating tasks for an old workflow.
-	
+
 		// Only log warnings for local-domain tasks (EmptyVersion) and tasks owned by the current cluster.
 		// Remote/standby tasks are expected to have timestamps behind the local read level or current time,
 		// so these warnings would be noisy and not actionable for this host.

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1344,7 +1344,7 @@ func (s *contextImpl) allocateTimerIDsLocked(
 		// or there is db write delay, or we are simply (re-)generating tasks for an old workflow.
 
 		// Only log warnings for local-domain tasks (EmptyVersion) and tasks owned by the current cluster.
-		// Remote/standby tasks are expected to have timestamps behind the local read level or current time,
+		// Remote/standby tasks are expected to have timestamps before the local read level or current time,
 		// so these warnings would be noisy and not actionable for this host.
 		shouldLog := task.GetVersion() == constants.EmptyVersion
 		if !shouldLog {

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1342,6 +1342,10 @@ func (s *contextImpl) allocateTimerIDsLocked(
 		// 2. current time. Otherwise the task timestamp is in the past and causes aritical load latency in queue processor metrics.
 		// Above cases can happen if shard move and new host have a time SKU,
 		// or there is db write delay, or we are simply (re-)generating tasks for an old workflow.
+	
+		// Only log warnings for local-domain tasks (EmptyVersion) and tasks owned by the current cluster.
+		// Remote/standby tasks are expected to have timestamps behind the local read level or current time,
+		// so these warnings would be noisy and not actionable for this host.
 		shouldLog := task.GetVersion() == constants.EmptyVersion
 		if !shouldLog {
 			clusterName, err := s.GetClusterMetadata().ClusterNameForFailoverVersion(task.GetVersion())


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
In service/history/shard/context.go, the two "New timer generated" warning logs now only emit when the task's failover version maps to the current cluster.

https://github.com/cadence-workflow/cadence/issues/7911

**Why?**
These logs were firing for standby tasks (tasks whose version belongs to another cluster), generating excessive noise. Since standby tasks are expected to have timestamps behind the read level, the warnings are only actionable for tasks belonging to the current cluster.

**How did you test it?**
go test -race -count=1 ./service/history/shard/...

**Potential risks**
No potential risks as the logs for the standby clusters are not actionable.

**Release notes**
N/A

**Documentation Changes**
N/A
