### PR TITLE
fix(scheduler): reject invalid SKIP_NEW + CATCH_UP_ALL policy combination

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -44,6 +44,20 @@ func scheduleWorkflowID(scheduleID string) string {
 	return scheduleWorkflowIDPrefix + scheduleID
 }
 
+func validateSchedulePolicies(policies *types.SchedulePolicies) error {
+	if policies == nil {
+		return nil
+	}
+	if policies.OverlapPolicy == types.ScheduleOverlapPolicySkipNew &&
+		policies.CatchUpPolicy == types.ScheduleCatchUpPolicyAll {
+		return &types.BadRequestError{
+			Message: "SKIP_NEW overlap policy with CATCH_UP_ALL catch-up policy is invalid: " +
+				"caught-up fires would be immediately skipped due to overlap with the previous run.",
+		}
+	}
+	return nil
+}
+
 func (wh *WorkflowHandler) CreateSchedule(
 	ctx context.Context,
 	request *types.CreateScheduleRequest,
@@ -71,6 +85,9 @@ func (wh *WorkflowHandler) CreateSchedule(
 	}
 	if request.GetAction() == nil || request.GetAction().GetStartWorkflow() == nil {
 		return nil, &types.BadRequestError{Message: "Action.StartWorkflow is not set on request."}
+	}
+	if err := validateSchedulePolicies(request.GetPolicies()); err != nil {
+		return nil, err
 	}
 
 	workflowInput := scheduler.SchedulerWorkflowInput{
@@ -208,6 +225,9 @@ func (wh *WorkflowHandler) UpdateSchedule(
 	}
 	if request.GetSpec() == nil && request.GetAction() == nil && request.GetPolicies() == nil {
 		return nil, &types.BadRequestError{Message: "At least one of Spec, Action, or Policies must be set on request."}
+	}
+	if err := validateSchedulePolicies(request.GetPolicies()); err != nil {
+		return nil, err
 	}
 
 	signal := scheduler.UpdateSignal{

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -146,6 +146,25 @@ func TestCreateSchedule(t *testing.T) {
 			mockFn:  func(f *scheduleTestFixture) {},
 			wantErr: true,
 		},
+		"invalid SKIP_NEW + CATCH_UP_ALL": {
+			request: &types.CreateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Spec:       &types.ScheduleSpec{CronExpression: "* * * * *"},
+				Action: &types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType: &types.WorkflowType{Name: "wf"},
+						TaskList:     &types.TaskList{Name: "tl"},
+					},
+				},
+				Policies: &types.SchedulePolicies{
+					OverlapPolicy: types.ScheduleOverlapPolicySkipNew,
+					CatchUpPolicy: types.ScheduleCatchUpPolicyAll,
+				},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
 		"domain not found": {
 			request: validRequest,
 			mockFn: func(f *scheduleTestFixture) {
@@ -457,6 +476,18 @@ func TestUpdateSchedule(t *testing.T) {
 			mockFn:  func(f *scheduleTestFixture) {},
 			wantErr: true,
 		},
+		"invalid SKIP_NEW + CATCH_UP_ALL": {
+			request: &types.UpdateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Policies: &types.SchedulePolicies{
+					OverlapPolicy: types.ScheduleOverlapPolicySkipNew,
+					CatchUpPolicy: types.ScheduleCatchUpPolicyAll,
+				},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
 		"success with spec update": {
 			request: &types.UpdateScheduleRequest{
 				Domain:     testDomain,
@@ -713,6 +744,63 @@ func TestNormalizeScheduleError(t *testing.T) {
 func TestScheduleWorkflowID(t *testing.T) {
 	assert.Equal(t, "cadence-scheduler:my-schedule", scheduleWorkflowID("my-schedule"))
 	assert.Equal(t, "cadence-scheduler:", scheduleWorkflowID(""))
+}
+
+func TestValidateSchedulePolicies(t *testing.T) {
+	tests := map[string]struct {
+		policies *types.SchedulePolicies
+		wantErr  bool
+	}{
+		"nil policies": {
+			policies: nil,
+			wantErr:  false,
+		},
+		"valid SKIP_NEW + SKIP": {
+			policies: &types.SchedulePolicies{
+				OverlapPolicy: types.ScheduleOverlapPolicySkipNew,
+				CatchUpPolicy: types.ScheduleCatchUpPolicySkip,
+			},
+			wantErr: false,
+		},
+		"valid SKIP_NEW + ONE": {
+			policies: &types.SchedulePolicies{
+				OverlapPolicy: types.ScheduleOverlapPolicySkipNew,
+				CatchUpPolicy: types.ScheduleCatchUpPolicyOne,
+			},
+			wantErr: false,
+		},
+		"invalid SKIP_NEW + ALL": {
+			policies: &types.SchedulePolicies{
+				OverlapPolicy: types.ScheduleOverlapPolicySkipNew,
+				CatchUpPolicy: types.ScheduleCatchUpPolicyAll,
+			},
+			wantErr: true,
+		},
+		"valid TERMINATE_PREVIOUS + ALL": {
+			policies: &types.SchedulePolicies{
+				OverlapPolicy: types.ScheduleOverlapPolicyTerminatePrevious,
+				CatchUpPolicy: types.ScheduleCatchUpPolicyAll,
+			},
+			wantErr: false,
+		},
+		"valid CONCURRENT + ALL": {
+			policies: &types.SchedulePolicies{
+				OverlapPolicy: types.ScheduleOverlapPolicyConcurrent,
+				CatchUpPolicy: types.ScheduleCatchUpPolicyAll,
+			},
+			wantErr: false,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := validateSchedulePolicies(tt.policies)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
 func TestCreateSchedule_ShuttingDown(t *testing.T) {


### PR DESCRIPTION
## What changed?

Adds validation to reject the invalid combination of `SKIP_NEW` overlap policy with `CATCH_UP_ALL` catch-up policy in `CreateSchedule` and `UpdateSchedule` handlers.

Relates to #7664

## Why?

`SKIP_NEW + CATCH_UP_ALL` is contradictory: when catching up missed fires, each fire is processed back-to-back. Since the previous target workflow is still running when the next fire is attempted, `SKIP_NEW` causes all but the first to be skipped. The user expects all missed fires to execute but only one actually does.

## How did you test it?

- `go build ./service/frontend/api/...` 
- `go test ./service/frontend/api/... -run "TestCreateSchedule|TestUpdateSchedule|TestValidateSchedulePolicies" -count=1` :all tests pass

## Potential risks

None: isolated validation check with no API/schema/flag impact.

## Release notes

N/A : internal change to scheduler.

## Documentation Changes

N/A