### PR TITLE
feat(scheduler): add search attributes to target workflows

### DIFF
--- a/service/worker/scheduler/activity.go
+++ b/service/worker/scheduler/activity.go
@@ -22,6 +22,7 @@ package scheduler
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -107,7 +108,7 @@ func processScheduleFireActivity(ctx context.Context, req ProcessFireRequest) (*
 		WorkflowIDReusePolicy:               &reusePolicy,
 		RetryPolicy:                         req.Action.RetryPolicy,
 		Memo:                                req.Action.Memo,
-		SearchAttributes:                    req.Action.SearchAttributes,
+		SearchAttributes:                    buildSearchAttributes(req),
 	}
 
 	resp, err := sc.FrontendClient.StartWorkflowExecution(ctx, startReq)
@@ -203,6 +204,30 @@ func terminateWorkflow(ctx context.Context, client frontend.Client, domain strin
 		return fmt.Errorf("failed to terminate workflow: %w", err)
 	}
 	return nil
+}
+
+func buildSearchAttributes(req ProcessFireRequest) *types.SearchAttributes {
+	fields := make(map[string][]byte)
+
+	// Preserve any user-provided search attributes from the action config
+	if req.Action.SearchAttributes != nil {
+		for k, v := range req.Action.SearchAttributes.IndexedFields {
+			fields[k] = v
+		}
+	}
+
+	// Add scheduler-managed attributes (overwrite user values if keys conflict)
+	if v, err := json.Marshal(req.ScheduleID); err == nil {
+		fields[SearchAttrScheduleID] = v
+	}
+	if v, err := json.Marshal(req.ScheduledTime); err == nil {
+		fields[SearchAttrScheduledTime] = v
+	}
+	if v, err := json.Marshal(req.TriggerSource == TriggerSourceBackfill); err == nil {
+		fields[SearchAttrIsBackfill] = v
+	}
+
+	return &types.SearchAttributes{IndexedFields: fields}
 }
 
 func isEntityNotExistsError(err error) bool {

--- a/service/worker/scheduler/activity.go
+++ b/service/worker/scheduler/activity.go
@@ -221,7 +221,7 @@ func buildSearchAttributes(req ProcessFireRequest) *types.SearchAttributes {
 		fields[SearchAttrScheduleID] = v
 	}
 	if v, err := json.Marshal(req.ScheduledTime); err == nil {
-		fields[SearchAttrScheduledTime] = v
+		fields[SearchAttrScheduleTime] = v
 	}
 	if v, err := json.Marshal(req.TriggerSource == TriggerSourceBackfill); err == nil {
 		fields[SearchAttrIsBackfill] = v

--- a/service/worker/scheduler/activity_test.go
+++ b/service/worker/scheduler/activity_test.go
@@ -22,6 +22,7 @@ package scheduler
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -360,6 +361,84 @@ func TestProcessScheduleFireActivity(t *testing.T) {
 			assert.Equal(t, tc.wantResult, result)
 		})
 	}
+}
+
+func TestBuildSearchAttributes(t *testing.T) {
+	scheduledTime := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+
+	t.Run("sets scheduler-managed attributes", func(t *testing.T) {
+		req := ProcessFireRequest{
+			ScheduleID:    "sched-1",
+			ScheduledTime: scheduledTime,
+			TriggerSource: TriggerSourceSchedule,
+		}
+		sa := buildSearchAttributes(req)
+		require.NotNil(t, sa)
+
+		var schedID string
+		require.NoError(t, json.Unmarshal(sa.IndexedFields[SearchAttrScheduleID], &schedID))
+		assert.Equal(t, "sched-1", schedID)
+
+		var isBackfill bool
+		require.NoError(t, json.Unmarshal(sa.IndexedFields[SearchAttrIsBackfill], &isBackfill))
+		assert.False(t, isBackfill)
+
+		assert.Contains(t, sa.IndexedFields, SearchAttrScheduledTime)
+	})
+
+	t.Run("backfill trigger sets isBackfill true", func(t *testing.T) {
+		req := ProcessFireRequest{
+			ScheduleID:    "sched-1",
+			ScheduledTime: scheduledTime,
+			TriggerSource: TriggerSourceBackfill,
+		}
+		sa := buildSearchAttributes(req)
+
+		var isBackfill bool
+		require.NoError(t, json.Unmarshal(sa.IndexedFields[SearchAttrIsBackfill], &isBackfill))
+		assert.True(t, isBackfill)
+	})
+
+	t.Run("preserves user search attributes", func(t *testing.T) {
+		userVal, _ := json.Marshal("my-value")
+		req := ProcessFireRequest{
+			ScheduleID:    "sched-1",
+			ScheduledTime: scheduledTime,
+			TriggerSource: TriggerSourceSchedule,
+			Action: types.StartWorkflowAction{
+				SearchAttributes: &types.SearchAttributes{
+					IndexedFields: map[string][]byte{
+						"CustomAttr": userVal,
+					},
+				},
+			},
+		}
+		sa := buildSearchAttributes(req)
+
+		assert.Equal(t, userVal, sa.IndexedFields["CustomAttr"])
+		assert.Contains(t, sa.IndexedFields, SearchAttrScheduleID)
+	})
+
+	t.Run("scheduler attributes override conflicting user attributes", func(t *testing.T) {
+		userVal, _ := json.Marshal("user-override")
+		req := ProcessFireRequest{
+			ScheduleID:    "sched-1",
+			ScheduledTime: scheduledTime,
+			TriggerSource: TriggerSourceSchedule,
+			Action: types.StartWorkflowAction{
+				SearchAttributes: &types.SearchAttributes{
+					IndexedFields: map[string][]byte{
+						SearchAttrScheduleID: userVal,
+					},
+				},
+			},
+		}
+		sa := buildSearchAttributes(req)
+
+		var schedID string
+		require.NoError(t, json.Unmarshal(sa.IndexedFields[SearchAttrScheduleID], &schedID))
+		assert.Equal(t, "sched-1", schedID, "scheduler-managed attribute should override user value")
+	})
 }
 
 func TestIsEntityNotExistsError(t *testing.T) {

--- a/service/worker/scheduler/activity_test.go
+++ b/service/worker/scheduler/activity_test.go
@@ -383,7 +383,7 @@ func TestBuildSearchAttributes(t *testing.T) {
 		require.NoError(t, json.Unmarshal(sa.IndexedFields[SearchAttrIsBackfill], &isBackfill))
 		assert.False(t, isBackfill)
 
-		assert.Contains(t, sa.IndexedFields, SearchAttrScheduledTime)
+		assert.Contains(t, sa.IndexedFields, SearchAttrScheduleTime)
 	})
 
 	t.Run("backfill trigger sets isBackfill true", func(t *testing.T) {

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -39,9 +39,9 @@ const (
 	QueryTypeDescribe = "scheduler-describe"
 
 	// Search attribute keys set on target workflows started by the scheduler.
-	SearchAttrScheduleID    = "CadenceScheduleID"
+	SearchAttrScheduleID   = "CadenceScheduleID"
 	SearchAttrScheduleTime = "CadenceScheduleTime"
-	SearchAttrIsBackfill    = "CadenceScheduleIsBackfill"
+	SearchAttrIsBackfill   = "CadenceScheduleIsBackfill"
 
 	maxIterationsBeforeContinueAsNew = 500
 	maxCatchUpFiresPerExecution      = 10

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -40,7 +40,7 @@ const (
 
 	// Search attribute keys set on target workflows started by the scheduler.
 	SearchAttrScheduleID    = "CadenceScheduleID"
-	SearchAttrScheduledTime = "CadenceScheduledTime"
+	SearchAttrScheduleTime = "CadenceScheduleTime"
 	SearchAttrIsBackfill    = "CadenceScheduleIsBackfill"
 
 	maxIterationsBeforeContinueAsNew = 500

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -39,9 +39,9 @@ const (
 	QueryTypeDescribe = "scheduler-describe"
 
 	// Search attribute keys set on target workflows started by the scheduler.
-	SearchAttrScheduleID     = "CadenceScheduleID"
-	SearchAttrScheduledTime  = "CadenceScheduledTime"
-	SearchAttrIsBackfill     = "CadenceScheduleIsBackfill"
+	SearchAttrScheduleID    = "CadenceScheduleID"
+	SearchAttrScheduledTime = "CadenceScheduledTime"
+	SearchAttrIsBackfill    = "CadenceScheduleIsBackfill"
 
 	maxIterationsBeforeContinueAsNew = 500
 	maxCatchUpFiresPerExecution      = 10

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -38,6 +38,11 @@ const (
 
 	QueryTypeDescribe = "scheduler-describe"
 
+	// Search attribute keys set on target workflows started by the scheduler.
+	SearchAttrScheduleID     = "CadenceScheduleID"
+	SearchAttrScheduledTime  = "CadenceScheduledTime"
+	SearchAttrIsBackfill     = "CadenceScheduleIsBackfill"
+
 	maxIterationsBeforeContinueAsNew = 500
 	maxCatchUpFiresPerExecution      = 10
 	maxBackfillFiresPerExecution     = 10


### PR DESCRIPTION
## What changed?

Sets scheduler-managed search attributes on target workflows started by the scheduler: `CadenceScheduleID` (keyword), `CadenceScheduledTime` (datetime), and `CadenceScheduleIsBackfill` (bool). User-provided search attributes from the action config are preserved; scheduler attributes take precedence on key conflict.

Relates to #7664

## Why?

Requires schedule workflows to be discoverable through schedule-specific visibility metadata. Without these search attributes, there is no way to trace a target workflow back to its parent schedule, distinguish backfill runs from regular runs, or implement `ListSchedules` via visibility queries.

## How did you test it?

- `go build ./service/worker/scheduler/...` — compiles cleanly
- `go test ./service/worker/scheduler/... -count=1` — all tests pass
- `TestBuildSearchAttributes` covers 4 cases: basic attributes set, backfill flag, user attributes preserved, scheduler attributes override conflicts

## Potential risks

None — isolated change within the scheduler activity. Search attribute keys are new and not yet registered in any cluster; they will need to be registered before use in visibility queries.

## Release notes

N/A — internal change to scheduler (not yet released).

## Documentation Changes

N/A