### PR TITLE
feat(schedules): implement ListSchedules via visibility query

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -38,6 +39,7 @@ const (
 	scheduleWorkflowIDPrefix          = "cadence-scheduler:"
 	schedulerWorkflowExecutionTimeout = 10 * 365 * 24 * time.Hour // ~10 years
 	schedulerWorkflowDecisionTimeout  = 10 * time.Second
+	defaultListSchedulesPageSize      = 10
 )
 
 func scheduleWorkflowID(scheduleID string) string {
@@ -388,7 +390,40 @@ func (wh *WorkflowHandler) ListSchedules(
 		return nil, validate.ErrDomainNotSet
 	}
 
-	return nil, &types.BadRequestError{Message: "ListSchedules is not yet implemented."}
+	pageSize := request.GetPageSize()
+	if pageSize <= 0 {
+		pageSize = defaultListSchedulesPageSize
+	}
+
+	// TODO: populate ScheduleListEntry.WorkflowType, State, and CronExpression once
+	// CreateSchedule stores schedule metadata in the scheduler workflow's Memo.
+	// Currently only ScheduleID is returned (derived from the workflow ID).
+	// Follow-up: store metadata in Memo at create time, update via UpsertMemo on
+	// pause/unpause/update signals, and read Memo from visibility results here.
+	listResp, err := wh.ListWorkflowExecutions(ctx, &types.ListWorkflowExecutionsRequest{
+		Domain:        domainName,
+		PageSize:      pageSize,
+		NextPageToken: request.GetNextPageToken(),
+		Query:         fmt.Sprintf("WorkflowType = '%s'", scheduler.WorkflowTypeName),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]*types.ScheduleListEntry, 0, len(listResp.GetExecutions()))
+	for _, exec := range listResp.GetExecutions() {
+		wfID := exec.GetExecution().GetWorkflowID()
+		scheduleID := strings.TrimPrefix(wfID, scheduleWorkflowIDPrefix)
+
+		entries = append(entries, &types.ScheduleListEntry{
+			ScheduleID: scheduleID,
+		})
+	}
+
+	return &types.ListSchedulesResponse{
+		Schedules:     entries,
+		NextPageToken: listResp.GetNextPageToken(),
+	}, nil
 }
 
 func (wh *WorkflowHandler) signalScheduleWorkflow(

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/yarpc"
@@ -38,6 +39,7 @@ import (
 	dc "github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/resource"
 	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/common/types"
@@ -654,36 +656,66 @@ func TestBackfillSchedule(t *testing.T) {
 }
 
 func TestListSchedules(t *testing.T) {
-	tests := map[string]struct {
-		request *types.ListSchedulesRequest
-		mockFn  func(*scheduleTestFixture)
-		wantErr bool
-	}{
-		"nil request": {
-			request: nil,
-			mockFn:  func(f *scheduleTestFixture) {},
-			wantErr: true,
-		},
-		"unimplemented": {
-			request: &types.ListSchedulesRequest{Domain: testDomain},
-			mockFn:  func(f *scheduleTestFixture) {},
-			wantErr: true,
-		},
-	}
+	t.Run("nil request", func(t *testing.T) {
+		f := newScheduleTestFixture(t)
+		defer f.finish()
 
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			f := newScheduleTestFixture(t)
-			defer f.finish()
-			tt.mockFn(f)
+		resp, err := f.handler.ListSchedules(context.Background(), nil)
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
 
-			resp, err := f.handler.ListSchedules(context.Background(), tt.request)
-			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Nil(t, resp)
-			}
+	t.Run("empty domain", func(t *testing.T) {
+		f := newScheduleTestFixture(t)
+		defer f.finish()
+
+		resp, err := f.handler.ListSchedules(context.Background(), &types.ListSchedulesRequest{})
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("success with results", func(t *testing.T) {
+		f := newScheduleTestFixture(t)
+		defer f.finish()
+
+		f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+
+		f.mockResource.VisibilityMgr.On("ListWorkflowExecutions", mock.Anything, mock.MatchedBy(func(req *persistence.ListWorkflowExecutionsByQueryRequest) bool {
+			return req.Domain == testDomain && req.Query == "WorkflowType = 'cadence-scheduler'"
+		})).Return(&persistence.ListWorkflowExecutionsResponse{
+			Executions: []*types.WorkflowExecutionInfo{
+				{
+					Execution: &types.WorkflowExecution{
+						WorkflowID: "cadence-scheduler:sched-1",
+						RunID:      "run-1",
+					},
+					Type: &types.WorkflowType{Name: scheduler.WorkflowTypeName},
+				},
+				{
+					Execution: &types.WorkflowExecution{
+						WorkflowID: "cadence-scheduler:sched-2",
+						RunID:      "run-2",
+					},
+					Type: &types.WorkflowType{Name: scheduler.WorkflowTypeName},
+				},
+			},
+			NextPageToken: []byte("next"),
+		}, nil).Once()
+
+		resp, err := f.handler.ListSchedules(context.Background(), &types.ListSchedulesRequest{
+			Domain:   testDomain,
+			PageSize: 10,
 		})
-	}
+		assert.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Len(t, resp.Schedules, 2)
+		assert.Equal(t, "sched-1", resp.Schedules[0].ScheduleID)
+		assert.Nil(t, resp.Schedules[0].WorkflowType)
+		assert.Nil(t, resp.Schedules[0].State)
+		assert.Empty(t, resp.Schedules[0].CronExpression)
+		assert.Equal(t, "sched-2", resp.Schedules[1].ScheduleID)
+		assert.Equal(t, []byte("next"), resp.NextPageToken)
+	})
 }
 
 func TestNormalizeScheduleError(t *testing.T) {


### PR DESCRIPTION
## What changed?

Replaced the `ListSchedules` stub with a working implementation that queries the visibility store for running scheduler workflows. Relates to #7664.

## Why?

`ListSchedules` was the last unimplemented schedule API, returning "not yet implemented". Users need a way to discover schedules in their domain. The implementation queries visibility for `WorkflowType = 'cadence-scheduler'` and extracts schedule IDs from the workflow IDs (stripping the `cadence-scheduler:` prefix).

Currently returns `ScheduleID` only. The `WorkflowType`, `State`, and `CronExpression` fields on `ScheduleListEntry` will be populated once schedule metadata is stored in the scheduler workflow's Memo.

## How did you test it?

```bash
make pr    # tidy, go-generate, fmt, lint — all pass
make build # all packages compile
go test -race -run Schedule ./service/frontend/api/...  # all pass
```

Tests cover: nil request, empty domain, and success path with mocked visibility manager returning multiple scheduler workflows.

## Potential risks

None — additive change replacing a stub. The visibility query uses the existing `ListWorkflowExecutions` handler (via `wh.ListWorkflowExecutions`), so all validation, rate limiting, and access control are inherited.

## Release notes

`ListSchedules` API now returns schedules in a domain. Currently returns schedule IDs; additional fields (cron expression, paused state, target workflow type) will be added in a follow-up.

## Documentation Changes

N/A