### PR TITLE
docs: Update maintainers and TSC

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,16 +1,18 @@
 # Maintainers
 
+## TSC
 - Ender Demirkaya (https://github.com/demirkayaender)
 - Jan Kisel (https://github.com/dkrotx)
+- Shijie Sheng (https://github.com/shijiesheng)
+- Zijian Chen (https://github.com/Shaddoll)
 
+## Maintainers
 - Abhishek Jha (https://github.com/abhishekj720)
 - Adhitya Mamallan (https://github.com/adhityamamallan)
-- Anshuman Pandey (https://github.com/pandeyanshuman)
 - Assem Hafez (https://github.com/Assem-Hafez)
 - Bowen Xiao (https://github.com/bowenxia)
 - Chris Warren (https://github.com/c-warren)
 - Diana Zawadzki (https://github.com/zawadzkidiana)
-- David Porter (https://github.com/davidporter-id-au)
 - Eleonora Di Gregorio (https://github.com/eleonoradgr)
 - Felipe Imanishi (https://github.com/fimanishi)
 - Gaziza Yestemirova (https://github.com/gazi-yestemirova)
@@ -18,9 +20,8 @@
 - Kevin Burns (https://github.com/Bueller87)
 - Nate Mortensen (https://github.com/natemort)
 - Neil Xie (https://github.com/neil-xie)
-- Shijie Sheng (https://github.com/shijiesheng)
+- Stanislav Bychkov (https://github.com/ribaraka)
 - Tim Chan (https://github.com/macrotim)
 - Tim Li (https://github.com/timl3136)
 - Vsevolod Kaloshin (https://github.com/arzonus)
-- Zijian Chen (https://github.com/Shaddoll)
 - Yawei Zhang (https://github.com/YaweiZhang-930)


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**


**Why?**


**How did you test it?**


**Potential risks**


**Release notes**


**Documentation Changes**

----
## Summary by Gitar

- **Reorganized structure:**
  - Added "TSC" section header with 4 members: Ender Demirkaya, Jan Kisel, Shijie Sheng, Zijian Chen
  - Moved remaining members under "Maintainers" section header
- **Personnel changes:**
  - Removed Anshuman Pandey and David Porter from maintainers list
  - Added Stanislav Bychkov to maintainers list

<sub>This will update automatically on new commits.</sub>