### PR TITLE
fix(task-completer): only emit error logs if not related to context

### DIFF
--- a/service/matching/tasklist/task_completer.go
+++ b/service/matching/tasklist/task_completer.go
@@ -161,7 +161,9 @@ func (tc *taskCompleterImpl) CompleteTaskIfStarted(ctx context.Context, task *In
 
 	if err != nil && !errors.Is(err, errDomainIsActive) && !errors.Is(err, errTaskNotStarted) {
 		tc.scope.IncCounter(metrics.StandbyClusterTasksCompletionFailurePerTaskList)
-		tc.logger.Error("Error completing task on domain's standby cluster", tag.Error(err), tag.WorkflowID(task.Event.WorkflowID), tag.WorkflowRunID(task.Event.RunID), tag.MatchingTaskID(task.Event.TaskID))
+		if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+			tc.logger.Error("Error completing task on domain's standby cluster", tag.Error(err), tag.WorkflowID(task.Event.WorkflowID), tag.WorkflowRunID(task.Event.RunID), tag.MatchingTaskID(task.Event.TaskID))
+		}
 	}
 
 	return err


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Only emit error logs in the task completer when the errors are not due to context expiration or cancellation.

https://github.com/cadence-workflow/cadence/issues/7911

**Why?**
Context expiration/cancellation do not represent concrete errors and cause the error log to be noisy if it happens often.

**How did you test it?**
go test -race ./service/matching/tasklist/... -run TestTaskCompleter

**Potential risks**
N/A

**Release notes**
N/A

**Documentation Changes**
N/A
