### PR TITLE
fix(matching): reclassify query-task-not-found as EntityNotExistsError

### DIFF
--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -1015,7 +1015,7 @@ func (e *matchingEngineImpl) RespondQueryTaskCompleted(hCtx *handlerContext, req
 func (e *matchingEngineImpl) deliverQueryResult(taskID string, queryResult *queryResult) error {
 	queryResultCh, ok := e.lockableQueryTaskMap.get(taskID)
 	if !ok {
-		return &types.InternalServiceError{Message: "query task not found, or already expired"}
+		return &types.EntityNotExistsError{Message: "query task not found, or already expired"}
 	}
 	queryResultCh <- queryResult
 	return nil


### PR DESCRIPTION
**What changed?**
Changed the error type returned by `deliverQueryResult` when a query task is not found from `InternalServiceError` to `EntityNotExistsError`.

**Why?**
When a worker responds to a query that has already expired (normal race condition), this was classified as an internal server error — triggering error-level logging, incrementing `CadenceFailuresPerTaskList`, and causing false availability alerts. This is not a server fault.

**How did you test it?**
- `go test ./service/matching/handler/... -count=1` — all pass

**Potential risks**
Callers that explicitly match on `InternalServiceError` for this message would need updating. In practice, callers don't retry this error meaningfully since the query already timed out.

**Release notes**
`RespondQueryTaskCompleted` now returns `EntityNotExistsError` instead of `InternalServiceError` when the query task has expired.

**Documentation Changes**
N/A