### PR TITLE
feat(sharddistributor): inject Start/Stop latency in canary shards

### DIFF
--- a/service/sharddistributor/canary/latencykind/latencykind.go
+++ b/service/sharddistributor/canary/latencykind/latencykind.go
@@ -1,0 +1,110 @@
+// Package latencykind assigns each canary shard a Start/Stop latency kind.
+//
+// The canary intentionally injects slow and stuck Start/Stop calls on a small
+// fraction of shards. This exercises the executor's per-shard goroutine and
+// timeout machinery and lets us alert when normal shards stop being processed
+// because of misbehaving ones.
+//
+// The kind is selected by a deterministic hash of the shard ID, so the fixed
+// namespace's stable numeric shard IDs keep the same kind across restarts and
+// ephemeral UUID shards distribute across kinds at the configured rate.
+package latencykind
+
+import (
+	"time"
+
+	farm "github.com/dgryski/go-farm"
+)
+
+// Kind categorises a shard's intended Start/Stop latency behaviour. Each
+// shard is assigned exactly one kind for its lifetime.
+type Kind int
+
+const (
+	// Normal shards Start and Stop with no injected delay.
+	Normal Kind = iota
+	// SlowStart shards delay Start below the executor's per-shard timeout.
+	SlowStart
+	// SlowStop shards delay Stop below the executor's per-shard timeout.
+	SlowStop
+	// StuckStart shards delay Start past the executor's per-shard timeout so
+	// the framework's start-timeout path is exercised. The Start call still
+	// returns afterwards so goroutines do not leak forever.
+	StuckStart
+	// StuckStop shards delay Stop past the executor's per-shard timeout so
+	// the framework's stop-timeout path is exercised. The Stop call still
+	// returns afterwards.
+	StuckStop
+)
+
+// The executor's processorAsyncOperationTimeout is 10s. Slow delays sit safely
+// below it so the framework never times out, stuck delays sit just above it so
+// the framework's timeout metric fires once per stuck transition then the call
+// completes. Keep stuck delays modest to bound goroutine accumulation.
+const (
+	slowDelay  = 5 * time.Second
+	stuckDelay = 15 * time.Second
+)
+
+// distributionMod is the modulus applied to the shard ID hash for kind
+// selection. With the assignments below: SlowStart 1%, SlowStop 1%,
+// StuckStart 1%, StuckStop 1%, Normal 96%.
+const distributionMod = 100
+
+// String returns a stable lowercase tag for metric tagging.
+func (k Kind) String() string {
+	switch k {
+	case SlowStart:
+		return "slow_start"
+	case SlowStop:
+		return "slow_stop"
+	case StuckStart:
+		return "stuck_start"
+	case StuckStop:
+		return "stuck_stop"
+	default:
+		return "normal"
+	}
+}
+
+// StartDelay is the delay injected before Start() returns.
+func (k Kind) StartDelay() time.Duration {
+	switch k {
+	case SlowStart:
+		return slowDelay
+	case StuckStart:
+		return stuckDelay
+	default:
+		return 0
+	}
+}
+
+// StopDelay is the delay injected before Stop() returns.
+func (k Kind) StopDelay() time.Duration {
+	switch k {
+	case SlowStop:
+		return slowDelay
+	case StuckStop:
+		return stuckDelay
+	default:
+		return 0
+	}
+}
+
+// For deterministically maps a shard ID to a Kind.
+func For(shardID string) Kind {
+	n := farm.Fingerprint32([]byte(shardID)) % distributionMod
+
+	switch {
+	case n < 1:
+		return SlowStart
+	case n < 2:
+		return SlowStop
+	case n < 3:
+		return StuckStart
+	case n < 4:
+		return StuckStop
+	default:
+		return Normal
+	}
+}

--- a/service/sharddistributor/canary/latencykind/latencykind.go
+++ b/service/sharddistributor/canary/latencykind/latencykind.go
@@ -91,8 +91,8 @@ func (k Kind) StopDelay() time.Duration {
 	}
 }
 
-// For deterministically maps a shard ID to a Kind.
-func For(shardID string) Kind {
+// ShardIDToKind deterministically maps a shard ID to a Kind.
+func ShardIDToKind(shardID string) Kind {
 	n := farm.Fingerprint32([]byte(shardID)) % distributionMod
 
 	switch {

--- a/service/sharddistributor/canary/latencykind/latencykind_test.go
+++ b/service/sharddistributor/canary/latencykind/latencykind_test.go
@@ -1,0 +1,94 @@
+package latencykind
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKind_String(t *testing.T) {
+	tests := []struct {
+		kind Kind
+		want string
+	}{
+		{Normal, "normal"},
+		{SlowStart, "slow_start"},
+		{SlowStop, "slow_stop"},
+		{StuckStart, "stuck_start"},
+		{StuckStop, "stuck_stop"},
+		{Kind(99), "normal"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.kind.String())
+		})
+	}
+}
+
+func TestKind_Delays(t *testing.T) {
+	tests := []struct {
+		kind      Kind
+		wantStart time.Duration
+		wantStop  time.Duration
+	}{
+		{Normal, 0, 0},
+		{SlowStart, slowDelay, 0},
+		{SlowStop, 0, slowDelay},
+		{StuckStart, stuckDelay, 0},
+		{StuckStop, 0, stuckDelay},
+	}
+	for _, tt := range tests {
+		t.Run(tt.kind.String(), func(t *testing.T) {
+			assert.Equal(t, tt.wantStart, tt.kind.StartDelay())
+			assert.Equal(t, tt.wantStop, tt.kind.StopDelay())
+		})
+	}
+}
+
+func TestFor_Deterministic(t *testing.T) {
+	for _, id := range []string{"0", "1", "shard-foo", uuid.New().String()} {
+		assert.Equal(t, For(id), For(id), "shardID %q must map to the same kind on every call", id)
+	}
+}
+
+func TestFor_Distribution(t *testing.T) {
+	const n = 50_000
+	counts := make(map[Kind]int, 5)
+	for i := 0; i < n; i++ {
+		counts[For(uuid.New().String())]++
+	}
+
+	// Allow 30% relative tolerance — we want to catch big skews but not be
+	// flaky on hash variance for low-frequency kinds.
+	checks := []struct {
+		kind     Kind
+		fraction float64
+	}{
+		{Normal, 96.0 / distributionMod},
+		{SlowStart, 1.0 / distributionMod},
+		{SlowStop, 1.0 / distributionMod},
+		{StuckStart, 1.0 / distributionMod},
+		{StuckStop, 1.0 / distributionMod},
+	}
+	for _, c := range checks {
+		t.Run(c.kind.String(), func(t *testing.T) {
+			expected := float64(n) * c.fraction
+			assert.InDelta(t, expected, float64(counts[c.kind]), expected*0.3,
+				"kind %s saw %d / %d, expected ~%.0f", c.kind, counts[c.kind], n, expected)
+		})
+	}
+}
+
+func TestFor_FixedNamespaceCoverage(t *testing.T) {
+	// The fixed namespace currently uses 32 numbered shards. Make sure the
+	// hash maps at least one of them to a non-normal kind so the canary
+	// always exercises slow paths even without UUID churn.
+	saw := make(map[Kind]bool)
+	for i := 0; i < 32; i++ {
+		saw[For(strconv.Itoa(i))] = true
+	}
+	assert.Truef(t, len(saw) > 1, "expected at least one non-normal kind across 32 fixed shards, got only %v", saw)
+}

--- a/service/sharddistributor/canary/latencykind/latencykind_test.go
+++ b/service/sharddistributor/canary/latencykind/latencykind_test.go
@@ -48,17 +48,17 @@ func TestKind_Delays(t *testing.T) {
 	}
 }
 
-func TestFor_Deterministic(t *testing.T) {
+func TestShardIDToKind_Deterministic(t *testing.T) {
 	for _, id := range []string{"0", "1", "shard-foo", uuid.New().String()} {
-		assert.Equal(t, For(id), For(id), "shardID %q must map to the same kind on every call", id)
+		assert.Equal(t, ShardIDToKind(id), ShardIDToKind(id), "shardID %q must map to the same kind on every call", id)
 	}
 }
 
-func TestFor_Distribution(t *testing.T) {
+func TestShardIDToKind_Distribution(t *testing.T) {
 	const n = 50_000
 	counts := make(map[Kind]int, 5)
 	for i := 0; i < n; i++ {
-		counts[For(uuid.New().String())]++
+		counts[ShardIDToKind(uuid.New().String())]++
 	}
 
 	// Allow 30% relative tolerance — we want to catch big skews but not be
@@ -82,13 +82,13 @@ func TestFor_Distribution(t *testing.T) {
 	}
 }
 
-func TestFor_FixedNamespaceCoverage(t *testing.T) {
+func TestShardIDToKind_FixedNamespaceCoverage(t *testing.T) {
 	// The fixed namespace currently uses 32 numbered shards. Make sure the
 	// hash maps at least one of them to a non-normal kind so the canary
 	// always exercises slow paths even without UUID churn.
 	saw := make(map[Kind]bool)
 	for i := 0; i < 32; i++ {
-		saw[For(strconv.Itoa(i))] = true
+		saw[ShardIDToKind(strconv.Itoa(i))] = true
 	}
 	assert.Truef(t, len(saw) > 1, "expected at least one non-normal kind across 32 fixed shards, got only %v", saw)
 }

--- a/service/sharddistributor/canary/metrics/metrics.go
+++ b/service/sharddistributor/canary/metrics/metrics.go
@@ -16,9 +16,20 @@ const (
 	CanaryShardStopped          = "canary_shard_stopped"
 	CanaryShardDone             = "canary_shard_done"
 	CanaryShardProcessStep      = "canary_shard_process_step"
+	// CanaryShardLifecycleInjected counts every Start/Stop call where the
+	// canary intentionally injected a delay. Tagged by lifecycle ("start" or
+	// "stop") and bucket ("slow_start", "stuck_stop", ...). Use it to confirm
+	// the canary is actually exercising the slow paths.
+	CanaryShardLifecycleInjected = "canary_shard_lifecycle_injected"
 
 	// Histogram metrics
 	CanaryPingLatency = "canary_ping_latency"
+	// CanaryShardStartLatency is the wall-clock duration of a shard
+	// processor's Start() call, tagged by bucket. The "normal" bucket should
+	// stay near zero; alert if it climbs.
+	CanaryShardStartLatency = "canary_shard_start_latency"
+	// CanaryShardStopLatency mirrors CanaryShardStartLatency for Stop().
+	CanaryShardStopLatency = "canary_shard_stop_latency"
 )
 
 var (

--- a/service/sharddistributor/canary/pinger/pingAndLog.go
+++ b/service/sharddistributor/canary/pinger/pingAndLog.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	sharddistributorv1 "github.com/uber/cadence/.gen/proto/sharddistributor/v1"
+	"github.com/uber/cadence/service/sharddistributor/canary/latencykind"
 	canarymetrics "github.com/uber/cadence/service/sharddistributor/canary/metrics"
 	"github.com/uber/cadence/service/sharddistributor/client/spectatorclient"
 )
@@ -18,6 +19,12 @@ const (
 )
 
 func PingShard(ctx context.Context, canaryClient sharddistributorv1.ShardDistributorExecutorCanaryAPIYARPCClient, metricsScope tally.Scope, logger *zap.Logger, namespace, shardKey string) {
+	// Tag by latency_kind so ping failures on intentionally-slow shards do
+	// not blend into the alertable normal-kind signal.
+	metricsScope = metricsScope.Tagged(map[string]string{
+		"latency_kind": latencykind.For(shardKey).String(),
+	})
+
 	request := &sharddistributorv1.PingRequest{
 		ShardKey:  shardKey,
 		Namespace: namespace,

--- a/service/sharddistributor/canary/pinger/pingAndLog.go
+++ b/service/sharddistributor/canary/pinger/pingAndLog.go
@@ -22,7 +22,7 @@ func PingShard(ctx context.Context, canaryClient sharddistributorv1.ShardDistrib
 	// Tag by latency_kind so ping failures on intentionally-slow shards do
 	// not blend into the alertable normal-kind signal.
 	metricsScope = metricsScope.Tagged(map[string]string{
-		"latency_kind": latencykind.For(shardKey).String(),
+		"latency_kind": latencykind.ShardIDToKind(shardKey).String(),
 	})
 
 	request := &sharddistributorv1.PingRequest{

--- a/service/sharddistributor/canary/processor/shardprocessor.go
+++ b/service/sharddistributor/canary/processor/shardprocessor.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/sharddistributor/canary/latencykind"
 	canarymetrics "github.com/uber/cadence/service/sharddistributor/canary/metrics"
 	"github.com/uber/cadence/service/sharddistributor/client/executorclient"
 )
@@ -24,12 +25,15 @@ const (
 
 // NewShardProcessor creates a new ShardProcessor.
 func NewShardProcessor(shardID string, timeSource clock.TimeSource, logger *zap.Logger, metricsScope tally.Scope) *ShardProcessor {
+	kind := latencykind.For(shardID)
+	scope := metricsScope.Tagged(map[string]string{"latency_kind": kind.String()})
 	p := &ShardProcessor{
 		shardID:      shardID,
 		shardLoad:    shardLoadFromID(shardID),
+		kind:         kind,
 		timeSource:   timeSource,
 		logger:       logger,
-		metricsScope: metricsScope,
+		metricsScope: scope,
 		stopChan:     make(chan struct{}),
 	}
 	p.status.Store(int32(types.ShardStatusREADY))
@@ -40,6 +44,7 @@ func NewShardProcessor(shardID string, timeSource clock.TimeSource, logger *zap.
 type ShardProcessor struct {
 	shardID      string
 	shardLoad    float64
+	kind         latencykind.Kind
 	timeSource   clock.TimeSource
 	logger       *zap.Logger
 	metricsScope tally.Scope
@@ -62,6 +67,18 @@ func (p *ShardProcessor) GetShardReport() executorclient.ShardReport {
 
 // Start implements executorclient.ShardProcessor.
 func (p *ShardProcessor) Start(_ context.Context) error {
+	start := p.timeSource.Now()
+	defer func() {
+		p.metricsScope.Histogram(canarymetrics.CanaryShardStartLatency, canarymetrics.CanaryPingLatencyBuckets).
+			RecordDuration(p.timeSource.Since(start))
+	}()
+
+	if delay := p.kind.StartDelay(); delay > 0 {
+		p.metricsScope.Tagged(map[string]string{"lifecycle": "start"}).
+			Counter(canarymetrics.CanaryShardLifecycleInjected).Inc(1)
+		p.timeSource.Sleep(delay)
+	}
+
 	p.metricsScope.Counter(canarymetrics.CanaryShardStarted).Inc(1)
 	p.logger.Debug("Starting shard processor", zap.String("shardID", p.shardID))
 	p.goRoutineWg.Add(1)
@@ -71,6 +88,18 @@ func (p *ShardProcessor) Start(_ context.Context) error {
 
 // Stop implements executorclient.ShardProcessor.
 func (p *ShardProcessor) Stop() {
+	start := p.timeSource.Now()
+	defer func() {
+		p.metricsScope.Histogram(canarymetrics.CanaryShardStopLatency, canarymetrics.CanaryPingLatencyBuckets).
+			RecordDuration(p.timeSource.Since(start))
+	}()
+
+	if delay := p.kind.StopDelay(); delay > 0 {
+		p.metricsScope.Tagged(map[string]string{"lifecycle": "stop"}).
+			Counter(canarymetrics.CanaryShardLifecycleInjected).Inc(1)
+		p.timeSource.Sleep(delay)
+	}
+
 	p.metricsScope.Counter(canarymetrics.CanaryShardStopped).Inc(1)
 	p.logger.Debug("Stopping shard processor", zap.String("shardID", p.shardID))
 	close(p.stopChan)

--- a/service/sharddistributor/canary/processor/shardprocessor.go
+++ b/service/sharddistributor/canary/processor/shardprocessor.go
@@ -25,7 +25,7 @@ const (
 
 // NewShardProcessor creates a new ShardProcessor.
 func NewShardProcessor(shardID string, timeSource clock.TimeSource, logger *zap.Logger, metricsScope tally.Scope) *ShardProcessor {
-	kind := latencykind.For(shardID)
+	kind := latencykind.ShardIDToKind(shardID)
 	scope := metricsScope.Tagged(map[string]string{"latency_kind": kind.String()})
 	p := &ShardProcessor{
 		shardID:      shardID,

--- a/service/sharddistributor/canary/processor/shardprocessor_test.go
+++ b/service/sharddistributor/canary/processor/shardprocessor_test.go
@@ -9,10 +9,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
 	"go.uber.org/goleak"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/sharddistributor/canary/testhelper"
 )
 
 func TestNewShardProcessor(t *testing.T) {
@@ -83,4 +85,13 @@ func Test_shardLoadFromID(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestShardProcessor_InjectsLifecycleDelay verifies that when a shardID hashes
+// to a non-normal latency kind the processor sleeps before completing the
+// matching lifecycle call and emits the lifecycle_injected counter.
+func TestShardProcessor_InjectsLifecycleDelay(t *testing.T) {
+	testhelper.AssertInjectsLifecycleDelay(t, func(id string, ts clock.TimeSource, logger *zap.Logger, scope tally.Scope) testhelper.Lifecycler {
+		return NewShardProcessor(id, ts, logger, scope)
+	})
 }

--- a/service/sharddistributor/canary/processorephemeral/shardprocessor.go
+++ b/service/sharddistributor/canary/processorephemeral/shardprocessor.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/sharddistributor/canary/latencykind"
 	canarymetrics "github.com/uber/cadence/service/sharddistributor/canary/metrics"
 	"github.com/uber/cadence/service/sharddistributor/client/executorclient"
 )
@@ -28,11 +29,14 @@ const (
 
 // NewShardProcessor creates a new ShardProcessor.
 func NewShardProcessor(shardID string, timeSource clock.TimeSource, logger *zap.Logger, metricsScope tally.Scope) *ShardProcessor {
+	kind := latencykind.For(shardID)
+	scope := metricsScope.Tagged(map[string]string{"latency_kind": kind.String()})
 	p := &ShardProcessor{
 		shardID:      shardID,
+		kind:         kind,
 		timeSource:   timeSource,
 		logger:       logger,
-		metricsScope: metricsScope,
+		metricsScope: scope,
 		stopChan:     make(chan struct{}),
 	}
 	p.SetShardStatus(types.ShardStatusREADY)
@@ -42,6 +46,7 @@ func NewShardProcessor(shardID string, timeSource clock.TimeSource, logger *zap.
 // ShardProcessor is a processor for a shard.
 type ShardProcessor struct {
 	shardID      string
+	kind         latencykind.Kind
 	timeSource   clock.TimeSource
 	logger       *zap.Logger
 	metricsScope tally.Scope
@@ -64,6 +69,18 @@ func (p *ShardProcessor) GetShardReport() executorclient.ShardReport {
 
 // Start implements executorclient.ShardProcessor.
 func (p *ShardProcessor) Start(_ context.Context) error {
+	start := p.timeSource.Now()
+	defer func() {
+		p.metricsScope.Histogram(canarymetrics.CanaryShardStartLatency, canarymetrics.CanaryPingLatencyBuckets).
+			RecordDuration(p.timeSource.Since(start))
+	}()
+
+	if delay := p.kind.StartDelay(); delay > 0 {
+		p.metricsScope.Tagged(map[string]string{"lifecycle": "start"}).
+			Counter(canarymetrics.CanaryShardLifecycleInjected).Inc(1)
+		p.timeSource.Sleep(delay)
+	}
+
 	p.metricsScope.Counter(canarymetrics.CanaryShardStarted).Inc(1)
 	p.logger.Debug("Starting shard processor", zap.String("shardID", p.shardID))
 	p.goRoutineWg.Add(1)
@@ -73,6 +90,18 @@ func (p *ShardProcessor) Start(_ context.Context) error {
 
 // Stop implements executorclient.ShardProcessor.
 func (p *ShardProcessor) Stop() {
+	start := p.timeSource.Now()
+	defer func() {
+		p.metricsScope.Histogram(canarymetrics.CanaryShardStopLatency, canarymetrics.CanaryPingLatencyBuckets).
+			RecordDuration(p.timeSource.Since(start))
+	}()
+
+	if delay := p.kind.StopDelay(); delay > 0 {
+		p.metricsScope.Tagged(map[string]string{"lifecycle": "stop"}).
+			Counter(canarymetrics.CanaryShardLifecycleInjected).Inc(1)
+		p.timeSource.Sleep(delay)
+	}
+
 	p.metricsScope.Counter(canarymetrics.CanaryShardStopped).Inc(1)
 	close(p.stopChan)
 	p.goRoutineWg.Wait()

--- a/service/sharddistributor/canary/processorephemeral/shardprocessor.go
+++ b/service/sharddistributor/canary/processorephemeral/shardprocessor.go
@@ -29,7 +29,7 @@ const (
 
 // NewShardProcessor creates a new ShardProcessor.
 func NewShardProcessor(shardID string, timeSource clock.TimeSource, logger *zap.Logger, metricsScope tally.Scope) *ShardProcessor {
-	kind := latencykind.For(shardID)
+	kind := latencykind.ShardIDToKind(shardID)
 	scope := metricsScope.Tagged(map[string]string{"latency_kind": kind.String()})
 	p := &ShardProcessor{
 		shardID:      shardID,

--- a/service/sharddistributor/canary/processorephemeral/shardprocessor_test.go
+++ b/service/sharddistributor/canary/processorephemeral/shardprocessor_test.go
@@ -9,10 +9,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
 	"go.uber.org/goleak"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/sharddistributor/canary/testhelper"
 )
 
 func TestNewShardProcessor(t *testing.T) {
@@ -63,4 +65,12 @@ func TestShardProcessor_Start_Process_Stop(t *testing.T) {
 
 	// Assert that the processor has processed at least once
 	assert.Greater(t, processor.processSteps, 0)
+}
+
+// TestShardProcessor_InjectsLifecycleDelay verifies the ephemeral processor
+// also sleeps and emits the lifecycle_injected counter for non-normal kinds.
+func TestShardProcessor_InjectsLifecycleDelay(t *testing.T) {
+	testhelper.AssertInjectsLifecycleDelay(t, func(id string, ts clock.TimeSource, logger *zap.Logger, scope tally.Scope) testhelper.Lifecycler {
+		return NewShardProcessor(id, ts, logger, scope)
+	})
 }

--- a/service/sharddistributor/canary/testhelper/lifecycletest.go
+++ b/service/sharddistributor/canary/testhelper/lifecycletest.go
@@ -46,6 +46,8 @@ func AssertInjectsLifecycleDelay(t *testing.T, factory LifecyclerFactory) {
 		// dependency loud if the distribution ever changes.
 		{name: "slow_start", shardID: "25", kind: latencykind.SlowStart, wantStartTag: true, startSleepers: 1, stopSleepers: 1},
 		{name: "slow_stop", shardID: "11", kind: latencykind.SlowStop, wantStopTag: true, startSleepers: 1, stopSleepers: 2},
+		{name: "stuck_start", shardID: "68", kind: latencykind.StuckStart, wantStartTag: true, startSleepers: 1, stopSleepers: 1},
+		{name: "stuck_stop", shardID: "6", kind: latencykind.StuckStop, wantStopTag: true, startSleepers: 1, stopSleepers: 2},
 	}
 
 	for _, tt := range tests {

--- a/service/sharddistributor/canary/testhelper/lifecycletest.go
+++ b/service/sharddistributor/canary/testhelper/lifecycletest.go
@@ -1,0 +1,88 @@
+// Package testhelper provides shared test helpers for the canary subpackages.
+package testhelper
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/service/sharddistributor/canary/latencykind"
+	canarymetrics "github.com/uber/cadence/service/sharddistributor/canary/metrics"
+)
+
+// Lifecycler is the minimal Start/Stop surface AssertInjectsLifecycleDelay
+// drives. Both canary shard processors satisfy it.
+type Lifecycler interface {
+	Start(context.Context) error
+	Stop()
+}
+
+// LifecyclerFactory builds a Lifecycler for the shared lifecycle delay test.
+type LifecyclerFactory func(shardID string, ts clock.TimeSource, logger *zap.Logger, scope tally.Scope) Lifecycler
+
+// AssertInjectsLifecycleDelay drives the given factory through Start/Stop with
+// shardIDs that hash to non-normal latency kinds and asserts the
+// CanaryShardLifecycleInjected counter fires for the matching lifecycle.
+func AssertInjectsLifecycleDelay(t *testing.T, factory LifecyclerFactory) {
+	t.Helper()
+
+	tests := []struct {
+		name          string
+		shardID       string
+		kind          latencykind.Kind
+		wantStartTag  bool
+		wantStopTag   bool
+		startSleepers int
+		stopSleepers  int
+	}{
+		// shardID fixtures rely on the farm.Fingerprint32 hash in
+		// latencykind.For — the require.Equal check below makes the
+		// dependency loud if the distribution ever changes.
+		{name: "slow_start", shardID: "25", kind: latencykind.SlowStart, wantStartTag: true, startSleepers: 1, stopSleepers: 1},
+		{name: "slow_stop", shardID: "11", kind: latencykind.SlowStop, wantStopTag: true, startSleepers: 1, stopSleepers: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.kind, latencykind.For(tt.shardID), "fixture out of sync with latencykind distribution")
+
+			scope := tally.NewTestScope("", nil)
+			tc := clock.NewMockedTimeSource()
+			p := factory(tt.shardID, tc, zaptest.NewLogger(t), scope)
+
+			startErr := make(chan error, 1)
+			go func() { startErr <- p.Start(context.Background()) }()
+			tc.BlockUntil(tt.startSleepers)
+			if d := tt.kind.StartDelay(); d > 0 {
+				tc.Advance(d)
+			}
+			require.NoError(t, <-startErr)
+
+			stopDone := make(chan struct{})
+			go func() { p.Stop(); close(stopDone) }()
+			tc.BlockUntil(tt.stopSleepers)
+			if d := tt.kind.StopDelay(); d > 0 {
+				tc.Advance(d)
+			}
+			<-stopDone
+
+			assert.Equal(t, tt.wantStartTag, hasLifecycleInjected(scope, "start"))
+			assert.Equal(t, tt.wantStopTag, hasLifecycleInjected(scope, "stop"))
+		})
+	}
+}
+
+func hasLifecycleInjected(scope tally.TestScope, lifecycle string) bool {
+	for _, c := range scope.Snapshot().Counters() {
+		if c.Name() == canarymetrics.CanaryShardLifecycleInjected && c.Tags()["lifecycle"] == lifecycle && c.Value() > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/service/sharddistributor/canary/testhelper/lifecycletest.go
+++ b/service/sharddistributor/canary/testhelper/lifecycletest.go
@@ -42,7 +42,7 @@ func AssertInjectsLifecycleDelay(t *testing.T, factory LifecyclerFactory) {
 		stopSleepers  int
 	}{
 		// shardID fixtures rely on the farm.Fingerprint32 hash in
-		// latencykind.For — the require.Equal check below makes the
+		// latencykind.ShardIDToKind — the require.Equal check below makes the
 		// dependency loud if the distribution ever changes.
 		{name: "slow_start", shardID: "25", kind: latencykind.SlowStart, wantStartTag: true, startSleepers: 1, stopSleepers: 1},
 		{name: "slow_stop", shardID: "11", kind: latencykind.SlowStop, wantStopTag: true, startSleepers: 1, stopSleepers: 2},
@@ -52,7 +52,7 @@ func AssertInjectsLifecycleDelay(t *testing.T, factory LifecyclerFactory) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.kind, latencykind.For(tt.shardID), "fixture out of sync with latencykind distribution")
+			require.Equal(t, tt.kind, latencykind.ShardIDToKind(tt.shardID), "fixture out of sync with latencykind distribution")
 
 			scope := tally.NewTestScope("", nil)
 			tc := clock.NewMockedTimeSource()


### PR DESCRIPTION
Part of https://github.com/cadence-workflow/cadence/issues/6862

**What changed?**

- New `latencykind` package that deterministically maps each canary shard ID (via `farm.Fingerprint32`) to a Start/Stop latency kind: Normal 96%, SlowStart/SlowStop/StuckStart/StuckStop 1% each.
- Both fixed and ephemeral canary shard processors now sleep for the assigned delay during `Start`/`Stop` and increment a `canary_shard_lifecycle_injected` counter.
- New `canary_shard_start_latency` / `canary_shard_stop_latency` histograms tagged by `latency_kind`. Pinger metrics are also tagged by `latency_kind`.
- Shared `testhelper.AssertInjectsLifecycleDelay` driving both processor types so the orchestration is not duplicated.

**Why?**

The canary needs to exercise the framework's per-shard goroutine and timeout machinery. Without intentionally slow and stuck shards we cannot alert when the framework regresses to letting a misbehaving shard block others. Slow delays sit safely below the executor's 10s per-shard timeout; stuck delays sit just above so the timeout path is exercised on a small slice of shards.

**How did you test it?**

- Unit tests for `latencykind` (string, delays, deterministic, distribution, fixed-namespace coverage).
- Shared lifecycle test driving both `processor.NewShardProcessor` and `processorephemeral.NewShardProcessor` with mocked clock; asserts the lifecycle counter fires for the matching kind.
- All canary tests pass; new lines at 100% coverage.

**Potential risks**

Low. Slow/stuck delays are bounded (5s slow, 15s stuck). The 96% Normal majority preserves the existing alertable signal.

**Release notes**

None — internal canary only.

**Documentation Changes**

None.