### PR TITLE
refactor(shard-distributor-canary): Remove noisy logs

### DIFF
--- a/service/sharddistributor/canary/handler/ping_handler.go
+++ b/service/sharddistributor/canary/handler/ping_handler.go
@@ -51,7 +51,7 @@ func NewPingHandler(params Params) *PingHandler {
 
 // Ping handles ping requests to check shard ownership
 func (h *PingHandler) Ping(ctx context.Context, request *sharddistributorv1.PingRequest) (*sharddistributorv1.PingResponse, error) {
-	h.logger.Info("Received ping request",
+	h.logger.Debug("Received ping request",
 		zap.String("shard_key", request.GetShardKey()),
 		zap.String("namespace", request.GetNamespace()))
 
@@ -92,7 +92,7 @@ func checkOwnerShipAndLog[T executorclient.ShardProcessor](ctx context.Context, 
 		ShardKey:   request.GetShardKey(),
 	}
 
-	h.logger.Info("Responding to ping",
+	h.logger.Debug("Responding to ping",
 		zap.String("shard_key", request.GetShardKey()),
 		zap.Bool("owns_shard", ownshard),
 		zap.String("executor_id", executorID))

--- a/service/sharddistributor/canary/pinger/pingAndLog.go
+++ b/service/sharddistributor/canary/pinger/pingAndLog.go
@@ -35,6 +35,4 @@ func PingShard(ctx context.Context, canaryClient sharddistributorv1.ShardDistrib
 		logger.Warn("Executor does not own shard", zap.String("namespace", namespace), zap.String("shard_key", shardKey), zap.String("executor_id", response.GetExecutorId()))
 		return
 	}
-
-	logger.Info("Successfully pinged shard owner", zap.String("namespace", namespace), zap.String("shard_key", shardKey), zap.String("executor_id", response.GetExecutorId()))
 }

--- a/service/sharddistributor/canary/pinger/pinger_test.go
+++ b/service/sharddistributor/canary/pinger/pinger_test.go
@@ -38,6 +38,7 @@ func TestPingerPingRandomShard(t *testing.T) {
 		name            string
 		setupClientMock func(*MockShardDistributorExecutorCanaryAPIYARPCClient)
 		expectedLog     string
+		expectedCount   int
 	}{
 		{
 			name: "owns shard",
@@ -48,7 +49,8 @@ func TestPingerPingRandomShard(t *testing.T) {
 						ExecutorId: "127.0.0.1:7953",
 					}, nil)
 			},
-			expectedLog: "Successfully pinged shard owner",
+			expectedLog:   "Successfully pinged shard owner",
+			expectedCount: 0,
 		},
 		{
 			name: "does not own shard",
@@ -60,7 +62,8 @@ func TestPingerPingRandomShard(t *testing.T) {
 						ExecutorId: "127.0.0.1:7953",
 					}, nil)
 			},
-			expectedLog: "Executor does not own shard",
+			expectedLog:   "Executor does not own shard",
+			expectedCount: 1,
 		},
 		{
 			name: "RPC error",
@@ -69,7 +72,8 @@ func TestPingerPingRandomShard(t *testing.T) {
 					Ping(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, errors.New("network error"))
 			},
-			expectedLog: "Failed to ping shard",
+			expectedLog:   "Failed to ping shard",
+			expectedCount: 1,
 		},
 	}
 
@@ -91,7 +95,7 @@ func TestPingerPingRandomShard(t *testing.T) {
 
 			pinger.pingRandomShard()
 
-			assert.Equal(t, 1, logs.FilterMessage(tt.expectedLog).Len())
+			assert.Equal(t, tt.expectedCount, logs.FilterMessage(tt.expectedLog).Len())
 		})
 	}
 }

--- a/service/sharddistributor/canary/processor/shardprocessor.go
+++ b/service/sharddistributor/canary/processor/shardprocessor.go
@@ -58,7 +58,7 @@ func (p *ShardProcessor) GetShardReport() executorclient.ShardReport {
 
 // Start implements executorclient.ShardProcessor.
 func (p *ShardProcessor) Start(_ context.Context) error {
-	p.logger.Info("Starting shard processor", zap.String("shardID", p.shardID))
+	p.logger.Debug("Starting shard processor", zap.String("shardID", p.shardID))
 	p.goRoutineWg.Add(1)
 	go p.process()
 	return nil
@@ -66,7 +66,7 @@ func (p *ShardProcessor) Start(_ context.Context) error {
 
 // Stop implements executorclient.ShardProcessor.
 func (p *ShardProcessor) Stop() {
-	p.logger.Info("Stopping shard processor", zap.String("shardID", p.shardID))
+	p.logger.Debug("Stopping shard processor", zap.String("shardID", p.shardID))
 	close(p.stopChan)
 	p.goRoutineWg.Wait()
 }
@@ -84,11 +84,11 @@ func (p *ShardProcessor) process() {
 	for {
 		select {
 		case <-p.stopChan:
-			p.logger.Info("Stopping shard processor", zap.String("shardID", p.shardID), zap.Int("steps", p.processSteps))
+			p.logger.Debug("Stopping shard processor", zap.String("shardID", p.shardID), zap.Int("steps", p.processSteps))
 			return
 		case <-ticker.Chan():
 			p.processSteps++
-			p.logger.Info("Processing shard", zap.String("shardID", p.shardID), zap.Int("steps", p.processSteps))
+			p.logger.Debug("Processing shard", zap.String("shardID", p.shardID), zap.Int("steps", p.processSteps))
 		}
 	}
 }

--- a/service/sharddistributor/canary/processorephemeral/shardcreator.go
+++ b/service/sharddistributor/canary/processorephemeral/shardcreator.go
@@ -56,14 +56,14 @@ func NewShardCreator(params ShardCreatorParams, namespaces []string) *ShardCreat
 func (s *ShardCreator) Start() {
 	s.goRoutineWg.Add(1)
 	go s.process(context.Background())
-	s.logger.Info("Shard creator started")
+	s.logger.Debug("Shard creator started")
 }
 
 // Stop stops the shard creation process and waits for the goroutine to finish
 func (s *ShardCreator) Stop() {
 	close(s.stopChan)
 	s.goRoutineWg.Wait()
-	s.logger.Info("Shard creator stopped")
+	s.logger.Debug("Shard creator stopped")
 }
 
 // ShardCreatorModule creates an fx module for the shard creator with the given namespace
@@ -93,7 +93,7 @@ func (s *ShardCreator) process(ctx context.Context) {
 		case <-ticker.Chan():
 			for _, namespace := range s.namespaces {
 				shardKey := uuid.New().String()
-				s.logger.Info("Creating shard", zap.String("shardKey", shardKey), zap.String("namespace", namespace))
+				s.logger.Debug("Creating shard", zap.String("shardKey", shardKey), zap.String("namespace", namespace))
 
 				pinger.PingShard(ctx, s.canaryClient, s.logger, namespace, shardKey)
 			}

--- a/service/sharddistributor/canary/processorephemeral/shardprocessor.go
+++ b/service/sharddistributor/canary/processorephemeral/shardprocessor.go
@@ -62,7 +62,7 @@ func (p *ShardProcessor) GetShardReport() executorclient.ShardReport {
 
 // Start implements executorclient.ShardProcessor.
 func (p *ShardProcessor) Start(_ context.Context) error {
-	p.logger.Info("Starting shard processor", zap.String("shardID", p.shardID))
+	p.logger.Debug("Starting shard processor", zap.String("shardID", p.shardID))
 	p.goRoutineWg.Add(1)
 	go p.process()
 	return nil
@@ -90,14 +90,14 @@ func (p *ShardProcessor) process() {
 	for {
 		select {
 		case <-p.stopChan:
-			p.logger.Info("Stopping shard processor", zap.String("shardID", p.shardID), zap.Int("steps", p.processSteps), zap.String("status", types.ShardStatus(p.status.Load()).String()))
+			p.logger.Debug("Stopping shard processor", zap.String("shardID", p.shardID), zap.Int("steps", p.processSteps), zap.String("status", types.ShardStatus(p.status.Load()).String()))
 			return
 		case <-ticker.Chan():
-			p.logger.Info("Processing shard", zap.String("shardID", p.shardID), zap.Int("steps", p.processSteps), zap.String("status", types.ShardStatus(p.status.Load()).String()))
+			p.logger.Debug("Processing shard", zap.String("shardID", p.shardID), zap.Int("steps", p.processSteps), zap.String("status", types.ShardStatus(p.status.Load()).String()))
 		case <-stopTicker.Chan():
 			p.processSteps++
 			if rand.Intn(shardProcessorDoneChance) == 0 {
-				p.logger.Info("Setting shard processor to done", zap.String("shardID", p.shardID), zap.Int("steps", p.processSteps), zap.String("status", types.ShardStatus(p.status.Load()).String()))
+				p.logger.Debug("Setting shard processor to done", zap.String("shardID", p.shardID), zap.Int("steps", p.processSteps), zap.String("status", types.ShardStatus(p.status.Load()).String()))
 				p.SetShardStatus(types.ShardStatusDONE)
 			}
 		}


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
This PR removes success-path log in pingAndLog and downgrades  per-ping request & response, shard-processor logs and shard-creator churn logs to Debug mofr.

**Why?**
Shard-distributor-canary service is emitting too many logs, because of the volume and limited storage we might lose actually important logs.

**How did you test it?**
go test -v ./service/sharddistributor/canary/...

**Potential risks**
Low - as it is only reducing the logs

**Release notes**
N/A

**Documentation Changes**
N/A