### PR TITLE
fix(schedule): exclude deleted schedules from ListSchedules

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -421,11 +421,16 @@ func (wh *WorkflowHandler) ListSchedules(
 	// which skips the cluster redirection middleware. For global (XDC) domains, the
 	// passive region may return stale visibility data. This applies to all schedule
 	// read APIs (Describe, List) and will be addressed when adding XDC support.
+	//
+	// CloseTime = missing restricts results to open scheduler workflows, so deleted
+	// schedules (closed workflows with state.Deleted=true returned nil) no longer
+	// surface here. This is the canonical "open only" filter used across the
+	// visibility layer (ES, Pinot, SQL-backed stores all recognize it).
 	listResp, err := wh.ListWorkflowExecutions(ctx, &types.ListWorkflowExecutionsRequest{
 		Domain:        domainName,
 		PageSize:      pageSize,
 		NextPageToken: request.GetNextPageToken(),
-		Query:         fmt.Sprintf("WorkflowType = '%s'", scheduler.WorkflowTypeName),
+		Query:         fmt.Sprintf("WorkflowType = '%s' and CloseTime = missing", scheduler.WorkflowTypeName),
 	})
 	if err != nil {
 		return nil, err

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -703,7 +703,7 @@ func TestListSchedules(t *testing.T) {
 		typeBytes, _ := json.Marshal("my-target-workflow")
 
 		f.mockResource.VisibilityMgr.On("ListWorkflowExecutions", mock.Anything, mock.MatchedBy(func(req *persistence.ListWorkflowExecutionsByQueryRequest) bool {
-			return req.Domain == testDomain && req.Query == "WorkflowType = 'cadence-scheduler'"
+			return req.Domain == testDomain && req.Query == "WorkflowType = 'cadence-scheduler' and CloseTime = missing"
 		})).Return(&persistence.ListWorkflowExecutionsResponse{
 			Executions: []*types.WorkflowExecutionInfo{
 				{


### PR DESCRIPTION
## What changed?

Adds `CloseTime = missing` to the visibility query in `ListSchedules` so that deleted schedules (closed scheduler workflows) no longer appear in the list output.

## Why?

A deleted schedule closes its scheduler workflow by returning `nil` after receiving the `scheduler-delete` signal. The workflow remains retrievable via visibility until the cluster's retention policy reaps it. The previous query (`WorkflowType = 'cadence-scheduler'`) matched both open and closed workflows, so deleted schedules kept showing up in `ListSchedules` responses — with their last-known `CadenceScheduleState` / `Cron` / `WorkflowType` search attributes — giving the impression they were still active.

`CloseTime = missing` is the canonical "open only" filter used across Cadence's visibility layer (ES, Pinot, SQL-backed advanced-visibility stores) and is already recognized by the shared query validator, so no other wiring changes are needed.

## How did you test it?

- `make pr` — tidy, go-generate, fmt, lint all pass with no generated-file drift
- `go build ./service/frontend/api/...` passes
- `go test -race ./service/frontend/api/... -run 'ListSchedules|Schedule' -count=1` passes; the existing `TestListSchedules/success with results` case asserts the exact query string via `mock.MatchedBy`, which now requires the new filter

## Potential risks

None — isolated change to a single visibility query. Pre-existing behavior was that deleted schedules surfaced in `ListSchedules`; this simply hides them as intended.

## Release notes

`ListSchedules` no longer returns entries for deleted schedules.

## Documentation Changes

N/A — ERD already documents schedule lifecycle; no doc update needed.