### PR TITLE
fix(worker): prevent goroutine leak in TestBatchWorkflowV2_TuneSignal

### DIFF
--- a/service/worker/batcher/workflow_v2_test.go
+++ b/service/worker/batcher/workflow_v2_test.go
@@ -185,9 +185,24 @@ func TestBatchWorkflowV2_TuneSignal(t *testing.T) {
 	// activity has confirmed it is running. This avoids relying on the test
 	// framework's 0ms timer mechanism (which uses a wall-clock AfterFunc path
 	// when runningCount > 0 and can occasionally miss the 3-second deadline).
+	//
+	// stopSig is closed by t.Cleanup (registered after firstActivityDone's cleanup,
+	// so it runs first in LIFO order): the goroutine exits via the stopSig arm,
+	// closes sigDone, then firstActivityDone is closed to unblock the activity mock.
+	stopSig := make(chan struct{})
+	sigDone := make(chan struct{})
+	t.Cleanup(func() {
+		close(stopSig) // unblock the goroutine if still waiting
+		<-sigDone      // wait for it to exit before firstActivityDone is closed
+	})
 	go func() {
-		<-firstActivityStarted
-		env.SignalWorkflow(SignalNameTune, TuneSignal{RPS: 20, Concurrency: 5})
+		defer close(sigDone)
+		select {
+		case <-firstActivityStarted:
+			env.SignalWorkflow(SignalNameTune, TuneSignal{RPS: 20, Concurrency: 5})
+		case <-stopSig:
+			// workflow ended before first activity started — nothing to signal
+		}
 	}()
 
 	params := createParams(BatchTypeCancel)


### PR DESCRIPTION
**What changed?**
Replaced the bare `go func() { <-firstActivityStarted; env.SignalWorkflow(...) }()` goroutine with a select on a dedicated `stopSig` channel in `service/worker/batcher/workflow_v2_test.go`. Both `close(stopSig)` and `<-sigDone` live in a single `t.Cleanup` func so LIFO ordering ensures the goroutine exits before `firstActivityDone` is closed.

**Why?**
If `env.ExecuteWorkflow` errors before the first activity runs, `firstActivityStarted` is never sent and the goroutine blocks indefinitely. This orphaned goroutine persists into subsequent tests, causing spurious `goleak.VerifyNone` failures elsewhere. The `stopSig` channel gives the goroutine a guaranteed exit path regardless of workflow outcome.

Detected as a flaky test: `TestBatchWorkflowV2_TuneSignal` fired 2× in CI (Jan–Apr 2026).

**How did you test it?**
```
go test -race -count=5 -run TestBatchWorkflowV2_TuneSignal \
  ./service/worker/batcher/...
```
All pass.

**Potential risks**
N/A — test-only change.

**Release notes**
N/A

**Documentation Changes**
N/A