### PR TITLE
fix(replication): correct sign of ReplicationTasksDelay metric

### DIFF
--- a/service/history/replication/task_ack_manager.go
+++ b/service/history/replication/task_ack_manager.go
@@ -173,7 +173,7 @@ func (t *TaskAckManager) getTasks(ctx context.Context, pollingCluster string, la
 	t.scope.RecordTimer(metrics.ReplicationTasksLagRaw, time.Duration(lagRaw))
 	t.scope.RecordHistogramValue(metrics.ReplicationTasksLagRawHistogram, float64(lagRaw))
 	t.scope.UpdateGauge(metrics.ReplicationTasksLagRawGauge, float64(lagRaw))
-	t.scope.RecordHistogramDuration(metrics.ReplicationTasksDelay, time.Duration(oldestUnprocessedTaskTimestamp-t.timeSource.Now().UnixNano()))
+	t.scope.RecordHistogramDuration(metrics.ReplicationTasksDelay, time.Duration(t.timeSource.Now().UnixNano()-oldestUnprocessedTaskTimestamp))
 
 	// hydrate the tasks
 	for _, info := range taskInfos {


### PR DESCRIPTION
**What changed?**

Swap the operands in the `ReplicationTasksDelay` histogram calculation in `service/history/replication/task_ack_manager.go` so the metric records `now - oldestUnprocessedTaskTimestamp` instead of `oldestUnprocessedTaskTimestamp - now`. Fixes #7942.

**Why?**

`oldestUnprocessedTaskTimestamp` is the visibility timestamp of the oldest replication task that hasn't been processed yet, which is always in the past relative to the history service clock. The old expression `oldest - now` therefore always produced a negative `time.Duration` for real replication lag. `time.Duration` stores this as a negative `int64` nanoseconds, and histogram/percentile math downstream treated those as large negative numbers, so `p50`/`p99` on the delay histogram were effectively useless and hid real replication lag from dashboards and alerts.

Conceptually replication delay should answer "how old is the oldest unprocessed replication task?" — i.e. `now - oldest`, a non-negative duration. Swapping the operands gives that.

No extra zero-guard is needed for the "no tasks fetched" case (per the issue's expected-behavior section): the existing branch a few lines above already assigns `oldestUnprocessedTaskTimestamp = t.timeSource.Now().UnixNano()` when `len(taskInfos) == 0`, so that path emits `now - now = 0` under the corrected formula.

**How did you test it?**

Ran the existing unit tests for the package:

`go test -race -count=1 ./service/history/replication/ -run TestTaskAckManager`

All tests pass. The existing `TestTaskAckManager_GetTasks` table uses `metrics.NewNoopMetricsClient()`, which discards metric emissions, so it cannot observe the sign change — the fix is a pure numeric sign swap on a single `RecordHistogramDuration` call. Post-merge, the `replication_tasks_delay` histogram should flip from reporting `<= 0` to reporting actual positive lag durations, which can be verified in Grafana.

**Potential risks**

Minimal. Single-line change to one metric emission; no change to replication task processing logic, acking, or persistence. Operators should expect `replication_tasks_delay` p50/p99 values to change from ~0 (or negative) to the true positive replication lag — existing alerts thresholded against this histogram may need to be re-tuned now that the metric reports real values.

**Release notes**

Fix: `replication_tasks_delay` histogram now records non-negative durations representing the actual age of the oldest unprocessed replication task. Previously it recorded the negated value, causing dashboards and alerts keyed off this metric to hide real replication lag. Fixes #7942.

**Documentation Changes**

N/A.