### PR TITLE
feat(simulation): make history simulation params configurable per scenario

### DIFF
--- a/docker/github_actions/docker-compose-local-history-simulation.yml
+++ b/docker/github_actions/docker-compose-local-history-simulation.yml
@@ -49,7 +49,7 @@ services:
       - -e
       - -c
       - >
-        go test -timeout 300s
+        go test -timeout 1800s
         -run ^TestHistorySimulation.*$
         -count 1
         -v

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -154,6 +154,7 @@ type (
 	}
 
 	HistorySimulationConfig struct {
+		// NumWorkflows is how many workflows the test starts in total. Defaults to 100.
 		NumWorkflows int
 		// WorkflowDeletionJitterRange defines the duration in minutes for workflow close tasks jittering
 		// defaults to 0 to remove jittering
@@ -162,6 +163,19 @@ type (
 		EnableTransferQueueV2 bool
 		// EnableTimerQueueV2 enables queue v2 framework for timer queue
 		EnableTimerQueueV2 bool
+
+		// SleepBetweenWorkflowStarts is how long the test waits between starting each workflow.
+		// A short gap keeps the frontend from getting hit with a burst on startup. Defaults to 0.
+		SleepBetweenWorkflowStarts time.Duration
+
+		// Timeout is the context deadline the test uses when waiting for all workflows to complete.
+		// Must be less than the go test -timeout ceiling (1800s in docker-compose). Defaults to 5 minutes.
+		Timeout time.Duration
+
+		// NumWorkflowSleeps is how many workflow.Sleep calls each workflow makes.
+		// Each sleep becomes a timer task, so this is the main knob for timer queue load
+		// without changing the number of workflows. Defaults to 0.
+		NumWorkflowSleeps int
 	}
 
 	MatchingConfig struct {

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -176,6 +176,11 @@ type (
 		// Each sleep becomes a timer task, so this is the main knob for timer queue load
 		// without changing the number of workflows. Defaults to 0.
 		NumWorkflowSleeps int
+
+		// SleepAfterAllWorkflows is how long the test waits after all workflows complete.
+		// This allows pending timer tasks (e.g. workflow timeout timers) to be processed
+		// before the simulation ends. Defaults to 120 seconds.
+		SleepAfterAllWorkflows time.Duration
 	}
 
 	MatchingConfig struct {

--- a/simulation/history/history_simulation_test.go
+++ b/simulation/history/history_simulation_test.go
@@ -147,29 +147,39 @@ func (s *HistorySimulationSuite) TearDownSuite() {
 	s.TearDownBaseSuite()
 }
 
+func (s *HistorySimulationSuite) getSimulationConfig() host.HistorySimulationConfig {
+	cfg := s.TestClusterConfig.HistoryConfig.SimulationConfig
+
+	if cfg.NumWorkflows == 0 {
+		cfg.NumWorkflows = 100
+	}
+
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 5 * time.Minute
+	}
+
+	if cfg.SleepAfterAllWorkflows == 0 {
+		cfg.SleepAfterAllWorkflows = 120 * time.Second
+	}
+
+	return cfg
+}
+
 func (s *HistorySimulationSuite) TestHistorySimulation() {
-	simCfg := s.TestClusterConfig.HistoryConfig.SimulationConfig
 
-	numWorkflows := simCfg.NumWorkflows
-	if numWorkflows == 0 {
-		numWorkflows = 100
-	}
-	timeout := simCfg.Timeout
-	if timeout == 0 {
-		timeout = 5 * time.Minute
-	}
+	cfg := s.getSimulationConfig()
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout)
 	defer cancel()
 
 	var runs []client.WorkflowRun
-	for i := 0; i < numWorkflows; i++ {
+	for i := 0; i < cfg.NumWorkflows; i++ {
 		workflowOptions := client.StartWorkflowOptions{
 			TaskList:                        s.taskList,
 			ExecutionStartToCloseTimeout:    120 * time.Second,
 			DecisionTaskStartToCloseTimeout: 5 * time.Second,
 		}
-		we, err := s.wfClient.ExecuteWorkflow(ctx, workflowOptions, workflow.SimulationWorkflow, simCfg.NumWorkflowSleeps)
+		we, err := s.wfClient.ExecuteWorkflow(ctx, workflowOptions, workflow.SimulationWorkflow, cfg.NumWorkflowSleeps)
 		if err != nil {
 			s.Logger.Fatal("Start workflow with err", tag.Error(err))
 		}
@@ -177,15 +187,11 @@ func (s *HistorySimulationSuite) TestHistorySimulation() {
 		s.True(we.GetRunID() != "")
 		s.Logger.Info("successfully start a workflow", tag.WorkflowID(we.GetID()), tag.WorkflowRunID(we.GetRunID()))
 		runs = append(runs, we)
-		time.Sleep(simCfg.SleepBetweenWorkflowStarts)
+		time.Sleep(cfg.SleepBetweenWorkflowStarts)
 	}
 	for _, we := range runs {
 		s.NoError(we.Get(ctx, nil))
 	}
 
-	sleepAfter := simCfg.SleepAfterAllWorkflows
-	if sleepAfter == 0 {
-		sleepAfter = 120 * time.Second
-	}
-	time.Sleep(sleepAfter)
+	time.Sleep(cfg.SleepAfterAllWorkflows)
 }

--- a/simulation/history/history_simulation_test.go
+++ b/simulation/history/history_simulation_test.go
@@ -148,17 +148,28 @@ func (s *HistorySimulationSuite) TearDownSuite() {
 }
 
 func (s *HistorySimulationSuite) TestHistorySimulation() {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	simCfg := s.TestClusterConfig.HistoryConfig.SimulationConfig
+
+	numWorkflows := simCfg.NumWorkflows
+	if numWorkflows == 0 {
+		numWorkflows = 100
+	}
+	timeout := simCfg.Timeout
+	if timeout == 0 {
+		timeout = 5 * time.Minute
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
+
 	var runs []client.WorkflowRun
-	for i := 0; i < 100; i++ {
-		// set a short timeout so that timer tasks can be executed before complete
+	for i := 0; i < numWorkflows; i++ {
 		workflowOptions := client.StartWorkflowOptions{
 			TaskList:                        s.taskList,
 			ExecutionStartToCloseTimeout:    120 * time.Second,
 			DecisionTaskStartToCloseTimeout: 5 * time.Second,
 		}
-		we, err := s.wfClient.ExecuteWorkflow(ctx, workflowOptions, workflow.NoopWorkflow)
+		we, err := s.wfClient.ExecuteWorkflow(ctx, workflowOptions, workflow.SimulationWorkflow, simCfg.NumWorkflowSleeps)
 		if err != nil {
 			s.Logger.Fatal("Start workflow with err", tag.Error(err))
 		}
@@ -166,9 +177,9 @@ func (s *HistorySimulationSuite) TestHistorySimulation() {
 		s.True(we.GetRunID() != "")
 		s.Logger.Info("successfully start a workflow", tag.WorkflowID(we.GetID()), tag.WorkflowRunID(we.GetRunID()))
 		runs = append(runs, we)
+		time.Sleep(simCfg.SleepBetweenWorkflowStarts)
 	}
 	for _, we := range runs {
 		s.NoError(we.Get(ctx, nil))
 	}
-	time.Sleep(120 * time.Second)
 }

--- a/simulation/history/history_simulation_test.go
+++ b/simulation/history/history_simulation_test.go
@@ -182,4 +182,10 @@ func (s *HistorySimulationSuite) TestHistorySimulation() {
 	for _, we := range runs {
 		s.NoError(we.Get(ctx, nil))
 	}
+
+	sleepAfter := simCfg.SleepAfterAllWorkflows
+	if sleepAfter == 0 {
+		sleepAfter = 120 * time.Second
+	}
+	time.Sleep(sleepAfter)
 }

--- a/simulation/history/workflow/workflow.go
+++ b/simulation/history/workflow/workflow.go
@@ -1,14 +1,19 @@
 package workflow
 
 import (
+	"time"
+
 	"go.uber.org/cadence/worker"
 	"go.uber.org/cadence/workflow"
 )
 
 func RegisterWorker(w worker.Registry) {
-	w.RegisterWorkflow(NoopWorkflow)
+	w.RegisterWorkflow(SimulationWorkflow)
 }
 
-func NoopWorkflow(ctx workflow.Context) error {
+func SimulationWorkflow(ctx workflow.Context, numSleeps int) error {
+	for i := 0; i < numSleeps; i++ {
+		workflow.Sleep(ctx, time.Second)
+	}
 	return nil
 }


### PR DESCRIPTION
**What changed?**

Added `NumWorkflows`, `Timeout`, `NumWorkflowSleeps`, and `SleepBetweenWorkflowStarts` fields to `HistorySimulationConfig` in `host/onebox.go`. Renamed `NoopWorkflow` to `SimulationWorkflow`, which now accepts a `numSleeps` parameter so each workflow can execute a configurable number of `workflow.Sleep` calls (generating timer tasks). The test reads all values from the scenario config with sensible defaults, replacing previously hardcoded constants. Increased the `go test -timeout` in docker-compose from 300s to 1800s to accommodate heavier scenarios.

**Why?**

The simulation test previously had fixed values: 100 workflows, 5-minute context timeout, a mandatory 120s `time.Sleep` at the end, and a noop workflow with no timer activity. This made it impossible to tune the load profile — number of workflows, timer task volume, and test duration — without editing test code. Making these per-scenario parameters means new scenarios can exercise different queue loads without touching shared test infrastructure.

The simulation is used for checking the Timer Task Read Optimization feature - https://github.com/cadence-workflow/cadence/issues/7953 

**How did you test it?**

```
./simulation/history/run.sh --scenario default --dockerfile-suffix .local
```

Test passed. All created `transfer` tasks were executed. Unexecuted `timer` tasks (types 3 and 4) are expected — they are scheduled beyond the simulation window (next-day retention timers) and are not a failure condition.

**Potential risks**

N/A — changes are confined to simulation test infrastructure. No production code paths affected. The `SimulationWorkflow` rename is backward-compatible within the simulation package; no external callers.

**Release notes**

N/A

**Documentation Changes**

N/A