### PR TITLE
feat(sharddistributor): add 10-minute timeout to spectator GRPC stream

### DIFF
--- a/service/sharddistributor/client/spectatorclient/clientimpl.go
+++ b/service/sharddistributor/client/spectatorclient/clientimpl.go
@@ -43,9 +43,9 @@ type spectatorImpl struct {
 	scope      tally.Scope
 	logger     log.Logger
 	timeSource clock.TimeSource
-	stream     sharddistributor.WatchNamespaceStateClient
 
 	cancel context.CancelFunc
+	stream *spectatorStream
 	stopWG sync.WaitGroup
 
 	// State storage with lock for thread-safe access
@@ -104,10 +104,7 @@ func (s *spectatorImpl) connectState(ctx context.Context) stateFn {
 		return s.disabledState
 	}
 
-	stream, err := s.client.WatchNamespaceState(ctx, &types.WatchNamespaceStateRequest{
-		Namespace: s.namespace,
-	})
-
+	stream, err := newSpectatorStream(ctx, s.client, s.timeSource, s.namespace)
 	if err != nil {
 		if ctx.Err() != nil {
 			return nil
@@ -127,11 +124,7 @@ func (s *spectatorImpl) connectState(ctx context.Context) stateFn {
 
 func (s *spectatorImpl) enabledState(ctx context.Context) stateFn {
 	defer s.logger.Info("Exiting enabled state", tag.ShardNamespace(s.namespace))
-	defer func() {
-		if err := s.stream.CloseSend(); err != nil {
-			s.logger.Warn("Failed to close stream", tag.Error(err), tag.ShardNamespace(s.namespace))
-		}
-	}()
+	defer s.stream.Close()
 
 	s.logger.Info("Starting enabled state for namespace", tag.ShardNamespace(s.namespace))
 
@@ -147,7 +140,12 @@ func (s *spectatorImpl) enabledState(ctx context.Context) stateFn {
 				return nil
 			}
 
-			s.logger.Warn("Stream error (server issue), will reconnect", tag.Error(err), tag.ShardNamespace(s.namespace))
+			if s.stream.ctx.Err() != nil {
+				s.logger.Info("Stream timeout, will reconnect", tag.ShardNamespace(s.namespace))
+			} else {
+				s.logger.Warn("Stream error (server issue), will reconnect", tag.Error(err), tag.ShardNamespace(s.namespace))
+			}
+
 			if err := s.timeSource.SleepWithContext(ctx, backoff.JitDuration(streamRetryInterval, streamRetryJitterCoeff)); err != nil {
 				return nil
 			}

--- a/service/sharddistributor/client/spectatorclient/clientimpl.go
+++ b/service/sharddistributor/client/spectatorclient/clientimpl.go
@@ -15,6 +15,7 @@ import (
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/sharddistributor/client/clientcommon"
+	"github.com/uber/cadence/service/sharddistributor/client/spectatorclient/metricsconstants"
 	csync "github.com/uber/cadence/service/sharddistributor/client/spectatorclient/sync"
 )
 
@@ -141,9 +142,10 @@ func (s *spectatorImpl) enabledState(ctx context.Context) stateFn {
 			}
 
 			if s.stream.ctx.Err() != nil {
-				s.logger.Info("Stream timeout, will reconnect", tag.ShardNamespace(s.namespace))
+				s.streamReconnectCounter(metricsconstants.StreamReconnectReasonTimeout).Inc(1)
 			} else {
-				s.logger.Warn("Stream error (server issue), will reconnect", tag.Error(err), tag.ShardNamespace(s.namespace))
+				s.streamReconnectCounter(metricsconstants.StreamReconnectReasonError).Inc(1)
+				s.logger.Warn("Stream recv error, will reconnect", tag.Error(err), tag.ShardNamespace(s.namespace))
 			}
 
 			if err := s.timeSource.SleepWithContext(ctx, backoff.JitDuration(streamRetryInterval, streamRetryJitterCoeff)); err != nil {
@@ -237,4 +239,10 @@ func (s *spectatorImpl) GetShardOwner(ctx context.Context, shardKey string) (*Sh
 		ExecutorID: response.Owner,
 		Metadata:   response.Metadata,
 	}, nil
+}
+
+func (s *spectatorImpl) streamReconnectCounter(reason string) tally.Counter {
+	return s.scope.Tagged(map[string]string{
+		metricsconstants.StreamReconnectReasonTagName: reason,
+	}).Counter(metricsconstants.ShardDistributorSpectatorStreamReconnects)
 }

--- a/service/sharddistributor/client/spectatorclient/clientimpl_test.go
+++ b/service/sharddistributor/client/spectatorclient/clientimpl_test.go
@@ -67,8 +67,6 @@ func TestWatchLoopBasicFlow(t *testing.T) {
 		return nil, streamCtx.Err()
 	})
 
-	mockStream.EXPECT().CloseSend().Return(nil)
-
 	ctx := context.Background()
 	err := spectator.Start(ctx)
 	require.NoError(t, err)
@@ -136,8 +134,6 @@ func TestGetShardOwner_CacheMiss_FallbackToRPC(t *testing.T) {
 		return nil, streamCtx.Err()
 	})
 
-	mockStream.EXPECT().CloseSend().Return(nil)
-
 	// Expect RPC fallback for unknown shard
 	mockClient.EXPECT().
 		GetShardOwner(gomock.Any(), &types.GetShardOwnerRequest{
@@ -199,7 +195,6 @@ func TestStreamReconnection(t *testing.T) {
 		Return(mockStream1, nil)
 
 	mockStream1.EXPECT().Recv().Return(nil, errors.New("network error"))
-	mockStream1.EXPECT().CloseSend().Return(nil)
 
 	// Second stream succeeds
 	mockClient.EXPECT().
@@ -218,8 +213,6 @@ func TestStreamReconnection(t *testing.T) {
 		return nil, errors.New("shutdown")
 	})
 
-	mockStream2.EXPECT().CloseSend().Return(nil)
-
 	spectator.Start(context.Background())
 	defer func() {
 		cancelStream()
@@ -227,7 +220,9 @@ func TestStreamReconnection(t *testing.T) {
 	}()
 
 	// Wait for the goroutine to be blocked in Sleep, then advance time
-	mockTimeSource.BlockUntil(1) // Wait for 1 goroutine to be blocked in Sleep
+	// BlockUntil(2) because connectState creates an AfterFunc timer (waiter #1)
+	// and the retry SleepWithContext creates another (waiter #2)
+	mockTimeSource.BlockUntil(2)
 	mockTimeSource.Advance(2 * time.Second)
 
 	require.NoError(t, spectator.firstStateSignal.Wait(context.Background()))

--- a/service/sharddistributor/client/spectatorclient/clientimpl_test.go
+++ b/service/sharddistributor/client/spectatorclient/clientimpl_test.go
@@ -175,6 +175,7 @@ func TestStreamReconnection(t *testing.T) {
 	mockStream1 := sharddistributor.NewMockWatchNamespaceStateClient(ctrl)
 	mockStream2 := sharddistributor.NewMockWatchNamespaceStateClient(ctrl)
 	mockTimeSource := clock.NewMockedTimeSource()
+	testScope := tally.NewTestScope("", nil)
 
 	// Create a context to control when the mock stream should unblock
 	streamCtx, cancelStream := context.WithCancel(context.Background())
@@ -183,7 +184,7 @@ func TestStreamReconnection(t *testing.T) {
 		namespace:        "test-ns",
 		client:           mockClient,
 		logger:           log.NewNoop(),
-		scope:            tally.NoopScope,
+		scope:            testScope,
 		timeSource:       mockTimeSource,
 		firstStateSignal: csync.NewResettableSignal(),
 		enabled:          func() bool { return true },
@@ -226,6 +227,10 @@ func TestStreamReconnection(t *testing.T) {
 	mockTimeSource.Advance(2 * time.Second)
 
 	require.NoError(t, spectator.firstStateSignal.Wait(context.Background()))
+
+	errorReconnects := testScope.Snapshot().Counters()["shard_distributor_spectator_stream_reconnects+reason=error"]
+	require.NotNil(t, errorReconnects)
+	assert.Equal(t, int64(1), errorReconnects.Value())
 }
 
 func TestGetShardOwner_TimeoutBeforeFirstState(t *testing.T) {

--- a/service/sharddistributor/client/spectatorclient/metricsconstants/metrics.go
+++ b/service/sharddistributor/client/spectatorclient/metricsconstants/metrics.go
@@ -7,9 +7,18 @@ const (
 	ShardDistributorSpectatorWatchNamespaceStateOperationTagName = "ShardDistributorSpectatorWatchNamespaceState"
 
 	// Counter metrics
-	ShardDistributorSpectatorClientRequests = "shard_distributor_spectator_client_requests"
-	ShardDistributorSpectatorClientFailures = "shard_distributor_spectator_client_failures"
+	ShardDistributorSpectatorClientRequests   = "shard_distributor_spectator_client_requests"
+	ShardDistributorSpectatorClientFailures   = "shard_distributor_spectator_client_failures"
+	ShardDistributorSpectatorStreamReconnects = "shard_distributor_spectator_stream_reconnects"
 
 	// Timer metrics
 	ShardDistributorSpectatorClientLatency = "shard_distributor_spectator_client_latency"
+
+	// Tag names
+	StreamReconnectReasonTagName = "reason"
+
+	// Tag values for StreamReconnectReasonTagName: timeout is the periodic forced reconnect,
+	// error is an unexpected stream failure (network, server issue, etc.).
+	StreamReconnectReasonTimeout = "timeout"
+	StreamReconnectReasonError   = "error"
 )

--- a/service/sharddistributor/client/spectatorclient/stream.go
+++ b/service/sharddistributor/client/spectatorclient/stream.go
@@ -1,0 +1,53 @@
+package spectatorclient
+
+import (
+	"context"
+	"time"
+
+	"github.com/uber/cadence/client/sharddistributor"
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/types"
+)
+
+const defaultStreamTimeout = 10 * time.Minute
+
+// spectatorStream holds the state for an active GRPC stream.
+// A timer cancels the stream context after a timeout to force reconnection,
+// avoiding network infrastructure silently killing long-lived connections.
+type spectatorStream struct {
+	sharddistributor.WatchNamespaceStateClient
+	ctx    context.Context
+	cancel context.CancelFunc
+	timer  clock.Timer
+}
+
+func newSpectatorStream(
+	ctx context.Context,
+	client sharddistributor.Client,
+	timeSource clock.TimeSource,
+	namespace string,
+) (*spectatorStream, error) {
+	streamCtx, streamCancel := context.WithCancel(ctx)
+	timer := timeSource.AfterFunc(defaultStreamTimeout, streamCancel)
+
+	stream, err := client.WatchNamespaceState(streamCtx, &types.WatchNamespaceStateRequest{
+		Namespace: namespace,
+	})
+	if err != nil {
+		timer.Stop()
+		streamCancel()
+		return nil, err
+	}
+
+	return &spectatorStream{
+		WatchNamespaceStateClient: stream,
+		ctx:                       streamCtx,
+		cancel:                    streamCancel,
+		timer:                     timer,
+	}, nil
+}
+
+func (ss *spectatorStream) Close() {
+	ss.timer.Stop()
+	ss.cancel()
+}

--- a/service/sharddistributor/client/spectatorclient/stream_test.go
+++ b/service/sharddistributor/client/spectatorclient/stream_test.go
@@ -1,0 +1,78 @@
+package spectatorclient
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"go.uber.org/mock/gomock"
+
+	"github.com/uber/cadence/client/sharddistributor"
+	"github.com/uber/cadence/common/clock"
+)
+
+func TestStreamTimesOutAfterDeadline(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	ctrl := gomock.NewController(t)
+	mockClient := sharddistributor.NewMockClient(ctrl)
+	mockStreamClient := sharddistributor.NewMockWatchNamespaceStateClient(ctrl)
+	mockTimeSource := clock.NewMockedTimeSource()
+
+	mockClient.EXPECT().
+		WatchNamespaceState(gomock.Any(), gomock.Any()).
+		Return(mockStreamClient, nil)
+
+	stream, err := newSpectatorStream(context.Background(), mockClient, mockTimeSource, "test-ns")
+	require.NoError(t, err)
+	require.NoError(t, stream.ctx.Err())
+
+	// Advance past the timeout — the timer should cancel the stream context
+	mockTimeSource.BlockUntil(1)
+	mockTimeSource.Advance(defaultStreamTimeout + time.Second)
+
+	// Verify that the stream context is canceled
+	require.Eventually(t, func() bool {
+		return stream.ctx.Err() != nil
+	}, time.Second, time.Millisecond)
+	assert.ErrorIs(t, stream.ctx.Err(), context.Canceled)
+}
+
+func TestStreamCloseStopsTimer(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	ctrl := gomock.NewController(t)
+	mockClient := sharddistributor.NewMockClient(ctrl)
+	mockStreamClient := sharddistributor.NewMockWatchNamespaceStateClient(ctrl)
+	mockTimeSource := clock.NewMockedTimeSource()
+
+	mockClient.EXPECT().
+		WatchNamespaceState(gomock.Any(), gomock.Any()).
+		Return(mockStreamClient, nil)
+
+	stream, err := newSpectatorStream(context.Background(), mockClient, mockTimeSource, "test-ns")
+	require.NoError(t, err)
+
+	stream.Close()
+
+	assert.ErrorIs(t, stream.ctx.Err(), context.Canceled)
+}
+
+func TestStreamCreationFailureCleansUp(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	ctrl := gomock.NewController(t)
+	mockClient := sharddistributor.NewMockClient(ctrl)
+	mockTimeSource := clock.NewMockedTimeSource()
+
+	mockClient.EXPECT().
+		WatchNamespaceState(gomock.Any(), gomock.Any()).
+		Return(nil, assert.AnError)
+
+	stream, err := newSpectatorStream(context.Background(), mockClient, mockTimeSource, "test-ns")
+	assert.Error(t, err)
+	assert.Nil(t, stream)
+}


### PR DESCRIPTION
**What changed?**

Added a 10-minute timeout to the spectator client's GRPC streaming connection. A new `spectatorStream` struct encapsulates the stream lifecycle (context, cancel, timer). Removed the now-unnecessary `CloseSend` call.

**Why?**

Long-lived GRPC streams can be silently killed by network infrastructure (load balancers, proxies). By proactively reconnecting every 10 minutes, we avoid the network layer closing the connection on us.

Uses `context.WithCancel` + `time.AfterFunc` (not `context.WithTimeout`) so the cancellation produces `codes.Canceled` — the same gRPC status as a normal client shutdown, avoiding distinct error codes in metrics.

`CloseSend` is removed as it is unnecessary for server-streaming RPCs — the client only sends one request, so the half-close is implicit. The context cancel handles the full stream teardown.

**How did you test it?**

Unit tests on `spectatorStream`: timeout fires and cancels context, `Close()` stops timer and cancels context, creation failure cleans up. Existing reconnection and state machine tests updated and passing.

**Potential risks**

Streams now reconnect every 10 minutes instead of staying open indefinitely. Brief gap in state during reconnection, same as existing server-side disconnection behavior.

**Release notes**

N/A

**Documentation Changes**

N/A

https://github.com/cadence-workflow/cadence/issues/6862

----
## Summary by Gitar

- **Added metrics:**
  - Introduced `shard_distributor_spectator_stream_reconnects` counter to track stream reconnections.
  - Added `reason` tag to distinguish between `timeout` and `error` reconnect scenarios.


<sub>This will update automatically on new commits.</sub>