### PR TITLE
fix(history): stop historyEventNotifier before finishing mocks

### DIFF
--- a/service/history/engine/engineimpl/history_engine_test.go
+++ b/service/history/engine/engineimpl/history_engine_test.go
@@ -189,9 +189,9 @@ func (s *engineSuite) SetupTest() {
 }
 
 func (s *engineSuite) TearDownTest() {
+	s.mockHistoryEngine.historyEventNotifier.Stop()
 	s.controller.Finish()
 	s.mockShard.Finish(s.T())
-	s.mockHistoryEngine.historyEventNotifier.Stop()
 }
 
 func (s *engineSuite) TestGetMutableStateSync() {


### PR DESCRIPTION
**What changed?**
Reordered `TearDownTest` in `engineSuite` (`service/history/engine/engineimpl/history_engine_test.go`) to call `historyEventNotifier.Stop()` before `controller.Finish()` and `mockShard.Finish()`.

**Why?**
`historyEventNotifier` is started with `clock.NewRealTimeSource()` and runs background goroutines. The previous order called `controller.Finish()` first, tearing down all mock objects while those goroutines were still running. This caused unexpected mock calls and intermittent test suite failures.

Detected as a flaky test: `TestEngineSuite` fired 3× in CI (Jan–Apr 2026).

**How did you test it?**
```
go test -race -count=3 -run TestEngineSuite \
  ./service/history/engine/engineimpl/...
```
All pass.

**Potential risks**
N/A — test-only change, two lines swapped.

**Release notes**
N/A

**Documentation Changes**
N/A