### PR TITLE
fix(configstore): wait for dynamic config polling goroutine to stop before closing persistence

### DIFF
--- a/common/dynamicconfig/configstore/config_store_client.go
+++ b/common/dynamicconfig/configstore/config_store_client.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -73,6 +74,7 @@ type configStoreClient struct {
 	config             *csc.ClientConfig
 	configStoreManager persistence.ConfigStoreManager
 	doneCh             chan struct{}
+	wg                 sync.WaitGroup
 	logger             log.Logger
 }
 
@@ -160,7 +162,9 @@ func (csc *configStoreClient) startUpdate() error {
 	if err := csc.update(); err != nil {
 		return err
 	}
+	csc.wg.Add(1)
 	go func() {
+		defer csc.wg.Done()
 		ticker := time.NewTicker(csc.config.PollInterval)
 		for {
 			select {
@@ -376,6 +380,7 @@ func (csc *configStoreClient) Stop() {
 		return
 	}
 	close(csc.doneCh)
+	csc.wg.Wait()
 	csc.configStoreManager.Close()
 }
 


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
`configStoreClient.Stop()` now waits for its background dynamic-config polling goroutine to finish before closing the underlying persistence store


**Why?**
It is consistent with the reported SQLite WASM panic stack https://github.com/cadence-workflow/cadence/issues/7978.
Before, `Stop()` closed `doneCh` and immediately shut down the config store without waiting for the polling goroutine to finish. If that goroutine was still running a DB query, the database could get closed mid query causing crash.

**How did you test it?**
 ```
go test -race -count=1 ./common/dynamicconfig/configstore/...
```


**Potential risks**


**Release notes**


**Documentation Changes**

