### PR TITLE
feat(metrics): replace event-based replication gauges with counters

### DIFF
--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -308,12 +308,9 @@ func (g *GaugeMigration) UnmarshalYAML(read func(any) error) error {
 // This is likely best done in an `init` func, to ensure it happens early enough
 // and does not race with config reading.
 var GaugeMigrationMetrics = map[string]struct{}{
-	"cache_size_gauge":                      {},
-	"replication_tasks_lag_gauge":           {},
-	"replication_tasks_lag_raw_gauge":       {},
-	"replication_tasks_fetched_gauge":       {},
-	"replication_tasks_returned_gauge":      {},
-	"replication_tasks_returned_diff_gauge": {},
+	"cache_size_gauge":                {},
+	"replication_tasks_lag_gauge":     {},
+	"replication_tasks_lag_raw_gauge": {},
 }
 
 func (g GaugeMigration) EmitTimer(name string) bool {
@@ -417,7 +414,11 @@ func (c *CounterMigration) UnmarshalYAML(read func(any) error) error {
 // loading config, in case they have any custom migrations to perform.
 // This is likely best done in an `init` func, to ensure it happens early enough
 // and does not race with config reading.
-var CounterMigrationMetrics = map[string]struct{}{}
+var CounterMigrationMetrics = map[string]struct{}{
+	"replication_tasks_fetched_counter":       {},
+	"replication_tasks_returned_counter":      {},
+	"replication_tasks_returned_diff_counter": {},
+}
 
 func (c CounterMigration) EmitTimer(name string) bool {
 	if _, ok := CounterMigrationMetrics[name]; !ok {

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2862,13 +2862,13 @@ const (
 	ReplicationTasksDelay
 	ReplicationTasksFetched
 	ReplicationTasksFetchedHistogram
-	ReplicationTasksFetchedGauge
+	ReplicationTasksFetchedCounter
 	ReplicationTasksReturned
 	ReplicationTasksReturnedHistogram
-	ReplicationTasksReturnedGauge
+	ReplicationTasksReturnedCounter
 	ReplicationTasksReturnedDiff
 	ReplicationTasksReturnedDiffHistogram
-	ReplicationTasksReturnedDiffGauge
+	ReplicationTasksReturnedDiffCounter
 	ReplicationTasksAppliedLatency
 	ReplicationTasksAppliedLatencyHistogram
 	ReplicationTasksBatchSize
@@ -3795,13 +3795,13 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 		ReplicationTasksDelay:                                         {metricName: "replication_tasks_delay", metricType: Histogram, buckets: ReplicationTaskDelayBucket},
 		ReplicationTasksFetched:                                       {metricName: "replication_tasks_fetched", metricType: Timer},
 		ReplicationTasksFetchedHistogram:                              {metricName: "replication_tasks_fetched_counts", metricType: Histogram, buckets: ResponseRowSizeBuckets},
-		ReplicationTasksFetchedGauge:                                  {metricName: "replication_tasks_fetched_gauge", metricType: Gauge},
+		ReplicationTasksFetchedCounter:                                {metricName: "replication_tasks_fetched_counter", metricType: Counter},
 		ReplicationTasksReturned:                                      {metricName: "replication_tasks_returned", metricType: Timer},
 		ReplicationTasksReturnedHistogram:                             {metricName: "replication_tasks_returned_counts", metricType: Histogram, buckets: ResponseRowSizeBuckets},
-		ReplicationTasksReturnedGauge:                                 {metricName: "replication_tasks_returned_gauge", metricType: Gauge},
+		ReplicationTasksReturnedCounter:                               {metricName: "replication_tasks_returned_counter", metricType: Counter},
 		ReplicationTasksReturnedDiff:                                  {metricName: "replication_tasks_returned_diff", metricType: Timer},
 		ReplicationTasksReturnedDiffHistogram:                         {metricName: "replication_tasks_returned_diff_counts", metricType: Histogram, buckets: ResponseRowSizeBuckets},
-		ReplicationTasksReturnedDiffGauge:                             {metricName: "replication_tasks_returned_diff_gauge", metricType: Gauge},
+		ReplicationTasksReturnedDiffCounter:                           {metricName: "replication_tasks_returned_diff_counter", metricType: Counter},
 		ReplicationTasksAppliedLatency:                                {metricName: "replication_tasks_applied_latency", metricType: Timer},
 		ReplicationTasksAppliedLatencyHistogram:                       {metricName: "replication_tasks_applied_latency_ns", metricType: Histogram, exponentialBuckets: Low1ms100s},
 		ReplicationTasksBatchSize:                                     {metricName: "replication_tasks_batch_size", metricType: Gauge},

--- a/service/history/replication/task_ack_manager.go
+++ b/service/history/replication/task_ack_manager.go
@@ -148,7 +148,7 @@ func (t *TaskAckManager) getTasks(ctx context.Context, pollingCluster string, la
 	tasksFetched := len(taskInfos)
 	t.scope.RecordTimer(metrics.ReplicationTasksFetched, time.Duration(tasksFetched))
 	t.scope.RecordHistogramValue(metrics.ReplicationTasksFetchedHistogram, float64(tasksFetched))
-	t.scope.UpdateGauge(metrics.ReplicationTasksFetchedGauge, float64(tasksFetched))
+	t.scope.AddCounter(metrics.ReplicationTasksFetchedCounter, int64(tasksFetched))
 
 	// Happy path assumption - we will push all tasks to replication tasks.
 	msgs := &types.ReplicationMessages{
@@ -212,12 +212,12 @@ func (t *TaskAckManager) getTasks(ctx context.Context, pollingCluster string, la
 	tasksReturned := len(msgs.ReplicationTasks)
 	t.scope.RecordTimer(metrics.ReplicationTasksReturned, time.Duration(tasksReturned))
 	t.scope.RecordHistogramValue(metrics.ReplicationTasksReturnedHistogram, float64(tasksReturned))
-	t.scope.UpdateGauge(metrics.ReplicationTasksReturnedGauge, float64(tasksReturned))
+	t.scope.AddCounter(metrics.ReplicationTasksReturnedCounter, int64(tasksReturned))
 
 	tasksReturnedDiff := len(taskInfos) - len(msgs.ReplicationTasks)
 	t.scope.RecordTimer(metrics.ReplicationTasksReturnedDiff, time.Duration(tasksReturnedDiff))
 	t.scope.RecordHistogramValue(metrics.ReplicationTasksReturnedDiffHistogram, float64(tasksReturnedDiff))
-	t.scope.UpdateGauge(metrics.ReplicationTasksReturnedDiffGauge, float64(tasksReturnedDiff))
+	t.scope.AddCounter(metrics.ReplicationTasksReturnedDiffCounter, int64(tasksReturnedDiff))
 
 	t.ackLevel(pollingCluster, lastReadTaskID)
 


### PR DESCRIPTION
**What changed?**

Converts three event-valued replication gauges (`replication_tasks_fetched_gauge`, `replication_tasks_returned_gauge`, `replication_tasks_returned_diff_gauge`) into counters (`*_counter`) and wires them into the `CounterMigration` framework alongside their timer counterparts.

**Why?**

These three gauges record values emitted at the moment of a discrete event (a batch fetch/return), not a point-in-time state, so a "last value" gauge becomes meaningless between emissions. The right type for an event-valued throughput signal is a counter: `derivative | scaleToSeconds` answers "how many tasks/sec?" — a question the gauge can't answer at all. Batch-size distribution is already covered by the existing `*_counts` histograms. The three genuine state gauges added alongside these (`cache_size_gauge`, `replication_tasks_lag_gauge`, `replication_tasks_lag_raw_gauge`) are preserved.

**How did you test it?**

- `go test -race -count=1 ./common/metrics/... ./service/history/replication/...` — all pass
- `make pr GEN_DIR=common/metrics` — clean, no generated-file drift

**Potential risks**

Minimal. Downstream dashboards should switch to `*_counter | derivative | scaleToSeconds 1` for per-second throughput panels and keep using `*_counts` histograms for batch-size distribution — follow-up PR in the dashboard repo.

**Release notes**

Replaced the three event-valued replication gauges with counters (`replication_tasks_fetched_counter`, `replication_tasks_returned_counter`, `replication_tasks_returned_diff_counter`). Dashboards/alerts using the old gauges need to switch to the new counters.

**Documentation Changes**

N/A.