### PR TITLE
feat(types): add ScheduleID to CreateScheduleResponse and Identity to PauseScheduleRequest

### DIFF
--- a/common/types/mapper/proto/schedule.go
+++ b/common/types/mapper/proto/schedule.go
@@ -392,14 +392,18 @@ func FromCreateScheduleResponse(t *types.CreateScheduleResponse) *apiv1.CreateSc
 	if t == nil {
 		return nil
 	}
-	return &apiv1.CreateScheduleResponse{}
+	return &apiv1.CreateScheduleResponse{
+		ScheduleId: t.ScheduleID,
+	}
 }
 
 func ToCreateScheduleResponse(t *apiv1.CreateScheduleResponse) *types.CreateScheduleResponse {
 	if t == nil {
 		return nil
 	}
-	return &types.CreateScheduleResponse{}
+	return &types.CreateScheduleResponse{
+		ScheduleID: t.ScheduleId,
+	}
 }
 
 func FromDescribeScheduleRequest(t *types.DescribeScheduleRequest) *apiv1.DescribeScheduleRequest {
@@ -538,6 +542,7 @@ func FromPauseScheduleRequest(t *types.PauseScheduleRequest) *apiv1.PauseSchedul
 		Domain:     t.Domain,
 		ScheduleId: t.ScheduleID,
 		Reason:     t.Reason,
+		Identity:   t.Identity,
 	}
 }
 
@@ -549,6 +554,7 @@ func ToPauseScheduleRequest(t *apiv1.PauseScheduleRequest) *types.PauseScheduleR
 		Domain:     t.Domain,
 		ScheduleID: t.ScheduleId,
 		Reason:     t.Reason,
+		Identity:   t.Identity,
 	}
 }
 

--- a/common/types/schedule_service.go
+++ b/common/types/schedule_service.go
@@ -121,7 +121,16 @@ func (v *CreateScheduleRequest) GetSearchAttributes() *SearchAttributes {
 }
 
 // CreateScheduleResponse is the response for creating a schedule.
-type CreateScheduleResponse struct{}
+type CreateScheduleResponse struct {
+	ScheduleID string `json:"scheduleId,omitempty"`
+}
+
+func (v *CreateScheduleResponse) GetScheduleID() (o string) {
+	if v != nil {
+		return v.ScheduleID
+	}
+	return
+}
 
 // DescribeScheduleRequest is the request to describe a schedule.
 type DescribeScheduleRequest struct {
@@ -286,6 +295,7 @@ type PauseScheduleRequest struct {
 	Domain     string `json:"domain,omitempty"`
 	ScheduleID string `json:"scheduleId,omitempty"`
 	Reason     string `json:"reason,omitempty"`
+	Identity   string `json:"identity,omitempty"`
 }
 
 func (v *PauseScheduleRequest) GetDomain() (o string) {
@@ -305,6 +315,13 @@ func (v *PauseScheduleRequest) GetScheduleID() (o string) {
 func (v *PauseScheduleRequest) GetReason() (o string) {
 	if v != nil {
 		return v.Reason
+	}
+	return
+}
+
+func (v *PauseScheduleRequest) GetIdentity() (o string) {
+	if v != nil {
+		return v.Identity
 	}
 	return
 }

--- a/common/types/schedule_service_test.go
+++ b/common/types/schedule_service_test.go
@@ -99,6 +99,7 @@ func TestPauseScheduleRequest_NilGetters(t *testing.T) {
 	assert.Equal(t, "", v.GetDomain())
 	assert.Equal(t, "", v.GetScheduleID())
 	assert.Equal(t, "", v.GetReason())
+	assert.Equal(t, "", v.GetIdentity())
 }
 
 func TestUnpauseScheduleRequest_NilGetters(t *testing.T) {

--- a/common/types/testdata/schedule.go
+++ b/common/types/testdata/schedule.go
@@ -119,7 +119,9 @@ var (
 		SearchAttributes: &SearchAttributes,
 	}
 
-	CreateScheduleResponse = types.CreateScheduleResponse{}
+	CreateScheduleResponse = types.CreateScheduleResponse{
+		ScheduleID: "my-schedule-id",
+	}
 
 	DescribeScheduleRequest = types.DescribeScheduleRequest{
 		Domain:     DomainName,
@@ -158,6 +160,7 @@ var (
 		Domain:     DomainName,
 		ScheduleID: "my-schedule-id",
 		Reason:     "maintenance window",
+		Identity:   "user@example.com",
 	}
 
 	PauseScheduleResponse = types.PauseScheduleResponse{}

--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -117,8 +117,7 @@ func (wh *WorkflowHandler) CreateSchedule(
 		return nil, err
 	}
 
-	// TODO: return ScheduleID in the response once the IDL CreateScheduleResponse has the field
-	return &types.CreateScheduleResponse{}, nil
+	return &types.CreateScheduleResponse{ScheduleID: scheduleID}, nil
 }
 
 func (wh *WorkflowHandler) DescribeSchedule(
@@ -269,9 +268,9 @@ func (wh *WorkflowHandler) PauseSchedule(
 		return nil, &types.BadRequestError{Message: "ScheduleID is not set on request."}
 	}
 
-	// TODO: populate PausedBy once PauseScheduleRequest has an Identity field in the IDL
 	signal := scheduler.PauseSignal{
-		Reason: request.GetReason(),
+		Reason:   request.GetReason(),
+		PausedBy: request.GetIdentity(),
 	}
 
 	if err := wh.signalScheduleWorkflow(ctx, domainName, scheduleID, scheduler.SignalNamePause, signal); err != nil {


### PR DESCRIPTION
## What changed?

Added two fields to schedule types and updated proto mappers and handler implementations:
- `ScheduleID` field to `CreateScheduleResponse` type
- `Identity` field to `PauseScheduleRequest` type

Relates to #7664.

## Why?

**CreateScheduleResponse.ScheduleID**: Echoing back the schedule ID confirms to the caller which schedule was created, improving API ergonomics. 

**PauseScheduleRequest.Identity**: Captures who paused the schedule (user or service name). This value is now passed to the scheduler workflow's `PauseSignal.PausedBy` field, enabling audit trails.

Depends on IDL PR: https://github.com/cadence-workflow/cadence-idl/pull/256

## How did you test it?

```bash
make pr             # tidy, go-generate, fmt, lint — passed, no files changed
make build          # full compile check — passed
go test ./common/types/... ./service/frontend/api/...  # schedule-related tests — passed
```
## Potential risks

None — these are internal type changes that extend the API surface in a backward-compatible way. The IDL changes are additive (proto3 optional fields), and handlers now populate fields that were previously empty/TODO.

## Release notes

N/A — internal type change, not yet user-facing until full schedule feature lands.

## Documentation Changes

N/A