### PR TITLE
chore: set deleting orphaned history branch during creation log to debug

### DIFF
--- a/service/history/engine/engineimpl/start_workflow_execution.go
+++ b/service/history/engine/engineimpl/start_workflow_execution.go
@@ -429,7 +429,7 @@ func (e *historyEngineImpl) handleCreateWorkflowExecutionFailureCleanup(
 
 	// The key here is to delete the additational branch, since it has just been created earlier in this call
 	// and is not used. However, we must be careful, there may be other existing branches that we must not touch
-	e.logger.Info("Deleting orphaned history branch during cleanup after identified failure during creation",
+	e.logger.Debug("Deleting orphaned history branch during cleanup after identified failure during creation",
 		tag.WorkflowDomainID(domainEntry.GetInfo().ID),
 		tag.WorkflowID(workflowExecution.WorkflowID),
 		tag.WorkflowRunID(workflowExecution.RunID),


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Changed log that informs about deletion of orphaned history branch during workflow creation to debug.

https://github.com/cadence-workflow/cadence/issues/7911

**Why?**
The change has been successfully validated and it became a noisy log.

**How did you test it?**
go test -race ./service/history/engine/engineimpl/...

**Potential risks**
N/A

**Release notes**
Changed log that informs about deletion of orphaned history branch during workflow creation to debug level due to noise.

**Documentation Changes**
N/A
