### PR TITLE
feat: enable dual emitting for persistence_latency_per_shard

### DIFF
--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -115,6 +115,10 @@ var HistogramMigrationMetrics = map[string]struct{}{
 	"persistence_latency_per_domain_ns": {},
 	"persistence_latency":               {},
 	"persistence_latency_ns":            {},
+	"persistence_latency_histogram":     {},
+
+	"persistence_latency_per_shard":    {},
+	"persistence_latency_per_shard_ns": {},
 
 	"elasticsearch_latency_per_domain":    {},
 	"elasticsearch_latency_per_domain_ns": {},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2334,6 +2334,7 @@ const (
 	PersistenceLatencyPerDomain
 	PersistenceLatencyPerDomainHistogram
 	PersistenceLatencyPerShard
+	PersistenceLatencyPerShardHistogram
 	PersistenceErrShardExistsCounterPerDomain
 	PersistenceErrShardOwnershipLostCounterPerDomain
 	PersistenceErrConditionFailedCounterPerDomain
@@ -3198,6 +3199,7 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 		PersistenceLatencyPerDomain:                                  {metricName: "persistence_latency_per_domain", metricRollupName: "persistence_latency", metricType: Timer},
 		PersistenceLatencyPerDomainHistogram:                         {metricName: "persistence_latency_per_domain_ns", metricRollupName: "persistence_latency_ns", metricType: Histogram, exponentialBuckets: Default1ms100s},
 		PersistenceLatencyPerShard:                                   {metricName: "persistence_latency_per_shard", metricType: Timer},
+		PersistenceLatencyPerShardHistogram:                          {metricName: "persistence_latency_per_shard_ns", metricType: Histogram, exponentialBuckets: Low1ms100s},
 		PersistenceErrShardExistsCounterPerDomain:                    {metricName: "persistence_errors_shard_exists_per_domain", metricRollupName: "persistence_errors_shard_exists", metricType: Counter},
 		PersistenceErrShardOwnershipLostCounterPerDomain:             {metricName: "persistence_errors_shard_ownership_lost_per_domain", metricRollupName: "persistence_errors_shard_ownership_lost", metricType: Counter},
 		PersistenceErrConditionFailedCounterPerDomain:                {metricName: "persistence_errors_condition_failed_per_domain", metricRollupName: "persistence_errors_condition_failed", metricType: Counter},

--- a/common/persistence/wrappers/metered/base.go
+++ b/common/persistence/wrappers/metered/base.go
@@ -199,7 +199,10 @@ func (p *base) callWithDomainAndShardScope(scope metrics.ScopeIdx, op func() err
 	domainMetricsScope.RecordHistogramDuration(metrics.PersistenceLatencyPerDomainHistogram, duration)
 	overallScope.RecordHistogramDuration(metrics.PersistenceLatencyHistogram, duration)
 	shardOperationsMetricsScope.RecordTimer(metrics.PersistenceLatencyPerShard, duration)
+	shardOperationsMetricsScope.RecordHistogramDuration(metrics.PersistenceLatencyPerShardHistogram, duration)
+
 	shardOverallMetricsScope.RecordTimer(metrics.PersistenceLatencyPerShard, duration)
+	shardOverallMetricsScope.RecordHistogramDuration(metrics.PersistenceLatencyPerShardHistogram, duration)
 	p.recordLatencyHistogram(scope, duration)
 
 	if err != nil {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Start dual emitting timer and histogram metrics for persistence_latency_per_shard which is the biggest metrics in server
https://github.com/cadence-workflow/cadence/issues/7741
Also merged remaining change from https://github.com/cadence-workflow/cadence/pull/7305. 

**Why?**
Timer -> Histogram migration, details in https://github.com/cadence-workflow/cadence/issues/7741

**How did you test it?**
go test -v ./common/metrics

**Potential risks**
Metrics storage increase

**Release notes**
In https://github.com/cadence-workflow/cadence/issues/7741

**Documentation Changes**

