### PR TITLE
feat(metrics): Define and emit scheduler activity metrics

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -3088,18 +3088,18 @@ const (
 	DiagnosticsWorkflowExecutionLatency
 
 	// Scheduler activity metrics
-	// SchedulerFireStartedCount measures successfully started target workflows
-	SchedulerFireStartedCount
-	// SchedulerFireSkippedCount measures fires skipped due to overlap policy
-	SchedulerFireSkippedCount
-	// SchedulerFireErrorCount measures fire activity failures
-	SchedulerFireErrorCount
-	// SchedulerFireLatency measures end-to-end latency from scheduled time to StartWorkflow completion
-	SchedulerFireLatency
-	// SchedulerOverlapCancelCount measures times the CancelPrevious overlap policy was applied
-	SchedulerOverlapCancelCount
-	// SchedulerOverlapTerminateCount measures times the TerminatePrevious overlap policy was applied
-	SchedulerOverlapTerminateCount
+	// SchedulerFireStartedCountPerDomain measures successfully started target workflows; use trigger_source to differentiate schedule vs backfill rates.
+	SchedulerFireStartedCountPerDomain
+	// SchedulerFireSkippedCountPerDomain measures fires skipped due to overlap policy.
+	SchedulerFireSkippedCountPerDomain
+	// SchedulerFireErrorCountPerDomain measures fire activity failures (will be retried by SDK).
+	SchedulerFireErrorCountPerDomain
+	// SchedulerFireLatencyPerDomainHistogram measures end-to-end latency from scheduled time to StartWorkflow completion.
+	SchedulerFireLatencyPerDomainHistogram
+	// SchedulerOverlapCancelCountPerDomain measures times the CancelPrevious overlap policy was applied.
+	SchedulerOverlapCancelCountPerDomain
+	// SchedulerOverlapTerminateCountPerDomain measures times the TerminatePrevious overlap policy was applied.
+	SchedulerOverlapTerminateCountPerDomain
 
 	NumWorkerMetrics
 )
@@ -3961,12 +3961,12 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 		DiagnosticsWorkflowStartedCount:               {metricName: "diagnostics_workflow_count", metricType: Counter},
 		DiagnosticsWorkflowSuccess:                    {metricName: "diagnostics_workflow_success", metricType: Counter},
 		DiagnosticsWorkflowExecutionLatency:           {metricName: "diagnostics_workflow_execution_latency", metricType: Timer},
-		SchedulerFireStartedCount:                     {metricName: "scheduler_fire_started_per_domain", metricType: Counter},
-		SchedulerFireSkippedCount:                     {metricName: "scheduler_fire_skipped_per_domain", metricType: Counter},
-		SchedulerFireErrorCount:                       {metricName: "scheduler_fire_error_per_domain", metricType: Counter},
-		SchedulerFireLatency:                          {metricName: "scheduler_fire_latency_per_domain_ns", metricType: Histogram, exponentialBuckets: Default1ms100s},
-		SchedulerOverlapCancelCount:                   {metricName: "scheduler_overlap_cancel_per_domain", metricType: Counter},
-		SchedulerOverlapTerminateCount:                {metricName: "scheduler_overlap_terminate_per_domain", metricType: Counter},
+		SchedulerFireStartedCountPerDomain:            {metricName: "scheduler_fire_started_per_domain", metricType: Counter},
+		SchedulerFireSkippedCountPerDomain:            {metricName: "scheduler_fire_skipped_per_domain", metricType: Counter},
+		SchedulerFireErrorCountPerDomain:              {metricName: "scheduler_fire_error_per_domain", metricType: Counter},
+		SchedulerFireLatencyPerDomainHistogram:        {metricName: "scheduler_fire_latency_per_domain_ns", metricType: Histogram, exponentialBuckets: Default1ms100s},
+		SchedulerOverlapCancelCountPerDomain:          {metricName: "scheduler_overlap_cancel_per_domain", metricType: Counter},
+		SchedulerOverlapTerminateCountPerDomain:       {metricName: "scheduler_overlap_terminate_per_domain", metricType: Counter},
 	},
 	ShardDistributor: {
 		ShardDistributorRequests:                        {metricName: "shard_distributor_requests", metricType: Counter},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1517,6 +1517,8 @@ const (
 	AsyncWorkflowConsumerScope
 	// DiagnosticsWorkflowScope is scope used by diagnostics workflow
 	DiagnosticsWorkflowScope
+	// SchedulerActivityScope is scope used by the scheduler fire activity
+	SchedulerActivityScope
 
 	NumWorkerScopes
 )
@@ -2243,6 +2245,7 @@ var ScopeDefs = map[ServiceIdx]map[ScopeIdx]scopeDefinition{
 		ESAnalyzerScope:                        {operation: "ESAnalyzer"},
 		AsyncWorkflowConsumerScope:             {operation: "AsyncWorkflowConsumer"},
 		DiagnosticsWorkflowScope:               {operation: "DiagnosticsWorkflow"},
+		SchedulerActivityScope:                 {operation: "SchedulerActivity"},
 	},
 	ShardDistributor: {
 		ShardDistributorGetShardOwnerScope:                         {operation: "GetShardOwner"},
@@ -3083,6 +3086,20 @@ const (
 	DiagnosticsWorkflowStartedCount
 	DiagnosticsWorkflowSuccess
 	DiagnosticsWorkflowExecutionLatency
+
+	// Scheduler activity metrics
+	// SchedulerFireStartedCount measures successfully started target workflows
+	SchedulerFireStartedCount
+	// SchedulerFireSkippedCount measures fires skipped due to overlap policy
+	SchedulerFireSkippedCount
+	// SchedulerFireErrorCount measures fire activity failures
+	SchedulerFireErrorCount
+	// SchedulerFireLatency measures end-to-end latency from scheduled time to StartWorkflow completion
+	SchedulerFireLatency
+	// SchedulerOverlapCancelCount measures times the CancelPrevious overlap policy was applied
+	SchedulerOverlapCancelCount
+	// SchedulerOverlapTerminateCount measures times the TerminatePrevious overlap policy was applied
+	SchedulerOverlapTerminateCount
 
 	NumWorkerMetrics
 )
@@ -3944,6 +3961,12 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 		DiagnosticsWorkflowStartedCount:               {metricName: "diagnostics_workflow_count", metricType: Counter},
 		DiagnosticsWorkflowSuccess:                    {metricName: "diagnostics_workflow_success", metricType: Counter},
 		DiagnosticsWorkflowExecutionLatency:           {metricName: "diagnostics_workflow_execution_latency", metricType: Timer},
+		SchedulerFireStartedCount:                     {metricName: "scheduler_fire_started_per_domain", metricType: Counter},
+		SchedulerFireSkippedCount:                     {metricName: "scheduler_fire_skipped_per_domain", metricType: Counter},
+		SchedulerFireErrorCount:                       {metricName: "scheduler_fire_error_per_domain", metricType: Counter},
+		SchedulerFireLatency:                          {metricName: "scheduler_fire_latency_per_domain_ns", metricType: Histogram, exponentialBuckets: Default1ms100s},
+		SchedulerOverlapCancelCount:                   {metricName: "scheduler_overlap_cancel_per_domain", metricType: Counter},
+		SchedulerOverlapTerminateCount:                {metricName: "scheduler_overlap_terminate_per_domain", metricType: Counter},
 	},
 	ShardDistributor: {
 		ShardDistributorRequests:                        {metricName: "shard_distributor_requests", metricType: Counter},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -3090,15 +3090,15 @@ const (
 	// Scheduler activity metrics
 	// SchedulerFireStartedCountPerDomain measures successfully started target workflows; use trigger_source to differentiate schedule vs backfill rates.
 	SchedulerFireStartedCountPerDomain
-	// SchedulerFireSkippedCountPerDomain measures fires skipped due to overlap policy.
+	// SchedulerFireSkippedCountPerDomain measures fires skipped due to overlap policy or WorkflowExecutionAlreadyStartedError.
 	SchedulerFireSkippedCountPerDomain
 	// SchedulerFireErrorCountPerDomain measures fire activity failures (will be retried by SDK).
 	SchedulerFireErrorCountPerDomain
-	// SchedulerFireLatencyPerDomainHistogram measures end-to-end latency from scheduled time to StartWorkflow completion.
+	// SchedulerFireLatencyPerDomainHistogram measures scheduler lag from cron-intended fire time to StartWorkflow completion. Schedule fires only; backfill excluded.
 	SchedulerFireLatencyPerDomainHistogram
-	// SchedulerOverlapCancelCountPerDomain measures times the CancelPrevious overlap policy was applied.
+	// SchedulerOverlapCancelCountPerDomain measures confirmed cancels under CancelPrevious policy; excludes workflows already gone.
 	SchedulerOverlapCancelCountPerDomain
-	// SchedulerOverlapTerminateCountPerDomain measures times the TerminatePrevious overlap policy was applied.
+	// SchedulerOverlapTerminateCountPerDomain measures confirmed terminates under TerminatePrevious policy; excludes workflows already gone.
 	SchedulerOverlapTerminateCountPerDomain
 
 	NumWorkerMetrics

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -3090,8 +3090,12 @@ const (
 	// Scheduler activity metrics
 	// SchedulerFireStartedCountPerDomain measures successfully started target workflows; use trigger_source to differentiate schedule vs backfill rates.
 	SchedulerFireStartedCountPerDomain
-	// SchedulerFireSkippedCountPerDomain measures fires skipped due to overlap policy or WorkflowExecutionAlreadyStartedError.
+	// SchedulerFireSkippedCountPerDomain measures fires dropped entirely under SkipNew overlap policy.
 	SchedulerFireSkippedCountPerDomain
+	// SchedulerFireBufferedCountPerDomain measures fires deferred for sequential execution under the Buffer overlap policy.
+	SchedulerFireBufferedCountPerDomain
+	// SchedulerFireAlreadyRunningCountPerDomain measures fires that lost the race between describe-check and start: a running workflow already owned the workflow ID.
+	SchedulerFireAlreadyRunningCountPerDomain
 	// SchedulerFireErrorCountPerDomain measures fire activity failures (will be retried by SDK).
 	SchedulerFireErrorCountPerDomain
 	// SchedulerFireLatencyPerDomainHistogram measures scheduler lag from cron-intended fire time to StartWorkflow completion. Schedule fires only; backfill excluded.
@@ -3963,6 +3967,8 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 		DiagnosticsWorkflowExecutionLatency:           {metricName: "diagnostics_workflow_execution_latency", metricType: Timer},
 		SchedulerFireStartedCountPerDomain:            {metricName: "scheduler_fire_started_per_domain", metricType: Counter},
 		SchedulerFireSkippedCountPerDomain:            {metricName: "scheduler_fire_skipped_per_domain", metricType: Counter},
+		SchedulerFireBufferedCountPerDomain:           {metricName: "scheduler_fire_buffered_per_domain", metricType: Counter},
+		SchedulerFireAlreadyRunningCountPerDomain:     {metricName: "scheduler_fire_already_running_per_domain", metricType: Counter},
 		SchedulerFireErrorCountPerDomain:              {metricName: "scheduler_fire_error_per_domain", metricType: Counter},
 		SchedulerFireLatencyPerDomainHistogram:        {metricName: "scheduler_fire_latency_per_domain_ns", metricType: Histogram, exponentialBuckets: Default1ms100s},
 		SchedulerOverlapCancelCountPerDomain:          {metricName: "scheduler_overlap_cancel_per_domain", metricType: Counter},

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -400,12 +400,12 @@ func ActiveClusterSelectionStrategyTag(strategy string) Tag {
 
 // OverlapPolicyTag returns a new overlap_policy tag for scheduler metrics.
 func OverlapPolicyTag(value string) Tag {
-	return simpleMetric{key: overlapPolicy, value: value}
+	return metricWithUnknown(overlapPolicy, value)
 }
 
 // TriggerSourceTag returns a new trigger_source tag for scheduler metrics.
 func TriggerSourceTag(value string) Tag {
-	return simpleMetric{key: triggerSource, value: value}
+	return metricWithUnknown(triggerSource, value)
 }
 
 // QueryConsistencyLevelTag returns a new query consistency level tag.

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -80,6 +80,10 @@ const (
 	globalRatelimitIsPrimary      = "is_primary"
 	globalRatelimitCollectionName = "global_ratelimit_collection"
 
+	// scheduler-specific tags
+	overlapPolicy = "overlap_policy"
+	triggerSource = "trigger_source"
+
 	allValue     = "all"
 	unknownValue = "_unknown_"
 )
@@ -392,6 +396,16 @@ func ActiveClusterLookupFnTag(fn string) Tag {
 // ActiveClusterSelectionStrategyTag returns a new active cluster selection strategy tag.
 func ActiveClusterSelectionStrategyTag(strategy string) Tag {
 	return metricWithUnknown("strategy", strategy)
+}
+
+// OverlapPolicyTag returns a new overlap_policy tag for scheduler metrics.
+func OverlapPolicyTag(value string) Tag {
+	return simpleMetric{key: overlapPolicy, value: value}
+}
+
+// TriggerSourceTag returns a new trigger_source tag for scheduler metrics.
+func TriggerSourceTag(value string) Tag {
+	return simpleMetric{key: triggerSource, value: value}
 }
 
 // QueryConsistencyLevelTag returns a new query consistency level tag.

--- a/service/worker/scheduler/activity.go
+++ b/service/worker/scheduler/activity.go
@@ -89,7 +89,7 @@ func processScheduleFireActivity(ctx context.Context, req ProcessFireRequest) (r
 				return result, nil
 			case types.ScheduleOverlapPolicyBuffer:
 				// TODO(overlap-buffer): implement sequential buffered execution
-				scope.Tagged(metrics.OverlapPolicyTag(policy.String()), metrics.TriggerSourceTag(string(req.TriggerSource))).IncCounter(metrics.SchedulerFireSkippedCountPerDomain)
+				scope.Tagged(metrics.OverlapPolicyTag(policy.String()), metrics.TriggerSourceTag(string(req.TriggerSource))).IncCounter(metrics.SchedulerFireBufferedCountPerDomain)
 				result.SkippedDelta = 1
 				result.StartedWorkflow = req.LastStartedWorkflow
 				return result, nil
@@ -134,7 +134,7 @@ func processScheduleFireActivity(ctx context.Context, req ProcessFireRequest) (r
 	if err != nil {
 		var alreadyStarted *types.WorkflowExecutionAlreadyStartedError
 		if errors.As(err, &alreadyStarted) {
-			scope.Tagged(metrics.OverlapPolicyTag(policy.String()), metrics.TriggerSourceTag(string(req.TriggerSource))).IncCounter(metrics.SchedulerFireSkippedCountPerDomain)
+			scope.Tagged(metrics.TriggerSourceTag(string(req.TriggerSource))).IncCounter(metrics.SchedulerFireAlreadyRunningCountPerDomain)
 			result.SkippedDelta = 1
 			result.StartedWorkflow = &RunningWorkflowInfo{
 				WorkflowID: workflowID,

--- a/service/worker/scheduler/activity.go
+++ b/service/worker/scheduler/activity.go
@@ -62,9 +62,10 @@ func processScheduleFireActivity(ctx context.Context, req ProcessFireRequest) (r
 	}
 
 	scope := sc.MetricsClient.Scope(metrics.SchedulerActivityScope, metrics.DomainTag(req.Domain))
-	startTime := time.Now()
 	defer func() {
-		scope.ExponentialHistogram(metrics.SchedulerFireLatencyPerDomainHistogram, time.Since(startTime))
+		if req.TriggerSource == TriggerSourceSchedule {
+			scope.ExponentialHistogram(metrics.SchedulerFireLatencyPerDomainHistogram, time.Since(req.ScheduledTime))
+		}
 		if err != nil {
 			scope.IncCounter(metrics.SchedulerFireErrorCountPerDomain)
 		}
@@ -96,14 +97,20 @@ func processScheduleFireActivity(ctx context.Context, req ProcessFireRequest) (r
 				result.StartedWorkflow = req.LastStartedWorkflow
 				return result, nil
 			case types.ScheduleOverlapPolicyCancelPrevious:
-				scope.IncCounter(metrics.SchedulerOverlapCancelCountPerDomain)
-				if err = cancelWorkflow(ctx, sc.FrontendClient, req.Domain, req.LastStartedWorkflow); err != nil {
+				var cancelled bool
+				if cancelled, err = cancelWorkflow(ctx, sc.FrontendClient, req.Domain, req.LastStartedWorkflow); err != nil {
 					return nil, err
 				}
+				if cancelled {
+					scope.IncCounter(metrics.SchedulerOverlapCancelCountPerDomain)
+				}
 			case types.ScheduleOverlapPolicyTerminatePrevious:
-				scope.IncCounter(metrics.SchedulerOverlapTerminateCountPerDomain)
-				if err = terminateWorkflow(ctx, sc.FrontendClient, req.Domain, req.LastStartedWorkflow); err != nil {
+				var terminated bool
+				if terminated, err = terminateWorkflow(ctx, sc.FrontendClient, req.Domain, req.LastStartedWorkflow); err != nil {
 					return nil, err
+				}
+				if terminated {
+					scope.IncCounter(metrics.SchedulerOverlapTerminateCountPerDomain)
 				}
 			}
 		}
@@ -193,7 +200,7 @@ func isWorkflowRunning(ctx context.Context, client frontend.Client, domain strin
 // but may continue running while it handles cleanup. A brief overlap with the
 // new run is expected. Use TERMINATE_PREVIOUS for a hard guarantee of no
 // concurrent execution.
-func cancelWorkflow(ctx context.Context, client frontend.Client, domain string, wf *RunningWorkflowInfo) error {
+func cancelWorkflow(ctx context.Context, client frontend.Client, domain string, wf *RunningWorkflowInfo) (bool, error) {
 	err := client.RequestCancelWorkflowExecution(ctx, &types.RequestCancelWorkflowExecutionRequest{
 		Domain: domain,
 		WorkflowExecution: &types.WorkflowExecution{
@@ -202,13 +209,16 @@ func cancelWorkflow(ctx context.Context, client frontend.Client, domain string, 
 		},
 		Cause: "schedule overlap policy: CANCEL_PREVIOUS",
 	})
-	if err != nil && !isEntityNotExistsError(err) {
-		return fmt.Errorf("failed to cancel workflow: %w", err)
+	if err != nil {
+		if isEntityNotExistsError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to cancel workflow: %w", err)
 	}
-	return nil
+	return true, nil
 }
 
-func terminateWorkflow(ctx context.Context, client frontend.Client, domain string, wf *RunningWorkflowInfo) error {
+func terminateWorkflow(ctx context.Context, client frontend.Client, domain string, wf *RunningWorkflowInfo) (bool, error) {
 	err := client.TerminateWorkflowExecution(ctx, &types.TerminateWorkflowExecutionRequest{
 		Domain: domain,
 		WorkflowExecution: &types.WorkflowExecution{
@@ -217,10 +227,13 @@ func terminateWorkflow(ctx context.Context, client frontend.Client, domain strin
 		},
 		Reason: "schedule overlap policy: TERMINATE_PREVIOUS",
 	})
-	if err != nil && !isEntityNotExistsError(err) {
-		return fmt.Errorf("failed to terminate workflow: %w", err)
+	if err != nil {
+		if isEntityNotExistsError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to terminate workflow: %w", err)
 	}
-	return nil
+	return true, nil
 }
 
 func buildSearchAttributes(req ProcessFireRequest) *types.SearchAttributes {

--- a/service/worker/scheduler/activity.go
+++ b/service/worker/scheduler/activity.go
@@ -63,9 +63,6 @@ func processScheduleFireActivity(ctx context.Context, req ProcessFireRequest) (r
 
 	scope := sc.MetricsClient.Scope(metrics.SchedulerActivityScope, metrics.DomainTag(req.Domain))
 	defer func() {
-		if req.TriggerSource == TriggerSourceSchedule {
-			scope.ExponentialHistogram(metrics.SchedulerFireLatencyPerDomainHistogram, time.Since(req.ScheduledTime))
-		}
 		if err != nil {
 			scope.IncCounter(metrics.SchedulerFireErrorCountPerDomain)
 		}
@@ -148,7 +145,11 @@ func processScheduleFireActivity(ctx context.Context, req ProcessFireRequest) (r
 		return nil, fmt.Errorf("failed to start workflow: %w", err)
 	}
 
-	scope.Tagged(metrics.TriggerSourceTag(string(req.TriggerSource))).IncCounter(metrics.SchedulerFireStartedCountPerDomain)
+	startedScope := scope.Tagged(metrics.TriggerSourceTag(string(req.TriggerSource)))
+	startedScope.IncCounter(metrics.SchedulerFireStartedCountPerDomain)
+	if req.TriggerSource == TriggerSourceSchedule {
+		startedScope.ExponentialHistogram(metrics.SchedulerFireLatencyPerDomainHistogram, time.Since(req.ScheduledTime))
+	}
 	result.TotalDelta = 1
 	result.StartedWorkflow = &RunningWorkflowInfo{
 		WorkflowID: workflowID,

--- a/service/worker/scheduler/activity.go
+++ b/service/worker/scheduler/activity.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/uber/cadence/client/frontend"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/types"
 )
 
@@ -45,6 +46,7 @@ const schedulerContextKey contextKey = "schedulerContext"
 // schedulerContext is the context passed to activities via BackgroundActivityContext.
 type schedulerContext struct {
 	FrontendClient frontend.Client
+	MetricsClient  metrics.Client
 }
 
 // processScheduleFireActivity is the single activity that handles a schedule fire.
@@ -53,13 +55,22 @@ type schedulerContext struct {
 // Keeping all of this in one activity means the workflow history records a single
 // activity call per fire, so the internal logic can evolve freely without
 // introducing nondeterminism.
-func processScheduleFireActivity(ctx context.Context, req ProcessFireRequest) (*ProcessFireResult, error) {
+func processScheduleFireActivity(ctx context.Context, req ProcessFireRequest) (result *ProcessFireResult, err error) {
 	sc, ok := ctx.Value(schedulerContextKey).(schedulerContext)
 	if !ok {
 		return nil, fmt.Errorf("scheduler context not found in activity context")
 	}
 
-	result := &ProcessFireResult{}
+	scope := sc.MetricsClient.Scope(metrics.SchedulerActivityScope, metrics.DomainTag(req.Domain))
+	startTime := time.Now()
+	defer func() {
+		scope.ExponentialHistogram(metrics.SchedulerFireLatencyPerDomainHistogram, time.Since(startTime))
+		if err != nil {
+			scope.IncCounter(metrics.SchedulerFireErrorCountPerDomain)
+		}
+	}()
+
+	result = &ProcessFireResult{}
 
 	policy := req.OverlapPolicy
 	if policy == types.ScheduleOverlapPolicyInvalid {
@@ -74,20 +85,24 @@ func processScheduleFireActivity(ctx context.Context, req ProcessFireRequest) (*
 		if running {
 			switch policy {
 			case types.ScheduleOverlapPolicySkipNew:
+				scope.Tagged(metrics.OverlapPolicyTag(policy.String()), metrics.TriggerSourceTag(string(req.TriggerSource))).IncCounter(metrics.SchedulerFireSkippedCountPerDomain)
 				result.SkippedDelta = 1
 				result.StartedWorkflow = req.LastStartedWorkflow
 				return result, nil
 			case types.ScheduleOverlapPolicyBuffer:
 				// TODO(overlap-buffer): implement sequential buffered execution
+				scope.Tagged(metrics.OverlapPolicyTag(policy.String()), metrics.TriggerSourceTag(string(req.TriggerSource))).IncCounter(metrics.SchedulerFireSkippedCountPerDomain)
 				result.SkippedDelta = 1
 				result.StartedWorkflow = req.LastStartedWorkflow
 				return result, nil
 			case types.ScheduleOverlapPolicyCancelPrevious:
-				if err := cancelWorkflow(ctx, sc.FrontendClient, req.Domain, req.LastStartedWorkflow); err != nil {
+				scope.IncCounter(metrics.SchedulerOverlapCancelCountPerDomain)
+				if err = cancelWorkflow(ctx, sc.FrontendClient, req.Domain, req.LastStartedWorkflow); err != nil {
 					return nil, err
 				}
 			case types.ScheduleOverlapPolicyTerminatePrevious:
-				if err := terminateWorkflow(ctx, sc.FrontendClient, req.Domain, req.LastStartedWorkflow); err != nil {
+				scope.IncCounter(metrics.SchedulerOverlapTerminateCountPerDomain)
+				if err = terminateWorkflow(ctx, sc.FrontendClient, req.Domain, req.LastStartedWorkflow); err != nil {
 					return nil, err
 				}
 			}
@@ -115,6 +130,7 @@ func processScheduleFireActivity(ctx context.Context, req ProcessFireRequest) (*
 	if err != nil {
 		var alreadyStarted *types.WorkflowExecutionAlreadyStartedError
 		if errors.As(err, &alreadyStarted) {
+			scope.Tagged(metrics.OverlapPolicyTag(policy.String()), metrics.TriggerSourceTag(string(req.TriggerSource))).IncCounter(metrics.SchedulerFireSkippedCountPerDomain)
 			result.SkippedDelta = 1
 			result.StartedWorkflow = &RunningWorkflowInfo{
 				WorkflowID: workflowID,
@@ -125,6 +141,7 @@ func processScheduleFireActivity(ctx context.Context, req ProcessFireRequest) (*
 		return nil, fmt.Errorf("failed to start workflow: %w", err)
 	}
 
+	scope.Tagged(metrics.TriggerSourceTag(string(req.TriggerSource))).IncCounter(metrics.SchedulerFireStartedCountPerDomain)
 	result.TotalDelta = 1
 	result.StartedWorkflow = &RunningWorkflowInfo{
 		WorkflowID: workflowID,

--- a/service/worker/scheduler/activity_test.go
+++ b/service/worker/scheduler/activity_test.go
@@ -40,8 +40,8 @@ import (
 // testScope is a metrics.Scope that records which MetricIdx counters and histograms were hit.
 type testScope struct {
 	metrics.Scope // delegates untracked methods to NoopScope
-	counters   map[metrics.MetricIdx]int64
-	histograms map[metrics.MetricIdx]int64
+	counters      map[metrics.MetricIdx]int64
+	histograms    map[metrics.MetricIdx]int64
 }
 
 func newTestScope() *testScope {
@@ -326,7 +326,7 @@ func TestProcessScheduleFireActivity(t *testing.T) {
 			},
 		},
 		{
-			name: "AlreadyStartedError returns already running workflow",
+			name: "AlreadyStartedError returns skipped with RunID",
 			req:  baseReq,
 			setupMock: func(m *frontend.MockClient) {
 				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
@@ -338,25 +338,6 @@ func TestProcessScheduleFireActivity(t *testing.T) {
 			wantResult: &ProcessFireResult{
 				SkippedDelta:    1,
 				StartedWorkflow: &RunningWorkflowInfo{WorkflowID: expectedWfID, RunID: "existing-run"},
-			},
-		},
-		{
-			name: "BUFFER defers fire when previous is running",
-			req: func() ProcessFireRequest {
-				r := baseReq
-				r.OverlapPolicy = types.ScheduleOverlapPolicyBuffer
-				r.LastStartedWorkflow = &RunningWorkflowInfo{WorkflowID: "old-wf", RunID: "old-run"}
-				return r
-			}(),
-			setupMock: func(m *frontend.MockClient) {
-				m.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
-					Return(&types.DescribeWorkflowExecutionResponse{
-						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{CloseStatus: nil},
-					}, nil)
-			},
-			wantResult: &ProcessFireResult{
-				SkippedDelta:    1,
-				StartedWorkflow: &RunningWorkflowInfo{WorkflowID: "old-wf", RunID: "old-run"},
 			},
 		},
 		{

--- a/service/worker/scheduler/activity_test.go
+++ b/service/worker/scheduler/activity_test.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/uber/cadence/client/frontend"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/types"
 )
 
@@ -349,6 +350,7 @@ func TestProcessScheduleFireActivity(t *testing.T) {
 			} else {
 				ctx = context.WithValue(context.Background(), schedulerContextKey, schedulerContext{
 					FrontendClient: mockClient,
+					MetricsClient:  metrics.NewNoopMetricsClient(),
 				})
 			}
 

--- a/service/worker/scheduler/activity_test.go
+++ b/service/worker/scheduler/activity_test.go
@@ -37,6 +37,40 @@ import (
 	"github.com/uber/cadence/common/types"
 )
 
+// testScope is a metrics.Scope that records which MetricIdx counters and histograms were hit.
+type testScope struct {
+	metrics.Scope // delegates untracked methods to NoopScope
+	counters   map[metrics.MetricIdx]int64
+	histograms map[metrics.MetricIdx]int64
+}
+
+func newTestScope() *testScope {
+	return &testScope{
+		Scope:      metrics.NoopScope,
+		counters:   make(map[metrics.MetricIdx]int64),
+		histograms: make(map[metrics.MetricIdx]int64),
+	}
+}
+
+func (s *testScope) IncCounter(idx metrics.MetricIdx)                            { s.counters[idx]++ }
+func (s *testScope) ExponentialHistogram(idx metrics.MetricIdx, d time.Duration) { s.histograms[idx]++ }
+func (s *testScope) Tagged(tags ...metrics.Tag) metrics.Scope                    { return s }
+
+// testMetricsClient implements metrics.Client and returns testScope from Scope().
+type testMetricsClient struct {
+	metrics.Client
+	scope *testScope
+}
+
+func newTestMetricsClient() (*testMetricsClient, *testScope) {
+	s := newTestScope()
+	return &testMetricsClient{Client: metrics.NoopClient, scope: s}, s
+}
+
+func (c *testMetricsClient) Scope(scopeIdx metrics.ScopeIdx, tags ...metrics.Tag) metrics.Scope {
+	return c.scope
+}
+
 func TestGenerateWorkflowID(t *testing.T) {
 	ts := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 	tests := []struct {
@@ -292,7 +326,7 @@ func TestProcessScheduleFireActivity(t *testing.T) {
 			},
 		},
 		{
-			name: "AlreadyStartedError returns skipped with RunID",
+			name: "AlreadyStartedError returns already running workflow",
 			req:  baseReq,
 			setupMock: func(m *frontend.MockClient) {
 				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
@@ -304,6 +338,25 @@ func TestProcessScheduleFireActivity(t *testing.T) {
 			wantResult: &ProcessFireResult{
 				SkippedDelta:    1,
 				StartedWorkflow: &RunningWorkflowInfo{WorkflowID: expectedWfID, RunID: "existing-run"},
+			},
+		},
+		{
+			name: "BUFFER defers fire when previous is running",
+			req: func() ProcessFireRequest {
+				r := baseReq
+				r.OverlapPolicy = types.ScheduleOverlapPolicyBuffer
+				r.LastStartedWorkflow = &RunningWorkflowInfo{WorkflowID: "old-wf", RunID: "old-run"}
+				return r
+			}(),
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{CloseStatus: nil},
+					}, nil)
+			},
+			wantResult: &ProcessFireResult{
+				SkippedDelta:    1,
+				StartedWorkflow: &RunningWorkflowInfo{WorkflowID: "old-wf", RunID: "old-run"},
 			},
 		},
 		{
@@ -451,4 +504,279 @@ func TestIsEntityNotExistsError(t *testing.T) {
 
 func formatTime(t time.Time) string {
 	return t.UTC().Format(time.RFC3339)
+}
+
+func TestProcessScheduleFireActivityMetrics(t *testing.T) {
+	scheduledTime := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	int32Ptr := func(v int32) *int32 { return &v }
+
+	baseReq := ProcessFireRequest{
+		Domain:     "test-domain",
+		ScheduleID: "sched-1",
+		Action: types.StartWorkflowAction{
+			WorkflowType:                        &types.WorkflowType{Name: "my-workflow"},
+			TaskList:                            &types.TaskList{Name: "my-tasklist"},
+			Input:                               []byte(`{"key":"value"}`),
+			WorkflowIDPrefix:                    "my-prefix",
+			ExecutionStartToCloseTimeoutSeconds: int32Ptr(3600),
+			TaskStartToCloseTimeoutSeconds:      int32Ptr(60),
+		},
+		ScheduledTime: scheduledTime,
+		TriggerSource: TriggerSourceSchedule,
+		OverlapPolicy: types.ScheduleOverlapPolicySkipNew,
+	}
+
+	tests := []struct {
+		name          string
+		req           ProcessFireRequest
+		setupMock     func(m *frontend.MockClient)
+		wantCounters  []metrics.MetricIdx
+		wantNoCounter []metrics.MetricIdx
+	}{
+		{
+			name: "successful start emits started counter",
+			req:  baseReq,
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.StartWorkflowExecutionResponse{RunID: "run-1"}, nil)
+			},
+			wantCounters: []metrics.MetricIdx{metrics.SchedulerFireStartedCountPerDomain},
+			wantNoCounter: []metrics.MetricIdx{
+				metrics.SchedulerFireSkippedCountPerDomain,
+				metrics.SchedulerFireBufferedCountPerDomain,
+				metrics.SchedulerFireAlreadyRunningCountPerDomain,
+				metrics.SchedulerFireErrorCountPerDomain,
+				metrics.SchedulerOverlapCancelCountPerDomain,
+				metrics.SchedulerOverlapTerminateCountPerDomain,
+			},
+		},
+		{
+			name: "SKIP_NEW overlap emits skipped counter",
+			req: func() ProcessFireRequest {
+				r := baseReq
+				r.OverlapPolicy = types.ScheduleOverlapPolicySkipNew
+				r.LastStartedWorkflow = &RunningWorkflowInfo{WorkflowID: "old-wf", RunID: "old-run"}
+				return r
+			}(),
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{CloseStatus: nil},
+					}, nil)
+			},
+			wantCounters: []metrics.MetricIdx{metrics.SchedulerFireSkippedCountPerDomain},
+			wantNoCounter: []metrics.MetricIdx{
+				metrics.SchedulerFireStartedCountPerDomain,
+				metrics.SchedulerFireBufferedCountPerDomain,
+				metrics.SchedulerFireAlreadyRunningCountPerDomain,
+				metrics.SchedulerFireErrorCountPerDomain,
+			},
+		},
+		{
+			name: "BUFFER overlap emits buffered counter",
+			req: func() ProcessFireRequest {
+				r := baseReq
+				r.OverlapPolicy = types.ScheduleOverlapPolicyBuffer
+				r.LastStartedWorkflow = &RunningWorkflowInfo{WorkflowID: "old-wf", RunID: "old-run"}
+				return r
+			}(),
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{CloseStatus: nil},
+					}, nil)
+			},
+			wantCounters: []metrics.MetricIdx{metrics.SchedulerFireBufferedCountPerDomain},
+			wantNoCounter: []metrics.MetricIdx{
+				metrics.SchedulerFireStartedCountPerDomain,
+				metrics.SchedulerFireSkippedCountPerDomain,
+				metrics.SchedulerFireAlreadyRunningCountPerDomain,
+				metrics.SchedulerFireErrorCountPerDomain,
+			},
+		},
+		{
+			name: "AlreadyStartedError emits already running counter",
+			req:  baseReq,
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(nil, &types.WorkflowExecutionAlreadyStartedError{RunID: "existing-run"})
+			},
+			wantCounters: []metrics.MetricIdx{metrics.SchedulerFireAlreadyRunningCountPerDomain},
+			wantNoCounter: []metrics.MetricIdx{
+				metrics.SchedulerFireStartedCountPerDomain,
+				metrics.SchedulerFireSkippedCountPerDomain,
+				metrics.SchedulerFireBufferedCountPerDomain,
+				metrics.SchedulerFireErrorCountPerDomain,
+			},
+		},
+		{
+			name: "start error emits error counter",
+			req:  baseReq,
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("connection refused"))
+			},
+			wantCounters: []metrics.MetricIdx{metrics.SchedulerFireErrorCountPerDomain},
+			wantNoCounter: []metrics.MetricIdx{
+				metrics.SchedulerFireStartedCountPerDomain,
+				metrics.SchedulerFireSkippedCountPerDomain,
+				metrics.SchedulerFireBufferedCountPerDomain,
+				metrics.SchedulerFireAlreadyRunningCountPerDomain,
+			},
+		},
+		{
+			name: "CANCEL_PREVIOUS emits overlap cancel counter",
+			req: func() ProcessFireRequest {
+				r := baseReq
+				r.OverlapPolicy = types.ScheduleOverlapPolicyCancelPrevious
+				r.LastStartedWorkflow = &RunningWorkflowInfo{WorkflowID: "old-wf", RunID: "old-run"}
+				return r
+			}(),
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{CloseStatus: nil},
+					}, nil)
+				m.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.StartWorkflowExecutionResponse{RunID: "new-run"}, nil)
+			},
+			wantCounters: []metrics.MetricIdx{metrics.SchedulerOverlapCancelCountPerDomain},
+			wantNoCounter: []metrics.MetricIdx{
+				metrics.SchedulerFireSkippedCountPerDomain,
+				metrics.SchedulerFireBufferedCountPerDomain,
+				metrics.SchedulerFireAlreadyRunningCountPerDomain,
+				metrics.SchedulerFireErrorCountPerDomain,
+				metrics.SchedulerOverlapTerminateCountPerDomain,
+			},
+		},
+		{
+			name: "TERMINATE_PREVIOUS emits overlap terminate counter",
+			req: func() ProcessFireRequest {
+				r := baseReq
+				r.OverlapPolicy = types.ScheduleOverlapPolicyTerminatePrevious
+				r.LastStartedWorkflow = &RunningWorkflowInfo{WorkflowID: "old-wf", RunID: "old-run"}
+				return r
+			}(),
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{CloseStatus: nil},
+					}, nil)
+				m.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.StartWorkflowExecutionResponse{RunID: "new-run"}, nil)
+			},
+			wantCounters: []metrics.MetricIdx{metrics.SchedulerOverlapTerminateCountPerDomain},
+			wantNoCounter: []metrics.MetricIdx{
+				metrics.SchedulerFireSkippedCountPerDomain,
+				metrics.SchedulerFireBufferedCountPerDomain,
+				metrics.SchedulerFireAlreadyRunningCountPerDomain,
+				metrics.SchedulerFireErrorCountPerDomain,
+				metrics.SchedulerOverlapCancelCountPerDomain,
+			},
+		},
+		{
+			name: "describe error emits error counter",
+			req: func() ProcessFireRequest {
+				r := baseReq
+				r.LastStartedWorkflow = &RunningWorkflowInfo{WorkflowID: "old-wf", RunID: "old-run"}
+				return r
+			}(),
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("connection refused"))
+			},
+			wantCounters: []metrics.MetricIdx{metrics.SchedulerFireErrorCountPerDomain},
+			wantNoCounter: []metrics.MetricIdx{
+				metrics.SchedulerFireStartedCountPerDomain,
+				metrics.SchedulerFireSkippedCountPerDomain,
+				metrics.SchedulerFireBufferedCountPerDomain,
+				metrics.SchedulerFireAlreadyRunningCountPerDomain,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mc, scope := newTestMetricsClient()
+
+			ctrl := gomock.NewController(t)
+			mockClient := frontend.NewMockClient(ctrl)
+			tc.setupMock(mockClient)
+
+			ctx := context.WithValue(context.Background(), schedulerContextKey, schedulerContext{
+				FrontendClient: mockClient,
+				MetricsClient:  mc,
+			})
+			_, _ = processScheduleFireActivity(ctx, tc.req)
+
+			for _, idx := range tc.wantCounters {
+				assert.Positive(t, scope.counters[idx], "expected counter %v to fire", idx)
+			}
+			for _, idx := range tc.wantNoCounter {
+				assert.Zero(t, scope.counters[idx], "expected counter %v NOT to fire", idx)
+			}
+		})
+	}
+}
+
+func TestProcessScheduleFireActivityLatency(t *testing.T) {
+	scheduledTime := time.Now().Add(-5 * time.Second)
+	int32Ptr := func(v int32) *int32 { return &v }
+
+	baseReq := ProcessFireRequest{
+		Domain:     "test-domain",
+		ScheduleID: "sched-1",
+		Action: types.StartWorkflowAction{
+			WorkflowType:                        &types.WorkflowType{Name: "my-workflow"},
+			TaskList:                            &types.TaskList{Name: "my-tasklist"},
+			Input:                               []byte(`{"key":"value"}`),
+			WorkflowIDPrefix:                    "my-prefix",
+			ExecutionStartToCloseTimeoutSeconds: int32Ptr(3600),
+			TaskStartToCloseTimeoutSeconds:      int32Ptr(60),
+		},
+		ScheduledTime: scheduledTime,
+		TriggerSource: TriggerSourceSchedule,
+		OverlapPolicy: types.ScheduleOverlapPolicySkipNew,
+	}
+
+	tests := []struct {
+		name          string
+		triggerSource TriggerSource
+		wantLatency   bool
+	}{
+		{
+			name:          "schedule trigger records latency histogram",
+			triggerSource: TriggerSourceSchedule,
+			wantLatency:   true,
+		},
+		{
+			name:          "backfill trigger does not record latency histogram",
+			triggerSource: TriggerSourceBackfill,
+			wantLatency:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mc, scope := newTestMetricsClient()
+			ctrl := gomock.NewController(t)
+			mockClient := frontend.NewMockClient(ctrl)
+			mockClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+				Return(&types.StartWorkflowExecutionResponse{RunID: "run-1"}, nil)
+
+			req := baseReq
+			req.TriggerSource = tc.triggerSource
+			ctx := context.WithValue(context.Background(), schedulerContextKey, schedulerContext{
+				FrontendClient: mockClient,
+				MetricsClient:  mc,
+			})
+			_, err := processScheduleFireActivity(ctx, req)
+			require.NoError(t, err)
+
+			fired := scope.histograms[metrics.SchedulerFireLatencyPerDomainHistogram] > 0
+			assert.Equal(t, tc.wantLatency, fired)
+		})
+	}
 }

--- a/service/worker/scheduler/client_worker.go
+++ b/service/worker/scheduler/client_worker.go
@@ -37,6 +37,7 @@ import (
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/membership"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/service"
 )
 
@@ -58,6 +59,7 @@ const (
 type BootstrapParams struct {
 	ServiceClient      workflowserviceclient.Interface
 	FrontendClient     frontend.Client
+	MetricsClient      metrics.Client
 	Logger             log.Logger
 	DomainCache        cache.DomainCache
 	MembershipResolver membership.Resolver
@@ -84,6 +86,7 @@ type WorkerManager struct {
 	enabledFn          dynamicproperties.BoolPropertyFn
 	serviceClient      workflowserviceclient.Interface
 	frontendClient     frontend.Client
+	metricsClient      metrics.Client
 	logger             log.Logger
 	domainCache        cache.DomainCache
 	membershipResolver membership.Resolver
@@ -106,6 +109,7 @@ func NewWorkerManager(params *BootstrapParams, enabledFn dynamicproperties.BoolP
 		enabledFn:          enabledFn,
 		serviceClient:      params.ServiceClient,
 		frontendClient:     params.FrontendClient,
+		metricsClient:      params.MetricsClient,
 		logger:             params.Logger.WithTags(tag.ComponentScheduler),
 		domainCache:        params.DomainCache,
 		membershipResolver: params.MembershipResolver,
@@ -277,6 +281,7 @@ func (m *WorkerManager) startWorkerForDomain(domainName string) {
 func (m *WorkerManager) defaultCreateWorker(domainName string) (workerHandle, error) {
 	actCtx := context.WithValue(context.Background(), schedulerContextKey, schedulerContext{
 		FrontendClient: m.frontendClient,
+		MetricsClient:  m.metricsClient,
 	})
 
 	w := cadenceworker.New(m.serviceClient, domainName, TaskListName, cadenceworker.Options{

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -349,6 +349,7 @@ func (s *Service) startSchedulerWorkerManager() *scheduler.WorkerManager {
 	params := &scheduler.BootstrapParams{
 		ServiceClient:      s.params.PublicClient,
 		FrontendClient:     s.GetClientBean().GetFrontendClient(),
+		MetricsClient:      s.GetMetricsClient(),
 		Logger:             s.GetLogger(),
 		DomainCache:        s.GetDomainCache(),
 		MembershipResolver: s.GetMembershipResolver(),


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

- Defined scheduler activity scope and metrics and emit the metrics
- Emit the metrics to measure scheduler activity metrics. [Observability one-pager]( https://docs.google.com/document/d/1tlu4iIz-zfuigmX9YoOF-7bSg-brePPTxzsc67z_RGo/edit?usp=sharing ) [JIRA](https://t3.uberinternal.com/browse/CDNC-18670)

**Why?**

**1. SchedulerFireLatencyPerDomainHistogram**                                                                                                                                                                     
```
- Measures E2E scheduler lag: time from when the cron expression said "fire now" to when StartWorkflowExecution completes
- Main signal for alerting on scheduler health: if this grows, the scheduler is falling behind its cron schedule
- Only emitted for TriggerSourceSchedule (not backfill) bc backfill replays historical timestamps, making time.Since(req.ScheduledTime) meaninglessly large and unrelated to scheduler health    
```             
                                                                                                                                                                                                                     
**2. SchedulerFireStartedCountPerDomain**                                                                                                                                                                     
```
  - Counts successfully started target workflows per domain                                                                                                                                                          
  - Tagged with trigger_source to differentiate normal schedule fires from backfill replays                                                                                                                          
                                                                                                                                                          
```                                                           
**3. schedulerFireSkippedCountPerDomain**                                                                                                                                                                     
```
  - Counts fires that were skipped or buffered due to overlap policy (SkipNew, Buffer) or because the workflow was already started (WorkflowExecutionAlreadyStartedError)                                            
  - Tagged with overlap_policy and trigger_source to identify which policy is causing skips and at what rate  
```
 
**4. SchedulerFireErrorCountPerDomain**                         
```
  - Counts activity failures that will be retried by the SDK
  - Useful for detecting persistent failures or elevated transient error rates per domain    
```                                                                                                                        
                                                                                         
**5. SchedulerOverlapCancelCountPerDomain / SchedulerOverlapTerminateCountPerDomain**                                                                                                                         
```
  - Counts confirmed cancels/terminates of the previous workflow under the CancelPrevious/TerminatePrevious overlap policies                                                                                         
  - Only incremented after the RPC succeeds — EntityNotExistsError (workflow already gone) does not count, so these reflect actual overlap enforcement actions   
```

**How did you test it?**


**Potential risks**
N/A


**Release notes**
N/A

**Documentation Changes**
N/A


----
## Summary by Gitar

- **Metrics updates:**
  - Updated `SchedulerFireLatencyPerDomainHistogram` to calculate latency based on `ScheduledTime` rather than execution start time.
  - Added conditional logic to only emit latency metrics when the `TriggerSource` is `TriggerSourceSchedule`.
- **Refactoring:**
  - Modified `cancelWorkflow` and `terminateWorkflow` to return a success status, ensuring overlap metrics are only incremented upon successful execution.
- **Metric tagging:**
  - Updated `OverlapPolicyTag` and `TriggerSourceTag` in `common/metrics/tags.go` to use `metricWithUnknown` for better tag handling.


<sub>This will update automatically on new commits.</sub>