### PR TITLE
feat(cadence-matching): add boolean flag for offboarding from SM

### DIFF
--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -187,6 +187,7 @@ func (s *server) startService() common.Daemon {
 			s.logger.Fatal("spectator does not support multiple namespaces", tag.Value(s.cfg.ShardDistributorMatchingConfig.Namespaces))
 		}
 		matchingPercentageOnboarded := dc.GetIntProperty(dynamicproperties.MatchingPercentageOnboardedToShardManager)
+		matchingEmergencyOffboarding := dc.GetBoolProperty(dynamicproperties.MatchingEmergencyOffboardingFromShardManager)
 
 		spectatorParams := spectatorclient.Params{
 			Client:       shardDistributorClient,
@@ -195,7 +196,7 @@ func (s *server) startService() common.Daemon {
 			Config:       s.cfg.ShardDistributorMatchingConfig,
 			TimeSource:   clock.NewRealTimeSource(),
 			Enabled: func() bool {
-				return matchingPercentageOnboarded() > 0
+				return !matchingEmergencyOffboarding() && matchingPercentageOnboarded() > 0
 			},
 		}
 		namespace := s.cfg.ShardDistributorMatchingConfig.Namespaces[0].Namespace
@@ -335,6 +336,7 @@ func (*server) wrapHashRingsWithShardDistributor(
 			spectator,
 			dc.GetBoolProperty(dynamicproperties.MatchingExcludeShortLivedTaskListsFromShardManager),
 			dc.GetIntProperty(dynamicproperties.MatchingPercentageOnboardedToShardManager),
+			dc.GetBoolProperty(dynamicproperties.MatchingEmergencyOffboardingFromShardManager),
 			hashRings[service.Matching],
 			logger,
 		)

--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -2356,6 +2356,13 @@ const (
 	// Default value: true
 	// Allowed filters: N/A
 	MatchingExcludeShortLivedTaskListsFromShardManager
+	// MatchingEmergencyOffboardingFromShardManager is a kill switch to immediately offboard all task lists from the shard manager.
+	// When true, all task lists fall back to the hash ring, ignoring MatchingPercentageOnboardedToShardManager.
+	// KeyName: matching.emergencyOffboardingFromShardManager
+	// Value type: Bool
+	// Default value: false
+	// Allowed filters: N/A
+	MatchingEmergencyOffboardingFromShardManager
 
 	// EnableHierarchicalWeightedRoundRobinTaskScheduler is to enable hierarchical weighted round robin task scheduler
 	// KeyName: history.enableHierarchicalWeightedRoundRobinTaskScheduler
@@ -5109,6 +5116,11 @@ var BoolKeys = map[BoolKey]DynamicBool{
 		KeyName:      "matching.excludeShortLivedTaskListsFromShardManager",
 		Description:  "MatchingExcludeShortLivedTaskListsFromShardManager excludes short-lived task lists (e.g. bits task lists and sticky task lists) from the shard manager",
 		DefaultValue: true,
+	},
+	MatchingEmergencyOffboardingFromShardManager: {
+		KeyName:      "matching.emergencyOffboardingFromShardManager",
+		Description:  "MatchingEmergencyOffboardingFromShardManager is a kill switch to immediately offboard all task lists from the shard manager, ignoring the onboarding percentage",
+		DefaultValue: false,
 	},
 	EnableHierarchicalWeightedRoundRobinTaskScheduler: {
 		KeyName:      "history.enableHierarchicalWeightedRoundRobinTaskScheduler",

--- a/common/membership/sharddistributorresolver.go
+++ b/common/membership/sharddistributorresolver.go
@@ -37,6 +37,7 @@ import (
 
 type shardDistributorResolver struct {
 	excludeShortLivedTaskLists dynamicproperties.BoolPropertyFn
+	emergencyOffboarding       dynamicproperties.BoolPropertyFn
 	percentageOnboarded        dynamicproperties.IntPropertyFn
 	spectator                  spectatorclient.Spectator
 	ring                       SingleProvider
@@ -51,6 +52,7 @@ func NewShardDistributorResolver(
 	spectator spectatorclient.Spectator,
 	excludeShortLivedTaskLists dynamicproperties.BoolPropertyFn,
 	percentageOnboarded dynamicproperties.IntPropertyFn,
+	emergencyOffboarding dynamicproperties.BoolPropertyFn,
 	ring SingleProvider,
 	logger log.Logger,
 ) SingleProvider {
@@ -58,6 +60,7 @@ func NewShardDistributorResolver(
 		spectator:                  spectator,
 		excludeShortLivedTaskLists: excludeShortLivedTaskLists,
 		percentageOnboarded:        percentageOnboarded,
+		emergencyOffboarding:       emergencyOffboarding,
 		ring:                       ring,
 		logger:                     logger,
 	}
@@ -74,6 +77,9 @@ func (s shardDistributorResolver) Stop() {
 }
 
 func (s shardDistributorResolver) Lookup(key string) (HostInfo, error) {
+	if s.emergencyOffboarding() {
+		return s.ring.Lookup(key)
+	}
 	excludeTaskList := TaskListExcludedFromShardDistributor(key, uint64(s.percentageOnboarded()), s.excludeShortLivedTaskLists())
 	if excludeTaskList {
 		return s.ring.Lookup(key)

--- a/common/membership/sharddistributorresolver_test.go
+++ b/common/membership/sharddistributorresolver_test.go
@@ -72,6 +72,7 @@ func TestShardDistributorResolver_Lookup_NilSpectatorFallsBackToHashRing(t *test
 		nil, // nil spectator
 		dynamicproperties.GetBoolPropertyFn(false),
 		dynamicproperties.GetIntPropertyFn(100),
+		dynamicproperties.GetBoolPropertyFn(false),
 		ring,
 		logger,
 	).(*shardDistributorResolver)
@@ -83,8 +84,19 @@ func TestShardDistributorResolver_Lookup_NilSpectatorFallsBackToHashRing(t *test
 	assert.Equal(t, "hash-ring-addr", host.addr)
 }
 
-/* Test all the simple proxies
- */
+func TestShardDistributorResolver_Lookup_EmergencyOffboardingFallsBackToHashRing(t *testing.T) {
+	resolver, ring, _ := newShardDistributorResolver(t)
+	// Emergency offboarding overrides the onboarding percentage
+	resolver.emergencyOffboarding = dynamicproperties.GetBoolPropertyFn(true)
+	resolver.percentageOnboarded = dynamicproperties.GetIntPropertyFn(100)
+
+	ring.EXPECT().Lookup("test-key").Return(HostInfo{addr: "hash-ring-addr"}, nil)
+
+	host, err := resolver.Lookup("test-key")
+	assert.NoError(t, err)
+	assert.Equal(t, "hash-ring-addr", host.addr)
+}
+
 func TestShardDistributorResolver_Start(t *testing.T) {
 	resolver, ring, _ := newShardDistributorResolver(t)
 	ring.EXPECT().Start().Times(1)
@@ -171,6 +183,7 @@ func TestShardDistributorResolver_Lookup_ExcludeShortLivedTaskLists(t *testing.T
 				spectator,
 				dynamicproperties.GetBoolPropertyFn(tc.excludeShortLivedTaskLists),
 				dynamicproperties.GetIntPropertyFn(100),
+				dynamicproperties.GetBoolPropertyFn(false),
 				ring,
 				logger,
 			).(*shardDistributorResolver)
@@ -209,7 +222,7 @@ func newShardDistributorResolver(t *testing.T) (*shardDistributorResolver, *Mock
 	ring := NewMockSingleProvider(ctrl)
 	logger := log.NewNoop()
 
-	resolver := NewShardDistributorResolver(spectator, excludeShortLivedTaskLists, percentageOnboarded, ring, logger).(*shardDistributorResolver)
+	resolver := NewShardDistributorResolver(spectator, excludeShortLivedTaskLists, percentageOnboarded, dynamicproperties.GetBoolPropertyFn(false), ring, logger).(*shardDistributorResolver)
 
 	return resolver, ring, spectator
 }

--- a/service/matching/config/config.go
+++ b/service/matching/config/config.go
@@ -111,6 +111,7 @@ type (
 
 		EnableTasklistOwnershipGuard               dynamicproperties.BoolPropertyFn
 		ExcludeShortLivedTaskListsFromShardManager dynamicproperties.BoolPropertyFn
+		EmergencyOffboardingFromShardManager       dynamicproperties.BoolPropertyFn
 		PercentageOnboardedToShardManager          dynamicproperties.IntPropertyFn
 	}
 
@@ -245,6 +246,7 @@ func NewConfig(dc *dynamicconfig.Collection, hostName string, rpcConfig config.R
 		EnableClientAutoConfig:                     dc.GetBoolPropertyFilteredByTaskListInfo(dynamicproperties.MatchingEnableClientAutoConfig),
 		EnableReturnAllTaskListKinds:               dc.GetBoolProperty(dynamicproperties.MatchingEnableReturnAllTaskListKinds),
 		ExcludeShortLivedTaskListsFromShardManager: dc.GetBoolProperty(dynamicproperties.MatchingExcludeShortLivedTaskListsFromShardManager),
+		EmergencyOffboardingFromShardManager:       dc.GetBoolProperty(dynamicproperties.MatchingEmergencyOffboardingFromShardManager),
 		PercentageOnboardedToShardManager:          dc.GetIntProperty(dynamicproperties.MatchingPercentageOnboardedToShardManager),
 	}
 }

--- a/service/matching/config/config_test.go
+++ b/service/matching/config/config_test.go
@@ -107,6 +107,7 @@ func TestNewConfig(t *testing.T) {
 		"EnableReturnAllTaskListKinds":               {dynamicproperties.MatchingEnableReturnAllTaskListKinds, true},
 		"AppendTaskTimeout":                          {dynamicproperties.AppendTaskTimeout, time.Duration(42)},
 		"ExcludeShortLivedTaskListsFromShardManager": {dynamicproperties.MatchingExcludeShortLivedTaskListsFromShardManager, false},
+		"EmergencyOffboardingFromShardManager":       {dynamicproperties.MatchingEmergencyOffboardingFromShardManager, false},
 		"PercentageOnboardedToShardManager":          {dynamicproperties.MatchingPercentageOnboardedToShardManager, 0},
 	}
 	client := dynamicconfig.NewInMemoryClient()

--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -1575,8 +1575,10 @@ func (e *matchingEngineImpl) isShuttingDown() bool {
 // This applies to short-lived task lists (e.g. sticky or bits task lists whose names
 // contain a UUID) when the corresponding feature flag is enabled.
 func (e *matchingEngineImpl) isExcludedFromShardDistributor(taskListName string) bool {
-	excludeTaskList := membership.TaskListExcludedFromShardDistributor(taskListName, uint64(e.config.PercentageOnboardedToShardManager()), e.config.ExcludeShortLivedTaskListsFromShardManager())
-	return excludeTaskList
+	if e.config.EmergencyOffboardingFromShardManager() {
+		return true
+	}
+	return membership.TaskListExcludedFromShardDistributor(taskListName, uint64(e.config.PercentageOnboardedToShardManager()), e.config.ExcludeShortLivedTaskListsFromShardManager())
 }
 
 func (e *matchingEngineImpl) domainChangeCallback(nextDomains []*cache.DomainCacheEntry) {

--- a/service/matching/handler/engine_test.go
+++ b/service/matching/handler/engine_test.go
@@ -394,6 +394,7 @@ func TestCancelOutstandingPoll(t *testing.T) {
 				executor:         executor,
 				config: &config.Config{
 					ExcludeShortLivedTaskListsFromShardManager: func(opts ...dynamicproperties.FilterOption) bool { return false },
+					EmergencyOffboardingFromShardManager:       func(opts ...dynamicproperties.FilterOption) bool { return false },
 					PercentageOnboardedToShardManager:          func(opts ...dynamicproperties.FilterOption) int { return 100 },
 				},
 			}
@@ -425,6 +426,7 @@ func TestErrIfShardOwnershipLost(t *testing.T) {
 			config: &config.Config{
 				EnableTasklistOwnershipGuard:               func(opts ...dynamicproperties.FilterOption) bool { return true },
 				ExcludeShortLivedTaskListsFromShardManager: func(opts ...dynamicproperties.FilterOption) bool { return false },
+				EmergencyOffboardingFromShardManager:       func(opts ...dynamicproperties.FilterOption) bool { return false },
 				PercentageOnboardedToShardManager:          func(opts ...dynamicproperties.FilterOption) int { return 100 },
 			},
 			shutdown: make(chan struct{}),
@@ -566,6 +568,7 @@ func TestIsExcludedFromShardDistributor(t *testing.T) {
 			engine := &matchingEngineImpl{
 				config: &config.Config{
 					ExcludeShortLivedTaskListsFromShardManager: func(opts ...dynamicproperties.FilterOption) bool { return tc.flagEnabled },
+					EmergencyOffboardingFromShardManager:       func(opts ...dynamicproperties.FilterOption) bool { return false },
 					PercentageOnboardedToShardManager:          func(opts ...dynamicproperties.FilterOption) int { return 100 },
 				},
 			}
@@ -1221,6 +1224,7 @@ func TestUpdateTaskListPartitionConfig(t *testing.T) {
 				config: &config.Config{
 					EnableAdaptiveScaler:                       dynamicproperties.GetBoolPropertyFilteredByTaskListInfo(tc.enableAdaptiveScaler),
 					ExcludeShortLivedTaskListsFromShardManager: func(opts ...dynamicproperties.FilterOption) bool { return false },
+					EmergencyOffboardingFromShardManager:       func(opts ...dynamicproperties.FilterOption) bool { return false },
 					PercentageOnboardedToShardManager:          func(opts ...dynamicproperties.FilterOption) int { return 100 },
 				},
 				executor: mockExecutor,
@@ -1403,6 +1407,7 @@ func TestRefreshTaskListPartitionConfig(t *testing.T) {
 				executor:         mockExecutor,
 				config: &config.Config{
 					ExcludeShortLivedTaskListsFromShardManager: func(opts ...dynamicproperties.FilterOption) bool { return false },
+					EmergencyOffboardingFromShardManager:       func(opts ...dynamicproperties.FilterOption) bool { return false },
 					PercentageOnboardedToShardManager:          func(opts ...dynamicproperties.FilterOption) int { return 100 },
 				},
 			}

--- a/service/matching/handler/engine_test.go
+++ b/service/matching/handler/engine_test.go
@@ -754,6 +754,7 @@ func TestQueryWorkflow(t *testing.T) {
 				executor:             executor,
 				config: &config.Config{
 					ExcludeShortLivedTaskListsFromShardManager: func(opts ...dynamicproperties.FilterOption) bool { return false },
+					EmergencyOffboardingFromShardManager:       func(opts ...dynamicproperties.FilterOption) bool { return false },
 					PercentageOnboardedToShardManager:          func(opts ...dynamicproperties.FilterOption) int { return 100 },
 				},
 			}

--- a/service/matching/handler/membership_test.go
+++ b/service/matching/handler/membership_test.go
@@ -352,6 +352,7 @@ func TestGetTasklistManagerShutdownScenario(t *testing.T) {
 		config: &config.Config{
 			EnableTasklistOwnershipGuard:               func(opts ...dynamicproperties.FilterOption) bool { return true },
 			ExcludeShortLivedTaskListsFromShardManager: func(opts ...dynamicproperties.FilterOption) bool { return true },
+			EmergencyOffboardingFromShardManager:       func(opts ...dynamicproperties.FilterOption) bool { return false },
 			PercentageOnboardedToShardManager:          func(opts ...dynamicproperties.FilterOption) int { return 100 },
 		},
 		shutdown:    make(chan struct{}),


### PR DESCRIPTION

<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
 Added a new boolean dynamic property MatchingEmergencyOffboardingFromShardManager (key: matching.emergencyOffboardingFromShardManager, default: false) and wired it through the stack:
  - dynamicproperties/constants.go — property declaration and metadata
  - membership/sharddistributorresolver.go — Lookup short-circuits to hash ring when flag is set
  - matching/config/config.go — field added to TaskListConfig, wired from DC
  - matching/handler/engine.go — isExcludedFromShardDistributor returns true immediately when flag is set
  - cmd/server/cadence/server.go — spectator Enabled func also returns false when flag is set, preventing the spectator from routing any traffic
part of https://github.com/cadence-workflow/cadence/issues/6862 

**Why?**
MatchingPercentageOnboardedToShardManager controls gradual rollout but the naming can be confusing during an incident — you'd need to set it to 0 and wait. The new flag is a kill switch: a single boolean that, when flipped true, immediately routes all task list lookups back to the hashring and disables the spectator, bypassing the percentage entirely. This makes emergency offboarding from shard manager fast and safe without touching the rollout percentage.


**How did you test it?**
go test -race -run "TestConfig|TestShardDistributor|TestIsExcluded|TestMembership" ./service/matching/... 2>&1


**Potential risks**
The defualt is false, so no changes in behavior expected

**Release notes**
N/A

**Documentation Changes**
N/A
