### PR TITLE
ci: Pin cassandra-driver and cqlsh to an old version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,8 @@ CMD /start-cadence.sh
 FROM cadence-server AS cadence-auto-setup
 
 RUN apk add --update --no-cache ca-certificates py3-pip mysql-client
-RUN pip3 install setuptools wheel && pip3 install cqlsh && cqlsh --version
+RUN pip3 install setuptools wheel
+RUN pip3 install cassandra-driver==3.29.3 && pip3 install cqlsh==6.2.1 && cqlsh --version
 
 COPY docker/start.sh /start.sh
 COPY docker/domain /etc/cadence/domain


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Pin cassandra-driver and cqlsh to an old version

**Why?**
The new version breaks our Dockerfile thus our CI

**How did you test it?**


**Potential risks**
No.

**Release notes**
N/A

**Documentation Changes**
N/A
