### PR TITLE
feat: Configure history task processor interval dynamically

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -3269,6 +3269,13 @@ const (
 	// Allowed filters: DomainID
 	DomainAuditLogTTL
 
+	// HistoryTaskDLQProcessorInterval is the interval for background processing of the History Task DLQ
+	// KeyName: history.historyTaskDLQProcessorInterval
+	// Value type: Duration
+	// Default value: 30m (30 * time.Minute)
+	// Allowed filters: domainName
+	HistoryTaskDLQProcessorInterval
+
 	// LastDurationKey must be the last one in this const group
 	LastDurationKey
 )
@@ -5888,6 +5895,12 @@ var DurationKeys = map[DurationKey]DynamicDuration{
 		Filters:      []Filter{DomainName},
 		Description:  "CorruptionRepairTimeout is the timeout for corruption repair operations",
 		DefaultValue: time.Second * 30,
+	},
+	HistoryTaskDLQProcessorInterval: {
+		KeyName:      "history.historyTaskDLQProcessorInterval",
+		Filters:      []Filter{DomainName},
+		Description:  "HistoryTaskDLQProcessorInterval is the interval for background processing of the History Task DLQ",
+		DefaultValue: time.Minute * 30,
 	},
 }
 

--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -3273,7 +3273,7 @@ const (
 	// KeyName: history.historyTaskDLQProcessorInterval
 	// Value type: Duration
 	// Default value: 30m (30 * time.Minute)
-	// Allowed filters: domainName
+	// Allowed filters: ShardID
 	HistoryTaskDLQProcessorInterval
 
 	// LastDurationKey must be the last one in this const group
@@ -5898,7 +5898,7 @@ var DurationKeys = map[DurationKey]DynamicDuration{
 	},
 	HistoryTaskDLQProcessorInterval: {
 		KeyName:      "history.historyTaskDLQProcessorInterval",
-		Filters:      []Filter{DomainName},
+		Filters:      []Filter{ShardID},
 		Description:  "HistoryTaskDLQProcessorInterval is the interval for background processing of the History Task DLQ",
 		DefaultValue: time.Minute * 30,
 	},


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

Adds a dynamically configurable flag for the interval for processing a domains history task dead letter queue.  

**Why?**

This will allow us to control at the domain level whether the period at which a domain processes its queue. This should mean that in large backlog situations it is possible to decrease the interval and process the queue more quickly.  

**How did you test it?**

N/A

**Potential risks**

N/A

**Release notes**

N/A

**Documentation Changes**

N/A

----
## Summary by Gitar

- **Configuration changes:**
  - Added `HistoryTaskDLQProcessorInterval` dynamic config key with a default interval of 30 minutes.
  - Configured `ShardID` as the valid filter for this new property.

<sub>This will update automatically on new commits.</sub>