### PR TITLE
fix(shard-distributor): fix latency of shard assignment

### DIFF
--- a/service/sharddistributor/handler/ephemeral_assigner.go
+++ b/service/sharddistributor/handler/ephemeral_assigner.go
@@ -60,7 +60,7 @@ func (h *handlerImpl) assignEphemeralBatch(ctx context.Context, namespace string
 		return nil, err
 	}
 
-	mergeAssignments(state, chosenExecutors)
+	h.mergeAssignments(state, chosenExecutors)
 
 	if err := h.storage.AssignShards(ctx, namespace, store.AssignShardsRequest{NewState: state}, store.NopGuard()); err != nil {
 		if errors.Is(err, store.ErrVersionConflict) {
@@ -77,6 +77,25 @@ func (h *handlerImpl) assignEphemeralBatch(ctx context.Context, namespace string
 	}
 
 	return buildResults(namespace, shardKeys, chosenExecutors, executorOwners), nil
+}
+
+// mergeAssignments folds the chosen shard→executor assignments back into state.
+// The AssignedShards maps are copied to avoid mutating the object returned by
+// GetState.
+func (h *handlerImpl) mergeAssignments(state *store.NamespaceState, chosenExecutors map[string]string) {
+	for executorID, shardsForExecutor := range invertMap(chosenExecutors) {
+		existing := state.ShardAssignments[executorID]
+		newShards := make(map[string]*types.ShardAssignment, len(existing.AssignedShards)+len(shardsForExecutor))
+		for k, v := range existing.AssignedShards {
+			newShards[k] = v
+		}
+		for _, shardKey := range shardsForExecutor {
+			newShards[shardKey] = &types.ShardAssignment{Status: types.AssignmentStatusREADY}
+		}
+		existing.AssignedShards = newShards
+		existing.LastUpdated = h.timeSource.Now().UTC()
+		state.ShardAssignments[executorID] = existing
+	}
 }
 
 // buildAssignedCounts returns a map of executorID -> current shard count for
@@ -114,24 +133,6 @@ func pickExecutors(namespace string, shardKeys []string, assignedCounts map[stri
 		assignedCounts[chosenExecutor]++
 	}
 	return chosenExecutors, nil
-}
-
-// mergeAssignments folds the chosen shard→executor assignments back into state.
-// The AssignedShards maps are copied to avoid mutating the object returned by
-// GetState.
-func mergeAssignments(state *store.NamespaceState, chosenExecutors map[string]string) {
-	for executorID, shardsForExecutor := range invertMap(chosenExecutors) {
-		existing := state.ShardAssignments[executorID]
-		newShards := make(map[string]*types.ShardAssignment, len(existing.AssignedShards)+len(shardsForExecutor))
-		for k, v := range existing.AssignedShards {
-			newShards[k] = v
-		}
-		for _, shardKey := range shardsForExecutor {
-			newShards[shardKey] = &types.ShardAssignment{Status: types.AssignmentStatusREADY}
-		}
-		existing.AssignedShards = newShards
-		state.ShardAssignments[executorID] = existing
-	}
 }
 
 // fetchExecutorMetadata calls GetExecutor once per unique chosen executor to

--- a/service/sharddistributor/handler/ephemeral_assigner_test.go
+++ b/service/sharddistributor/handler/ephemeral_assigner_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/sharddistributor/store"
@@ -183,8 +184,9 @@ func TestAssignEphemeralBatch(t *testing.T) {
 			mockStorage := store.NewMockStore(ctrl)
 
 			h := &handlerImpl{
-				logger:  testlogger.New(t),
-				storage: mockStorage,
+				logger:     testlogger.New(t),
+				storage:    mockStorage,
+				timeSource: clock.NewMockedTimeSource(),
 			}
 
 			if tt.setupMocks != nil {

--- a/service/sharddistributor/handler/handler.go
+++ b/service/sharddistributor/handler/handler.go
@@ -63,6 +63,7 @@ func NewHandler(
 		logger:               logger,
 		shardDistributionCfg: shardDistributionCfg,
 		storage:              storage,
+		timeSource:           timeSource,
 	}
 
 	handler.batcher = newShardBatcher(timeSource, ephemeralBatchInterval, handler.assignEphemeralBatch)
@@ -79,6 +80,7 @@ type handlerImpl struct {
 
 	storage              store.Store
 	shardDistributionCfg config.ShardDistribution
+	timeSource           clock.TimeSource
 
 	batcher *shardBatcher
 }

--- a/service/sharddistributor/handler/handler_test.go
+++ b/service/sharddistributor/handler/handler_test.go
@@ -50,12 +50,14 @@ const (
 // ready to use; callers should call Stop() when done.
 func newTestHandler(t *testing.T, cfg config.ShardDistribution, mockStore *store.MockStore) *handlerImpl {
 	t.Helper()
+	ts := clock.NewRealTimeSource()
 	handler := &handlerImpl{
 		logger:               testlogger.New(t),
 		shardDistributionCfg: cfg,
 		storage:              mockStore,
+		timeSource:           ts,
 	}
-	handler.batcher = newShardBatcher(clock.NewRealTimeSource(), 10*time.Millisecond, handler.assignEphemeralBatch)
+	handler.batcher = newShardBatcher(ts, 10*time.Millisecond, handler.assignEphemeralBatch)
 	handler.batcher.Start()
 	t.Cleanup(handler.batcher.Stop)
 	return handler


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
 Added existing.LastUpdated = h.timeSource.Now().UTC() so every ephemeral shard assignment is timestamped correctly before being written to etcd 
par of #6862 
**Why?**
shard_distributor_shard_assignment_distribution_latency is computed as heartbeatTime - assignedState.LastUpdated. For ephemeral namespaces, mergeAssignments built the new AssignedState without ever setting LastUpdated, leaving it at the Go zero time (time.Time{}). On the next executor heartbeat, the metric computed now - year 0001 ≈ 2026 years, landing in the maximum histogram bucket.                                                                                                                                                                                                                                                                                                            Fixed namespaces were unaffected because their assignments go through getNewAssignmentsState in the leader processor, which always sets LastUpdated = now. 

**How did you test it?**
go test ./service/sharddistributor/handler/... 2>&1

**Potential risks**
It is a fix, the metric is already broken for new assigned shards

**Release notes**
N/A

**Documentation Changes**
N/A

