### PR TITLE
refactor(sql domain-audit): Move domain audit time defaulting to the manager

### DIFF
--- a/common/persistence/sql/sql_domain_audit_store.go
+++ b/common/persistence/sql/sql_domain_audit_store.go
@@ -93,16 +93,13 @@ func (m *sqlDomainAuditStore) GetDomainAuditLogs(
 	ctx context.Context,
 	request *persistence.GetDomainAuditLogsRequest,
 ) (*persistence.InternalGetDomainAuditLogsResponse, error) {
-	minCreatedTime := time.Unix(0, 0)
-	maxCreatedTime := time.Now().UTC()
-	if request.MinCreatedTime != nil {
-		minCreatedTime = *request.MinCreatedTime
-	}
-	if request.MaxCreatedTime != nil {
-		maxCreatedTime = *request.MaxCreatedTime
+	if request.MinCreatedTime == nil || request.MaxCreatedTime == nil {
+		return nil, &types.InternalServiceError{
+			Message: "GetDomainAuditLogs requires non-nil MinCreatedTime and MaxCreatedTime",
+		}
 	}
 
-	pageMaxCreatedTime := maxCreatedTime
+	pageMaxCreatedTime := *request.MaxCreatedTime
 	// if next page token is not present, set pageMinEventID to largest possible uuid
 	// to prevent the query from returning rows where created_time is equal to pageMaxCreatedTime
 	pageMinEventID := "ffffffff-ffff-ffff-ffff-ffffffffffff"
@@ -118,7 +115,7 @@ func (m *sqlDomainAuditStore) GetDomainAuditLogs(
 	filter := &sqlplugin.DomainAuditLogFilter{
 		DomainID:           request.DomainID,
 		OperationType:      request.OperationType,
-		MinCreatedTime:     &minCreatedTime,
+		MinCreatedTime:     request.MinCreatedTime,
 		PageSize:           request.PageSize,
 		PageMaxCreatedTime: &pageMaxCreatedTime,
 		PageMinEventID:     &pageMinEventID,

--- a/common/persistence/sql/sql_domain_audit_store_test.go
+++ b/common/persistence/sql/sql_domain_audit_store_test.go
@@ -354,8 +354,10 @@ func TestGetDomainAuditLogs(t *testing.T) {
 				dbMock.EXPECT().SelectFromDomainAuditLogs(ctx, gomock.Any()).Return(rows, nil).Times(1)
 			},
 			request: &persistence.GetDomainAuditLogsRequest{
-				DomainID: "d2222222-2222-2222-2222-222222222222",
-				PageSize: 10,
+				DomainID:       "d2222222-2222-2222-2222-222222222222",
+				MinCreatedTime: &minTime,
+				MaxCreatedTime: &maxTime,
+				PageSize:       10,
 			},
 			expectError:   false,
 			expectedCount: 1,
@@ -371,8 +373,10 @@ func TestGetDomainAuditLogs(t *testing.T) {
 				dbMock.EXPECT().SelectFromDomainAuditLogs(ctx, gomock.Any()).Return([]*sqlplugin.DomainAuditLogRow{}, nil).Times(1)
 			},
 			request: &persistence.GetDomainAuditLogsRequest{
-				DomainID: "d3333333-3333-3333-3333-333333333333",
-				PageSize: 10,
+				DomainID:       "d3333333-3333-3333-3333-333333333333",
+				MinCreatedTime: &minTime,
+				MaxCreatedTime: &maxTime,
+				PageSize:       10,
 			},
 			expectError:   false,
 			expectedCount: 0,
@@ -381,14 +385,26 @@ func TestGetDomainAuditLogs(t *testing.T) {
 				assert.Nil(t, resp.NextPageToken)
 			},
 		},
+		"missing time bounds": {
+			setupMock: func(dbMock *sqlplugin.MockDB) {
+				// No DB call expected because the store should reject nil bounds.
+			},
+			request: &persistence.GetDomainAuditLogsRequest{
+				DomainID: "d3333333-3333-3333-3333-333333333333",
+				PageSize: 10,
+			},
+			expectError: true,
+		},
 		"invalid page token": {
 			setupMock: func(dbMock *sqlplugin.MockDB) {
 				// No DB call expected since deserialization should fail first
 			},
 			request: &persistence.GetDomainAuditLogsRequest{
-				DomainID:      "d3333333-3333-3333-3333-333333333333",
-				PageSize:      10,
-				NextPageToken: []byte("invalid-token-data"),
+				DomainID:       "d3333333-3333-3333-3333-333333333333",
+				MinCreatedTime: &minTime,
+				MaxCreatedTime: &maxTime,
+				PageSize:       10,
+				NextPageToken:  []byte("invalid-token-data"),
 			},
 			expectError: true,
 		},
@@ -402,8 +418,10 @@ func TestGetDomainAuditLogs(t *testing.T) {
 				dbMock.EXPECT().IsDupEntryError(err).Return(false).AnyTimes()
 			},
 			request: &persistence.GetDomainAuditLogsRequest{
-				DomainID: "d3333333-3333-3333-3333-333333333333",
-				PageSize: 10,
+				DomainID:       "d3333333-3333-3333-3333-333333333333",
+				MinCreatedTime: &minTime,
+				MaxCreatedTime: &maxTime,
+				PageSize:       10,
 			},
 			expectError: true,
 		},


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Move domain audit time defaulting into the manager for the SQL store. Require non-nil `MinCreatedTime` and `MaxCreatedTime` instead of defaulting them in the store.

This removes the SQL store's internal `time.Now()` usage, passes the manager-provided lower bound directly into the SQL filter, and updates tests to provide explicit bounds and cover missing-bound validation.


**Why?**
https://github.com/cadence-workflow/cadence/issues/6610

**How did you test it?**
unit tests:
```
go test ./common/persistence/sql
```
and integration tests

**Potential risks**


**Release notes**


**Documentation Changes**

