### PR TITLE
fix(matching): fix rate-limiter token waste and CPU spin under low task rates

### DIFF
--- a/service/matching/tasklist/task_reader.go
+++ b/service/matching/tasklist/task_reader.go
@@ -50,7 +50,11 @@ import (
 var epochStartTime = time.Unix(0, 0)
 
 const (
-	defaultTaskBufferIsolationGroup = "" // a task buffer which is not using an isolation group
+	// a task buffer which is not using an isolation group
+	defaultTaskBufferIsolationGroup = ""
+
+	// a buffer to add to the dispatch timeout to have some room even task waits for the whole rate-limit period
+	taskDispatchTimeoutBuffer = 100 * time.Millisecond
 )
 
 type (
@@ -430,7 +434,8 @@ func (tr *taskReader) newDispatchContext(isolationGroup string, isolationDuratio
 func (tr *taskReader) getDispatchTimeout(rps float64, isolationDuration time.Duration) time.Duration {
 	// this is the minimum timeout required to dispatch a task, if the timeout value is smaller than this
 	// async task dispatch can be completely throttled, which could happen when ratePerSecond is pretty low
-	minTimeout := time.Duration(float64(len(tr.taskBuffers))/rps) * time.Second
+	minTimeout := time.Duration((float64)(time.Second*time.Duration(len(tr.taskBuffers)))/rps) + taskDispatchTimeoutBuffer
+
 	// timeout = max (min(asyncDispatchTimeout, isolationDuration), minTimeout)
 	timeout := tr.config.AsyncTaskDispatchTimeout()
 	if timeout > isolationDuration && isolationDuration != noIsolationTimeout {

--- a/service/matching/tasklist/task_reader_test.go
+++ b/service/matching/tasklist/task_reader_test.go
@@ -270,7 +270,8 @@ func TestGetDispatchTimeout(t *testing.T) {
 			isolationDuration: noIsolationTimeout,
 			dispatchRps:       0.1,
 			// rate is divided by 4 isolation groups (plus default buffer) and only one task gets dispatched per 10 seconds
-			expected: 50 * time.Second,
+			// taskDispatchTimeoutBuffer is added to ensure there is room for the rate-limiter wait
+			expected: 50*time.Second + taskDispatchTimeoutBuffer,
 		},
 		{
 			name:              "with isolation - low dispatch rps extends timeout",
@@ -279,7 +280,8 @@ func TestGetDispatchTimeout(t *testing.T) {
 			// rate is divided by 4 isolation groups (plus default buffer) and only one task gets dispatched per 10 seconds
 			// This means taskIsolationDuration is extended, and we don't leak tasks as quickly if the
 			// task list has a very low RPS
-			expected: 50 * time.Second,
+			// taskDispatchTimeoutBuffer is added to ensure there is room for the rate-limiter wait
+			expected: 50*time.Second + taskDispatchTimeoutBuffer,
 		},
 	}
 
@@ -293,7 +295,6 @@ func TestGetDispatchTimeout(t *testing.T) {
 
 			actual := reader.getDispatchTimeout(tc.dispatchRps, tc.isolationDuration)
 			assert.Equal(t, tc.expected, actual)
-
 		})
 	}
 }


### PR DESCRIPTION
----
fix(matching): fix dispatch timeout truncation causing skipped rate-limit intervals

Fixes #7976

**[What changed?]**
Fixed `getDispatchTimeout` in `task_reader.go` and added a `taskDispatchTimeoutBuffer`:

1. The timeout formula was `time.Duration(float64(N)/rps) * time.Second`. For
   rps=0.167 (1 task per ~6 s) and N=1 buffer this evaluates as:
     `time.Duration(5.988...) * time.Second`
   Casting 5.988 to `time.Duration` (int64) truncates it to 5,
   so the result was 5 s instead of the correct ~5.988 s. The fix moves the
   multiplication inside the float expression:
     `time.Duration(float64(N*time.Second) / rps)`
   which preserves sub-second precision correctly.

2. Even with the corrected formula the timeout equalled the rate-limiter period
   exactly, leaving no extra time for the actual dispatch after `Wait()` returned.
   A `taskDispatchTimeoutBuffer` of 100 ms is added so the dispatch context
   always has headroom after the rate-limit token is obtained.

**[Why?]**
With `task_list_activities_per_second=0.167` the dispatch context timed out at
exactly the moment the rate-limiter released a token. The token was already
spent but the subsequent `dispatchTask` call immediately saw a cancelled
context, so the interval was silently skipped. Workflows stalled or timed out
even though the rate-limiter was making forward progress internally.

**[How did you test it?]**
- Updated `TestGetDispatchTimeout` expectations to include `taskDispatchTimeoutBuffer`.

**[Potential risks]**
Core task-dispatch path change. The 100 ms buffer is small relative to any
realistic rate-limit period and is bounded by the task-list cancel context.

Signed-off-by: Jan Kisel <dkrot@uber.com>