### PR TITLE
fix(matching): add goroutine leak detection to TestGetTaskListsByDomain

### DIFF
--- a/service/matching/handler/engine_test.go
+++ b/service/matching/handler/engine_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
 
 	"github.com/uber/cadence/client/history"
@@ -66,6 +67,7 @@ func newMockManagerWithTaskListID(ctrl *gomock.Controller, id *tasklist.Identifi
 }
 
 func TestGetTaskListsByDomain(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	testCases := []struct {
 		name           string
 		mockSetup      func(*cache.MockDomainCache, map[tasklist.Identifier]*tasklist.MockManager, map[tasklist.Identifier]*tasklist.MockManager)


### PR DESCRIPTION
**What changed?**
Added `go.uber.org/goleak` import and `defer goleak.VerifyNone(t)` to `TestGetTaskListsByDomain` in `service/matching/handler/engine_test.go`.

**Why?**
This test is fully synchronous (no goroutines spawned). Its 2× flakiness over 3 months likely stems from goroutine pollution by other tests in the same package. Adding the goroutine leak check surfaces such pollution at this test immediately, rather than causing unexplained failures in unrelated tests downstream.

Detected as a flaky test: `TestGetTaskListsByDomain` fired 2× in CI (Jan–Apr 2026).

**How did you test it?**
```
go test -race -count=5 -run TestGetTaskListsByDomain \
  ./service/matching/handler/...
```
All pass.

**Potential risks**
N/A — test-only change.

**Release notes**
N/A

**Documentation Changes**
N/A