### PR TITLE
feat(schedules): enrich ListSchedules with cron and workflow type

### DIFF
--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -35,6 +35,8 @@ frontend.validSearchAttributes:
     CadenceScheduleTime: 5
     CadenceScheduleIsBackfill: 4
     CadenceScheduleState: 1
+    CadenceScheduleCron: 1
+    CadenceScheduleWorkflowType: 1
     CloseStatus: 2
     CloseTime: 2
     CustomBoolField: 4

--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -440,15 +440,15 @@ func (wh *WorkflowHandler) ListSchedules(
 			ScheduleID: scheduleID,
 		}
 
-		// CronExpression and WorkflowType are populated in a follow-up PR that
-		// stores them as search attributes (so they can be updated on UpdateSchedule).
-
-		// Default to not paused. The scheduler workflow upserts this search attribute
-		// on start and on state change, so a missing value means the workflow hasn't
-		// run its first decision task yet (brief window after CreateSchedule).
+		// Default to not paused. The scheduler workflow upserts these search
+		// attributes on start (and ContinueAsNew) and on state change, so a missing
+		// value means the workflow hasn't run its first decision task yet (brief
+		// window after CreateSchedule).
 		paused := false
+		var cronExpr, workflowTypeName string
 		if exec.SearchAttributes != nil {
-			if stateBytes, ok := exec.SearchAttributes.IndexedFields[scheduler.SearchAttrScheduleState]; ok {
+			idx := exec.SearchAttributes.IndexedFields
+			if stateBytes, ok := idx[scheduler.SearchAttrScheduleState]; ok {
 				var stateStr string
 				if err := json.Unmarshal(stateBytes, &stateStr); err != nil {
 					wh.GetLogger().Warn("failed to unmarshal CadenceScheduleState search attribute, defaulting to active",
@@ -459,8 +459,28 @@ func (wh *WorkflowHandler) ListSchedules(
 					paused = stateStr == scheduler.ScheduleStatePaused
 				}
 			}
+			if cronBytes, ok := idx[scheduler.SearchAttrScheduleCron]; ok {
+				if err := json.Unmarshal(cronBytes, &cronExpr); err != nil {
+					wh.GetLogger().Warn("failed to unmarshal CadenceScheduleCron search attribute, defaulting to empty",
+						tag.WorkflowID(scheduleWorkflowID(scheduleID)),
+						tag.Error(err),
+					)
+				}
+			}
+			if typeBytes, ok := idx[scheduler.SearchAttrScheduleWorkflowType]; ok {
+				if err := json.Unmarshal(typeBytes, &workflowTypeName); err != nil {
+					wh.GetLogger().Warn("failed to unmarshal CadenceScheduleWorkflowType search attribute, defaulting to empty",
+						tag.WorkflowID(scheduleWorkflowID(scheduleID)),
+						tag.Error(err),
+					)
+				}
+			}
 		}
 		entry.State = &types.ScheduleState{Paused: paused}
+		entry.CronExpression = cronExpr
+		if workflowTypeName != "" {
+			entry.WorkflowType = &types.WorkflowType{Name: workflowTypeName}
+		}
 
 		entries = append(entries, entry)
 	}

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -699,6 +699,8 @@ func TestListSchedules(t *testing.T) {
 		f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
 
 		pausedStateBytes, _ := json.Marshal(scheduler.ScheduleStatePaused)
+		cronBytes, _ := json.Marshal("0 6 * * *")
+		typeBytes, _ := json.Marshal("my-target-workflow")
 
 		f.mockResource.VisibilityMgr.On("ListWorkflowExecutions", mock.Anything, mock.MatchedBy(func(req *persistence.ListWorkflowExecutionsByQueryRequest) bool {
 			return req.Domain == testDomain && req.Query == "WorkflowType = 'cadence-scheduler'"
@@ -711,7 +713,9 @@ func TestListSchedules(t *testing.T) {
 					},
 					Type: &types.WorkflowType{Name: scheduler.WorkflowTypeName},
 					SearchAttributes: &types.SearchAttributes{IndexedFields: map[string][]byte{
-						scheduler.SearchAttrScheduleState: pausedStateBytes,
+						scheduler.SearchAttrScheduleState:        pausedStateBytes,
+						scheduler.SearchAttrScheduleCron:         cronBytes,
+						scheduler.SearchAttrScheduleWorkflowType: typeBytes,
 					}},
 				},
 				{
@@ -736,10 +740,15 @@ func TestListSchedules(t *testing.T) {
 		assert.Equal(t, "sched-1", resp.Schedules[0].ScheduleID)
 		require.NotNil(t, resp.Schedules[0].State)
 		assert.True(t, resp.Schedules[0].State.Paused)
+		assert.Equal(t, "0 6 * * *", resp.Schedules[0].CronExpression)
+		require.NotNil(t, resp.Schedules[0].WorkflowType)
+		assert.Equal(t, "my-target-workflow", resp.Schedules[0].WorkflowType.Name)
 
 		assert.Equal(t, "sched-2", resp.Schedules[1].ScheduleID)
 		require.NotNil(t, resp.Schedules[1].State)
 		assert.False(t, resp.Schedules[1].State.Paused, "missing search attribute should default to not paused")
+		assert.Empty(t, resp.Schedules[1].CronExpression, "missing cron search attribute should yield empty string")
+		assert.Nil(t, resp.Schedules[1].WorkflowType, "missing workflow type search attribute should yield nil")
 
 		assert.Equal(t, []byte("next"), resp.NextPageToken)
 	})

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -50,6 +50,13 @@ const (
 	// search attributes. "Deleted" is not a value because a deleted schedule's
 	// workflow is closed and filtered by workflow status instead.
 	SearchAttrScheduleState = "CadenceScheduleState"
+	// CadenceScheduleCron holds the current cron expression so ListSchedules
+	// can display it without querying each scheduler workflow. Refreshed on
+	// workflow start (including after ContinueAsNew triggered by UpdateSchedule).
+	SearchAttrScheduleCron = "CadenceScheduleCron"
+	// CadenceScheduleWorkflowType holds the target workflow type name that the
+	// schedule starts on each fire. Same refresh semantics as the cron SA.
+	SearchAttrScheduleWorkflowType = "CadenceScheduleWorkflowType"
 
 	ScheduleStateActive = "active"
 	ScheduleStatePaused = "paused"

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -67,14 +67,13 @@ func SchedulerWorkflow(ctx workflow.Context, input SchedulerWorkflowInput) error
 		return fmt.Errorf("failed to register query handler: %w", err)
 	}
 
-	// Re-upsert the state search attribute on every execution (including after
-	// ContinueAsNew). Search attributes set via UpsertSearchAttributes in a prior
-	// execution are not automatically carried over, so we must refresh them here
-	// to keep ListSchedules visibility results in sync with the current state.
-	if err := workflow.UpsertSearchAttributes(ctx, map[string]interface{}{
-		SearchAttrScheduleState: scheduleStateFromPaused(state.Paused),
-	}); err != nil {
-		logger.Warn("failed to upsert schedule state search attribute", zap.Error(err))
+	// Re-upsert search attributes on every execution (including after ContinueAsNew).
+	// Values set via UpsertSearchAttributes in a prior execution are not automatically
+	// carried over, so we must refresh them here to keep ListSchedules visibility
+	// results in sync with the current state/spec/action. UpdateSchedule triggers
+	// ContinueAsNew, so the new cron and workflow type land here on the next start.
+	if err := workflow.UpsertSearchAttributes(ctx, buildScheduleSearchAttributes(&input, state)); err != nil {
+		logger.Warn("failed to upsert schedule search attributes", zap.Error(err))
 	}
 
 	chs := signalChannels{
@@ -144,6 +143,9 @@ func SchedulerWorkflow(ctx workflow.Context, input SchedulerWorkflowInput) error
 				logger.Warn("failed to upsert schedule state search attribute", zap.Error(err))
 			}
 		}
+		// Note: cron and workflow type search attributes are refreshed at the top
+		// of the next workflow execution after UpdateSchedule triggers ContinueAsNew,
+		// so no inline upsert is needed here.
 
 		// Deleted schedules terminate the workflow here. Any further signals
 		// (pause, unpause, update, backfill) sent after this point fail with
@@ -300,6 +302,24 @@ func scheduleStateFromPaused(paused bool) string {
 		return ScheduleStatePaused
 	}
 	return ScheduleStateActive
+}
+
+// buildScheduleSearchAttributes returns the search attributes that describe a
+// scheduler workflow for ListSchedules: lifecycle state, cron expression, and
+// target workflow type. The state SA is always written (the boolean Paused has
+// a meaningful default). Optional fields (cron, workflow type) are omitted when
+// empty so visibility queries can distinguish "absent" from "empty string".
+func buildScheduleSearchAttributes(input *SchedulerWorkflowInput, state *SchedulerWorkflowState) map[string]interface{} {
+	sa := map[string]interface{}{
+		SearchAttrScheduleState: scheduleStateFromPaused(state.Paused),
+	}
+	if cron := input.Spec.CronExpression; cron != "" {
+		sa[SearchAttrScheduleCron] = cron
+	}
+	if sw := input.Action.StartWorkflow; sw != nil && sw.WorkflowType != nil && sw.WorkflowType.Name != "" {
+		sa[SearchAttrScheduleWorkflowType] = sw.WorkflowType.Name
+	}
+	return sa
 }
 
 func handlePause(logger *zap.Logger, sig PauseSignal, state *SchedulerWorkflowState) bool {

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -816,3 +816,112 @@ func TestBackfillFireComputation(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildScheduleSearchAttributes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input *SchedulerWorkflowInput
+		state *SchedulerWorkflowState
+		want  map[string]interface{}
+	}{
+		{
+			name: "active schedule with cron and workflow type",
+			input: &SchedulerWorkflowInput{
+				Spec: types.ScheduleSpec{CronExpression: "0 6 * * *"},
+				Action: types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType: &types.WorkflowType{Name: "my-workflow"},
+					},
+				},
+			},
+			state: &SchedulerWorkflowState{Paused: false},
+			want: map[string]interface{}{
+				SearchAttrScheduleState:        ScheduleStateActive,
+				SearchAttrScheduleCron:         "0 6 * * *",
+				SearchAttrScheduleWorkflowType: "my-workflow",
+			},
+		},
+		{
+			name: "paused schedule",
+			input: &SchedulerWorkflowInput{
+				Spec: types.ScheduleSpec{CronExpression: "*/5 * * * *"},
+				Action: types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType: &types.WorkflowType{Name: "wf-a"},
+					},
+				},
+			},
+			state: &SchedulerWorkflowState{Paused: true},
+			want: map[string]interface{}{
+				SearchAttrScheduleState:        ScheduleStatePaused,
+				SearchAttrScheduleCron:         "*/5 * * * *",
+				SearchAttrScheduleWorkflowType: "wf-a",
+			},
+		},
+		{
+			name: "missing start-workflow action omits workflow type SA",
+			input: &SchedulerWorkflowInput{
+				Spec:   types.ScheduleSpec{CronExpression: "@hourly"},
+				Action: types.ScheduleAction{}, // no StartWorkflow
+			},
+			state: &SchedulerWorkflowState{},
+			want: map[string]interface{}{
+				SearchAttrScheduleState: ScheduleStateActive,
+				SearchAttrScheduleCron:  "@hourly",
+			},
+		},
+		{
+			name: "nil workflow type omits workflow type SA",
+			input: &SchedulerWorkflowInput{
+				Spec: types.ScheduleSpec{CronExpression: "@daily"},
+				Action: types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{WorkflowType: nil},
+				},
+			},
+			state: &SchedulerWorkflowState{},
+			want: map[string]interface{}{
+				SearchAttrScheduleState: ScheduleStateActive,
+				SearchAttrScheduleCron:  "@daily",
+			},
+		},
+		{
+			name: "empty-name workflow type omits workflow type SA",
+			input: &SchedulerWorkflowInput{
+				Spec: types.ScheduleSpec{CronExpression: "@daily"},
+				Action: types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType: &types.WorkflowType{Name: ""},
+					},
+				},
+			},
+			state: &SchedulerWorkflowState{},
+			want: map[string]interface{}{
+				SearchAttrScheduleState: ScheduleStateActive,
+				SearchAttrScheduleCron:  "@daily",
+			},
+		},
+		{
+			name: "empty cron expression omits cron SA",
+			input: &SchedulerWorkflowInput{
+				Spec: types.ScheduleSpec{CronExpression: ""},
+				Action: types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType: &types.WorkflowType{Name: "wf"},
+					},
+				},
+			},
+			state: &SchedulerWorkflowState{},
+			want: map[string]interface{}{
+				SearchAttrScheduleState:        ScheduleStateActive,
+				SearchAttrScheduleWorkflowType: "wf",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildScheduleSearchAttributes(tt.input, tt.state)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## What changed?

Adds two keyword search attributes on the scheduler workflow itself so that `ListSchedules` can surface the current cron expression and target workflow type without a per-schedule fan-out query:

- `CadenceScheduleCron` current cron expression
- `CadenceScheduleWorkflowType` target workflow type name

Both are refreshed at the top of every workflow execution (so values reflect the current input, including after `UpdateSchedule` triggers ContinueAsNew). The state SA (`CadenceScheduleState`, from #7999) is still upserted inline on pause/unpause since it changes mid-execution.

Implemented via a new `buildScheduleSearchAttributes` helper that consolidates all three scheduler-workflow SAs.

## Why?

`ListSchedules` was returning entries with only `ScheduleID` + `State.Paused` populated — UIs and CLIs had no way to show what the schedule does without calling `DescribeSchedule` per entry. Storing the cron and workflow type as search attributes keeps `ListSchedules` O(page_size) instead of O(page_size × extra round trips).

Optional fields are omitted when empty so visibility queries can distinguish absent values from explicit empty strings (avoids polluting the index with empty-string rows on malformed schedules).

## How did you test it?

- `make pr`: tidy, go-generate, fmt, lint all pass with no generated-file drift
- `make build`: all packages + tests compile
- `make test`: full unit-test suite passes, including new `TestBuildScheduleSearchAttributes` table test covering active/paused/empty-cron/nil-action/empty-name-type variants, and extended `ListSchedules` handler test asserting cron + workflow type are populated when SAs are set and default to empty/nil when absent

## Potential risks

- **Visibility schema**: two new keyword SAs must be registered in the visibility store. `development.yaml` is updated; production clusters must add `CadenceScheduleCron` and `CadenceScheduleWorkflowType` (both `Keyword`, type `1`) before this change takes effect.
- **Pre-existing, not regression**: `ListSchedules` query matches both open and closed scheduler workflows, so deleted schedules may appear with stale SAs. Tracked for a follow-up; not introduced by this PR.

## Release notes

`ListSchedules` now returns `CronExpression` and `WorkflowType` on each entry for schedulers whose workflows have upserted these search attributes (any new or re-started scheduler).

## Documentation Changes

Updated Schedules ERD.