### PR TITLE
fix(sharddistributor): defer goleak checks in election tests

### DIFF
--- a/service/sharddistributor/leader/election/election_test.go
+++ b/service/sharddistributor/leader/election/election_test.go
@@ -34,7 +34,7 @@ var (
 )
 
 func TestElector_Run(t *testing.T) {
-	goleak.VerifyNone(t)
+	defer goleak.VerifyNone(t)
 
 	ctrl := gomock.NewController(t)
 	logger := testlogger.New(t)
@@ -118,7 +118,7 @@ func TestElector_Run(t *testing.T) {
 }
 
 func TestElector_Run_Resign(t *testing.T) {
-	goleak.VerifyNone(t)
+	defer goleak.VerifyNone(t)
 	t.Run("context_canceled", func(t *testing.T) {
 		leaderChan, p := prepareRun(t, nil, nil)
 		p.election.EXPECT().Resign(gomock.Any()).Return(nil)
@@ -305,7 +305,7 @@ func prepareRun(t *testing.T, onLeader, onResign ProcessFunc) (<-chan bool, runP
 }
 
 func TestOnLeader_Error(t *testing.T) {
-	goleak.VerifyNone(t)
+	defer goleak.VerifyNone(t)
 
 	ctrl := gomock.NewController(t)
 	logger := testlogger.New(t)


### PR DESCRIPTION
**What changed?**
Changed `goleak.VerifyNone(t)` to `defer goleak.VerifyNone(t)` in `TestElector_Run`, `TestElector_Run_Resign`, and `TestOnLeader_Error` in `service/sharddistributor/leader/election/election_test.go`.

**Why?**
Without `defer`, `goleak.VerifyNone(t)` runs at test **start**, checking for goroutines left over by the *previous* test rather than validating cleanup of *this* test. Any goroutine leak in a preceding test in the same package causes these tests to fail spuriously. Adding `defer` moves the check to test end where it belongs.

Detected as a flaky test: `TestElector_Run` fired 5× in CI (Jan–Apr 2026).

**How did you test it?**
```
go test -race -count=10 \
  -run 'TestElector_Run$|TestElector_Run_Resign|TestOnLeader_Error' \
  ./service/sharddistributor/leader/election/...
```
All pass.

**Potential risks**
N/A — test-only change.

**Release notes**
N/A

**Documentation Changes**
N/A