### PR TITLE
fix: fix domain tag for sync activity task metrics

### DIFF
--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -483,7 +483,15 @@ func (p *taskProcessorImpl) processTaskOnce(replicationTask *types.ReplicationTa
 	} else {
 		now := ts.Now()
 		mScope := p.metricsClient.Scope(scope, metrics.TargetClusterTag(p.sourceCluster))
-		domainID := replicationTask.HistoryTaskV2Attributes.GetDomainID()
+		var domainID string
+		switch replicationTask.GetTaskType() {
+		case types.ReplicationTaskTypeHistoryV2:
+			domainID = replicationTask.HistoryTaskV2Attributes.GetDomainID()
+		case types.ReplicationTaskTypeSyncActivity:
+			domainID = replicationTask.SyncActivityTaskAttributes.GetDomainID()
+		case types.ReplicationTaskTypeFailoverMarker:
+			domainID = replicationTask.FailoverMarkerAttributes.GetDomainID()
+		}
 		var domainName string
 		if domainID != "" {
 			cachedName, errorDomainName := p.shard.GetDomainCache().GetDomainName(domainID)


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
fix domain tag for sync activity task metrics

**Why?**
The domain tag was incorrect

**How did you test it?**
cd service/history/replication && go test ./... -race

**Potential risks**
No.

**Release notes**
N/A

**Documentation Changes**
N/A
