### PR TITLE
fix(scheduler): Fix race between submit and stop

### DIFF
--- a/common/task/hierarchical_weighted_round_robin_task_scheduler.go
+++ b/common/task/hierarchical_weighted_round_robin_task_scheduler.go
@@ -102,6 +102,13 @@ func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K, T]) Stop() {
 		w.logger.Warn("Hierarchical weighted round robin task scheduler timedout on shutdown.")
 	}
 
+	// Acquire and immediately release the write lock to ensure all Submit/TrySubmit calls
+	// that passed the isStopped() check have finished enqueueing before we drain.
+	// Without this, a Submit that slipped past isStopped() could write to a channel
+	// after drainAndNackTasks() completes, leaving that task permanently unprocessed.
+	w.Lock()
+	w.Unlock()
+
 	w.drainAndNackTasks()
 
 	w.logger.Info("Hierarchical weighted round robin task scheduler stopped.")
@@ -111,6 +118,9 @@ func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K, T]) Submit(task T) e
 	w.metricsScope.IncCounter(metrics.PriorityTaskSubmitRequest)
 	sw := w.metricsScope.StartTimer(metrics.PriorityTaskSubmitLatency)
 	defer sw.Stop()
+
+	w.RLock()
+	defer w.RUnlock()
 
 	if w.isStopped() {
 		return ErrTaskSchedulerClosed
@@ -129,6 +139,9 @@ func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K, T]) TrySubmit(
 	w.metricsScope.IncCounter(metrics.PriorityTaskSubmitRequest)
 	sw := w.metricsScope.StartTimer(metrics.PriorityTaskSubmitLatency)
 	defer sw.Stop()
+
+	w.RLock()
+	defer w.RUnlock()
 
 	if w.isStopped() {
 		return false, ErrTaskSchedulerClosed


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Use the embedded sync.RWMutex (currently unused) to synchronize Submit with the post-Stop drain

fixes https://github.com/cadence-workflow/cadence/issues/7989

**Why?**
 Race condition: Between isStopped() returning false in Submit()/TrySubmit() and drainAndNackTasks() completing in Stop(), there's a window where:                                                
  1. Submit passes the isStopped() check                                                                                                                                                           
  2. Stop() runs fully — dispatcher exits, drainAndNackTasks() finds nothing (pool is empty)                                                                                                       
  3. Submit calls pool.Enqueue() — pool ctx is already cancelled, but when both the channel-write and ctx.Done() are simultaneously ready, Go's select picks one at random. If the channel write   
  wins, the task lands in a channel nobody will ever read → taskWG hangs                                                    

**How did you test it?**
go test ./common/task/... -race -count=100 

**Potential risks**
No.

**Release notes**
N/A

**Documentation Changes**
N/A
