### PR TITLE
fix(frontend): Stop task list global ratelimiter collections on shutdown

### DIFF
--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -371,4 +371,13 @@ func (s *Service) stopRatelimiters() {
 	if err := s.ratelimiterCollections.async.OnStop(ctx); err != nil {
 		s.GetLogger().Error("failed to stop async global ratelimiter collection", tag.Error(err))
 	}
+	if err := s.ratelimiterCollections.userTaskList.OnStop(ctx); err != nil {
+		s.GetLogger().Error("failed to stop user task list global ratelimiter collection", tag.Error(err))
+	}
+	if err := s.ratelimiterCollections.workerTaskList.OnStop(ctx); err != nil {
+		s.GetLogger().Error("failed to stop worker task list global ratelimiter collection", tag.Error(err))
+	}
+	if err := s.ratelimiterCollections.asyncTaskList.OnStop(ctx); err != nil {
+		s.GetLogger().Error("failed to stop async task list global ratelimiter collection", tag.Error(err))
+	}
 }


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Frontend shutdown now stops the task-list global ratelimiter collections

**Why?**
https://github.com/cadence-workflow/cadence/issues/7963
Because the task-list collections were not stopped, their background update loops could continue running after frontend shutdown or test teardown. In integration tests this can surface as logged `too late: update tick` warnings/failures.

**How did you test it?**
```
go test -json ./host -race -timeout 20m -persistenceType=sql -sqlPluginName=sqlite
```

**Potential risks**


**Release notes**


**Documentation Changes**

