### PR TITLE
fix(sharddistributor): guard disabledState against Reset after Stop

### DIFF
--- a/service/sharddistributor/client/spectatorclient/clientimpl.go
+++ b/service/sharddistributor/client/spectatorclient/clientimpl.go
@@ -161,6 +161,11 @@ func (s *spectatorImpl) enabledState(ctx context.Context) stateFn {
 }
 
 func (s *spectatorImpl) disabledState(ctx context.Context) stateFn {
+	if ctx.Err() != nil {
+		// shutting down — Reset() would replace doneCh with a new channel
+		// nobody will close, causing Wait() callers to block forever
+		return nil
+	}
 	defer s.logger.Info("Exiting disabled state", tag.ShardNamespace(s.namespace))
 	s.logger.Info("Starting disabled state for namespace", tag.ShardNamespace(s.namespace))
 	// We reset the first state signal to ensure we wait for the first state to be received when we re-enable.


### PR DESCRIPTION
**What changed?**
Added `ctx.Err() != nil` guard at the top of `disabledState()` in `service/sharddistributor/client/spectatorclient/clientimpl.go`, before `firstStateSignal.Reset()`.

**Why?**
`Stop()` cancels the context and calls `firstStateSignal.Done()` (closing the internal `doneCh`), then waits on `stopWG`. If a goroutine transitions into `disabledState()` during shutdown (e.g., returning from `connectState`), it calls `Reset()` — which replaces `doneCh` with a fresh channel that nobody will ever close. Any concurrent `Wait()` caller then blocks forever. The guard short-circuits `disabledState` when shutdown is in progress, preserving the closed `doneCh`.

Detected as a flaky test: `TestWatchLoopDisabled` fired 6× in CI (Jan–Apr 2026).

**How did you test it?**
```
go test -race -count=10 -run TestWatchLoopDisabled \
  ./service/sharddistributor/client/spectatorclient/...
```
10/10 PASS, no race detector output.

**Potential risks**
N/A — single guard clause; no behavior change in the non-shutdown path.

**Release notes**
N/A

**Documentation Changes**
N/A