### PR TITLE
test: Add fuzz tests for errors mappers

### DIFF
--- a/common/types/mapper/proto/errors_test.go
+++ b/common/types/mapper/proto/errors_test.go
@@ -24,10 +24,14 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
+	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/yarpc/yarpcerrors"
 
+	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/common/types/mapper/testutils"
 	"github.com/uber/cadence/common/types/testdata"
 )
 
@@ -61,4 +65,45 @@ func TestFromUnknownErrorMapsToUnknownError(t *testing.T) {
 func TestToDeadlineExceededMapsToItself(t *testing.T) {
 	timeout := yarpcerrors.DeadlineExceededErrorf("timeout")
 	assert.Equal(t, timeout, ToError(timeout))
+}
+
+// RetryTaskV2ErrorFuzzer ensures StartEventID/StartEventVersion and
+// EndEventID/EndEventVersion are either both nil or both non-nil.
+// FromEventIDVersionPair returns nil if either field is nil, which would
+// drop the non-nil partner on round-trip.
+func RetryTaskV2ErrorFuzzer(e *types.RetryTaskV2Error, c fuzz.Continue) {
+	c.FuzzNoCustom(e)
+	if e.StartEventID == nil || e.StartEventVersion == nil {
+		e.StartEventID = nil
+		e.StartEventVersion = nil
+	}
+	if e.EndEventID == nil || e.EndEventVersion == nil {
+		e.EndEventID = nil
+		e.EndEventVersion = nil
+	}
+}
+
+func TestErrorsFuzz(t *testing.T) {
+	seed := time.Now().UnixNano()
+	defer func() {
+		if t.Failed() {
+			t.Logf("fuzz seed: %v", seed)
+		}
+	}()
+
+	for _, errTemplate := range testdata.Errors {
+		errType := reflect.TypeOf(errTemplate).Elem()
+		t.Run(errType.Name(), func(t *testing.T) {
+			var customFuncs []interface{}
+			if _, ok := errTemplate.(*types.RetryTaskV2Error); ok {
+				customFuncs = []interface{}{RetryTaskV2ErrorFuzzer}
+			}
+			f := fuzz.NewWithSeed(seed).Funcs(customFuncs...)
+			for i := 0; i < testutils.DefaultIterations; i++ {
+				newErr := reflect.New(errType).Interface()
+				f.Fuzz(newErr)
+				assert.Equal(t, newErr, ToError(FromError(newErr.(error))), "iteration %d", i)
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

This adds fuzz tests for all mappers within common/types/mapper/proto/errors.go

**Why?**
This is part of the implementation of https://github.com/cadence-workflow/cadence/issues/7611. Further follow ups will work on additional files. 

**How did you test it?**
```
go test ./common/types/mapper/...
ok      github.com/uber/cadence/common/types/mapper/errorutils  (cached)
ok      github.com/uber/cadence/common/types/mapper/proto       (cached)
ok      github.com/uber/cadence/common/types/mapper/testutils   (cached)
ok      github.com/uber/cadence/common/types/mapper/thrift      (cached)
```

**Potential risks**
N/A

**Release notes**
N/A

**Documentation Changes**
N/A
