### PR TITLE
feat(scheduler): add paused search attribute for ListSchedules

### DIFF
--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -34,7 +34,7 @@ frontend.validSearchAttributes:
     CadenceScheduleID: 1
     CadenceScheduleTime: 5
     CadenceScheduleIsBackfill: 4
-    CadenceSchedulePaused: 4
+    CadenceScheduleState: 1
     CloseStatus: 2
     CloseTime: 2
     CustomBoolField: 4

--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -34,6 +34,7 @@ frontend.validSearchAttributes:
     CadenceScheduleID: 1
     CadenceScheduleTime: 5
     CadenceScheduleIsBackfill: 4
+    CadenceSchedulePaused: 4
     CloseStatus: 2
     CloseTime: 2
     CustomBoolField: 4

--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/frontend/validate"
 	"github.com/uber/cadence/service/worker/scheduler"
@@ -55,6 +56,24 @@ func validateSchedulePolicies(policies *types.SchedulePolicies) error {
 		return &types.BadRequestError{
 			Message: "SKIP_NEW overlap policy with CATCH_UP_ALL catch-up policy is invalid: " +
 				"caught-up fires would be immediately skipped due to overlap with the previous run.",
+		}
+	}
+	return nil
+}
+
+// validateUserSearchAttributes rejects user search attribute keys that collide
+// with scheduler-reserved keys (CadenceSchedule* prefix). Without this check,
+// user values would be silently overwritten by the scheduler workflow's
+// UpsertSearchAttributes calls on start and on state change.
+func validateUserSearchAttributes(sa *types.SearchAttributes) error {
+	if sa == nil {
+		return nil
+	}
+	for k := range sa.IndexedFields {
+		if strings.HasPrefix(k, "CadenceSchedule") {
+			return &types.BadRequestError{
+				Message: fmt.Sprintf("search attribute key %q is reserved for internal use", k),
+			}
 		}
 	}
 	return nil
@@ -89,6 +108,9 @@ func (wh *WorkflowHandler) CreateSchedule(
 		return nil, &types.BadRequestError{Message: "Action.StartWorkflow is not set on request."}
 	}
 	if err := validateSchedulePolicies(request.GetPolicies()); err != nil {
+		return nil, err
+	}
+	if err := validateUserSearchAttributes(request.GetSearchAttributes()); err != nil {
 		return nil, err
 	}
 
@@ -395,11 +417,10 @@ func (wh *WorkflowHandler) ListSchedules(
 		pageSize = defaultListSchedulesPageSize
 	}
 
-	// TODO: populate ScheduleListEntry.WorkflowType, State, and CronExpression once
-	// CreateSchedule stores schedule metadata in the scheduler workflow's Memo.
-	// Currently only ScheduleID is returned (derived from the workflow ID).
-	// Follow-up: store metadata in Memo at create time, update via UpsertMemo on
-	// pause/unpause/update signals, and read Memo from visibility results here.
+	// NOTE: this calls wh.ListWorkflowExecutions directly (not via frontend client),
+	// which skips the cluster redirection middleware. For global (XDC) domains, the
+	// passive region may return stale visibility data. This applies to all schedule
+	// read APIs (Describe, List) and will be addressed when adding XDC support.
 	listResp, err := wh.ListWorkflowExecutions(ctx, &types.ListWorkflowExecutionsRequest{
 		Domain:        domainName,
 		PageSize:      pageSize,
@@ -415,9 +436,30 @@ func (wh *WorkflowHandler) ListSchedules(
 		wfID := exec.GetExecution().GetWorkflowID()
 		scheduleID := strings.TrimPrefix(wfID, scheduleWorkflowIDPrefix)
 
-		entries = append(entries, &types.ScheduleListEntry{
+		entry := &types.ScheduleListEntry{
 			ScheduleID: scheduleID,
-		})
+		}
+
+		// CronExpression and WorkflowType are populated in a follow-up PR that
+		// stores them as search attributes (so they can be updated on UpdateSchedule).
+
+		// Default to not paused. The scheduler workflow upserts this search attribute
+		// on start and on state change, so a missing value means the workflow hasn't
+		// run its first decision task yet (brief window after CreateSchedule).
+		paused := false
+		if exec.SearchAttributes != nil {
+			if pausedBytes, ok := exec.SearchAttributes.IndexedFields[scheduler.SearchAttrSchedulePaused]; ok {
+				if err := json.Unmarshal(pausedBytes, &paused); err != nil {
+					wh.GetLogger().Warn("failed to unmarshal CadenceSchedulePaused search attribute, defaulting to false",
+						tag.WorkflowID(scheduleWorkflowID(scheduleID)),
+						tag.Error(err),
+					)
+				}
+			}
+		}
+		entry.State = &types.ScheduleState{Paused: paused}
+
+		entries = append(entries, entry)
 	}
 
 	return &types.ListSchedulesResponse{

--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -448,12 +448,15 @@ func (wh *WorkflowHandler) ListSchedules(
 		// run its first decision task yet (brief window after CreateSchedule).
 		paused := false
 		if exec.SearchAttributes != nil {
-			if pausedBytes, ok := exec.SearchAttributes.IndexedFields[scheduler.SearchAttrSchedulePaused]; ok {
-				if err := json.Unmarshal(pausedBytes, &paused); err != nil {
-					wh.GetLogger().Warn("failed to unmarshal CadenceSchedulePaused search attribute, defaulting to false",
+			if stateBytes, ok := exec.SearchAttributes.IndexedFields[scheduler.SearchAttrScheduleState]; ok {
+				var stateStr string
+				if err := json.Unmarshal(stateBytes, &stateStr); err != nil {
+					wh.GetLogger().Warn("failed to unmarshal CadenceScheduleState search attribute, defaulting to active",
 						tag.WorkflowID(scheduleWorkflowID(scheduleID)),
 						tag.Error(err),
 					)
+				} else {
+					paused = stateStr == scheduler.ScheduleStatePaused
 				}
 			}
 		}

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -195,7 +195,7 @@ func TestCreateSchedule(t *testing.T) {
 					},
 				},
 				SearchAttributes: &types.SearchAttributes{IndexedFields: map[string][]byte{
-					"CadenceSchedulePaused": []byte("true"),
+					"CadenceScheduleState": []byte(`"paused"`),
 				}},
 			},
 			mockFn:  func(f *scheduleTestFixture) {},
@@ -698,7 +698,7 @@ func TestListSchedules(t *testing.T) {
 
 		f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
 
-		pausedBytes, _ := json.Marshal(true)
+		pausedStateBytes, _ := json.Marshal(scheduler.ScheduleStatePaused)
 
 		f.mockResource.VisibilityMgr.On("ListWorkflowExecutions", mock.Anything, mock.MatchedBy(func(req *persistence.ListWorkflowExecutionsByQueryRequest) bool {
 			return req.Domain == testDomain && req.Query == "WorkflowType = 'cadence-scheduler'"
@@ -711,7 +711,7 @@ func TestListSchedules(t *testing.T) {
 					},
 					Type: &types.WorkflowType{Name: scheduler.WorkflowTypeName},
 					SearchAttributes: &types.SearchAttributes{IndexedFields: map[string][]byte{
-						scheduler.SearchAttrSchedulePaused: pausedBytes,
+						scheduler.SearchAttrScheduleState: pausedStateBytes,
 					}},
 				},
 				{

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -183,6 +183,24 @@ func TestCreateSchedule(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		"user search attributes use reserved key": {
+			request: &types.CreateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "my-schedule",
+				Spec:       &types.ScheduleSpec{CronExpression: "*/5 * * * *"},
+				Action: &types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType: &types.WorkflowType{Name: "my-workflow"},
+						TaskList:     &types.TaskList{Name: "my-tasklist"},
+					},
+				},
+				SearchAttributes: &types.SearchAttributes{IndexedFields: map[string][]byte{
+					"CadenceSchedulePaused": []byte("true"),
+				}},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
 		"history error": {
 			request: validRequest,
 			mockFn: func(f *scheduleTestFixture) {
@@ -680,6 +698,8 @@ func TestListSchedules(t *testing.T) {
 
 		f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
 
+		pausedBytes, _ := json.Marshal(true)
+
 		f.mockResource.VisibilityMgr.On("ListWorkflowExecutions", mock.Anything, mock.MatchedBy(func(req *persistence.ListWorkflowExecutionsByQueryRequest) bool {
 			return req.Domain == testDomain && req.Query == "WorkflowType = 'cadence-scheduler'"
 		})).Return(&persistence.ListWorkflowExecutionsResponse{
@@ -690,6 +710,9 @@ func TestListSchedules(t *testing.T) {
 						RunID:      "run-1",
 					},
 					Type: &types.WorkflowType{Name: scheduler.WorkflowTypeName},
+					SearchAttributes: &types.SearchAttributes{IndexedFields: map[string][]byte{
+						scheduler.SearchAttrSchedulePaused: pausedBytes,
+					}},
 				},
 				{
 					Execution: &types.WorkflowExecution{
@@ -709,11 +732,15 @@ func TestListSchedules(t *testing.T) {
 		assert.NoError(t, err)
 		require.NotNil(t, resp)
 		assert.Len(t, resp.Schedules, 2)
+
 		assert.Equal(t, "sched-1", resp.Schedules[0].ScheduleID)
-		assert.Nil(t, resp.Schedules[0].WorkflowType)
-		assert.Nil(t, resp.Schedules[0].State)
-		assert.Empty(t, resp.Schedules[0].CronExpression)
+		require.NotNil(t, resp.Schedules[0].State)
+		assert.True(t, resp.Schedules[0].State.Paused)
+
 		assert.Equal(t, "sched-2", resp.Schedules[1].ScheduleID)
+		require.NotNil(t, resp.Schedules[1].State)
+		assert.False(t, resp.Schedules[1].State.Paused, "missing search attribute should default to not paused")
+
 		assert.Equal(t, []byte("next"), resp.NextPageToken)
 	})
 }

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -44,7 +44,15 @@ const (
 	SearchAttrIsBackfill   = "CadenceScheduleIsBackfill"
 
 	// Search attribute keys set on the scheduler workflow itself for ListSchedules.
-	SearchAttrSchedulePaused = "CadenceSchedulePaused"
+	// CadenceScheduleState is a Keyword SA holding the current lifecycle state
+	// ("active" or "paused"). Modeled as a string rather than a boolean so it can
+	// be extended to additional states (e.g. "expired") without introducing new
+	// search attributes. "Deleted" is not a value because a deleted schedule's
+	// workflow is closed and filtered by workflow status instead.
+	SearchAttrScheduleState = "CadenceScheduleState"
+
+	ScheduleStateActive = "active"
+	ScheduleStatePaused = "paused"
 
 	maxIterationsBeforeContinueAsNew = 500
 	maxCatchUpFiresPerExecution      = 10

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -43,6 +43,9 @@ const (
 	SearchAttrScheduleTime = "CadenceScheduleTime"
 	SearchAttrIsBackfill   = "CadenceScheduleIsBackfill"
 
+	// Search attribute keys set on the scheduler workflow itself for ListSchedules.
+	SearchAttrSchedulePaused = "CadenceSchedulePaused"
+
 	maxIterationsBeforeContinueAsNew = 500
 	maxCatchUpFiresPerExecution      = 10
 	maxBackfillFiresPerExecution     = 10

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -67,14 +67,14 @@ func SchedulerWorkflow(ctx workflow.Context, input SchedulerWorkflowInput) error
 		return fmt.Errorf("failed to register query handler: %w", err)
 	}
 
-	// Re-upsert the paused search attribute on every execution (including after
+	// Re-upsert the state search attribute on every execution (including after
 	// ContinueAsNew). Search attributes set via UpsertSearchAttributes in a prior
 	// execution are not automatically carried over, so we must refresh them here
 	// to keep ListSchedules visibility results in sync with the current state.
 	if err := workflow.UpsertSearchAttributes(ctx, map[string]interface{}{
-		SearchAttrSchedulePaused: state.Paused,
+		SearchAttrScheduleState: scheduleStateFromPaused(state.Paused),
 	}); err != nil {
-		logger.Warn("failed to upsert schedule paused search attribute", zap.Error(err))
+		logger.Warn("failed to upsert schedule state search attribute", zap.Error(err))
 	}
 
 	chs := signalChannels{
@@ -139,12 +139,16 @@ func SchedulerWorkflow(ctx workflow.Context, input SchedulerWorkflowInput) error
 
 		if state.Paused != previousPaused {
 			if err := workflow.UpsertSearchAttributes(ctx, map[string]interface{}{
-				SearchAttrSchedulePaused: state.Paused,
+				SearchAttrScheduleState: scheduleStateFromPaused(state.Paused),
 			}); err != nil {
-				logger.Warn("failed to upsert schedule paused search attribute", zap.Error(err))
+				logger.Warn("failed to upsert schedule state search attribute", zap.Error(err))
 			}
 		}
 
+		// Deleted schedules terminate the workflow here. Any further signals
+		// (pause, unpause, update, backfill) sent after this point fail with
+		// EntityNotExistsError at the RPC layer because the workflow is closed;
+		// the frontend normalizes that to a user-friendly "schedule not found".
 		if state.Deleted {
 			logger.Info("schedule deleted")
 			return nil
@@ -287,6 +291,15 @@ func drainBufferedSignals(
 	}
 
 	return stateChanged
+}
+
+// scheduleStateFromPaused maps the workflow's boolean Paused flag to the
+// keyword value stored in the CadenceScheduleState search attribute.
+func scheduleStateFromPaused(paused bool) string {
+	if paused {
+		return ScheduleStatePaused
+	}
+	return ScheduleStateActive
 }
 
 func handlePause(logger *zap.Logger, sig PauseSignal, state *SchedulerWorkflowState) bool {

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -67,6 +67,16 @@ func SchedulerWorkflow(ctx workflow.Context, input SchedulerWorkflowInput) error
 		return fmt.Errorf("failed to register query handler: %w", err)
 	}
 
+	// Re-upsert the paused search attribute on every execution (including after
+	// ContinueAsNew). Search attributes set via UpsertSearchAttributes in a prior
+	// execution are not automatically carried over, so we must refresh them here
+	// to keep ListSchedules visibility results in sync with the current state.
+	if err := workflow.UpsertSearchAttributes(ctx, map[string]interface{}{
+		SearchAttrSchedulePaused: state.Paused,
+	}); err != nil {
+		logger.Warn("failed to upsert schedule paused search attribute", zap.Error(err))
+	}
+
 	chs := signalChannels{
 		pause:    workflow.GetSignalChannel(ctx, SignalNamePause),
 		unpause:  workflow.GetSignalChannel(ctx, SignalNameUnpause),
@@ -120,10 +130,19 @@ func SchedulerWorkflow(ctx workflow.Context, input SchedulerWorkflowInput) error
 			timerFuture = workflow.NewTimer(timerCtx, dur)
 		}
 
+		previousPaused := state.Paused
 		changed, timerFired := applyAllInputs(ctx, logger, timerFuture, chs, state, &input)
 
 		if timerCancel != nil {
 			timerCancel()
+		}
+
+		if state.Paused != previousPaused {
+			if err := workflow.UpsertSearchAttributes(ctx, map[string]interface{}{
+				SearchAttrSchedulePaused: state.Paused,
+			}); err != nil {
+				logger.Warn("failed to upsert schedule paused search attribute", zap.Error(err))
+			}
 		}
 
 		if state.Deleted {


### PR DESCRIPTION
## What changed?

Adds a `CadenceSchedulePaused` search attribute on the scheduler workflow so `ListSchedules` can return the paused state for each schedule without per-schedule `QueryWorkflow` calls. Relates to #7664.

## Why?

After #7993, `ListSchedules` only returned `ScheduleID`. We use search attributes (since memo is not indexable), this PR adds the first scheduler-level search attribute: `CadenceSchedulePaused`.

The scheduler workflow upserts this attribute in two places:
- **On workflow start** (including after `ContinueAsNew`) — search attributes set via `UpsertSearchAttributes` do not automatically carry across `ContinueAsNew` in the Cadence Go SDK
- **On pause/unpause signals** — to keep visibility in sync with the authoritative workflow state.

`ListSchedules` reads the attribute from visibility and defaults to `Paused: false` when missing (brief window after `CreateSchedule` before the workflow's first decision task).

Follow-up PR will add `CadenceScheduleCron` and `CadenceScheduleWorkflowType` search attributes to populate the remaining `ScheduleListEntry` fields (cron, target workflow type) and allow users to filter schedules by those values.

## How did you test it?

```bash
make pr    # tidy, go-generate, fmt, lint — all pass
make build # all packages compile
go test -race -run Schedule ./service/frontend/api/... ./service/worker/scheduler/...  # all pass
```

Test cases:
- `CreateSchedule` rejects user search attributes with reserved `CadenceSchedule*` keys
- `ListSchedules` populates `State.Paused` from the search attribute when present
- `ListSchedules` defaults to `Paused: false` when the search attribute is absent

## Potential risks

- Adds one new search attribute key (`CadenceSchedulePaused`) that needs to be registered in the visibility store. Dev config updated; staging/prod operators follow the standard Flipr + ES onboarding flow.
- `workflow.UpsertSearchAttributes` is called on every scheduler workflow start — adds one extra decision per schedule at start time, negligible cost.
- No API/IDL changes.

## Release notes

`ListSchedules` now includes paused state for each schedule. Requires `CadenceSchedulePaused` search attribute to be registered in the visibility store.

## Documentation Changes

N/A