### PR TITLE
chore(cadence-matching): remove ownership check

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -1778,14 +1778,6 @@ const (
 	// Default value: false
 	// Allowed filters: DomainID
 	MatchingEnableTaskInfoLogByDomainID
-	// MatchingEnableTasklistGuardAgainstOwnershipShardLoss
-	// enables guards to prevent tasklists from processing if there is any detection that the host
-	// no longer is active or owns the shard
-	// KeyName: matching.enableTasklistGuardAgainstOwnershipLoss
-	// Value type: Bool
-	// Default value: false
-	// Allowed filters: N/A
-	MatchingEnableTasklistGuardAgainstOwnershipShardLoss
 	// MatchingEnableStandbyTaskCompletion is to enable completion of tasks in the domain's passive side
 	// KeyName: matching.enableStandbyTaskCompletion
 	// Value type: Bool
@@ -4609,11 +4601,6 @@ var BoolKeys = map[BoolKey]DynamicBool{
 		KeyName:      "matching.enableTaskInfoLogByDomainID",
 		Filters:      []Filter{DomainID},
 		Description:  "MatchingEnableTaskInfoLogByDomainID is enables info level logs for decision/activity task based on the request domainID",
-		DefaultValue: false,
-	},
-	MatchingEnableTasklistGuardAgainstOwnershipShardLoss: {
-		KeyName:      "matching.enableTasklistGuardAgainstOwnershipLoss",
-		Description:  "allows guards to ensure that tasklists don't continue processing if there's signal that they've lost ownership",
 		DefaultValue: false,
 	},
 	MatchingEnableGetNumberOfPartitionsFromCache: {

--- a/service/matching/config/config.go
+++ b/service/matching/config/config.go
@@ -109,7 +109,6 @@ type (
 		// task gc configuration
 		MaxTimeBetweenTaskDeletes time.Duration
 
-		EnableTasklistOwnershipGuard               dynamicproperties.BoolPropertyFn
 		ExcludeShortLivedTaskListsFromShardManager dynamicproperties.BoolPropertyFn
 		PercentageOnboardedToShardManager          dynamicproperties.IntPropertyFn
 	}
@@ -215,7 +214,6 @@ func NewConfig(dc *dynamicconfig.Collection, hostName string, rpcConfig config.R
 		EnableTasklistIsolation:                    dc.GetBoolPropertyFilteredByDomain(dynamicproperties.EnableTasklistIsolation),
 		AppendTaskTimeout:                          dc.GetDurationPropertyFilteredByTaskListInfo(dynamicproperties.AppendTaskTimeout),
 		AsyncTaskDispatchTimeout:                   dc.GetDurationPropertyFilteredByTaskListInfo(dynamicproperties.AsyncTaskDispatchTimeout),
-		EnableTasklistOwnershipGuard:               dc.GetBoolProperty(dynamicproperties.MatchingEnableTasklistGuardAgainstOwnershipShardLoss),
 		LocalPollWaitTime:                          dc.GetDurationPropertyFilteredByTaskListInfo(dynamicproperties.LocalPollWaitTime),
 		LocalTaskWaitTime:                          dc.GetDurationPropertyFilteredByTaskListInfo(dynamicproperties.LocalTaskWaitTime),
 		PartitionUpscaleRPS:                        dc.GetIntPropertyFilteredByTaskListInfo(dynamicproperties.MatchingPartitionUpscaleRPS),

--- a/service/matching/config/config_test.go
+++ b/service/matching/config/config_test.go
@@ -83,7 +83,6 @@ func TestNewConfig(t *testing.T) {
 		"TaskDispatchRPSTTL":                         {nil, time.Minute},
 		"MaxTimeBetweenTaskDeletes":                  {nil, time.Second},
 		"AllIsolationGroups":                         {nil, []string{"zone-1", "zone-2"}},
-		"EnableTasklistOwnershipGuard":               {dynamicproperties.MatchingEnableTasklistGuardAgainstOwnershipShardLoss, false},
 		"EnableGetNumberOfPartitionsFromCache":       {dynamicproperties.MatchingEnableGetNumberOfPartitionsFromCache, false},
 		"EnablePartitionEmptyCheck":                  {dynamicproperties.MatchingEnablePartitionEmptyCheck, true},
 		"PartitionUpscaleRPS":                        {dynamicproperties.MatchingPartitionUpscaleRPS, 30},

--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -1494,10 +1494,6 @@ func (e *matchingEngineImpl) emitInfoOrDebugLog(
 }
 
 func (e *matchingEngineImpl) errIfShardOwnershipLost(ctx context.Context, taskList *tasklist.Identifier) error {
-	if !e.config.EnableTasklistOwnershipGuard() {
-		return nil
-	}
-
 	self, err := e.membershipResolver.WhoAmI()
 	if err != nil {
 		return fmt.Errorf("failed to lookup self im membership: %w", err)

--- a/service/matching/handler/engine_integration_test.go
+++ b/service/matching/handler/engine_integration_test.go
@@ -1423,7 +1423,6 @@ func defaultTestConfig() *config.Config {
 	config.GetTasksBatchSize = dynamicproperties.GetIntPropertyFilteredByTaskListInfo(10)
 	config.AsyncTaskDispatchTimeout = dynamicproperties.GetDurationPropertyFnFilteredByTaskListInfo(10 * time.Millisecond)
 	config.MaxTimeBetweenTaskDeletes = time.Duration(0)
-	config.EnableTasklistOwnershipGuard = func(opts ...dynamicproperties.FilterOption) bool { return true }
 	return config
 }
 

--- a/service/matching/handler/engine_test.go
+++ b/service/matching/handler/engine_test.go
@@ -423,7 +423,6 @@ func TestErrIfShardOwnershipLost(t *testing.T) {
 			executor:           executor,
 			membershipResolver: resolver,
 			config: &config.Config{
-				EnableTasklistOwnershipGuard:               func(opts ...dynamicproperties.FilterOption) bool { return true },
 				ExcludeShortLivedTaskListsFromShardManager: func(opts ...dynamicproperties.FilterOption) bool { return false },
 				PercentageOnboardedToShardManager:          func(opts ...dynamicproperties.FilterOption) int { return 100 },
 			},
@@ -441,13 +440,6 @@ func TestErrIfShardOwnershipLost(t *testing.T) {
 		assert.Equal(t, ownedBy, ownershipErr.OwnedByIdentity)
 		assert.Equal(t, me, ownershipErr.MyIdentity)
 	}
-
-	t.Run("ownership guard disabled", func(t *testing.T) {
-		engine, _, _ := newEngine(t)
-		engine.config.EnableTasklistOwnershipGuard = func(opts ...dynamicproperties.FilterOption) bool { return false }
-		err := engine.errIfShardOwnershipLost(context.Background(), taskListID)
-		require.NoError(t, err)
-	})
 
 	t.Run("not excluded from sd with shard process error", func(t *testing.T) {
 		engine, executor, _ := newEngine(t)
@@ -951,9 +943,7 @@ func TestGetTasklistsNotOwned(t *testing.T) {
 		shutdown:           make(chan struct{}),
 		membershipResolver: resolver,
 		taskListRegistry:   tasklist.NewTaskListRegistry(metrics.NewNoopMetricsClient()),
-		config: &config.Config{
-			EnableTasklistOwnershipGuard: func(opts ...dynamicproperties.FilterOption) bool { return true },
-		},
+		config: &config.Config{},
 		logger: log.NewNoop(),
 	}
 	e.taskListRegistry.Register(*tl1, tl1m)
@@ -989,9 +979,7 @@ func TestShutDownTasklistsNotOwned(t *testing.T) {
 		shutdown:           make(chan struct{}),
 		membershipResolver: resolver,
 		taskListRegistry:   tasklist.NewTaskListRegistry(metrics.NewNoopMetricsClient()),
-		config: &config.Config{
-			EnableTasklistOwnershipGuard: func(opts ...dynamicproperties.FilterOption) bool { return true },
-		},
+		config: &config.Config{},
 		metricsClient: metrics.NewNoopMetricsClient(),
 		logger:        log.NewNoop(),
 	}

--- a/service/matching/handler/engine_test.go
+++ b/service/matching/handler/engine_test.go
@@ -943,8 +943,8 @@ func TestGetTasklistsNotOwned(t *testing.T) {
 		shutdown:           make(chan struct{}),
 		membershipResolver: resolver,
 		taskListRegistry:   tasklist.NewTaskListRegistry(metrics.NewNoopMetricsClient()),
-		config: &config.Config{},
-		logger: log.NewNoop(),
+		config:             &config.Config{},
+		logger:             log.NewNoop(),
 	}
 	e.taskListRegistry.Register(*tl1, tl1m)
 	e.taskListRegistry.Register(*tl2, tl2m)
@@ -979,9 +979,9 @@ func TestShutDownTasklistsNotOwned(t *testing.T) {
 		shutdown:           make(chan struct{}),
 		membershipResolver: resolver,
 		taskListRegistry:   tasklist.NewTaskListRegistry(metrics.NewNoopMetricsClient()),
-		config: &config.Config{},
-		metricsClient: metrics.NewNoopMetricsClient(),
-		logger:        log.NewNoop(),
+		config:             &config.Config{},
+		metricsClient:      metrics.NewNoopMetricsClient(),
+		logger:             log.NewNoop(),
 	}
 	e.taskListRegistry.Register(*tl1, tl1m)
 	e.taskListRegistry.Register(*tl2, tl2m)

--- a/service/matching/handler/membership.go
+++ b/service/matching/handler/membership.go
@@ -53,10 +53,6 @@ func (e *matchingEngineImpl) runMembershipChangeLoop() {
 
 	defer e.shutdownCompletion.Done()
 
-	if !e.config.EnableTasklistOwnershipGuard() {
-		return
-	}
-
 	listener := make(chan *membership.ChangedEvent, subscriptionBufferSize)
 	if err := e.membershipResolver.Subscribe(service.Matching, "matching-engine", listener); err != nil {
 		e.logger.Error("Failed to subscribe to membership updates")
@@ -80,9 +76,6 @@ func (e *matchingEngineImpl) runMembershipChangeLoop() {
 }
 
 func (e *matchingEngineImpl) shutDownNonOwnedTasklists() error {
-	if !e.config.EnableTasklistOwnershipGuard() {
-		return nil
-	}
 	noLongerOwned, err := e.getNonOwnedTasklistsLocked()
 	if err != nil {
 		return err
@@ -121,10 +114,6 @@ func (e *matchingEngineImpl) shutDownNonOwnedTasklists() error {
 }
 
 func (e *matchingEngineImpl) getNonOwnedTasklistsLocked() ([]tasklist.Manager, error) {
-	if !e.config.EnableTasklistOwnershipGuard() {
-		return nil, nil
-	}
-
 	var toShutDown []tasklist.Manager
 
 	taskLists := e.taskListRegistry.AllManagers()

--- a/service/matching/handler/membership_test.go
+++ b/service/matching/handler/membership_test.go
@@ -67,9 +67,9 @@ func TestGetTaskListManager_OwnerShip(t *testing.T) {
 		expectedError error
 	}{
 		{
-			name:                 "Not owned by current host",
-			lookUpResult:         "A",
-			whoAmIResult:         "B",
+			name:         "Not owned by current host",
+			lookUpResult: "A",
+			whoAmIResult: "B",
 
 			expectedError: new(cadence_errors.TaskListNotOwnedByHostError),
 		},

--- a/service/matching/handler/membership_test.go
+++ b/service/matching/handler/membership_test.go
@@ -58,12 +58,11 @@ import (
 func TestGetTaskListManager_OwnerShip(t *testing.T) {
 
 	testCases := []struct {
-		name                 string
-		lookUpResult         string
-		lookUpErr            error
-		whoAmIResult         string
-		whoAmIErr            error
-		tasklistGuardEnabled bool
+		name         string
+		lookUpResult string
+		lookUpErr    error
+		whoAmIResult string
+		whoAmIErr    error
 
 		expectedError error
 	}{
@@ -71,29 +70,18 @@ func TestGetTaskListManager_OwnerShip(t *testing.T) {
 			name:                 "Not owned by current host",
 			lookUpResult:         "A",
 			whoAmIResult:         "B",
-			tasklistGuardEnabled: true,
 
 			expectedError: new(cadence_errors.TaskListNotOwnedByHostError),
 		},
 		{
-			name:                 "LookupError",
-			lookUpErr:            assert.AnError,
-			tasklistGuardEnabled: true,
-			expectedError:        assert.AnError,
+			name:          "LookupError",
+			lookUpErr:     assert.AnError,
+			expectedError: assert.AnError,
 		},
 		{
-			name:                 "WhoAmIError",
-			whoAmIErr:            assert.AnError,
-			tasklistGuardEnabled: true,
-			expectedError:        assert.AnError,
-		},
-		{
-			name:                 "when feature is not enabled, expect previous behaviour to continue",
-			lookUpResult:         "A",
-			whoAmIResult:         "B",
-			tasklistGuardEnabled: false,
-
-			expectedError: nil,
+			name:          "WhoAmIError",
+			whoAmIErr:     assert.AnError,
+			expectedError: assert.AnError,
 		},
 	}
 
@@ -119,10 +107,6 @@ func TestGetTaskListManager_OwnerShip(t *testing.T) {
 			mockDomainCache.EXPECT().GetDomainName(gomock.Any()).Return(matchingTestDomainName, nil).AnyTimes()
 
 			config := defaultTestConfig()
-			taskListEnabled := tc.tasklistGuardEnabled
-			config.EnableTasklistOwnershipGuard = func(opts ...dynamicproperties.FilterOption) bool {
-				return taskListEnabled
-			}
 			// Exclude all task lists from the ShardDistributor so that errIfShardOwnershipLost
 			// exercises the ringpop (hash-ring) ownership path that these test cases are actually
 			// testing. With PercentageOnboardedToShardManager=0, no task list name is below the
@@ -187,11 +171,9 @@ func TestMembershipSubscriptionRecoversAfterPanic(t *testing.T) {
 
 		engine := matchingEngineImpl{
 			membershipResolver: r.MembershipResolver,
-			config: &config.Config{
-				EnableTasklistOwnershipGuard: func(opts ...dynamicproperties.FilterOption) bool { return true },
-			},
-			logger:   log.NewNoop(),
-			shutdown: make(chan struct{}),
+			config:             &config.Config{},
+			logger:             log.NewNoop(),
+			shutdown:           make(chan struct{}),
 		}
 
 		engine.runMembershipChangeLoop()
@@ -213,7 +195,7 @@ func TestSubscriptionAndShutdown(t *testing.T) {
 		shutdownCompletion: &shutdownWG,
 		membershipResolver: mockResolver,
 		taskListRegistry:   tasklist.NewTaskListRegistry(metrics.NewNoopMetricsClient()),
-		config:             &config.Config{EnableTasklistOwnershipGuard: func(opts ...dynamicproperties.FilterOption) bool { return true }},
+		config:             &config.Config{},
 		shutdown:           make(chan struct{}),
 		logger:             log.NewNoop(),
 		domainCache:        mockDomainCache,
@@ -248,7 +230,7 @@ func TestSubscriptionAndErrorReturned(t *testing.T) {
 		shutdownCompletion: &shutdownWG,
 		membershipResolver: mockResolver,
 		taskListRegistry:   tasklist.NewTaskListRegistry(metrics.NewNoopMetricsClient()),
-		config:             &config.Config{EnableTasklistOwnershipGuard: func(opts ...dynamicproperties.FilterOption) bool { return true }},
+		config:             &config.Config{},
 		shutdown:           make(chan struct{}),
 		logger:             log.NewNoop(),
 		domainCache:        mockDomainCache,
@@ -302,7 +284,7 @@ func TestSubscribeToMembershipChangesQuitsIfSubscribeFails(t *testing.T) {
 		shutdownCompletion: &shutdownWG,
 		membershipResolver: mockResolver,
 		taskListRegistry:   tasklist.NewTaskListRegistry(metrics.NewNoopMetricsClient()),
-		config:             &config.Config{EnableTasklistOwnershipGuard: func(opts ...dynamicproperties.FilterOption) bool { return true }},
+		config:             &config.Config{},
 		shutdown:           make(chan struct{}),
 		logger:             logger,
 		domainCache:        mockDomainCache,
@@ -350,7 +332,6 @@ func TestGetTasklistManagerShutdownScenario(t *testing.T) {
 		membershipResolver: mockResolver,
 		taskListRegistry:   tasklist.NewTaskListRegistry(metrics.NewNoopMetricsClient()),
 		config: &config.Config{
-			EnableTasklistOwnershipGuard:               func(opts ...dynamicproperties.FilterOption) bool { return true },
 			ExcludeShortLivedTaskListsFromShardManager: func(opts ...dynamicproperties.FilterOption) bool { return true },
 			PercentageOnboardedToShardManager:          func(opts ...dynamicproperties.FilterOption) int { return 100 },
 		},


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Removing the definition and usages of EnableTasklistOwnershipGuard
par of https://github.com/cadence-workflow/cadence/issues/6862 

**Why?**
By now this optimization should be sued by default after being tested for a long time.

**How did you test it?**


**Potential risks**
Open source users hav

**Release notes**
Open source users will get the optimization of a fast failure and cleanup in case of changes of ownership, instead of failing at the db operations level. Also the tasklists will be cleanup in matching by default when the ownership changes.

**Documentation Changes**
N/A
----
## Summary by Gitar

- **Cleanup of ownership guard:**
  - Removed `EnableTasklistOwnershipGuard` configuration and associated logic from `service/matching/handler/membership.go` and `service/matching/handler/engine.go`.
- **Dynamic config removal:**
  - Deleted `EnableTasklistOwnershipGuard` constant from `common/dynamicconfig/dynamicproperties/constants.go`.
- **Test suite updates:**
  - Simplified `membership_test.go` and `engine_test.go` by removing test cases and configurations previously dependent on the removed ownership guard.


<sub>This will update automatically on new commits.</sub>