### PR TITLE
feat(scheduler): implement BUFFER overlap policy

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -61,22 +61,22 @@ func validateSchedulePolicies(policies *types.SchedulePolicies) error {
 	return nil
 }
 
-// warnIfBufferLimitExceedsSafetyCap logs a warning when buffer_limit exceeds
-// MaxBufferedFiresHardCap. The value is accepted (the policy still queues
-// up to the safety cap), but drops at that cap will be tagged
-// reason=safety_cap rather than reason=buffer_limit.
-func (wh *WorkflowHandler) warnIfBufferLimitExceedsSafetyCap(scheduleID, domainName string, policies *types.SchedulePolicies) {
+// warnIfBufferLimitExceedsSystemLimit logs a warning when buffer_limit exceeds
+// MaxBufferedFiresSystemLimit. The value is accepted (the policy still queues
+// up to the system limit), but drops at that cap will be tagged
+// reason=system_limit rather than reason=user_limit.
+func (wh *WorkflowHandler) warnIfBufferLimitExceedsSystemLimit(scheduleID, domainName string, policies *types.SchedulePolicies) {
 	if policies == nil ||
 		policies.OverlapPolicy != types.ScheduleOverlapPolicyBuffer ||
-		int(policies.BufferLimit) <= scheduler.MaxBufferedFiresHardCap {
+		int(policies.BufferLimit) <= scheduler.MaxBufferedFiresSystemLimit {
 		return
 	}
 	wh.GetLogger().Warn(
-		"buffer_limit exceeds scheduler safety cap; drops will be attributed to safety_cap",
+		"buffer_limit exceeds scheduler system limit; drops will be attributed to system_limit",
 		tag.WorkflowDomainName(domainName),
 		tag.WorkflowID(scheduleWorkflowID(scheduleID)),
 		tag.Dynamic("bufferLimit", int(policies.BufferLimit)),
-		tag.Dynamic("safetyCap", scheduler.MaxBufferedFiresHardCap),
+		tag.Dynamic("systemLimit", scheduler.MaxBufferedFiresSystemLimit),
 	)
 }
 
@@ -129,7 +129,7 @@ func (wh *WorkflowHandler) CreateSchedule(
 	if err := validateSchedulePolicies(request.GetPolicies()); err != nil {
 		return nil, err
 	}
-	wh.warnIfBufferLimitExceedsSafetyCap(scheduleID, domainName, request.GetPolicies())
+	wh.warnIfBufferLimitExceedsSystemLimit(scheduleID, domainName, request.GetPolicies())
 	if err := validateUserSearchAttributes(request.GetSearchAttributes()); err != nil {
 		return nil, err
 	}
@@ -273,7 +273,7 @@ func (wh *WorkflowHandler) UpdateSchedule(
 	if err := validateSchedulePolicies(request.GetPolicies()); err != nil {
 		return nil, err
 	}
-	wh.warnIfBufferLimitExceedsSafetyCap(scheduleID, domainName, request.GetPolicies())
+	wh.warnIfBufferLimitExceedsSystemLimit(scheduleID, domainName, request.GetPolicies())
 
 	signal := scheduler.UpdateSignal{
 		Spec:     request.GetSpec(),

--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -61,14 +61,10 @@ func validateSchedulePolicies(policies *types.SchedulePolicies) error {
 	return nil
 }
 
-// warnIfBufferLimitExceedsSafetyCap logs a warning when the user-supplied
-// buffer_limit for the BUFFER overlap policy exceeds the scheduler's hard
-// safety cap. In that case, drops at the safety cap will be attributed to
-// reason=safety_cap rather than reason=buffer_limit, which surprises operators
-// monitoring the per-domain buffer overflow metric. We don't reject the value
-// (it's not invalid; the policy still queues fires up to the safety cap),
-// but we surface the discrepancy at write time so it isn't only discovered
-// later by reading metrics.
+// warnIfBufferLimitExceedsSafetyCap logs a warning when buffer_limit exceeds
+// MaxBufferedFiresHardCap. The value is accepted (the policy still queues
+// up to the safety cap), but drops at that cap will be tagged
+// reason=safety_cap rather than reason=buffer_limit.
 func (wh *WorkflowHandler) warnIfBufferLimitExceedsSafetyCap(scheduleID, domainName string, policies *types.SchedulePolicies) {
 	if policies == nil ||
 		policies.OverlapPolicy != types.ScheduleOverlapPolicyBuffer ||

--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -61,6 +61,29 @@ func validateSchedulePolicies(policies *types.SchedulePolicies) error {
 	return nil
 }
 
+// warnIfBufferLimitExceedsSafetyCap logs a warning when the user-supplied
+// buffer_limit for the BUFFER overlap policy exceeds the scheduler's hard
+// safety cap. In that case, drops at the safety cap will be attributed to
+// reason=safety_cap rather than reason=buffer_limit, which surprises operators
+// monitoring the per-domain buffer overflow metric. We don't reject the value
+// (it's not invalid; the policy still queues fires up to the safety cap),
+// but we surface the discrepancy at write time so it isn't only discovered
+// later by reading metrics.
+func (wh *WorkflowHandler) warnIfBufferLimitExceedsSafetyCap(scheduleID, domainName string, policies *types.SchedulePolicies) {
+	if policies == nil ||
+		policies.OverlapPolicy != types.ScheduleOverlapPolicyBuffer ||
+		int(policies.BufferLimit) <= scheduler.MaxBufferedFiresHardCap {
+		return
+	}
+	wh.GetLogger().Warn(
+		"buffer_limit exceeds scheduler safety cap; drops will be attributed to safety_cap",
+		tag.WorkflowDomainName(domainName),
+		tag.WorkflowID(scheduleWorkflowID(scheduleID)),
+		tag.Dynamic("bufferLimit", int(policies.BufferLimit)),
+		tag.Dynamic("safetyCap", scheduler.MaxBufferedFiresHardCap),
+	)
+}
+
 // validateUserSearchAttributes rejects user search attribute keys that collide
 // with scheduler-reserved keys (CadenceSchedule* prefix). Without this check,
 // user values would be silently overwritten by the scheduler workflow's
@@ -110,6 +133,7 @@ func (wh *WorkflowHandler) CreateSchedule(
 	if err := validateSchedulePolicies(request.GetPolicies()); err != nil {
 		return nil, err
 	}
+	wh.warnIfBufferLimitExceedsSafetyCap(scheduleID, domainName, request.GetPolicies())
 	if err := validateUserSearchAttributes(request.GetSearchAttributes()); err != nil {
 		return nil, err
 	}
@@ -253,6 +277,7 @@ func (wh *WorkflowHandler) UpdateSchedule(
 	if err := validateSchedulePolicies(request.GetPolicies()); err != nil {
 		return nil, err
 	}
+	wh.warnIfBufferLimitExceedsSafetyCap(scheduleID, domainName, request.GetPolicies())
 
 	signal := scheduler.UpdateSignal{
 		Spec:     request.GetSpec(),

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -210,6 +210,34 @@ func TestCreateSchedule(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		// buffer_limit > safety cap is allowed (the BUFFER policy still functions,
+		// it's just capped at MaxBufferedFiresHardCap), so CreateSchedule should
+		// succeed. The handler logs a warning so operators aren't surprised when
+		// buffer overflow drops are tagged reason=safety_cap rather than
+		// reason=buffer_limit.
+		"BUFFER with buffer_limit above safety cap succeeds (warns)": {
+			request: &types.CreateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "my-schedule",
+				Spec:       &types.ScheduleSpec{CronExpression: "*/5 * * * *"},
+				Action: &types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType: &types.WorkflowType{Name: "my-workflow"},
+						TaskList:     &types.TaskList{Name: "my-tasklist"},
+					},
+				},
+				Policies: &types.SchedulePolicies{
+					OverlapPolicy: types.ScheduleOverlapPolicyBuffer,
+					BufferLimit:   int32(scheduler.MaxBufferedFiresHardCap * 2),
+				},
+			},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.StartWorkflowExecutionResponse{RunID: "test-run-id"}, nil)
+			},
+			wantErr: false,
+		},
 		"success": {
 			request: validRequest,
 			mockFn: func(f *scheduleTestFixture) {

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -210,7 +210,7 @@ func TestCreateSchedule(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		"BUFFER with buffer_limit above safety cap succeeds (warns)": {
+		"BUFFER with buffer_limit above system limit succeeds (warns)": {
 			request: &types.CreateScheduleRequest{
 				Domain:     testDomain,
 				ScheduleID: "my-schedule",
@@ -223,7 +223,7 @@ func TestCreateSchedule(t *testing.T) {
 				},
 				Policies: &types.SchedulePolicies{
 					OverlapPolicy: types.ScheduleOverlapPolicyBuffer,
-					BufferLimit:   int32(scheduler.MaxBufferedFiresHardCap * 2),
+					BufferLimit:   int32(scheduler.MaxBufferedFiresSystemLimit * 2),
 				},
 			},
 			mockFn: func(f *scheduleTestFixture) {

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -210,11 +210,6 @@ func TestCreateSchedule(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		// buffer_limit > safety cap is allowed (the BUFFER policy still functions,
-		// it's just capped at MaxBufferedFiresHardCap), so CreateSchedule should
-		// succeed. The handler logs a warning so operators aren't surprised when
-		// buffer overflow drops are tagged reason=safety_cap rather than
-		// reason=buffer_limit.
 		"BUFFER with buffer_limit above safety cap succeeds (warns)": {
 			request: &types.CreateScheduleRequest{
 				Domain:     testDomain,

--- a/service/worker/scheduler/activity.go
+++ b/service/worker/scheduler/activity.go
@@ -88,9 +88,7 @@ func processScheduleFireActivity(ctx context.Context, req ProcessFireRequest) (r
 				result.StartedWorkflow = req.LastStartedWorkflow
 				return result, nil
 			case types.ScheduleOverlapPolicyBuffer:
-				// Previous workflow is still running: defer this fire. The workflow
-				// will append it to state.BufferedFires and retry on the next
-				// timer/signal wakeup. The activity does not mutate state itself.
+				// Defer the fire; the workflow enqueues it in state.BufferedFires.
 				scope.Tagged(metrics.OverlapPolicyTag(policy.String()), metrics.TriggerSourceTag(string(req.TriggerSource))).IncCounter(metrics.SchedulerFireBufferedCountPerDomain)
 				result.Buffered = true
 				result.StartedWorkflow = req.LastStartedWorkflow

--- a/service/worker/scheduler/activity.go
+++ b/service/worker/scheduler/activity.go
@@ -88,9 +88,11 @@ func processScheduleFireActivity(ctx context.Context, req ProcessFireRequest) (r
 				result.StartedWorkflow = req.LastStartedWorkflow
 				return result, nil
 			case types.ScheduleOverlapPolicyBuffer:
-				// TODO(overlap-buffer): implement sequential buffered execution
+				// Previous workflow is still running: defer this fire. The workflow
+				// will append it to state.BufferedFires and retry on the next
+				// timer/signal wakeup. The activity does not mutate state itself.
 				scope.Tagged(metrics.OverlapPolicyTag(policy.String()), metrics.TriggerSourceTag(string(req.TriggerSource))).IncCounter(metrics.SchedulerFireBufferedCountPerDomain)
-				result.SkippedDelta = 1
+				result.Buffered = true
 				result.StartedWorkflow = req.LastStartedWorkflow
 				return result, nil
 			case types.ScheduleOverlapPolicyCancelPrevious:

--- a/service/worker/scheduler/activity_test.go
+++ b/service/worker/scheduler/activity_test.go
@@ -229,6 +229,64 @@ func TestProcessScheduleFireActivity(t *testing.T) {
 			},
 		},
 		{
+			name: "BUFFER defers when previous is running",
+			req: func() ProcessFireRequest {
+				r := baseReq
+				r.OverlapPolicy = types.ScheduleOverlapPolicyBuffer
+				r.LastStartedWorkflow = &RunningWorkflowInfo{WorkflowID: "old-wf", RunID: "old-run"}
+				return r
+			}(),
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{CloseStatus: nil},
+					}, nil)
+			},
+			wantResult: &ProcessFireResult{
+				Buffered:        true,
+				StartedWorkflow: &RunningWorkflowInfo{WorkflowID: "old-wf", RunID: "old-run"},
+			},
+		},
+		{
+			name: "BUFFER starts when previous is closed",
+			req: func() ProcessFireRequest {
+				r := baseReq
+				r.OverlapPolicy = types.ScheduleOverlapPolicyBuffer
+				r.LastStartedWorkflow = &RunningWorkflowInfo{WorkflowID: "old-wf", RunID: "old-run"}
+				return r
+			}(),
+			setupMock: func(m *frontend.MockClient) {
+				status := types.WorkflowExecutionCloseStatusCompleted
+				m.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{CloseStatus: &status},
+					}, nil)
+				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.StartWorkflowExecutionResponse{RunID: "new-run"}, nil)
+			},
+			wantResult: &ProcessFireResult{
+				TotalDelta:      1,
+				StartedWorkflow: &RunningWorkflowInfo{WorkflowID: expectedWfID, RunID: "new-run"},
+			},
+		},
+		{
+			name: "BUFFER starts when no previous",
+			req: func() ProcessFireRequest {
+				r := baseReq
+				r.OverlapPolicy = types.ScheduleOverlapPolicyBuffer
+				// LastStartedWorkflow is nil (no previous fire yet)
+				return r
+			}(),
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.StartWorkflowExecutionResponse{RunID: "run-abc"}, nil)
+			},
+			wantResult: &ProcessFireResult{
+				TotalDelta:      1,
+				StartedWorkflow: &RunningWorkflowInfo{WorkflowID: expectedWfID, RunID: "run-abc"},
+			},
+		},
+		{
 			name: "TERMINATE_PREVIOUS terminates then starts",
 			req: func() ProcessFireRequest {
 				r := baseReq

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -44,6 +44,11 @@ const (
 	SchedulerMissedSkippedCountPerDomain  = "scheduler_missed_skipped_count_per_domain"
 	SchedulerBackfillFiredCountPerDomain  = "scheduler_backfill_fired_count_per_domain"
 	SchedulerContinueAsNewCountPerDomain  = "scheduler_continue_as_new_count_per_domain"
+	// SchedulerBufferOverflowCountPerDomain measures fires dropped because the
+	// BUFFER overlap policy queue is at its configured buffer_limit. Tagged with
+	// the drop reason so operators can distinguish user-imposed limits
+	// (reason=buffer_limit) from the safety cap (reason=safety_cap).
+	SchedulerBufferOverflowCountPerDomain = "scheduler_buffer_overflow_count_per_domain"
 
 	// Tag key strings for scheduler workflow metrics.
 	SignalTypeTag    = "signal_type"
@@ -55,6 +60,20 @@ const (
 	ContinueAsNewReasonBackfill     = "back_fill"
 	ContinueAsNewReasonSignal       = "signal"
 	ContinueAsNewReasonIterationCap = "iteration_cap"
+
+	// Buffer overflow reason tag values for scheduler_buffer_overflow_count metric.
+	BufferOverflowReasonBufferLimit = "buffer_limit"
+	BufferOverflowReasonSafetyCap   = "safety_cap"
+
+	// MaxBufferedFiresHardCap is a defense-in-depth cap on the BUFFER overlap
+	// policy queue that applies even when buffer_limit=0 (unlimited). It exists
+	// to keep the ContinueAsNew payload size bounded: each BufferedFire is ~50
+	// bytes JSON, so 1000 entries fits comfortably within Cadence's workflow
+	// input size limit (~256 KB) with headroom for the rest of the state.
+	// Exported so the frontend handler can warn at CreateSchedule/UpdateSchedule
+	// time when a user-supplied buffer_limit exceeds it (drops in that range
+	// will be attributed to safety_cap, which would otherwise be surprising).
+	MaxBufferedFiresHardCap = 1000
 
 	// signal_type tag values for scheduler_signal_received_count metric.
 	signalTypeTagPause    = "pause"
@@ -114,19 +133,34 @@ type SchedulerWorkflowState struct {
 	PauseReason       string            `json:"pauseReason,omitempty"`
 	PausedBy          string            `json:"pausedBy,omitempty"`
 	Deleted           bool              `json:"-"`                           // transient flag, not persisted across ContinueAsNew
-	LastRunTime       time.Time         `json:"lastRunTime,omitempty"`       // last time a workflow was actually started
+	LastRunTime       time.Time         `json:"lastRunTime,omitempty"`       // most recent scheduled run time the workflow has processed (clamped monotonically increasing; matches ERD semantics)
 	LastProcessedTime time.Time         `json:"lastProcessedTime,omitempty"` // catch-up watermark: latest missed fire we've processed (fired or skipped)
 	NextRunTime       time.Time         `json:"nextRunTime,omitempty"`
 	TotalRuns         int64             `json:"totalRuns"`
 	MissedRuns        int64             `json:"missedRuns"`
 	SkippedRuns       int64             `json:"skippedRuns"`
 	Iterations        int               `json:"iterations"`
-	BufferedRuns      int               `json:"bufferedRuns"`
 	PendingBackfills  []BackfillRequest `json:"pendingBackfills,omitempty"`
+	// BufferedFires holds fires queued for sequential execution under the BUFFER
+	// overlap policy. Fires are appended when the previous target workflow is
+	// still running at fire time and drained in FIFO order on subsequent
+	// opportunities (timer wakeups, signal wakeups). Persisted across
+	// ContinueAsNew so buffered work isn't lost on workflow recycling.
+	BufferedFires []BufferedFire `json:"bufferedFires,omitempty"`
 	// LastStartedWorkflow tracks the most recently started target workflow so
 	// the overlap policy can check whether it is still running before starting
 	// the next one. Nil when no workflow has been started yet.
 	LastStartedWorkflow *RunningWorkflowInfo `json:"lastStartedWorkflow,omitempty"`
+}
+
+// BufferedFire represents a schedule fire that has been queued for later
+// sequential execution by the BUFFER overlap policy. The scheduled time is
+// preserved so that the eventual target workflow keeps its original workflow
+// ID (derived from scheduledTime) and RequestID (derived from scheduledTime +
+// triggerSource), matching the non-BUFFER semantics.
+type BufferedFire struct {
+	ScheduledTime time.Time     `json:"scheduledTime"`
+	TriggerSource TriggerSource `json:"triggerSource"`
 }
 
 // RunningWorkflowInfo identifies a target workflow started by the scheduler,
@@ -220,4 +254,9 @@ type ProcessFireResult struct {
 	StartedWorkflow *RunningWorkflowInfo `json:"startedWorkflow,omitempty"`
 	TotalDelta      int64                `json:"totalDelta"`
 	SkippedDelta    int64                `json:"skippedDelta"`
+	// Buffered is true when the BUFFER overlap policy deferred this fire
+	// because the previous target workflow was still running. The workflow
+	// appends the fire to state.BufferedFires and retries draining on the
+	// next loop iteration.
+	Buffered bool `json:"buffered,omitempty"`
 }

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -227,6 +227,20 @@ const (
 	TriggerSourceBackfill TriggerSource = "backfill"
 )
 
+// fireOutcome is the result of attempting to fire a single schedule run. It
+// tells the workflow whether the fire was processed to completion or was
+// deferred by the BUFFER overlap policy and should be re-attempted later.
+type fireOutcome int
+
+const (
+	// fireOutcomeDone means the fire was processed to completion (started, skipped,
+	// cancelled/terminated-then-started, already-running, or errored-and-logged).
+	fireOutcomeDone fireOutcome = iota
+	// fireOutcomeBuffered means the BUFFER overlap policy deferred the fire
+	// because the previous target workflow is still running.
+	fireOutcomeBuffered
+)
+
 // ProcessFireRequest is the input to processScheduleFireActivity. It contains
 // everything the activity needs to resolve the overlap policy and start the
 // target workflow. All side effects (describe, cancel, terminate, start) happen

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -45,9 +45,10 @@ const (
 	SchedulerBackfillFiredCountPerDomain  = "scheduler_backfill_fired_count_per_domain"
 	SchedulerContinueAsNewCountPerDomain  = "scheduler_continue_as_new_count_per_domain"
 	// SchedulerBufferOverflowCountPerDomain measures fires dropped because the
-	// BUFFER overlap policy queue is at its configured buffer_limit. Tagged with
-	// the drop reason so operators can distinguish user-imposed limits
-	// (reason=buffer_limit) from the safety cap (reason=safety_cap).
+	// BUFFER overlap policy queue is full. Tagged with the drop reason so
+	// operators can distinguish drops driven by the user's buffer_limit
+	// (reason=user_limit) from drops driven by the server-side ceiling that
+	// protects ContinueAsNew payload size (reason=system_limit).
 	SchedulerBufferOverflowCountPerDomain = "scheduler_buffer_overflow_count_per_domain"
 
 	// Tag key strings for scheduler workflow metrics.
@@ -58,18 +59,21 @@ const (
 	// ContinueAsNew reason tag values for scheduler_continue_as_new_count metric.
 	ContinueAsNewReasonMissedRun    = "missed_run"
 	ContinueAsNewReasonBackfill     = "back_fill"
+	ContinueAsNewReasonBufferDrain  = "buffer_drain"
 	ContinueAsNewReasonSignal       = "signal"
 	ContinueAsNewReasonIterationCap = "iteration_cap"
 
 	// Buffer overflow reason tag values for scheduler_buffer_overflow_count metric.
-	BufferOverflowReasonBufferLimit = "buffer_limit"
-	BufferOverflowReasonSafetyCap   = "safety_cap"
+	// Distinguishes drops driven by the user's buffer_limit from drops driven by
+	// the server-side cap that protects ContinueAsNew payload size.
+	BufferOverflowReasonUserLimit   = "user_limit"
+	BufferOverflowReasonSystemLimit = "system_limit"
 
-	// MaxBufferedFiresHardCap caps the BUFFER overlap policy queue regardless
-	// of buffer_limit (including buffer_limit=0 meaning unlimited). It bounds
-	// the ContinueAsNew payload size: each BufferedFire is ~50 bytes JSON, so
-	// 1000 entries stays well within the workflow input size limit.
-	MaxBufferedFiresHardCap = 1000
+	// MaxBufferedFiresSystemLimit caps the BUFFER overlap policy queue regardless
+	// of buffer_limit (including buffer_limit=0 meaning unlimited). It bounds the
+	// ContinueAsNew payload size: each BufferedFire is ~50 bytes JSON, so 1000
+	// entries stays well within the workflow input size limit.
+	MaxBufferedFiresSystemLimit = 1000
 
 	// signal_type tag values for scheduler_signal_received_count metric.
 	signalTypeTagPause    = "pause"
@@ -104,6 +108,7 @@ const (
 	maxIterationsBeforeContinueAsNew = 500
 	maxCatchUpFiresPerExecution      = 10
 	maxBackfillFiresPerExecution     = 10
+	maxDrainFiresPerExecution        = 10
 	maxPendingBackfills              = 10
 
 	localActivityScheduleToCloseTimeout = 60 * time.Second

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -133,7 +133,7 @@ type SchedulerWorkflowState struct {
 	PauseReason       string            `json:"pauseReason,omitempty"`
 	PausedBy          string            `json:"pausedBy,omitempty"`
 	Deleted           bool              `json:"-"`                           // transient flag, not persisted across ContinueAsNew
-	LastRunTime       time.Time         `json:"lastRunTime,omitempty"`       // most recent scheduled run time the workflow has processed (clamped monotonically increasing; matches ERD semantics)
+	LastRunTime       time.Time         `json:"lastRunTime,omitempty"`       // most recent scheduled run time the workflow has processed
 	LastProcessedTime time.Time         `json:"lastProcessedTime,omitempty"` // catch-up watermark: latest missed fire we've processed (fired or skipped)
 	NextRunTime       time.Time         `json:"nextRunTime,omitempty"`
 	TotalRuns         int64             `json:"totalRuns"`

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -65,14 +65,10 @@ const (
 	BufferOverflowReasonBufferLimit = "buffer_limit"
 	BufferOverflowReasonSafetyCap   = "safety_cap"
 
-	// MaxBufferedFiresHardCap is a defense-in-depth cap on the BUFFER overlap
-	// policy queue that applies even when buffer_limit=0 (unlimited). It exists
-	// to keep the ContinueAsNew payload size bounded: each BufferedFire is ~50
-	// bytes JSON, so 1000 entries fits comfortably within Cadence's workflow
-	// input size limit (~256 KB) with headroom for the rest of the state.
-	// Exported so the frontend handler can warn at CreateSchedule/UpdateSchedule
-	// time when a user-supplied buffer_limit exceeds it (drops in that range
-	// will be attributed to safety_cap, which would otherwise be surprising).
+	// MaxBufferedFiresHardCap caps the BUFFER overlap policy queue regardless
+	// of buffer_limit (including buffer_limit=0 meaning unlimited). It bounds
+	// the ContinueAsNew payload size: each BufferedFire is ~50 bytes JSON, so
+	// 1000 entries stays well within the workflow input size limit.
 	MaxBufferedFiresHardCap = 1000
 
 	// signal_type tag values for scheduler_signal_received_count metric.
@@ -153,11 +149,9 @@ type SchedulerWorkflowState struct {
 	LastStartedWorkflow *RunningWorkflowInfo `json:"lastStartedWorkflow,omitempty"`
 }
 
-// BufferedFire represents a schedule fire that has been queued for later
-// sequential execution by the BUFFER overlap policy. The scheduled time is
-// preserved so that the eventual target workflow keeps its original workflow
-// ID (derived from scheduledTime) and RequestID (derived from scheduledTime +
-// triggerSource), matching the non-BUFFER semantics.
+// BufferedFire is a schedule fire queued for sequential execution by the BUFFER
+// overlap policy. ScheduledTime and TriggerSource are preserved so the deferred
+// start uses the same WorkflowID and RequestID it would have used at fire time.
 type BufferedFire struct {
 	ScheduledTime time.Time     `json:"scheduledTime"`
 	TriggerSource TriggerSource `json:"triggerSource"`

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -96,12 +96,27 @@ type SchedulerWorkflowState struct {
 	MissedRuns        int64             `json:"missedRuns"`
 	SkippedRuns       int64             `json:"skippedRuns"`
 	Iterations        int               `json:"iterations"`
-	BufferedRuns      int               `json:"bufferedRuns"`
 	PendingBackfills  []BackfillRequest `json:"pendingBackfills,omitempty"`
+	// BufferedFires holds fires queued for sequential execution under the BUFFER
+	// overlap policy. Fires are appended when the previous target workflow is
+	// still running at fire time and drained in FIFO order on subsequent
+	// opportunities (timer wakeups, signal wakeups). Persisted across
+	// ContinueAsNew so buffered work isn't lost on workflow recycling.
+	BufferedFires []BufferedFire `json:"bufferedFires,omitempty"`
 	// LastStartedWorkflow tracks the most recently started target workflow so
 	// the overlap policy can check whether it is still running before starting
 	// the next one. Nil when no workflow has been started yet.
 	LastStartedWorkflow *RunningWorkflowInfo `json:"lastStartedWorkflow,omitempty"`
+}
+
+// BufferedFire represents a schedule fire that has been queued for later
+// sequential execution by the BUFFER overlap policy. The scheduled time is
+// preserved so that the eventual target workflow keeps its original workflow
+// ID (derived from scheduledTime) and RequestID (derived from scheduledTime +
+// triggerSource), matching the non-BUFFER semantics.
+type BufferedFire struct {
+	ScheduledTime time.Time     `json:"scheduledTime"`
+	TriggerSource TriggerSource `json:"triggerSource"`
 }
 
 // RunningWorkflowInfo identifies a target workflow started by the scheduler,
@@ -195,4 +210,9 @@ type ProcessFireResult struct {
 	StartedWorkflow *RunningWorkflowInfo `json:"startedWorkflow,omitempty"`
 	TotalDelta      int64                `json:"totalDelta"`
 	SkippedDelta    int64                `json:"skippedDelta"`
+	// Buffered is true when the BUFFER overlap policy deferred this fire
+	// because the previous target workflow was still running. The workflow
+	// appends the fire to state.BufferedFires and retries draining on the
+	// next loop iteration.
+	Buffered bool `json:"buffered,omitempty"`
 }

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -474,8 +474,7 @@ func handleBackfill(logger *zap.Logger, sig BackfillSignal, state *SchedulerWork
 // BufferLimit and MaxBufferedFiresHardCap) and retried on the next loop
 // iteration by drainBufferedFires.
 func processScheduleFire(ctx workflow.Context, logger *zap.Logger, scope tally.Scope, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource) {
-	switch tryStartFire(ctx, logger, input, state, scheduledTime, trigger) {
-	case fireOutcomeBuffered:
+	if tryStartFire(ctx, logger, input, state, scheduledTime, trigger) == fireOutcomeBuffered {
 		enqueueBufferedFire(logger, scope, input, state, scheduledTime, trigger)
 	}
 }
@@ -560,7 +559,7 @@ func enqueueBufferedFire(logger *zap.Logger, scope tally.Scope, input *Scheduler
 			zap.Time("scheduledTime", scheduledTime),
 			zap.String("reason", reason),
 			zap.Int("effectiveLimit", effective),
-			zap.Int("userBufferLimit", int(input.Policies.BufferLimit)),
+			zap.Int32("userBufferLimit", input.Policies.BufferLimit),
 			zap.Int("safetyCap", MaxBufferedFiresHardCap),
 			zap.Int("bufferSize", len(state.BufferedFires)),
 		)

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -93,11 +93,22 @@ func SchedulerWorkflow(ctx workflow.Context, input SchedulerWorkflowInput) error
 		return fmt.Errorf("invalid cron expression %q: %w", input.Spec.CronExpression, err)
 	}
 
-	// On the first iteration (after ContinueAsNew or fresh start), check for
-	// fires that were missed during the transition gap or prior pause period.
-	// Subsequent iterations don't need this because the timer handles fire times.
-	// If more missed fires remain beyond the per-execution cap, ContinueAsNew
-	// immediately so each batch runs in its own decision task.
+	// On the first iteration (after ContinueAsNew or fresh start), drain any
+	// fires buffered by the BUFFER overlap policy in the previous execution
+	// before processing missed runs and backfills. Buffered fires are
+	// chronologically older than anything processMissedRuns can compute (their
+	// scheduledTime predates the watermark used for catch-up), so draining them
+	// first preserves FIFO order. Without this, a missed-run fire from the
+	// ContinueAsNew gap could start a workflow before older buffered fires get
+	// a chance to drain.
+	if !state.Paused {
+		drainBufferedFires(ctx, logger, &input, state)
+	}
+
+	// Check for fires that were missed during the transition gap or prior pause
+	// period. Subsequent loop iterations don't need this because the timer
+	// handles fire times. If more missed fires remain beyond the per-execution
+	// cap, ContinueAsNew immediately so each batch runs in its own decision task.
 	if moreMissed := processMissedRuns(ctx, logger, scope, sched, &input, state); moreMissed {
 		return safeContinueAsNew(ctx, logger, scope, ContinueAsNewReasonMissedRun, chs.delete, input, state)
 	}

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -96,9 +96,13 @@ func SchedulerWorkflow(ctx workflow.Context, input SchedulerWorkflowInput) error
 	// Drain fires buffered by the BUFFER overlap policy in the previous
 	// execution before processing missed runs. Buffered fires are older than
 	// anything processMissedRuns can compute, so draining them first preserves
-	// FIFO order across ContinueAsNew.
+	// FIFO order across ContinueAsNew. If the queue is large, drain in batches
+	// (at most maxDrainFiresPerExecution per execution) so a single decision
+	// task doesn't time out.
 	if !state.Paused {
-		drainBufferedFires(ctx, logger, &input, state)
+		if moreToDrain := drainBufferedFires(ctx, logger, &input, state); moreToDrain {
+			return safeContinueAsNew(ctx, logger, scope, ContinueAsNewReasonBufferDrain, chs.delete, input, state)
+		}
 	}
 
 	// On the first iteration (after ContinueAsNew or fresh start), check for
@@ -168,9 +172,12 @@ func SchedulerWorkflow(ctx workflow.Context, input SchedulerWorkflowInput) error
 		}
 
 		// Drain BUFFER-overlap fires before handling the current fire so the
-		// queue is processed in FIFO order.
+		// queue is processed in FIFO order. If the cap is hit, ContinueAsNew
+		// so the next batch runs in a fresh decision task.
 		if !state.Paused {
-			drainBufferedFires(ctx, logger, &input, state)
+			if moreToDrain := drainBufferedFires(ctx, logger, &input, state); moreToDrain {
+				return safeContinueAsNew(ctx, logger, scope, ContinueAsNewReasonBufferDrain, chs.delete, input, state)
+			}
 		}
 
 		if timerFired && !state.Paused {
@@ -471,9 +478,25 @@ func handleBackfill(logger *zap.Logger, sig BackfillSignal, state *SchedulerWork
 //
 // Under the BUFFER overlap policy, a fire that finds the previous target
 // workflow still running is enqueued in state.BufferedFires (subject to
-// BufferLimit and MaxBufferedFiresHardCap) and retried on the next loop
+// BufferLimit and MaxBufferedFiresSystemLimit) and retried on the next loop
 // iteration by drainBufferedFires.
+//
+// If BUFFER's queue is already non-empty when a new live fire arrives, we
+// enqueue it directly without calling the activity. This both saves the
+// describe RPC and prevents a FIFO-violation race: between the prior drain
+// (which left fires queued because the previous workflow was running) and
+// the live-fire activity call, the previous workflow could complete.
+// tryStartFire would then start the live fire ahead of older queued fires,
+// breaking FIFO.
 func processScheduleFire(ctx workflow.Context, logger *zap.Logger, scope tally.Scope, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource) {
+	if input.Policies.OverlapPolicy == types.ScheduleOverlapPolicyBuffer && len(state.BufferedFires) > 0 {
+		// Skipping tryStartFire, so advance LastRunTime here.
+		if scheduledTime.After(state.LastRunTime) {
+			state.LastRunTime = scheduledTime
+		}
+		enqueueBufferedFire(logger, scope, input, state, scheduledTime, trigger)
+		return
+	}
 	if tryStartFire(ctx, logger, input, state, scheduledTime, trigger) == fireOutcomeBuffered {
 		enqueueBufferedFire(logger, scope, input, state, scheduledTime, trigger)
 	}
@@ -546,9 +569,9 @@ func tryStartFire(ctx workflow.Context, logger *zap.Logger, input *SchedulerWork
 }
 
 // enqueueBufferedFire appends a fire to state.BufferedFires, enforcing both the
-// user-configured buffer_limit and the MaxBufferedFiresHardCap safety cap.
+// user-configured buffer_limit and the MaxBufferedFiresSystemLimit ceiling.
 // Drops increment SkippedRuns and emit scheduler_buffer_overflow_count_per_domain
-// tagged with the binding limit (buffer_limit vs. safety_cap).
+// tagged with the binding limit (user_limit vs. system_limit).
 func enqueueBufferedFire(logger *zap.Logger, scope tally.Scope, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource) {
 	effective, reason := effectiveBufferLimit(input.Policies.BufferLimit)
 	if len(state.BufferedFires) >= effective {
@@ -560,7 +583,7 @@ func enqueueBufferedFire(logger *zap.Logger, scope tally.Scope, input *Scheduler
 			zap.String("reason", reason),
 			zap.Int("effectiveLimit", effective),
 			zap.Int32("userBufferLimit", input.Policies.BufferLimit),
-			zap.Int("safetyCap", MaxBufferedFiresHardCap),
+			zap.Int("systemLimit", MaxBufferedFiresSystemLimit),
 			zap.Int("bufferSize", len(state.BufferedFires)),
 		)
 		return
@@ -578,29 +601,43 @@ func enqueueBufferedFire(logger *zap.Logger, scope tally.Scope, input *Scheduler
 // effectiveBufferLimit returns the queue cap actually enforced for the BUFFER
 // overlap policy and the reason tag value to attribute drops at that cap.
 //
-//   - userLimit == 0 (unlimited): returns the safety cap, reason=safety_cap.
-//   - 0 < userLimit <= safety cap: returns userLimit, reason=buffer_limit.
-//   - userLimit > safety cap: returns the safety cap, reason=safety_cap (the
-//     user's limit cannot be honored without risking ContinueAsNew payload bloat).
+//   - userLimit == 0 (unlimited): returns the system limit, reason=system_limit.
+//   - 0 < userLimit <= system limit: returns userLimit, reason=user_limit.
+//   - userLimit > system limit: returns the system limit, reason=system_limit
+//     (the user's limit cannot be honored without risking ContinueAsNew payload bloat).
 func effectiveBufferLimit(userLimit int32) (effective int, reason string) {
-	if userLimit <= 0 || int(userLimit) > MaxBufferedFiresHardCap {
-		return MaxBufferedFiresHardCap, BufferOverflowReasonSafetyCap
+	if userLimit <= 0 || int(userLimit) > MaxBufferedFiresSystemLimit {
+		return MaxBufferedFiresSystemLimit, BufferOverflowReasonSystemLimit
 	}
-	return int(userLimit), BufferOverflowReasonBufferLimit
+	return int(userLimit), BufferOverflowReasonUserLimit
 }
 
 // drainBufferedFires executes queued fires in FIFO order, stopping as soon as
-// one re-buffers (previous target workflow still running). Retries are safe
-// because the activity derives WorkflowID and RequestID from scheduledTime
-// and triggerSource, so the server de-duplicates.
-func drainBufferedFires(ctx workflow.Context, logger *zap.Logger, input *SchedulerWorkflowInput, state *SchedulerWorkflowState) {
+// one re-buffers (previous target workflow still running) or
+// maxDrainFiresPerExecution fires have been processed. Returns true when more
+// queued work remains and the caller should ContinueAsNew so the next batch
+// runs in a fresh decision task (mirrors processMissedRuns / processBackfills).
+//
+// Retries are safe because the activity derives WorkflowID and RequestID from
+// scheduledTime and triggerSource, so the server de-duplicates on replay.
+func drainBufferedFires(ctx workflow.Context, logger *zap.Logger, input *SchedulerWorkflowInput, state *SchedulerWorkflowState) bool {
+	drained := 0
 	for len(state.BufferedFires) > 0 {
+		if drained >= maxDrainFiresPerExecution {
+			logger.Info("buffer drain cap reached, continuing after ContinueAsNew",
+				zap.Int("drainedThisBatch", drained),
+				zap.Int("remaining", len(state.BufferedFires)),
+			)
+			return true
+		}
 		head := state.BufferedFires[0]
 		if tryStartFire(ctx, logger, input, state, head.ScheduledTime, head.TriggerSource) == fireOutcomeBuffered {
-			return
+			return false
 		}
 		state.BufferedFires = state.BufferedFires[1:]
+		drained++
 	}
+	return false
 }
 
 // defaultActivityOptions returns the standard local activity options used by
@@ -708,16 +745,27 @@ func applyMissedRunPolicy(policy types.ScheduleCatchUpPolicy, window time.Durati
 // fires are executed per workflow execution. Returns true if there are more missed
 // fires remaining, signalling the caller to ContinueAsNew for the next batch.
 func processMissedRuns(ctx workflow.Context, logger *zap.Logger, scope tally.Scope, sched cron.Schedule, input *SchedulerWorkflowInput, state *SchedulerWorkflowState) bool {
-	// Use LastProcessedTime as the catch-up watermark; fall back to
-	// LastRunTime for schedules created before this field existed.
-	watermark := state.LastProcessedTime
-	if watermark.IsZero() {
-		watermark = state.LastRunTime
-	}
+	watermark := catchUpWatermark(state)
 	if state.Paused || watermark.IsZero() {
 		return false
 	}
 	return processMissedRunsAt(ctx, logger, scope, sched, input, state, watermark, workflow.Now(ctx))
+}
+
+// catchUpWatermark returns the high-water mark for catch-up fire computation:
+// the most recent timestamp the scheduler is known to have already attempted.
+// We take max(LastProcessedTime, LastRunTime) because LastProcessedTime is
+// only advanced by catch-up itself, while LastRunTime is advanced on every
+// fire (live or buffered). Using only LastProcessedTime would let catch-up
+// recompute fire times for fires that already happened (or were buffered
+// under BUFFER), which deduplicates server-side via WorkflowID/RequestID but
+// still double-counts state.TotalRuns / state.SkippedRuns.
+func catchUpWatermark(state *SchedulerWorkflowState) time.Time {
+	watermark := state.LastProcessedTime
+	if state.LastRunTime.After(watermark) {
+		watermark = state.LastRunTime
+	}
+	return watermark
 }
 
 // processMissedRunsAt is the testable core of processMissedRuns, accepting an explicit now

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -159,8 +159,15 @@ func SchedulerWorkflow(ctx workflow.Context, input SchedulerWorkflowInput) error
 			return nil
 		}
 
+		// Drain any fires previously buffered under the BUFFER overlap policy
+		// before handling the current fire. Drain stops as soon as one fire
+		// re-buffers (previous still running), preserving FIFO order.
+		if !state.Paused {
+			drainBufferedFires(ctx, logger, &input, state)
+		}
+
 		if timerFired && !state.Paused {
-			processScheduleFire(ctx, logger, &input, state, state.NextRunTime, TriggerSourceSchedule)
+			processScheduleFire(ctx, logger, scope, &input, state, state.NextRunTime, TriggerSourceSchedule)
 		}
 
 		if changed || state.Iterations >= maxIterationsBeforeContinueAsNew {
@@ -386,8 +393,23 @@ func handleUpdate(logger *zap.Logger, sig UpdateSignal, input *SchedulerWorkflow
 		changed = true
 	}
 	if sig.Policies != nil {
+		previousOverlap := input.Policies.OverlapPolicy
 		input.Policies = *sig.Policies
 		changed = true
+		// Drop any buffered fires if the overlap policy moved away from BUFFER.
+		// Mixing semantics (queued fires under BUFFER draining under SKIP_NEW,
+		// CANCEL_PREVIOUS, etc.) is confusing and error-prone, so we mirror the
+		// "spec change clears pending backfills" pattern and drop them explicitly.
+		if previousOverlap == types.ScheduleOverlapPolicyBuffer &&
+			input.Policies.OverlapPolicy != types.ScheduleOverlapPolicyBuffer &&
+			len(state.BufferedFires) > 0 {
+			logger.Warn("overlap policy change cleared buffered fires",
+				zap.String("from", previousOverlap.String()),
+				zap.String("to", input.Policies.OverlapPolicy.String()),
+				zap.Int("clearedCount", len(state.BufferedFires)))
+			state.SkippedRuns += int64(len(state.BufferedFires))
+			state.BufferedFires = nil
+		}
 	}
 	if changed {
 		logger.Info("schedule updated")
@@ -441,8 +463,40 @@ func handleBackfill(logger *zap.Logger, sig BackfillSignal, state *SchedulerWork
 // All side effects (overlap check, cancel/terminate, start) are encapsulated in
 // a single activity so that the overlap logic can evolve without introducing
 // nondeterminism in the workflow history.
-func processScheduleFire(ctx workflow.Context, logger *zap.Logger, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource) {
-	state.LastRunTime = scheduledTime
+//
+// Under the BUFFER overlap policy, if the previous target workflow is still
+// running the activity returns result.Buffered=true. In that case the fire is
+// appended to state.BufferedFires (subject to BufferLimit and a hard safety
+// cap) and will be retried on the next loop iteration by drainBufferedFires.
+func processScheduleFire(ctx workflow.Context, logger *zap.Logger, scope tally.Scope, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource) {
+	switch tryStartFire(ctx, logger, input, state, scheduledTime, trigger) {
+	case fireOutcomeBuffered:
+		enqueueBufferedFire(logger, scope, input, state, scheduledTime, trigger)
+	}
+}
+
+type fireOutcome int
+
+const (
+	// fireOutcomeDone means the fire was processed to completion (started, skipped,
+	// cancelled/terminated-then-started, already-running, or errored-and-logged).
+	fireOutcomeDone fireOutcome = iota
+	// fireOutcomeBuffered means the BUFFER overlap policy deferred the fire
+	// because the previous target workflow is still running.
+	fireOutcomeBuffered
+)
+
+// tryStartFire runs the scheduler activity for a single fire and applies the
+// result to state, returning whether the fire was buffered. This is shared
+// between the "live fire" and "drain buffered fire" code paths; the caller
+// decides how to handle a buffered outcome (enqueue vs. leave-at-head).
+func tryStartFire(ctx workflow.Context, logger *zap.Logger, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource) fireOutcome {
+	// Keep LastRunTime monotonically increasing. This matters for BUFFER, where
+	// an older queued fire can drain after a newer fire was already processed;
+	// without the clamp, LastRunTime would regress to the older scheduledTime.
+	if scheduledTime.After(state.LastRunTime) {
+		state.LastRunTime = scheduledTime
+	}
 
 	logger.Info("schedule fired",
 		zap.Time("scheduledTime", scheduledTime),
@@ -451,7 +505,7 @@ func processScheduleFire(ctx workflow.Context, logger *zap.Logger, input *Schedu
 	if input.Action.StartWorkflow == nil {
 		state.MissedRuns++
 		logger.Error("schedule action has no StartWorkflow configuration")
-		return
+		return fireOutcomeDone
 	}
 
 	actCtx := workflow.WithLocalActivityOptions(ctx, defaultActivityOptions())
@@ -473,7 +527,11 @@ func processScheduleFire(ctx workflow.Context, logger *zap.Logger, input *Schedu
 			zap.Time("scheduledTime", scheduledTime),
 			zap.Error(err),
 		)
-		return
+		return fireOutcomeDone
+	}
+
+	if result.Buffered {
+		return fireOutcomeBuffered
 	}
 
 	state.TotalRuns += result.TotalDelta
@@ -491,6 +549,89 @@ func processScheduleFire(ctx workflow.Context, logger *zap.Logger, input *Schedu
 		logger.Info("schedule fire skipped",
 			zap.Time("scheduledTime", scheduledTime),
 		)
+	}
+	return fireOutcomeDone
+}
+
+// enqueueBufferedFire appends a fire to state.BufferedFires, enforcing both the
+// user-configured buffer_limit and a hard safety cap on queue depth.
+//
+// buffer_limit of 0 means unlimited per the ERD, but the safety cap
+// (MaxBufferedFiresHardCap) still applies to keep the ContinueAsNew payload
+// size bounded. Drops are counted in SkippedRuns and emitted to
+// scheduler_buffer_overflow_count_per_domain tagged with the drop reason
+// (buffer_limit vs. safety_cap) so operators can distinguish user-imposed
+// limits from defense-in-depth.
+//
+// Attribution: the metric reason is whichever limit is "binding". When the
+// user's buffer_limit is set and within the safety cap, drops at that limit
+// report reason=buffer_limit. When buffer_limit is unset (unlimited) or set
+// above the safety cap, drops at the safety cap report reason=safety_cap.
+// This means an operator who configures buffer_limit=2000 will see drops
+// attributed to safety_cap (not buffer_limit) at 1000 — that's intentional;
+// the schedule is being held back by the safety cap, not the user's setting.
+// CreateSchedule/UpdateSchedule warn at validation time when
+// buffer_limit > safety cap so this attribution isn't surprising.
+func enqueueBufferedFire(logger *zap.Logger, scope tally.Scope, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource) {
+	effective, reason := effectiveBufferLimit(input.Policies.BufferLimit)
+	if len(state.BufferedFires) >= effective {
+		state.SkippedRuns++
+		scope.Tagged(map[string]string{ReasonTag: reason}).
+			Counter(SchedulerBufferOverflowCountPerDomain).Inc(1)
+		logger.Warn("buffer cap reached; dropping fire",
+			zap.Time("scheduledTime", scheduledTime),
+			zap.String("reason", reason),
+			zap.Int("effectiveLimit", effective),
+			zap.Int("userBufferLimit", int(input.Policies.BufferLimit)),
+			zap.Int("safetyCap", MaxBufferedFiresHardCap),
+			zap.Int("bufferSize", len(state.BufferedFires)),
+		)
+		return
+	}
+	state.BufferedFires = append(state.BufferedFires, BufferedFire{
+		ScheduledTime: scheduledTime,
+		TriggerSource: trigger,
+	})
+	logger.Info("schedule fire buffered",
+		zap.Time("scheduledTime", scheduledTime),
+		zap.Int("bufferSize", len(state.BufferedFires)),
+	)
+}
+
+// effectiveBufferLimit returns the queue cap actually enforced for the BUFFER
+// overlap policy and the reason tag value to attribute drops at that cap.
+//
+//   - userLimit == 0 (unlimited): returns the safety cap, reason=safety_cap.
+//   - 0 < userLimit <= safety cap: returns userLimit, reason=buffer_limit.
+//   - userLimit > safety cap: returns the safety cap, reason=safety_cap (the
+//     user's limit cannot be honored without risking ContinueAsNew payload bloat).
+func effectiveBufferLimit(userLimit int32) (effective int, reason string) {
+	if userLimit <= 0 || int(userLimit) > MaxBufferedFiresHardCap {
+		return MaxBufferedFiresHardCap, BufferOverflowReasonSafetyCap
+	}
+	return int(userLimit), BufferOverflowReasonBufferLimit
+}
+
+// drainBufferedFires attempts to execute queued fires in FIFO order. The loop
+// can drain multiple fires per call only when each one finds the previous
+// target workflow already closed; the common case is at most one drained fire
+// per call, since starting a fire makes that fire the new "previous" and the
+// next drain attempt sees it still running. The loop body still matters for
+// edge cases such as a transient describe-result inversion or a previously
+// orphaned LastStartedWorkflow.
+//
+// Drained fires can be safely retried because the activity's WorkflowID and
+// RequestID are derived from the original scheduledTime + triggerSource, so
+// the server de-duplicates on replay.
+func drainBufferedFires(ctx workflow.Context, logger *zap.Logger, input *SchedulerWorkflowInput, state *SchedulerWorkflowState) {
+	for len(state.BufferedFires) > 0 {
+		head := state.BufferedFires[0]
+		if tryStartFire(ctx, logger, input, state, head.ScheduledTime, head.TriggerSource) == fireOutcomeBuffered {
+			// Previous workflow is still running; leave the head in place and
+			// stop draining. Subsequent iterations will retry.
+			return
+		}
+		state.BufferedFires = state.BufferedFires[1:]
 	}
 }
 
@@ -634,7 +775,7 @@ func processMissedRunsAt(ctx workflow.Context, logger *zap.Logger, scope tally.S
 		if fired >= maxCatchUpFiresPerExecution {
 			break
 		}
-		processScheduleFire(ctx, logger, input, state, t, TriggerSourceSchedule)
+		processScheduleFire(ctx, logger, scope, input, state, t, TriggerSourceSchedule)
 		fired++
 	}
 	unfired := int64(len(result.toFire) - fired)
@@ -697,7 +838,7 @@ func processBackfills(ctx workflow.Context, logger *zap.Logger, scope tally.Scop
 				scope.Counter(SchedulerBackfillFiredCountPerDomain).Inc(int64(fired))
 				return true
 			}
-			processScheduleFire(ctx, logger, input, state, t, TriggerSourceBackfill)
+			processScheduleFire(ctx, logger, scope, input, state, t, TriggerSourceBackfill)
 			fired++
 		}
 

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -480,17 +480,6 @@ func processScheduleFire(ctx workflow.Context, logger *zap.Logger, scope tally.S
 	}
 }
 
-type fireOutcome int
-
-const (
-	// fireOutcomeDone means the fire was processed to completion (started, skipped,
-	// cancelled/terminated-then-started, already-running, or errored-and-logged).
-	fireOutcomeDone fireOutcome = iota
-	// fireOutcomeBuffered means the BUFFER overlap policy deferred the fire
-	// because the previous target workflow is still running.
-	fireOutcomeBuffered
-)
-
 // tryStartFire runs the scheduler activity for a single fire and applies the
 // result to state, returning whether the fire was buffered. Shared by the
 // live-fire and drain-buffered-fire paths; the caller decides how to handle

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -93,22 +93,19 @@ func SchedulerWorkflow(ctx workflow.Context, input SchedulerWorkflowInput) error
 		return fmt.Errorf("invalid cron expression %q: %w", input.Spec.CronExpression, err)
 	}
 
-	// On the first iteration (after ContinueAsNew or fresh start), drain any
-	// fires buffered by the BUFFER overlap policy in the previous execution
-	// before processing missed runs and backfills. Buffered fires are
-	// chronologically older than anything processMissedRuns can compute (their
-	// scheduledTime predates the watermark used for catch-up), so draining them
-	// first preserves FIFO order. Without this, a missed-run fire from the
-	// ContinueAsNew gap could start a workflow before older buffered fires get
-	// a chance to drain.
+	// Drain fires buffered by the BUFFER overlap policy in the previous
+	// execution before processing missed runs. Buffered fires are older than
+	// anything processMissedRuns can compute, so draining them first preserves
+	// FIFO order across ContinueAsNew.
 	if !state.Paused {
 		drainBufferedFires(ctx, logger, &input, state)
 	}
 
-	// Check for fires that were missed during the transition gap or prior pause
-	// period. Subsequent loop iterations don't need this because the timer
-	// handles fire times. If more missed fires remain beyond the per-execution
-	// cap, ContinueAsNew immediately so each batch runs in its own decision task.
+	// On the first iteration (after ContinueAsNew or fresh start), check for
+	// fires that were missed during the transition gap or prior pause period.
+	// Subsequent iterations don't need this because the timer handles fire times.
+	// If more missed fires remain beyond the per-execution cap, ContinueAsNew
+	// immediately so each batch runs in its own decision task.
 	if moreMissed := processMissedRuns(ctx, logger, scope, sched, &input, state); moreMissed {
 		return safeContinueAsNew(ctx, logger, scope, ContinueAsNewReasonMissedRun, chs.delete, input, state)
 	}
@@ -170,9 +167,8 @@ func SchedulerWorkflow(ctx workflow.Context, input SchedulerWorkflowInput) error
 			return nil
 		}
 
-		// Drain any fires previously buffered under the BUFFER overlap policy
-		// before handling the current fire. Drain stops as soon as one fire
-		// re-buffers (previous still running), preserving FIFO order.
+		// Drain BUFFER-overlap fires before handling the current fire so the
+		// queue is processed in FIFO order.
 		if !state.Paused {
 			drainBufferedFires(ctx, logger, &input, state)
 		}
@@ -407,10 +403,8 @@ func handleUpdate(logger *zap.Logger, sig UpdateSignal, input *SchedulerWorkflow
 		previousOverlap := input.Policies.OverlapPolicy
 		input.Policies = *sig.Policies
 		changed = true
-		// Drop any buffered fires if the overlap policy moved away from BUFFER.
-		// Mixing semantics (queued fires under BUFFER draining under SKIP_NEW,
-		// CANCEL_PREVIOUS, etc.) is confusing and error-prone, so we mirror the
-		// "spec change clears pending backfills" pattern and drop them explicitly.
+		// Drop buffered fires if the overlap policy is no longer BUFFER:
+		// draining a queue under non-BUFFER semantics is ill-defined.
 		if previousOverlap == types.ScheduleOverlapPolicyBuffer &&
 			input.Policies.OverlapPolicy != types.ScheduleOverlapPolicyBuffer &&
 			len(state.BufferedFires) > 0 {
@@ -475,10 +469,10 @@ func handleBackfill(logger *zap.Logger, sig BackfillSignal, state *SchedulerWork
 // a single activity so that the overlap logic can evolve without introducing
 // nondeterminism in the workflow history.
 //
-// Under the BUFFER overlap policy, if the previous target workflow is still
-// running the activity returns result.Buffered=true. In that case the fire is
-// appended to state.BufferedFires (subject to BufferLimit and a hard safety
-// cap) and will be retried on the next loop iteration by drainBufferedFires.
+// Under the BUFFER overlap policy, a fire that finds the previous target
+// workflow still running is enqueued in state.BufferedFires (subject to
+// BufferLimit and MaxBufferedFiresHardCap) and retried on the next loop
+// iteration by drainBufferedFires.
 func processScheduleFire(ctx workflow.Context, logger *zap.Logger, scope tally.Scope, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource) {
 	switch tryStartFire(ctx, logger, input, state, scheduledTime, trigger) {
 	case fireOutcomeBuffered:
@@ -498,13 +492,12 @@ const (
 )
 
 // tryStartFire runs the scheduler activity for a single fire and applies the
-// result to state, returning whether the fire was buffered. This is shared
-// between the "live fire" and "drain buffered fire" code paths; the caller
-// decides how to handle a buffered outcome (enqueue vs. leave-at-head).
+// result to state, returning whether the fire was buffered. Shared by the
+// live-fire and drain-buffered-fire paths; the caller decides how to handle
+// a buffered outcome.
 func tryStartFire(ctx workflow.Context, logger *zap.Logger, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource) fireOutcome {
-	// Keep LastRunTime monotonically increasing. This matters for BUFFER, where
-	// an older queued fire can drain after a newer fire was already processed;
-	// without the clamp, LastRunTime would regress to the older scheduledTime.
+	// LastRunTime moves forward only. Under BUFFER, an older queued fire can
+	// drain after a newer fire has already been processed.
 	if scheduledTime.After(state.LastRunTime) {
 		state.LastRunTime = scheduledTime
 	}
@@ -565,24 +558,9 @@ func tryStartFire(ctx workflow.Context, logger *zap.Logger, input *SchedulerWork
 }
 
 // enqueueBufferedFire appends a fire to state.BufferedFires, enforcing both the
-// user-configured buffer_limit and a hard safety cap on queue depth.
-//
-// buffer_limit of 0 means unlimited per the ERD, but the safety cap
-// (MaxBufferedFiresHardCap) still applies to keep the ContinueAsNew payload
-// size bounded. Drops are counted in SkippedRuns and emitted to
-// scheduler_buffer_overflow_count_per_domain tagged with the drop reason
-// (buffer_limit vs. safety_cap) so operators can distinguish user-imposed
-// limits from defense-in-depth.
-//
-// Attribution: the metric reason is whichever limit is "binding". When the
-// user's buffer_limit is set and within the safety cap, drops at that limit
-// report reason=buffer_limit. When buffer_limit is unset (unlimited) or set
-// above the safety cap, drops at the safety cap report reason=safety_cap.
-// This means an operator who configures buffer_limit=2000 will see drops
-// attributed to safety_cap (not buffer_limit) at 1000 — that's intentional;
-// the schedule is being held back by the safety cap, not the user's setting.
-// CreateSchedule/UpdateSchedule warn at validation time when
-// buffer_limit > safety cap so this attribution isn't surprising.
+// user-configured buffer_limit and the MaxBufferedFiresHardCap safety cap.
+// Drops increment SkippedRuns and emit scheduler_buffer_overflow_count_per_domain
+// tagged with the binding limit (buffer_limit vs. safety_cap).
 func enqueueBufferedFire(logger *zap.Logger, scope tally.Scope, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource) {
 	effective, reason := effectiveBufferLimit(input.Policies.BufferLimit)
 	if len(state.BufferedFires) >= effective {
@@ -623,23 +601,14 @@ func effectiveBufferLimit(userLimit int32) (effective int, reason string) {
 	return int(userLimit), BufferOverflowReasonBufferLimit
 }
 
-// drainBufferedFires attempts to execute queued fires in FIFO order. The loop
-// can drain multiple fires per call only when each one finds the previous
-// target workflow already closed; the common case is at most one drained fire
-// per call, since starting a fire makes that fire the new "previous" and the
-// next drain attempt sees it still running. The loop body still matters for
-// edge cases such as a transient describe-result inversion or a previously
-// orphaned LastStartedWorkflow.
-//
-// Drained fires can be safely retried because the activity's WorkflowID and
-// RequestID are derived from the original scheduledTime + triggerSource, so
-// the server de-duplicates on replay.
+// drainBufferedFires executes queued fires in FIFO order, stopping as soon as
+// one re-buffers (previous target workflow still running). Retries are safe
+// because the activity derives WorkflowID and RequestID from scheduledTime
+// and triggerSource, so the server de-duplicates.
 func drainBufferedFires(ctx workflow.Context, logger *zap.Logger, input *SchedulerWorkflowInput, state *SchedulerWorkflowState) {
 	for len(state.BufferedFires) > 0 {
 		head := state.BufferedFires[0]
 		if tryStartFire(ctx, logger, input, state, head.ScheduledTime, head.TriggerSource) == fireOutcomeBuffered {
-			// Previous workflow is still running; leave the head in place and
-			// stop draining. Subsequent iterations will retry.
 			return
 		}
 		state.BufferedFires = state.BufferedFires[1:]

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -156,6 +156,13 @@ func SchedulerWorkflow(ctx workflow.Context, input SchedulerWorkflowInput) error
 			return nil
 		}
 
+		// Drain any fires previously buffered under the BUFFER overlap policy
+		// before handling the current fire. Drain stops as soon as one fire
+		// re-buffers (previous still running), preserving FIFO order.
+		if !state.Paused {
+			drainBufferedFires(ctx, logger, &input, state)
+		}
+
 		if timerFired && !state.Paused {
 			processScheduleFire(ctx, logger, &input, state, state.NextRunTime, TriggerSourceSchedule)
 		}
@@ -367,8 +374,23 @@ func handleUpdate(logger *zap.Logger, sig UpdateSignal, input *SchedulerWorkflow
 		changed = true
 	}
 	if sig.Policies != nil {
+		previousOverlap := input.Policies.OverlapPolicy
 		input.Policies = *sig.Policies
 		changed = true
+		// Drop any buffered fires if the overlap policy moved away from BUFFER.
+		// Mixing semantics (queued fires under BUFFER draining under SKIP_NEW,
+		// CANCEL_PREVIOUS, etc.) is confusing and error-prone, so we mirror the
+		// "spec change clears pending backfills" pattern and drop them explicitly.
+		if previousOverlap == types.ScheduleOverlapPolicyBuffer &&
+			input.Policies.OverlapPolicy != types.ScheduleOverlapPolicyBuffer &&
+			len(state.BufferedFires) > 0 {
+			logger.Warn("overlap policy change cleared buffered fires",
+				zap.String("from", previousOverlap.String()),
+				zap.String("to", input.Policies.OverlapPolicy.String()),
+				zap.Int("clearedCount", len(state.BufferedFires)))
+			state.SkippedRuns += int64(len(state.BufferedFires))
+			state.BufferedFires = nil
+		}
 	}
 	if changed {
 		logger.Info("schedule updated")
@@ -422,8 +444,40 @@ func handleBackfill(logger *zap.Logger, sig BackfillSignal, state *SchedulerWork
 // All side effects (overlap check, cancel/terminate, start) are encapsulated in
 // a single activity so that the overlap logic can evolve without introducing
 // nondeterminism in the workflow history.
+//
+// Under the BUFFER overlap policy, if the previous target workflow is still
+// running the activity returns result.Buffered=true. In that case the fire is
+// appended to state.BufferedFires (subject to BufferLimit) and will be retried
+// on the next loop iteration by drainBufferedFires.
 func processScheduleFire(ctx workflow.Context, logger *zap.Logger, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource) {
-	state.LastRunTime = scheduledTime
+	switch tryStartFire(ctx, logger, input, state, scheduledTime, trigger) {
+	case fireOutcomeBuffered:
+		enqueueBufferedFire(logger, input, state, scheduledTime, trigger)
+	}
+}
+
+type fireOutcome int
+
+const (
+	// fireOutcomeDone means the fire was processed to completion (started, skipped,
+	// cancelled/terminated-then-started, already-running, or errored-and-logged).
+	fireOutcomeDone fireOutcome = iota
+	// fireOutcomeBuffered means the BUFFER overlap policy deferred the fire
+	// because the previous target workflow is still running.
+	fireOutcomeBuffered
+)
+
+// tryStartFire runs the scheduler activity for a single fire and applies the
+// result to state, returning whether the fire was buffered. This is shared
+// between the "live fire" and "drain buffered fire" code paths; the caller
+// decides how to handle a buffered outcome (enqueue vs. leave-at-head).
+func tryStartFire(ctx workflow.Context, logger *zap.Logger, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource) fireOutcome {
+	// Keep LastRunTime monotonically increasing. This matters for BUFFER, where
+	// an older queued fire can drain after a newer fire was already processed;
+	// without the clamp, LastRunTime would regress to the older scheduledTime.
+	if scheduledTime.After(state.LastRunTime) {
+		state.LastRunTime = scheduledTime
+	}
 
 	logger.Info("schedule fired",
 		zap.Time("scheduledTime", scheduledTime),
@@ -432,7 +486,7 @@ func processScheduleFire(ctx workflow.Context, logger *zap.Logger, input *Schedu
 	if input.Action.StartWorkflow == nil {
 		state.MissedRuns++
 		logger.Error("schedule action has no StartWorkflow configuration")
-		return
+		return fireOutcomeDone
 	}
 
 	actCtx := workflow.WithLocalActivityOptions(ctx, defaultActivityOptions())
@@ -454,7 +508,11 @@ func processScheduleFire(ctx workflow.Context, logger *zap.Logger, input *Schedu
 			zap.Time("scheduledTime", scheduledTime),
 			zap.Error(err),
 		)
-		return
+		return fireOutcomeDone
+	}
+
+	if result.Buffered {
+		return fireOutcomeBuffered
 	}
 
 	state.TotalRuns += result.TotalDelta
@@ -472,6 +530,49 @@ func processScheduleFire(ctx workflow.Context, logger *zap.Logger, input *Schedu
 		logger.Info("schedule fire skipped",
 			zap.Time("scheduledTime", scheduledTime),
 		)
+	}
+	return fireOutcomeDone
+}
+
+// enqueueBufferedFire appends a fire to state.BufferedFires, enforcing the
+// buffer_limit policy. A buffer_limit of 0 means unlimited (per ERD). When the
+// limit is exceeded the fire is dropped and counted as skipped so operators
+// can monitor drops via scheduler_fire_skipped_per_domain{overlap_policy=BUFFER}.
+func enqueueBufferedFire(logger *zap.Logger, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource) {
+	limit := int(input.Policies.BufferLimit)
+	if limit > 0 && len(state.BufferedFires) >= limit {
+		state.SkippedRuns++
+		logger.Warn("buffer limit reached; dropping fire",
+			zap.Time("scheduledTime", scheduledTime),
+			zap.Int("bufferLimit", limit),
+			zap.Int("bufferSize", len(state.BufferedFires)),
+		)
+		return
+	}
+	state.BufferedFires = append(state.BufferedFires, BufferedFire{
+		ScheduledTime: scheduledTime,
+		TriggerSource: trigger,
+	})
+	logger.Info("schedule fire buffered",
+		zap.Time("scheduledTime", scheduledTime),
+		zap.Int("bufferSize", len(state.BufferedFires)),
+	)
+}
+
+// drainBufferedFires attempts to execute queued fires in FIFO order. Stops as
+// soon as the head fire re-buffers (previous still running) so the queue head
+// never regresses. Any queued fire can be safely retried because the activity's
+// WorkflowID and RequestID are derived from the original scheduledTime +
+// triggerSource, so the server de-duplicates on replay.
+func drainBufferedFires(ctx workflow.Context, logger *zap.Logger, input *SchedulerWorkflowInput, state *SchedulerWorkflowState) {
+	for len(state.BufferedFires) > 0 {
+		head := state.BufferedFires[0]
+		if tryStartFire(ctx, logger, input, state, head.ScheduledTime, head.TriggerSource) == fireOutcomeBuffered {
+			// Previous workflow is still running; leave the head in place and
+			// stop draining. Subsequent iterations will retry.
+			return
+		}
+		state.BufferedFires = state.BufferedFires[1:]
 	}
 }
 

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1144,7 +1144,7 @@ func TestEnqueueBufferedFire(t *testing.T) {
 			},
 		},
 		{
-			name:        "enqueue at user limit drops fire and emits buffer_limit metric",
+			name:        "enqueue at user limit drops fire and emits user_limit metric",
 			bufferLimit: 2,
 			initialFires: []BufferedFire{
 				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
@@ -1158,28 +1158,28 @@ func TestEnqueueBufferedFire(t *testing.T) {
 				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule},
 			},
 			wantSkippedRuns:    6,
-			wantOverflowReason: BufferOverflowReasonBufferLimit,
+			wantOverflowReason: BufferOverflowReasonUserLimit,
 		},
 		{
-			name:               "enqueue at safety cap with unlimited buffer_limit attributes to safety_cap",
+			name:               "enqueue at system limit with unlimited buffer_limit attributes to system_limit",
 			bufferLimit:        0,
-			initialFires:       largeBufferedFires(MaxBufferedFiresHardCap, t0),
+			initialFires:       largeBufferedFires(MaxBufferedFiresSystemLimit, t0),
 			initialSkipped:     0,
 			enqueueTime:        t0.Add(time.Hour),
 			trigger:            TriggerSourceSchedule,
-			wantFires:          largeBufferedFires(MaxBufferedFiresHardCap, t0),
+			wantFires:          largeBufferedFires(MaxBufferedFiresSystemLimit, t0),
 			wantSkippedRuns:    1,
-			wantOverflowReason: BufferOverflowReasonSafetyCap,
+			wantOverflowReason: BufferOverflowReasonSystemLimit,
 		},
 		{
-			name:               "enqueue at safety cap when user buffer_limit exceeds it attributes to safety_cap",
-			bufferLimit:        int32(MaxBufferedFiresHardCap * 2),
-			initialFires:       largeBufferedFires(MaxBufferedFiresHardCap, t0),
+			name:               "enqueue at system limit when user buffer_limit exceeds it attributes to system_limit",
+			bufferLimit:        int32(MaxBufferedFiresSystemLimit * 2),
+			initialFires:       largeBufferedFires(MaxBufferedFiresSystemLimit, t0),
 			enqueueTime:        t0.Add(time.Hour),
 			trigger:            TriggerSourceSchedule,
-			wantFires:          largeBufferedFires(MaxBufferedFiresHardCap, t0),
+			wantFires:          largeBufferedFires(MaxBufferedFiresSystemLimit, t0),
 			wantSkippedRuns:    1,
-			wantOverflowReason: BufferOverflowReasonSafetyCap,
+			wantOverflowReason: BufferOverflowReasonSystemLimit,
 		},
 		{
 			name:         "backfill trigger source is preserved",
@@ -1252,11 +1252,121 @@ func TestDrainBufferedFiresFIFO(t *testing.T) {
 		BufferedFires: append([]BufferedFire(nil), queue...),
 	}
 
-	drainBufferedFires(nil, testLogger, input, state)
+	moreToDrain := drainBufferedFires(nil, testLogger, input, state)
 
+	assert.False(t, moreToDrain, "queue smaller than cap should fully drain")
 	assert.Empty(t, state.BufferedFires)
 	assert.Equal(t, int64(3), state.MissedRuns)
 	assert.Equal(t, t0.Add(2*time.Minute), state.LastRunTime)
+}
+
+// TestProcessScheduleFireBufferEnqueuesWhenQueueNonEmpty verifies the
+// FIFO-preserving fast path: under BUFFER, if the queue already has waiters,
+// a new live fire is appended directly without invoking the scheduler
+// activity. This both saves a describe RPC and closes a race where the
+// previous target could complete between drain and live-fire, letting the
+// live fire jump ahead of older queued fires.
+func TestProcessScheduleFireBufferEnqueuesWhenQueueNonEmpty(t *testing.T) {
+	t0 := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	input := &SchedulerWorkflowInput{
+		Spec: types.ScheduleSpec{CronExpression: "* * * * *"},
+		Action: types.ScheduleAction{
+			StartWorkflow: &types.StartWorkflowAction{
+				WorkflowType: &types.WorkflowType{Name: "wf"},
+				TaskList:     &types.TaskList{Name: "tl"},
+			},
+		},
+		Policies: types.SchedulePolicies{OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
+	}
+	state := &SchedulerWorkflowState{
+		BufferedFires: []BufferedFire{
+			{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
+		},
+	}
+	scope := tally.NewTestScope("", nil)
+	liveFire := t0.Add(2 * time.Minute)
+
+	// nil ctx is safe because the BUFFER+non-empty-queue branch returns before
+	// touching workflow.ExecuteLocalActivity. If the fast path were ever
+	// removed, this call would panic — which is the property we want to lock in.
+	processScheduleFire(nil, testLogger, scope, input, state, liveFire, TriggerSourceSchedule)
+
+	require.Len(t, state.BufferedFires, 2, "live fire should be enqueued at the tail")
+	assert.Equal(t, t0, state.BufferedFires[0].ScheduledTime, "older queued fire stays at head")
+	assert.Equal(t, liveFire, state.BufferedFires[1].ScheduledTime, "live fire goes to tail")
+	assert.Equal(t, liveFire, state.LastRunTime, "LastRunTime should still advance even on the fast path")
+}
+
+// TestCatchUpWatermark verifies the catch-up watermark is the max of the
+// two relevant timestamps. LastProcessedTime advances only via catch-up;
+// LastRunTime advances on every fire (live or buffered). Picking only
+// LastProcessedTime would let catch-up rediscover fire times we already
+// attempted, double-counting TotalRuns / SkippedRuns on the next CAN.
+func TestCatchUpWatermark(t *testing.T) {
+	t0 := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name              string
+		lastProcessedTime time.Time
+		lastRunTime       time.Time
+		want              time.Time
+	}{
+		{
+			name: "both zero -> zero",
+			want: time.Time{},
+		},
+		{
+			name:        "only LastRunTime set (no catch-up has run yet) -> LastRunTime",
+			lastRunTime: t0,
+			want:        t0,
+		},
+		{
+			name:              "only LastProcessedTime set (catch-up ran but no live fires since) -> LastProcessedTime",
+			lastProcessedTime: t0,
+			want:              t0,
+		},
+		{
+			name:              "live fires happened after catch-up -> LastRunTime is newer",
+			lastProcessedTime: t0,
+			lastRunTime:       t0.Add(time.Hour),
+			want:              t0.Add(time.Hour),
+		},
+		{
+			name:              "catch-up ran after a quiet period (LastProcessedTime newer)",
+			lastProcessedTime: t0.Add(time.Hour),
+			lastRunTime:       t0,
+			want:              t0.Add(time.Hour),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := catchUpWatermark(&SchedulerWorkflowState{
+				LastProcessedTime: tt.lastProcessedTime,
+				LastRunTime:       tt.lastRunTime,
+			})
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestDrainBufferedFiresRespectsCap verifies drainBufferedFires processes at
+// most maxDrainFiresPerExecution fires per call and signals more remaining
+// work via the bool return so the caller ContinueAsNews. Mirrors the
+// existing per-execution caps on processMissedRuns and processBackfills.
+func TestDrainBufferedFiresRespectsCap(t *testing.T) {
+	t0 := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	queue := largeBufferedFires(maxDrainFiresPerExecution+5, t0)
+	input := &SchedulerWorkflowInput{
+		Spec: types.ScheduleSpec{CronExpression: "* * * * *"},
+	}
+	state := &SchedulerWorkflowState{
+		BufferedFires: append([]BufferedFire(nil), queue...),
+	}
+
+	moreToDrain := drainBufferedFires(nil, testLogger, input, state)
+
+	assert.True(t, moreToDrain, "should signal more work when queue exceeds the cap")
+	assert.Len(t, state.BufferedFires, 5, "should leave the unprocessed remainder on the queue")
+	assert.Equal(t, int64(maxDrainFiresPerExecution), state.MissedRuns, "should consume exactly the cap on this execution")
 }
 
 func TestEffectiveBufferLimit(t *testing.T) {
@@ -1267,34 +1377,34 @@ func TestEffectiveBufferLimit(t *testing.T) {
 		wantReason string
 	}{
 		{
-			name:       "userLimit=0 (unlimited) yields safety cap",
+			name:       "userLimit=0 (unlimited) yields system limit",
 			userLimit:  0,
-			wantLimit:  MaxBufferedFiresHardCap,
-			wantReason: BufferOverflowReasonSafetyCap,
+			wantLimit:  MaxBufferedFiresSystemLimit,
+			wantReason: BufferOverflowReasonSystemLimit,
 		},
 		{
-			name:       "negative userLimit treated as unlimited yields safety cap",
+			name:       "negative userLimit treated as unlimited yields system limit",
 			userLimit:  -1,
-			wantLimit:  MaxBufferedFiresHardCap,
-			wantReason: BufferOverflowReasonSafetyCap,
+			wantLimit:  MaxBufferedFiresSystemLimit,
+			wantReason: BufferOverflowReasonSystemLimit,
 		},
 		{
-			name:       "userLimit below safety cap is honored",
+			name:       "userLimit below system limit is honored",
 			userLimit:  100,
 			wantLimit:  100,
-			wantReason: BufferOverflowReasonBufferLimit,
+			wantReason: BufferOverflowReasonUserLimit,
 		},
 		{
-			name:       "userLimit equal to safety cap is honored as buffer_limit",
-			userLimit:  int32(MaxBufferedFiresHardCap),
-			wantLimit:  MaxBufferedFiresHardCap,
-			wantReason: BufferOverflowReasonBufferLimit,
+			name:       "userLimit equal to system limit is honored as user_limit",
+			userLimit:  int32(MaxBufferedFiresSystemLimit),
+			wantLimit:  MaxBufferedFiresSystemLimit,
+			wantReason: BufferOverflowReasonUserLimit,
 		},
 		{
-			name:       "userLimit above safety cap is clamped to safety cap",
-			userLimit:  int32(MaxBufferedFiresHardCap * 2),
-			wantLimit:  MaxBufferedFiresHardCap,
-			wantReason: BufferOverflowReasonSafetyCap,
+			name:       "userLimit above system limit is clamped to system limit",
+			userLimit:  int32(MaxBufferedFiresSystemLimit * 2),
+			wantLimit:  MaxBufferedFiresSystemLimit,
+			wantReason: BufferOverflowReasonSystemLimit,
 		},
 	}
 	for _, tt := range tests {

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1113,10 +1113,8 @@ func TestEnqueueBufferedFire(t *testing.T) {
 		initialSkipped  int64
 		enqueueTime     time.Time
 		trigger         TriggerSource
-		wantFires       []BufferedFire
-		wantSkippedRuns int64
-		// wantOverflowReason is "" when no overflow metric is expected;
-		// otherwise it is the expected reason tag value (buffer_limit / safety_cap).
+		wantFires          []BufferedFire
+		wantSkippedRuns    int64
 		wantOverflowReason string
 	}{
 		{
@@ -1155,7 +1153,6 @@ func TestEnqueueBufferedFire(t *testing.T) {
 			initialSkipped: 5,
 			enqueueTime:    t0.Add(2 * time.Minute),
 			trigger:        TriggerSourceSchedule,
-			// Buffer unchanged (limit was 2, already at 2).
 			wantFires: []BufferedFire{
 				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
 				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule},
@@ -1164,8 +1161,8 @@ func TestEnqueueBufferedFire(t *testing.T) {
 			wantOverflowReason: BufferOverflowReasonBufferLimit,
 		},
 		{
-			name:               "enqueue at safety cap drops fire and emits safety_cap metric",
-			bufferLimit:        0, // unlimited per user, but safety cap still enforces
+			name:               "enqueue at safety cap with unlimited buffer_limit attributes to safety_cap",
+			bufferLimit:        0,
 			initialFires:       largeBufferedFires(MaxBufferedFiresHardCap, t0),
 			initialSkipped:     0,
 			enqueueTime:        t0.Add(time.Hour),
@@ -1175,10 +1172,6 @@ func TestEnqueueBufferedFire(t *testing.T) {
 			wantOverflowReason: BufferOverflowReasonSafetyCap,
 		},
 		{
-			// buffer_limit > safety cap: drops at the safety cap should be
-			// attributed to safety_cap (not buffer_limit), because the user's
-			// limit was never the binding constraint. CreateSchedule/UpdateSchedule
-			// warn at write time so this attribution isn't surprising.
 			name:               "enqueue at safety cap when user buffer_limit exceeds it attributes to safety_cap",
 			bufferLimit:        int32(MaxBufferedFiresHardCap * 2),
 			initialFires:       largeBufferedFires(MaxBufferedFiresHardCap, t0),
@@ -1227,9 +1220,8 @@ func TestEnqueueBufferedFire(t *testing.T) {
 	}
 }
 
-// largeBufferedFires builds a slice of n synthetic BufferedFire entries
-// starting at the given base time, used to exercise the safety-cap path
-// without each test case having to construct ~1000 entries inline.
+// largeBufferedFires builds a slice of n BufferedFire entries with one-second
+// spacing starting at base.
 func largeBufferedFires(n int, base time.Time) []BufferedFire {
 	out := make([]BufferedFire, n)
 	for i := 0; i < n; i++ {
@@ -1242,16 +1234,7 @@ func largeBufferedFires(n int, base time.Time) []BufferedFire {
 }
 
 // TestDrainBufferedFiresFIFO verifies that drainBufferedFires consumes the
-// queue in FIFO order. This is the building block that, together with the
-// startup-phase ordering in SchedulerWorkflow (drain before processMissedRuns),
-// preserves chronological order across ContinueAsNew when older fires were
-// buffered in the previous execution and missed runs accrued in the gap.
-//
-// Uses the nil-StartWorkflow + nil-ctx trick (see TestProcessMissedRunsAtMetrics
-// for the same pattern): processScheduleFire short-circuits via the
-// "schedule action has no StartWorkflow configuration" branch, mutating state
-// without touching the workflow environment, so we can assert the queue
-// shrinks in head-to-tail order without spinning up a workflow runtime.
+// queue in chronological order.
 func TestDrainBufferedFiresFIFO(t *testing.T) {
 	t0 := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 	queue := []BufferedFire{
@@ -1261,9 +1244,9 @@ func TestDrainBufferedFiresFIFO(t *testing.T) {
 	}
 	input := &SchedulerWorkflowInput{
 		Spec: types.ScheduleSpec{CronExpression: "* * * * *"},
-		// Action.StartWorkflow intentionally nil so processScheduleFire returns
-		// early via the missing-action branch (incrementing MissedRuns) without
-		// touching the workflow environment.
+		// StartWorkflow nil makes processScheduleFire short-circuit on the
+		// missing-action branch, so each fire is consumed without invoking the
+		// activity.
 	}
 	state := &SchedulerWorkflowState{
 		BufferedFires: append([]BufferedFire(nil), queue...),
@@ -1271,15 +1254,9 @@ func TestDrainBufferedFiresFIFO(t *testing.T) {
 
 	drainBufferedFires(nil, testLogger, input, state)
 
-	// All three fires processed (each via the missing-action short-circuit) and
-	// the queue is now empty. MissedRuns is incremented per fire, demonstrating
-	// each was actually consumed.
-	assert.Empty(t, state.BufferedFires, "drain should consume the full queue when each fire short-circuits")
-	assert.Equal(t, int64(3), state.MissedRuns, "each consumed fire should increment MissedRuns via the missing-action branch")
-	// LastRunTime advanced to the latest scheduledTime: with the monotonic clamp,
-	// this proves the drain processed entries in increasing-time order rather
-	// than tail-first.
-	assert.Equal(t, t0.Add(2*time.Minute), state.LastRunTime, "LastRunTime should advance monotonically as drain processes the queue")
+	assert.Empty(t, state.BufferedFires)
+	assert.Equal(t, int64(3), state.MissedRuns)
+	assert.Equal(t, t0.Add(2*time.Minute), state.LastRunTime)
 }
 
 func TestEffectiveBufferLimit(t *testing.T) {
@@ -1361,14 +1338,14 @@ func TestHandleUpdate_BufferedFiresClearedOnOverlapPolicyChange(t *testing.T) {
 			wantSkippedRuns: 2,
 		},
 		{
-			name:         "BUFFER -> BUFFER preserves queue (no-op policy change)",
+			name:         "BUFFER -> BUFFER preserves queue",
 			fromOverlap:  types.ScheduleOverlapPolicyBuffer,
 			toOverlap:    types.ScheduleOverlapPolicyBuffer,
 			initialFires: initialFires,
 			wantFiresLen: 2,
 		},
 		{
-			name:         "SKIP_NEW -> BUFFER leaves queue unchanged (was already empty)",
+			name:         "SKIP_NEW -> BUFFER leaves empty queue empty",
 			fromOverlap:  types.ScheduleOverlapPolicySkipNew,
 			toOverlap:    types.ScheduleOverlapPolicyBuffer,
 			initialFires: nil,

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1103,3 +1103,257 @@ func TestBuildScheduleSearchAttributes(t *testing.T) {
 		})
 	}
 }
+
+func TestEnqueueBufferedFire(t *testing.T) {
+	t0 := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name            string
+		bufferLimit     int32
+		initialFires    []BufferedFire
+		initialSkipped  int64
+		enqueueTime     time.Time
+		trigger         TriggerSource
+		wantFires       []BufferedFire
+		wantSkippedRuns int64
+		// wantOverflowReason is "" when no overflow metric is expected;
+		// otherwise it is the expected reason tag value (buffer_limit / safety_cap).
+		wantOverflowReason string
+	}{
+		{
+			name:         "unlimited buffer accepts fire when bufferLimit=0",
+			bufferLimit:  0,
+			initialFires: []BufferedFire{{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule}},
+			enqueueTime:  t0.Add(time.Minute),
+			trigger:      TriggerSourceSchedule,
+			wantFires: []BufferedFire{
+				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
+				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule},
+			},
+		},
+		{
+			name:        "enqueue below limit appends to tail",
+			bufferLimit: 3,
+			initialFires: []BufferedFire{
+				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
+				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule},
+			},
+			enqueueTime: t0.Add(2 * time.Minute),
+			trigger:     TriggerSourceSchedule,
+			wantFires: []BufferedFire{
+				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
+				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule},
+				{ScheduledTime: t0.Add(2 * time.Minute), TriggerSource: TriggerSourceSchedule},
+			},
+		},
+		{
+			name:        "enqueue at user limit drops fire and emits buffer_limit metric",
+			bufferLimit: 2,
+			initialFires: []BufferedFire{
+				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
+				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule},
+			},
+			initialSkipped: 5,
+			enqueueTime:    t0.Add(2 * time.Minute),
+			trigger:        TriggerSourceSchedule,
+			// Buffer unchanged (limit was 2, already at 2).
+			wantFires: []BufferedFire{
+				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
+				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule},
+			},
+			wantSkippedRuns:    6,
+			wantOverflowReason: BufferOverflowReasonBufferLimit,
+		},
+		{
+			name:               "enqueue at safety cap drops fire and emits safety_cap metric",
+			bufferLimit:        0, // unlimited per user, but safety cap still enforces
+			initialFires:       largeBufferedFires(MaxBufferedFiresHardCap, t0),
+			initialSkipped:     0,
+			enqueueTime:        t0.Add(time.Hour),
+			trigger:            TriggerSourceSchedule,
+			wantFires:          largeBufferedFires(MaxBufferedFiresHardCap, t0),
+			wantSkippedRuns:    1,
+			wantOverflowReason: BufferOverflowReasonSafetyCap,
+		},
+		{
+			// buffer_limit > safety cap: drops at the safety cap should be
+			// attributed to safety_cap (not buffer_limit), because the user's
+			// limit was never the binding constraint. CreateSchedule/UpdateSchedule
+			// warn at write time so this attribution isn't surprising.
+			name:               "enqueue at safety cap when user buffer_limit exceeds it attributes to safety_cap",
+			bufferLimit:        int32(MaxBufferedFiresHardCap * 2),
+			initialFires:       largeBufferedFires(MaxBufferedFiresHardCap, t0),
+			enqueueTime:        t0.Add(time.Hour),
+			trigger:            TriggerSourceSchedule,
+			wantFires:          largeBufferedFires(MaxBufferedFiresHardCap, t0),
+			wantSkippedRuns:    1,
+			wantOverflowReason: BufferOverflowReasonSafetyCap,
+		},
+		{
+			name:         "backfill trigger source is preserved",
+			bufferLimit:  0,
+			initialFires: nil,
+			enqueueTime:  t0,
+			trigger:      TriggerSourceBackfill,
+			wantFires: []BufferedFire{
+				{ScheduledTime: t0, TriggerSource: TriggerSourceBackfill},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := &SchedulerWorkflowInput{
+				Policies: types.SchedulePolicies{BufferLimit: tt.bufferLimit},
+			}
+			state := &SchedulerWorkflowState{
+				BufferedFires: append([]BufferedFire(nil), tt.initialFires...),
+				SkippedRuns:   tt.initialSkipped,
+			}
+			scope := tally.NewTestScope("", nil)
+			enqueueBufferedFire(testLogger, scope, input, state, tt.enqueueTime, tt.trigger)
+			assert.Equal(t, tt.wantFires, state.BufferedFires)
+			assert.Equal(t, tt.wantSkippedRuns, state.SkippedRuns)
+
+			counters := scope.Snapshot().Counters()
+			if tt.wantOverflowReason != "" {
+				c, ok := findCounter(counters, SchedulerBufferOverflowCountPerDomain, map[string]string{ReasonTag: tt.wantOverflowReason})
+				require.True(t, ok, "overflow metric should be emitted with reason=%s", tt.wantOverflowReason)
+				assert.Equal(t, int64(1), c.Value())
+			} else {
+				_, ok := findCounter(counters, SchedulerBufferOverflowCountPerDomain, map[string]string{})
+				assert.False(t, ok, "overflow metric should not be emitted on successful enqueue")
+			}
+		})
+	}
+}
+
+// largeBufferedFires builds a slice of n synthetic BufferedFire entries
+// starting at the given base time, used to exercise the safety-cap path
+// without each test case having to construct ~1000 entries inline.
+func largeBufferedFires(n int, base time.Time) []BufferedFire {
+	out := make([]BufferedFire, n)
+	for i := 0; i < n; i++ {
+		out[i] = BufferedFire{
+			ScheduledTime: base.Add(time.Duration(i) * time.Second),
+			TriggerSource: TriggerSourceSchedule,
+		}
+	}
+	return out
+}
+
+func TestEffectiveBufferLimit(t *testing.T) {
+	tests := []struct {
+		name       string
+		userLimit  int32
+		wantLimit  int
+		wantReason string
+	}{
+		{
+			name:       "userLimit=0 (unlimited) yields safety cap",
+			userLimit:  0,
+			wantLimit:  MaxBufferedFiresHardCap,
+			wantReason: BufferOverflowReasonSafetyCap,
+		},
+		{
+			name:       "negative userLimit treated as unlimited yields safety cap",
+			userLimit:  -1,
+			wantLimit:  MaxBufferedFiresHardCap,
+			wantReason: BufferOverflowReasonSafetyCap,
+		},
+		{
+			name:       "userLimit below safety cap is honored",
+			userLimit:  100,
+			wantLimit:  100,
+			wantReason: BufferOverflowReasonBufferLimit,
+		},
+		{
+			name:       "userLimit equal to safety cap is honored as buffer_limit",
+			userLimit:  int32(MaxBufferedFiresHardCap),
+			wantLimit:  MaxBufferedFiresHardCap,
+			wantReason: BufferOverflowReasonBufferLimit,
+		},
+		{
+			name:       "userLimit above safety cap is clamped to safety cap",
+			userLimit:  int32(MaxBufferedFiresHardCap * 2),
+			wantLimit:  MaxBufferedFiresHardCap,
+			wantReason: BufferOverflowReasonSafetyCap,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotLimit, gotReason := effectiveBufferLimit(tt.userLimit)
+			assert.Equal(t, tt.wantLimit, gotLimit)
+			assert.Equal(t, tt.wantReason, gotReason)
+		})
+	}
+}
+
+func TestHandleUpdate_BufferedFiresClearedOnOverlapPolicyChange(t *testing.T) {
+	t0 := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	initialFires := []BufferedFire{
+		{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
+		{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule},
+	}
+
+	tests := []struct {
+		name            string
+		fromOverlap     types.ScheduleOverlapPolicy
+		toOverlap       types.ScheduleOverlapPolicy
+		initialFires    []BufferedFire
+		wantFiresLen    int
+		wantSkippedRuns int64
+	}{
+		{
+			name:            "BUFFER -> SKIP_NEW clears queue and counts drops as skipped",
+			fromOverlap:     types.ScheduleOverlapPolicyBuffer,
+			toOverlap:       types.ScheduleOverlapPolicySkipNew,
+			initialFires:    initialFires,
+			wantFiresLen:    0,
+			wantSkippedRuns: 2,
+		},
+		{
+			name:            "BUFFER -> TERMINATE_PREVIOUS clears queue",
+			fromOverlap:     types.ScheduleOverlapPolicyBuffer,
+			toOverlap:       types.ScheduleOverlapPolicyTerminatePrevious,
+			initialFires:    initialFires,
+			wantFiresLen:    0,
+			wantSkippedRuns: 2,
+		},
+		{
+			name:         "BUFFER -> BUFFER preserves queue (no-op policy change)",
+			fromOverlap:  types.ScheduleOverlapPolicyBuffer,
+			toOverlap:    types.ScheduleOverlapPolicyBuffer,
+			initialFires: initialFires,
+			wantFiresLen: 2,
+		},
+		{
+			name:         "SKIP_NEW -> BUFFER leaves queue unchanged (was already empty)",
+			fromOverlap:  types.ScheduleOverlapPolicySkipNew,
+			toOverlap:    types.ScheduleOverlapPolicyBuffer,
+			initialFires: nil,
+			wantFiresLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := &SchedulerWorkflowInput{
+				Spec:     types.ScheduleSpec{CronExpression: "0 * * * *"},
+				Policies: types.SchedulePolicies{OverlapPolicy: tt.fromOverlap},
+			}
+			state := &SchedulerWorkflowState{
+				BufferedFires: append([]BufferedFire(nil), tt.initialFires...),
+			}
+			sig := UpdateSignal{
+				Policies: &types.SchedulePolicies{OverlapPolicy: tt.toOverlap},
+			}
+
+			changed := handleUpdate(testLogger, sig, input, state)
+
+			assert.True(t, changed, "policy change should always report as changed")
+			assert.Equal(t, tt.toOverlap, input.Policies.OverlapPolicy)
+			assert.Len(t, state.BufferedFires, tt.wantFiresLen)
+			assert.Equal(t, tt.wantSkippedRuns, state.SkippedRuns)
+		})
+	}
+}

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1241,6 +1241,47 @@ func largeBufferedFires(n int, base time.Time) []BufferedFire {
 	return out
 }
 
+// TestDrainBufferedFiresFIFO verifies that drainBufferedFires consumes the
+// queue in FIFO order. This is the building block that, together with the
+// startup-phase ordering in SchedulerWorkflow (drain before processMissedRuns),
+// preserves chronological order across ContinueAsNew when older fires were
+// buffered in the previous execution and missed runs accrued in the gap.
+//
+// Uses the nil-StartWorkflow + nil-ctx trick (see TestProcessMissedRunsAtMetrics
+// for the same pattern): processScheduleFire short-circuits via the
+// "schedule action has no StartWorkflow configuration" branch, mutating state
+// without touching the workflow environment, so we can assert the queue
+// shrinks in head-to-tail order without spinning up a workflow runtime.
+func TestDrainBufferedFiresFIFO(t *testing.T) {
+	t0 := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	queue := []BufferedFire{
+		{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
+		{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule},
+		{ScheduledTime: t0.Add(2 * time.Minute), TriggerSource: TriggerSourceBackfill},
+	}
+	input := &SchedulerWorkflowInput{
+		Spec: types.ScheduleSpec{CronExpression: "* * * * *"},
+		// Action.StartWorkflow intentionally nil so processScheduleFire returns
+		// early via the missing-action branch (incrementing MissedRuns) without
+		// touching the workflow environment.
+	}
+	state := &SchedulerWorkflowState{
+		BufferedFires: append([]BufferedFire(nil), queue...),
+	}
+
+	drainBufferedFires(nil, testLogger, input, state)
+
+	// All three fires processed (each via the missing-action short-circuit) and
+	// the queue is now empty. MissedRuns is incremented per fire, demonstrating
+	// each was actually consumed.
+	assert.Empty(t, state.BufferedFires, "drain should consume the full queue when each fire short-circuits")
+	assert.Equal(t, int64(3), state.MissedRuns, "each consumed fire should increment MissedRuns via the missing-action branch")
+	// LastRunTime advanced to the latest scheduledTime: with the monotonic clamp,
+	// this proves the drain processed entries in increasing-time order rather
+	// than tail-first.
+	assert.Equal(t, t0.Add(2*time.Minute), state.LastRunTime, "LastRunTime should advance monotonically as drain processes the queue")
+}
+
 func TestEffectiveBufferLimit(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1107,12 +1107,12 @@ func TestBuildScheduleSearchAttributes(t *testing.T) {
 func TestEnqueueBufferedFire(t *testing.T) {
 	t0 := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 	tests := []struct {
-		name            string
-		bufferLimit     int32
-		initialFires    []BufferedFire
-		initialSkipped  int64
-		enqueueTime     time.Time
-		trigger         TriggerSource
+		name               string
+		bufferLimit        int32
+		initialFires       []BufferedFire
+		initialSkipped     int64
+		enqueueTime        time.Time
+		trigger            TriggerSource
 		wantFires          []BufferedFire
 		wantSkippedRuns    int64
 		wantOverflowReason string

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -925,3 +925,156 @@ func TestBuildScheduleSearchAttributes(t *testing.T) {
 		})
 	}
 }
+
+func TestEnqueueBufferedFire(t *testing.T) {
+	t0 := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name            string
+		bufferLimit     int32
+		initialFires    []BufferedFire
+		initialSkipped  int64
+		enqueueTime     time.Time
+		trigger         TriggerSource
+		wantFires       []BufferedFire
+		wantSkippedRuns int64
+	}{
+		{
+			name:         "unlimited buffer accepts fire when bufferLimit=0",
+			bufferLimit:  0,
+			initialFires: []BufferedFire{{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule}},
+			enqueueTime:  t0.Add(time.Minute),
+			trigger:      TriggerSourceSchedule,
+			wantFires: []BufferedFire{
+				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
+				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule},
+			},
+		},
+		{
+			name:        "enqueue below limit appends to tail",
+			bufferLimit: 3,
+			initialFires: []BufferedFire{
+				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
+				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule},
+			},
+			enqueueTime: t0.Add(2 * time.Minute),
+			trigger:     TriggerSourceSchedule,
+			wantFires: []BufferedFire{
+				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
+				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule},
+				{ScheduledTime: t0.Add(2 * time.Minute), TriggerSource: TriggerSourceSchedule},
+			},
+		},
+		{
+			name:        "enqueue at limit drops fire and increments SkippedRuns",
+			bufferLimit: 2,
+			initialFires: []BufferedFire{
+				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
+				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule},
+			},
+			initialSkipped: 5,
+			enqueueTime:    t0.Add(2 * time.Minute),
+			trigger:        TriggerSourceSchedule,
+			// Buffer unchanged (limit was 2, already at 2).
+			wantFires: []BufferedFire{
+				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
+				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule},
+			},
+			wantSkippedRuns: 6,
+		},
+		{
+			name:         "backfill trigger source is preserved",
+			bufferLimit:  0,
+			initialFires: nil,
+			enqueueTime:  t0,
+			trigger:      TriggerSourceBackfill,
+			wantFires: []BufferedFire{
+				{ScheduledTime: t0, TriggerSource: TriggerSourceBackfill},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := &SchedulerWorkflowInput{
+				Policies: types.SchedulePolicies{BufferLimit: tt.bufferLimit},
+			}
+			state := &SchedulerWorkflowState{
+				BufferedFires: append([]BufferedFire(nil), tt.initialFires...),
+				SkippedRuns:   tt.initialSkipped,
+			}
+			enqueueBufferedFire(testLogger, input, state, tt.enqueueTime, tt.trigger)
+			assert.Equal(t, tt.wantFires, state.BufferedFires)
+			assert.Equal(t, tt.wantSkippedRuns, state.SkippedRuns)
+		})
+	}
+}
+
+func TestHandleUpdate_BufferedFiresClearedOnOverlapPolicyChange(t *testing.T) {
+	t0 := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	initialFires := []BufferedFire{
+		{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
+		{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule},
+	}
+
+	tests := []struct {
+		name            string
+		fromOverlap     types.ScheduleOverlapPolicy
+		toOverlap       types.ScheduleOverlapPolicy
+		initialFires    []BufferedFire
+		wantFiresLen    int
+		wantSkippedRuns int64
+	}{
+		{
+			name:            "BUFFER -> SKIP_NEW clears queue and counts drops as skipped",
+			fromOverlap:     types.ScheduleOverlapPolicyBuffer,
+			toOverlap:       types.ScheduleOverlapPolicySkipNew,
+			initialFires:    initialFires,
+			wantFiresLen:    0,
+			wantSkippedRuns: 2,
+		},
+		{
+			name:            "BUFFER -> TERMINATE_PREVIOUS clears queue",
+			fromOverlap:     types.ScheduleOverlapPolicyBuffer,
+			toOverlap:       types.ScheduleOverlapPolicyTerminatePrevious,
+			initialFires:    initialFires,
+			wantFiresLen:    0,
+			wantSkippedRuns: 2,
+		},
+		{
+			name:         "BUFFER -> BUFFER preserves queue (no-op policy change)",
+			fromOverlap:  types.ScheduleOverlapPolicyBuffer,
+			toOverlap:    types.ScheduleOverlapPolicyBuffer,
+			initialFires: initialFires,
+			wantFiresLen: 2,
+		},
+		{
+			name:         "SKIP_NEW -> BUFFER leaves queue unchanged (was already empty)",
+			fromOverlap:  types.ScheduleOverlapPolicySkipNew,
+			toOverlap:    types.ScheduleOverlapPolicyBuffer,
+			initialFires: nil,
+			wantFiresLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := &SchedulerWorkflowInput{
+				Spec:     types.ScheduleSpec{CronExpression: "0 * * * *"},
+				Policies: types.SchedulePolicies{OverlapPolicy: tt.fromOverlap},
+			}
+			state := &SchedulerWorkflowState{
+				BufferedFires: append([]BufferedFire(nil), tt.initialFires...),
+			}
+			sig := UpdateSignal{
+				Policies: &types.SchedulePolicies{OverlapPolicy: tt.toOverlap},
+			}
+
+			changed := handleUpdate(testLogger, sig, input, state)
+
+			assert.True(t, changed, "policy change should always report as changed")
+			assert.Equal(t, tt.toOverlap, input.Policies.OverlapPolicy)
+			assert.Len(t, state.BufferedFires, tt.wantFiresLen)
+			assert.Equal(t, tt.wantSkippedRuns, state.SkippedRuns)
+		})
+	}
+}


### PR DESCRIPTION
## What changed?

BUFFER was a stub — it just hard-skipped fires with a different metric tag. This PR makes it actually buffer: queue fires while the previous target is running, drain them sequentially as it completes.

The activity returns `Buffered=true` instead of mutating state; the workflow owns the queue (`state.BufferedFires`, persisted across CAN). Two limits: the user's `buffer_limit`, and a 1000-entry hard cap so an unlimited queue can't blow the CAN payload size.

## Why?

Last overlap policy still missing for Q1. Sequential execution is what most users expect from "buffer" — e.g. a nightly ETL that shouldn't overlap.

## Tests

`make pr` clean. New unit tests for `enqueueBufferedFire` (limits + metric attribution), `effectiveBufferLimit`, `drainBufferedFires` FIFO order, and

## Risks

- `BufferedFires` is a new state field (`omitempty`, so existing schedulers deserialize cleanly).
- Drain latency is bounded by the cron interval — a buffered fire waits until the next timer/signal wakeup. Could tighten later with`GetWorkflowExecutionHistory(WaitForNewEvent)`.
- BUFFER + `CATCH_UP_ALL` means the queue cap effectively bounds catch-up depth.

## Release notes

BUFFER queues fires and runs them sequentially instead of skipping. Set `buffer_limit > 0` to cap queue depth (`0` = unlimited up to the 1000-entry safety cap). Drops emit `scheduler_buffer_overflow_count_per_domain{reason=buffer_limit|safety_cap}`.

## Documentation Notes
N/A