### PR TITLE
feat(scheduler): enable scheduler worker by default with per-domain filter

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -2068,11 +2068,12 @@ const (
 	// Default value: true
 	// Allowed filters: N/A
 	EnableBatcher
-	// EnableScheduler decides whether to start the scheduler worker for cron-based scheduling
+	// EnableScheduler decides whether to start the scheduler worker for cron-based scheduling.
+	// Can be filtered by domain to enable/disable per domain.
 	// KeyName: worker.enableScheduler
 	// Value type: Bool
-	// Default value: false
-	// Allowed filters: N/A
+	// Default value: true
+	// Allowed filters: DomainName
 	EnableScheduler
 	// EnableParentClosePolicyWorker decides whether or not enable system workers for processing parent close policy task
 	// KeyName: system.enableParentClosePolicyWorker
@@ -4856,8 +4857,9 @@ var BoolKeys = map[BoolKey]DynamicBool{
 	},
 	EnableScheduler: {
 		KeyName:      "worker.enableScheduler",
-		Description:  "EnableScheduler decides whether to start the scheduler worker for cron-based scheduling",
-		DefaultValue: false,
+		Filters:      []Filter{DomainName},
+		Description:  "EnableScheduler decides whether to start the scheduler worker for cron-based scheduling. Can be filtered by domain to enable/disable per domain.",
+		DefaultValue: true,
 	},
 	EnableParentClosePolicyWorker: {
 		KeyName:      "system.enableParentClosePolicyWorker",

--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -31,6 +31,9 @@ frontend.validSearchAttributes:
 - value:
     BinaryChecksums: 1
     CadenceChangeVersion: 1
+    CadenceScheduleID: 1
+    CadenceScheduleTime: 5
+    CadenceScheduleIsBackfill: 4
     CloseStatus: 2
     CloseTime: 2
     CustomBoolField: 4

--- a/service/worker/scheduler/client_worker.go
+++ b/service/worker/scheduler/client_worker.go
@@ -81,7 +81,7 @@ type workerFactory func(domainName string) (workerHandle, error)
 // workerRedundancyFactor hosts simultaneously so that a single host failure
 // does not cause a scheduling gap.
 type WorkerManager struct {
-	enabledFn          dynamicproperties.BoolPropertyFn
+	enabledFn          dynamicproperties.BoolPropertyFnWithDomainFilter
 	serviceClient      workflowserviceclient.Interface
 	frontendClient     frontend.Client
 	logger             log.Logger
@@ -100,7 +100,7 @@ type WorkerManager struct {
 }
 
 // NewWorkerManager creates a new per-domain scheduler worker manager.
-func NewWorkerManager(params *BootstrapParams, enabledFn dynamicproperties.BoolPropertyFn) *WorkerManager {
+func NewWorkerManager(params *BootstrapParams, enabledFn dynamicproperties.BoolPropertyFnWithDomainFilter) *WorkerManager {
 	ctx, cancel := context.WithCancel(context.Background())
 	wm := &WorkerManager{
 		enabledFn:          enabledFn,
@@ -153,39 +153,17 @@ func (m *WorkerManager) run() {
 	ticker := m.timeSrc.NewTicker(m.refreshInterval)
 	defer ticker.Stop()
 
-	enabled := m.enabledFn()
-	if enabled {
-		m.refreshWorkers()
-	} else {
-		m.logger.Info("scheduler worker manager is disabled, skipping initial refresh")
-	}
+	m.refreshWorkers()
 
 	for {
 		select {
 		case <-ticker.Chan():
-			previouslyEnabled := enabled
-			enabled = m.enabledFn()
-			if enabled != previouslyEnabled {
-				m.logger.Info("scheduler worker manager enabled state changed",
-					tag.Dynamic("enabled", enabled),
-				)
-			}
-
-			if enabled {
-				m.refreshWorkers()
-			} else {
-				m.stopAllWorkers()
-			}
+			m.refreshWorkers()
 
 		case <-m.membershipChangeCh:
 			drainMembershipCh(m.membershipChangeCh)
-			enabled = m.enabledFn()
-			if enabled {
-				m.logger.Debug("membership ring changed, refreshing scheduler workers")
-				m.refreshWorkers()
-			} else {
-				m.stopAllWorkers()
-			}
+			m.logger.Debug("membership ring changed, refreshing scheduler workers")
+			m.refreshWorkers()
 
 		case <-m.ctx.Done():
 			m.logger.Info("scheduler worker manager background loop stopped")
@@ -225,6 +203,10 @@ func (m *WorkerManager) refreshWorkers() {
 		}
 
 		if !containsHost(owners, m.hostInfo) {
+			continue
+		}
+
+		if !m.enabledFn(domainName) {
 			continue
 		}
 

--- a/service/worker/scheduler/client_worker_test.go
+++ b/service/worker/scheduler/client_worker_test.go
@@ -238,8 +238,8 @@ func TestRefreshWorkers_StopsWorkerWhenDomainDisabled(t *testing.T) {
 	defer cancel()
 
 	wm := &WorkerManager{
-		enabledFn: func(domain string) bool { return false },
-		logger:    testlogger.New(t),
+		enabledFn:          func(domain string) bool { return false },
+		logger:             testlogger.New(t),
 		domainCache:        mockDomainCache,
 		membershipResolver: mockResolver,
 		hostInfo:           selfHost,

--- a/service/worker/scheduler/client_worker_test.go
+++ b/service/worker/scheduler/client_worker_test.go
@@ -173,7 +173,7 @@ func TestRefreshWorkers(t *testing.T) {
 			defer cancel()
 
 			wm := &WorkerManager{
-				enabledFn:          dynamicproperties.GetBoolPropertyFn(true),
+				enabledFn:          dynamicproperties.GetBoolPropertyFnFilteredByDomain(true),
 				logger:             testlogger.New(t),
 				domainCache:        mockDomainCache,
 				membershipResolver: mockResolver,
@@ -215,6 +215,52 @@ func TestRefreshWorkers(t *testing.T) {
 	}
 }
 
+func TestRefreshWorkers_StopsWorkerWhenDomainDisabled(t *testing.T) {
+	selfHost := membership.NewDetailedHostInfo("10.0.0.1:7933", "self", nil)
+	otherHost := membership.NewDetailedHostInfo("10.0.0.2:7933", "other", nil)
+	ctrl := gomock.NewController(t)
+
+	mockDomainCache := cache.NewMockDomainCache(ctrl)
+	mockDomainCache.EXPECT().GetAllDomain().Return(map[string]*cache.DomainCacheEntry{
+		"domain-a": cache.NewDomainCacheEntryForTest(
+			&persistence.DomainInfo{Name: "domain-a"},
+			nil, false, nil, 0, nil, 0, 0, 0,
+		),
+	})
+
+	mockResolver := membership.NewMockResolver(ctrl)
+	mockResolver.EXPECT().LookupN(service.Worker, "domain-a", workerRedundancyFactor).Return(
+		[]membership.HostInfo{selfHost, otherHost}, nil,
+	)
+
+	stopped := make(map[string]bool)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wm := &WorkerManager{
+		enabledFn: func(domain string) bool { return false },
+		logger:    testlogger.New(t),
+		domainCache:        mockDomainCache,
+		membershipResolver: mockResolver,
+		hostInfo:           selfHost,
+		activeWorkers:      make(map[string]workerHandle),
+		ctx:                ctx,
+		createWorker: func(domainName string) (workerHandle, error) {
+			t.Fatal("should not start a worker for a disabled domain")
+			return nil, nil
+		},
+	}
+
+	wm.activeWorkers["domain-a"] = &fakeWorker{
+		stopFn: func() { stopped["domain-a"] = true },
+	}
+
+	wm.refreshWorkers()
+
+	assert.Empty(t, wm.activeWorkers, "worker should be removed for disabled domain")
+	assert.True(t, stopped["domain-a"], "worker for disabled domain should have been stopped")
+}
+
 func TestRefreshWorkersHandlesCreateWorkerError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	selfHost := membership.NewDetailedHostInfo("10.0.0.1:7933", "self", nil)
@@ -234,7 +280,7 @@ func TestRefreshWorkersHandlesCreateWorkerError(t *testing.T) {
 	defer cancel()
 
 	wm := &WorkerManager{
-		enabledFn:          dynamicproperties.GetBoolPropertyFn(true),
+		enabledFn:          dynamicproperties.GetBoolPropertyFnFilteredByDomain(true),
 		logger:             testlogger.New(t),
 		domainCache:        mockDomainCache,
 		membershipResolver: mockResolver,
@@ -315,7 +361,7 @@ func TestMembershipChangeTriggersRefresh(t *testing.T) {
 		DomainCache:        mockDomainCache,
 		MembershipResolver: mockResolver,
 		HostInfo:           selfHost,
-	}, dynamicproperties.GetBoolPropertyFn(true))
+	}, dynamicproperties.GetBoolPropertyFnFilteredByDomain(true))
 
 	wm.createWorker = func(domainName string) (workerHandle, error) {
 		return &fakeWorker{}, nil

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -85,7 +85,7 @@ type (
 		PersistenceGlobalMaxQPS             dynamicproperties.IntPropertyFn
 		PersistenceMaxQPS                   dynamicproperties.IntPropertyFn
 		EnableBatcher                       dynamicproperties.BoolPropertyFn
-		EnableScheduler            dynamicproperties.BoolPropertyFnWithDomainFilter
+		EnableScheduler                     dynamicproperties.BoolPropertyFnWithDomainFilter
 		EnableParentClosePolicyWorker       dynamicproperties.BoolPropertyFn
 		NumParentClosePolicySystemWorkflows dynamicproperties.IntPropertyFn
 		EnableFailoverManager               dynamicproperties.BoolPropertyFn
@@ -183,7 +183,7 @@ func NewConfig(params *resource.Params) *Config {
 			ESAnalyzerWorkflowTypeDomains:            dc.GetStringProperty(dynamicproperties.ESAnalyzerWorkflowTypeMetricDomains),
 		},
 		EnableBatcher:                       dc.GetBoolProperty(dynamicproperties.EnableBatcher),
-		EnableScheduler:            dc.GetBoolPropertyFilteredByDomain(dynamicproperties.EnableScheduler),
+		EnableScheduler:                     dc.GetBoolPropertyFilteredByDomain(dynamicproperties.EnableScheduler),
 		EnableParentClosePolicyWorker:       dc.GetBoolProperty(dynamicproperties.EnableParentClosePolicyWorker),
 		NumParentClosePolicySystemWorkflows: dc.GetIntProperty(dynamicproperties.NumParentClosePolicySystemWorkflows),
 		EnableESAnalyzer:                    dc.GetBoolProperty(dynamicproperties.EnableESAnalyzer),

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -85,7 +85,7 @@ type (
 		PersistenceGlobalMaxQPS             dynamicproperties.IntPropertyFn
 		PersistenceMaxQPS                   dynamicproperties.IntPropertyFn
 		EnableBatcher                       dynamicproperties.BoolPropertyFn
-		EnableScheduler                     dynamicproperties.BoolPropertyFn
+		EnableScheduler            dynamicproperties.BoolPropertyFnWithDomainFilter
 		EnableParentClosePolicyWorker       dynamicproperties.BoolPropertyFn
 		NumParentClosePolicySystemWorkflows dynamicproperties.IntPropertyFn
 		EnableFailoverManager               dynamicproperties.BoolPropertyFn
@@ -183,7 +183,7 @@ func NewConfig(params *resource.Params) *Config {
 			ESAnalyzerWorkflowTypeDomains:            dc.GetStringProperty(dynamicproperties.ESAnalyzerWorkflowTypeMetricDomains),
 		},
 		EnableBatcher:                       dc.GetBoolProperty(dynamicproperties.EnableBatcher),
-		EnableScheduler:                     dc.GetBoolProperty(dynamicproperties.EnableScheduler),
+		EnableScheduler:            dc.GetBoolPropertyFilteredByDomain(dynamicproperties.EnableScheduler),
 		EnableParentClosePolicyWorker:       dc.GetBoolProperty(dynamicproperties.EnableParentClosePolicyWorker),
 		NumParentClosePolicySystemWorkflows: dc.GetIntProperty(dynamicproperties.NumParentClosePolicySystemWorkflows),
 		EnableESAnalyzer:                    dc.GetBoolProperty(dynamicproperties.EnableESAnalyzer),
@@ -248,10 +248,8 @@ func (s *Service) Start() {
 		s.ensureDomainExists(constants.BatcherLocalDomainName)
 		s.startBatcher()
 	}
-	if s.config.EnableScheduler() {
-		sm := s.startSchedulerWorkerManager()
-		defer sm.Stop()
-	}
+	sm := s.startSchedulerWorkerManager()
+	defer sm.Stop()
 	if s.config.EnableParentClosePolicyWorker() {
 		s.startParentClosePolicyProcessor()
 	}


### PR DESCRIPTION
## What changed?

Added a domain filter to the existing `worker.enableScheduler` dynamic config property (type changed from `BoolPropertyFn` to `BoolPropertyFnWithDomainFilter`, default `true`). Also registered schedule search attributes in the development dynamic config. Relates to #7664.

## Why?

Two issues:

1. **Scheduler was silently broken** — `worker.enableScheduler` defaulted to `false`, so scheduler workers never started unless operators explicitly overrode it.

2. **No per-domain control** — the global bool was all-or-nothing. Per Shijie's feedback, adding a domain filter allows selective enablement via Flipr domain constraints while keeping the same key name and backward compatibility.

The `WorkerManager` now always starts, and checks `enabledFn(domainName)` for each domain inside `refreshWorkers`. Domains where the property resolves to `false` are skipped.

## How did you test it?

```bash
make build  # all packages compile
go test -race ./service/worker/scheduler/...  # all pass
```

Local end-to-end with SQLite: scheduler worker starts automatically, `schedule create/describe/pause/unpause` all work without any config override.

## Potential risks

Clusters upgrading will start the `WorkerManager` automatically, but it only starts workers for domains where `enableScheduler` resolves to `true`. On clusters with no schedules, the overhead is a single background goroutine with periodic no-op domain scans. Operators can disable per-domain or globally via dynamic config.

## Release notes

The `worker.enableScheduler` property now supports per-domain filtering and defaults to `true`. Schedules work out of the box. Use domain constraints in dynamic config to disable for specific domains.

## Documentation Changes

N/A