### PR TITLE
feat(active-active): Add MySQL support for cluster selection policy

### DIFF
--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -1577,6 +1577,158 @@ func (s *ExecutionManagerSuite) TestGetWorkflow() {
 	s.assertChecksumsEqual(csum, state.Checksum)
 }
 
+// TestGetActiveClusterSelectionPolicy test
+func (s *ExecutionManagerSuite) TestGetActiveClusterSelectionPolicy() {
+	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
+	defer cancel()
+
+	domainID := uuid.New()
+	workflowID := "get-active-cluster-selection-policy-test"
+	runID := uuid.New()
+	policy := &types.ActiveClusterSelectionPolicy{
+		ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyRegionSticky.Ptr(),
+		StickyRegion:                   "region1",
+	}
+
+	decisionScheduleID := int64(rand.Int31())
+	versionHistory := p.NewVersionHistory([]byte{}, []*p.VersionHistoryItem{
+		{
+			EventID: decisionScheduleID,
+			Version: constants.EmptyVersion,
+		},
+	})
+	versionHistories := p.NewVersionHistories(versionHistory)
+	createReq := &p.CreateWorkflowExecutionRequest{
+		RangeID: s.ShardInfo.RangeID,
+		NewWorkflowSnapshot: p.WorkflowSnapshot{
+			ExecutionInfo: &p.WorkflowExecutionInfo{
+				CreateRequestID:              uuid.New(),
+				DomainID:                     domainID,
+				WorkflowID:                   workflowID,
+				RunID:                        runID,
+				FirstExecutionRunID:          runID,
+				TaskList:                     "tasklist",
+				WorkflowTypeName:             "wf-type",
+				WorkflowTimeout:              20,
+				DecisionStartToCloseTimeout:  13,
+				State:                        p.WorkflowStateRunning,
+				CloseStatus:                  p.WorkflowCloseStatusNone,
+				LastFirstEventID:             constants.FirstEventID,
+				NextEventID:                  3,
+				LastProcessedEvent:           0,
+				DecisionScheduleID:           decisionScheduleID,
+				DecisionStartedID:            constants.EmptyEventID,
+				DecisionTimeout:              1,
+				ActiveClusterSelectionPolicy: policy,
+			},
+			ExecutionStats:   &p.ExecutionStats{},
+			VersionHistories: versionHistories,
+		},
+		Mode: p.CreateWorkflowModeBrandNew,
+	}
+	_, err := s.ExecutionManager.CreateWorkflowExecution(ctx, createReq)
+	s.NoError(err)
+
+	got, err := s.ExecutionManager.GetActiveClusterSelectionPolicy(ctx, &p.GetActiveClusterSelectionPolicyRequest{
+		DomainID:   domainID,
+		WorkflowID: workflowID,
+		RunID:      runID,
+	})
+	s.NoError(err)
+	s.Equal(policy, got)
+
+	_, err = s.ExecutionManager.GetActiveClusterSelectionPolicy(ctx, &p.GetActiveClusterSelectionPolicyRequest{
+		DomainID:   domainID,
+		WorkflowID: workflowID,
+		RunID:      uuid.New(),
+	})
+	s.Error(err)
+	s.IsType(&types.EntityNotExistsError{}, err)
+}
+
+// TestDeleteActiveClusterSelectionPolicy test
+func (s *ExecutionManagerSuite) TestDeleteActiveClusterSelectionPolicy() {
+	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
+	defer cancel()
+
+	domainID := uuid.New()
+	workflowID := "delete-active-cluster-selection-policy-test"
+	runID := uuid.New()
+	policy := &types.ActiveClusterSelectionPolicy{
+		ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyRegionSticky.Ptr(),
+		StickyRegion:                   "region1",
+	}
+
+	decisionScheduleID := int64(rand.Int31())
+	versionHistory := p.NewVersionHistory([]byte{}, []*p.VersionHistoryItem{
+		{
+			EventID: decisionScheduleID,
+			Version: constants.EmptyVersion,
+		},
+	})
+	versionHistories := p.NewVersionHistories(versionHistory)
+	createReq := &p.CreateWorkflowExecutionRequest{
+		RangeID: s.ShardInfo.RangeID,
+		NewWorkflowSnapshot: p.WorkflowSnapshot{
+			ExecutionInfo: &p.WorkflowExecutionInfo{
+				CreateRequestID:              uuid.New(),
+				DomainID:                     domainID,
+				WorkflowID:                   workflowID,
+				RunID:                        runID,
+				FirstExecutionRunID:          runID,
+				TaskList:                     "tasklist",
+				WorkflowTypeName:             "wf-type",
+				WorkflowTimeout:              20,
+				DecisionStartToCloseTimeout:  13,
+				State:                        p.WorkflowStateRunning,
+				CloseStatus:                  p.WorkflowCloseStatusNone,
+				LastFirstEventID:             constants.FirstEventID,
+				NextEventID:                  3,
+				LastProcessedEvent:           0,
+				DecisionScheduleID:           decisionScheduleID,
+				DecisionStartedID:            constants.EmptyEventID,
+				DecisionTimeout:              1,
+				ActiveClusterSelectionPolicy: policy,
+			},
+			ExecutionStats:   &p.ExecutionStats{},
+			VersionHistories: versionHistories,
+		},
+		Mode: p.CreateWorkflowModeBrandNew,
+	}
+	_, err := s.ExecutionManager.CreateWorkflowExecution(ctx, createReq)
+	s.NoError(err)
+
+	got, err := s.ExecutionManager.GetActiveClusterSelectionPolicy(ctx, &p.GetActiveClusterSelectionPolicyRequest{
+		DomainID:   domainID,
+		WorkflowID: workflowID,
+		RunID:      runID,
+	})
+	s.NoError(err)
+	s.Equal(policy, got)
+
+	err = s.ExecutionManager.DeleteActiveClusterSelectionPolicy(ctx, &p.DeleteActiveClusterSelectionPolicyRequest{
+		DomainID:   domainID,
+		WorkflowID: workflowID,
+		RunID:      runID,
+	})
+	s.NoError(err)
+
+	_, err = s.ExecutionManager.GetActiveClusterSelectionPolicy(ctx, &p.GetActiveClusterSelectionPolicyRequest{
+		DomainID:   domainID,
+		WorkflowID: workflowID,
+		RunID:      runID,
+	})
+	s.Error(err)
+	s.IsType(&types.EntityNotExistsError{}, err)
+
+	err = s.ExecutionManager.DeleteActiveClusterSelectionPolicy(ctx, &p.DeleteActiveClusterSelectionPolicyRequest{
+		DomainID:   domainID,
+		WorkflowID: workflowID,
+		RunID:      runID,
+	})
+	s.NoError(err)
+}
+
 // TestUpdateWorkflow test
 func (s *ExecutionManagerSuite) TestUpdateWorkflow() {
 	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)

--- a/common/persistence/sql/sql_execution_store.go
+++ b/common/persistence/sql/sql_execution_store.go
@@ -25,6 +25,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"runtime/debug"
@@ -1430,7 +1431,7 @@ func (m *sqlExecutionStore) GetActiveClusterSelectionPolicy(
 		RunID:      runID,
 	})
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if err == sql.ErrNoRows || errors.Is(err, sqlplugin.ErrNotImplemented) {
 			return nil, &types.EntityNotExistsError{
 				Message: fmt.Sprintf(
 					"Active cluster selection policy not found. DomainId: %v, WorkflowId: %v, RunId: %v",
@@ -1455,6 +1456,9 @@ func (m *sqlExecutionStore) DeleteActiveClusterSelectionPolicy(
 		WorkflowID: request.WorkflowID,
 		RunID:      runID,
 	}); err != nil {
+		if errors.Is(err, sqlplugin.ErrNotImplemented) {
+			return nil
+		}
 		return convertCommonErrors(m.db, "DeleteActiveClusterSelectionPolicy", "", err)
 	}
 	return nil

--- a/common/persistence/sql/sql_execution_store.go
+++ b/common/persistence/sql/sql_execution_store.go
@@ -1421,16 +1421,41 @@ func (m *sqlExecutionStore) GetActiveClusterSelectionPolicy(
 	ctx context.Context,
 	request *p.GetActiveClusterSelectionPolicyRequest,
 ) (*p.DataBlob, error) {
-	// TODO(active-active): Active cluster selection policy for SQL stores is not yet implemented
-	// It requires creating a new table in the database to store the active cluster selection policy
-	return nil, &types.InternalServiceError{Message: "Not yet implemented"}
+	domainID := serialization.MustParseUUID(request.DomainID)
+	runID := serialization.MustParseUUID(request.RunID)
+	row, err := m.db.SelectFromActiveClusterSelectionPolicy(ctx, &sqlplugin.ActiveClusterSelectionPolicyFilter{
+		ShardID:    m.shardID,
+		DomainID:   domainID,
+		WorkflowID: request.WorkflowID,
+		RunID:      runID,
+	})
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, &types.EntityNotExistsError{
+				Message: fmt.Sprintf(
+					"Active cluster selection policy not found. DomainId: %v, WorkflowId: %v, RunId: %v",
+					request.DomainID, request.WorkflowID, request.RunID,
+				),
+			}
+		}
+		return nil, convertCommonErrors(m.db, "GetActiveClusterSelectionPolicy", "", err)
+	}
+	return p.NewDataBlob(row.Data, constants.EncodingType(row.DataEncoding)), nil
 }
 
 func (m *sqlExecutionStore) DeleteActiveClusterSelectionPolicy(
 	ctx context.Context,
 	request *p.DeleteActiveClusterSelectionPolicyRequest,
 ) error {
-	// TODO(active-active): Active cluster selection policy for SQL stores is not yet implemented
-	// It requires creating a new table in the database to store the active cluster selection policy
+	domainID := serialization.MustParseUUID(request.DomainID)
+	runID := serialization.MustParseUUID(request.RunID)
+	if _, err := m.db.DeleteFromActiveClusterSelectionPolicy(ctx, &sqlplugin.ActiveClusterSelectionPolicyFilter{
+		ShardID:    m.shardID,
+		DomainID:   domainID,
+		WorkflowID: request.WorkflowID,
+		RunID:      runID,
+	}); err != nil {
+		return convertCommonErrors(m.db, "DeleteActiveClusterSelectionPolicy", "", err)
+	}
 	return nil
 }

--- a/common/persistence/sql/sql_execution_store_test.go
+++ b/common/persistence/sql/sql_execution_store_test.go
@@ -3165,3 +3165,140 @@ func TestCompleteHistoryTask(t *testing.T) {
 		})
 	}
 }
+
+func TestGetActiveClusterSelectionPolicy(t *testing.T) {
+	shardID := 7
+	domainID := "abdcea69-61d5-44c3-9d55-afe23505a542"
+	workflowID := "wf-1"
+	runID := "fd65967f-777d-45de-8dee-be49dfda6716"
+
+	wantFilter := &sqlplugin.ActiveClusterSelectionPolicyFilter{
+		ShardID:    shardID,
+		DomainID:   serialization.MustParseUUID(domainID),
+		WorkflowID: workflowID,
+		RunID:      serialization.MustParseUUID(runID),
+	}
+
+	tests := []struct {
+		name      string
+		mockSetup func(*sqlplugin.MockDB)
+		wantBlob  *persistence.DataBlob
+		wantErr   error
+	}{
+		{
+			name: "row found",
+			mockSetup: func(db *sqlplugin.MockDB) {
+				db.EXPECT().SelectFromActiveClusterSelectionPolicy(gomock.Any(), wantFilter).Return(&sqlplugin.ActiveClusterSelectionPolicyRow{
+					ShardID:      shardID,
+					DomainID:     wantFilter.DomainID,
+					WorkflowID:   workflowID,
+					RunID:        wantFilter.RunID,
+					Data:         []byte("policy-bytes"),
+					DataEncoding: "thriftrw",
+				}, nil)
+			},
+			wantBlob: persistence.NewDataBlob([]byte("policy-bytes"), constants.EncodingType("thriftrw")),
+		},
+		{
+			name: "no rows returns EntityNotExistsError",
+			mockSetup: func(db *sqlplugin.MockDB) {
+				db.EXPECT().SelectFromActiveClusterSelectionPolicy(gomock.Any(), wantFilter).Return(nil, sql.ErrNoRows)
+			},
+			wantErr: &types.EntityNotExistsError{},
+		},
+		{
+			name: "any other error is wrapped",
+			mockSetup: func(db *sqlplugin.MockDB) {
+				err := errors.New("boom")
+				db.EXPECT().SelectFromActiveClusterSelectionPolicy(gomock.Any(), wantFilter).Return(nil, err)
+				db.EXPECT().IsNotFoundError(err).Return(false)
+				db.EXPECT().IsTimeoutError(err).Return(false)
+				db.EXPECT().IsThrottlingError(err).Return(false)
+			},
+			wantErr: &types.InternalServiceError{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDB := sqlplugin.NewMockDB(ctrl)
+			tc.mockSetup(mockDB)
+
+			store := &sqlExecutionStore{sqlStore: sqlStore{db: mockDB}, shardID: shardID}
+			got, err := store.GetActiveClusterSelectionPolicy(context.Background(), &persistence.GetActiveClusterSelectionPolicyRequest{
+				DomainID:   domainID,
+				WorkflowID: workflowID,
+				RunID:      runID,
+			})
+			if tc.wantErr != nil {
+				require.ErrorAs(t, err, &tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantBlob, got)
+		})
+	}
+}
+
+func TestDeleteActiveClusterSelectionPolicy(t *testing.T) {
+	shardID := 7
+	domainID := "abdcea69-61d5-44c3-9d55-afe23505a542"
+	workflowID := "wf-1"
+	runID := "fd65967f-777d-45de-8dee-be49dfda6716"
+
+	wantFilter := &sqlplugin.ActiveClusterSelectionPolicyFilter{
+		ShardID:    shardID,
+		DomainID:   serialization.MustParseUUID(domainID),
+		WorkflowID: workflowID,
+		RunID:      serialization.MustParseUUID(runID),
+	}
+
+	tests := []struct {
+		name      string
+		mockSetup func(*sqlplugin.MockDB)
+		wantErr   error
+	}{
+		{
+			name: "successful delete",
+			mockSetup: func(db *sqlplugin.MockDB) {
+				db.EXPECT().DeleteFromActiveClusterSelectionPolicy(gomock.Any(), wantFilter).Return(nil, nil)
+			},
+		},
+		{
+			name: "error is wrapped",
+			mockSetup: func(db *sqlplugin.MockDB) {
+				err := errors.New("boom")
+				db.EXPECT().DeleteFromActiveClusterSelectionPolicy(gomock.Any(), wantFilter).Return(nil, err)
+				db.EXPECT().IsNotFoundError(err).Return(false)
+				db.EXPECT().IsTimeoutError(err).Return(false)
+				db.EXPECT().IsThrottlingError(err).Return(false)
+			},
+			wantErr: &types.InternalServiceError{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDB := sqlplugin.NewMockDB(ctrl)
+			tc.mockSetup(mockDB)
+
+			store := &sqlExecutionStore{sqlStore: sqlStore{db: mockDB}, shardID: shardID}
+			err := store.DeleteActiveClusterSelectionPolicy(context.Background(), &persistence.DeleteActiveClusterSelectionPolicyRequest{
+				DomainID:   domainID,
+				WorkflowID: workflowID,
+				RunID:      runID,
+			})
+			if tc.wantErr != nil {
+				require.ErrorAs(t, err, &tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/common/persistence/sql/sql_execution_store_util.go
+++ b/common/persistence/sql/sql_execution_store_util.go
@@ -411,7 +411,17 @@ func applyWorkflowSnapshotTxAsNew(
 	workflowID := executionInfo.WorkflowID
 	runID := serialization.MustParseUUID(executionInfo.RunID)
 
-	// TODO(active-active): store active cluster selection policy row. It requires a new table in sql DB schemas.
+	if err := insertActiveClusterSelectionPolicy(
+		ctx,
+		tx,
+		shardID,
+		domainID,
+		workflowID,
+		runID,
+		executionInfo.ActiveClusterSelectionPolicy,
+	); err != nil {
+		return err
+	}
 
 	if err := createExecution(
 		ctx,
@@ -1139,5 +1149,30 @@ func updateExecution(
 		}
 	}
 
+	return nil
+}
+
+func insertActiveClusterSelectionPolicy(
+	ctx context.Context,
+	tx sqlplugin.Tx,
+	shardID int,
+	domainID serialization.UUID,
+	workflowID string,
+	runID serialization.UUID,
+	policy *p.DataBlob,
+) error {
+	if policy == nil {
+		return nil
+	}
+	if _, err := tx.InsertIntoActiveClusterSelectionPolicy(ctx, &sqlplugin.ActiveClusterSelectionPolicyRow{
+		ShardID:      shardID,
+		DomainID:     domainID,
+		WorkflowID:   workflowID,
+		RunID:        runID,
+		Data:         policy.Data,
+		DataEncoding: policy.GetEncodingString(),
+	}); err != nil {
+		return convertCommonErrors(tx, "InsertIntoActiveClusterSelectionPolicy", "", err)
+	}
 	return nil
 }

--- a/common/persistence/sql/sql_execution_store_util.go
+++ b/common/persistence/sql/sql_execution_store_util.go
@@ -25,6 +25,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -1172,6 +1173,9 @@ func insertActiveClusterSelectionPolicy(
 		Data:         policy.Data,
 		DataEncoding: policy.GetEncodingString(),
 	}); err != nil {
+		if errors.Is(err, sqlplugin.ErrNotImplemented) {
+			return nil
+		}
 		return convertCommonErrors(tx, "InsertIntoActiveClusterSelectionPolicy", "", err)
 	}
 	return nil

--- a/common/persistence/sql/sqlplugin/interface_mock.go
+++ b/common/persistence/sql/sqlplugin/interface_mock.go
@@ -99,6 +99,21 @@ func (m *MocktableCRUD) EXPECT() *MocktableCRUDMockRecorder {
 	return m.recorder
 }
 
+// DeleteFromActiveClusterSelectionPolicy mocks base method.
+func (m *MocktableCRUD) DeleteFromActiveClusterSelectionPolicy(ctx context.Context, filter *ActiveClusterSelectionPolicyFilter) (sql.Result, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteFromActiveClusterSelectionPolicy", ctx, filter)
+	ret0, _ := ret[0].(sql.Result)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteFromActiveClusterSelectionPolicy indicates an expected call of DeleteFromActiveClusterSelectionPolicy.
+func (mr *MocktableCRUDMockRecorder) DeleteFromActiveClusterSelectionPolicy(ctx, filter any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFromActiveClusterSelectionPolicy", reflect.TypeOf((*MocktableCRUD)(nil).DeleteFromActiveClusterSelectionPolicy), ctx, filter)
+}
+
 // DeleteFromActivityInfoMaps mocks base method.
 func (m *MocktableCRUD) DeleteFromActivityInfoMaps(ctx context.Context, filter *ActivityInfoMapsFilter) (sql.Result, error) {
 	m.ctrl.T.Helper()
@@ -575,6 +590,21 @@ func (m *MocktableCRUD) InsertConfig(ctx context.Context, row *persistence.Inter
 func (mr *MocktableCRUDMockRecorder) InsertConfig(ctx, row any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertConfig", reflect.TypeOf((*MocktableCRUD)(nil).InsertConfig), ctx, row)
+}
+
+// InsertIntoActiveClusterSelectionPolicy mocks base method.
+func (m *MocktableCRUD) InsertIntoActiveClusterSelectionPolicy(ctx context.Context, row *ActiveClusterSelectionPolicyRow) (sql.Result, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InsertIntoActiveClusterSelectionPolicy", ctx, row)
+	ret0, _ := ret[0].(sql.Result)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InsertIntoActiveClusterSelectionPolicy indicates an expected call of InsertIntoActiveClusterSelectionPolicy.
+func (mr *MocktableCRUDMockRecorder) InsertIntoActiveClusterSelectionPolicy(ctx, row any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertIntoActiveClusterSelectionPolicy", reflect.TypeOf((*MocktableCRUD)(nil).InsertIntoActiveClusterSelectionPolicy), ctx, row)
 }
 
 // InsertIntoBufferedEvents mocks base method.
@@ -1159,6 +1189,21 @@ func (m *MocktableCRUD) ReplaceIntoVisibility(ctx context.Context, row *Visibili
 func (mr *MocktableCRUDMockRecorder) ReplaceIntoVisibility(ctx, row any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceIntoVisibility", reflect.TypeOf((*MocktableCRUD)(nil).ReplaceIntoVisibility), ctx, row)
+}
+
+// SelectFromActiveClusterSelectionPolicy mocks base method.
+func (m *MocktableCRUD) SelectFromActiveClusterSelectionPolicy(ctx context.Context, filter *ActiveClusterSelectionPolicyFilter) (*ActiveClusterSelectionPolicyRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SelectFromActiveClusterSelectionPolicy", ctx, filter)
+	ret0, _ := ret[0].(*ActiveClusterSelectionPolicyRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SelectFromActiveClusterSelectionPolicy indicates an expected call of SelectFromActiveClusterSelectionPolicy.
+func (mr *MocktableCRUDMockRecorder) SelectFromActiveClusterSelectionPolicy(ctx, filter any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectFromActiveClusterSelectionPolicy", reflect.TypeOf((*MocktableCRUD)(nil).SelectFromActiveClusterSelectionPolicy), ctx, filter)
 }
 
 // SelectFromActivityInfoMaps mocks base method.
@@ -1922,6 +1967,21 @@ func (mr *MockTxMockRecorder) Commit() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockTx)(nil).Commit))
 }
 
+// DeleteFromActiveClusterSelectionPolicy mocks base method.
+func (m *MockTx) DeleteFromActiveClusterSelectionPolicy(ctx context.Context, filter *ActiveClusterSelectionPolicyFilter) (sql.Result, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteFromActiveClusterSelectionPolicy", ctx, filter)
+	ret0, _ := ret[0].(sql.Result)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteFromActiveClusterSelectionPolicy indicates an expected call of DeleteFromActiveClusterSelectionPolicy.
+func (mr *MockTxMockRecorder) DeleteFromActiveClusterSelectionPolicy(ctx, filter any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFromActiveClusterSelectionPolicy", reflect.TypeOf((*MockTx)(nil).DeleteFromActiveClusterSelectionPolicy), ctx, filter)
+}
+
 // DeleteFromActivityInfoMaps mocks base method.
 func (m *MockTx) DeleteFromActivityInfoMaps(ctx context.Context, filter *ActivityInfoMapsFilter) (sql.Result, error) {
 	m.ctrl.T.Helper()
@@ -2398,6 +2458,21 @@ func (m *MockTx) InsertConfig(ctx context.Context, row *persistence.InternalConf
 func (mr *MockTxMockRecorder) InsertConfig(ctx, row any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertConfig", reflect.TypeOf((*MockTx)(nil).InsertConfig), ctx, row)
+}
+
+// InsertIntoActiveClusterSelectionPolicy mocks base method.
+func (m *MockTx) InsertIntoActiveClusterSelectionPolicy(ctx context.Context, row *ActiveClusterSelectionPolicyRow) (sql.Result, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InsertIntoActiveClusterSelectionPolicy", ctx, row)
+	ret0, _ := ret[0].(sql.Result)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InsertIntoActiveClusterSelectionPolicy indicates an expected call of InsertIntoActiveClusterSelectionPolicy.
+func (mr *MockTxMockRecorder) InsertIntoActiveClusterSelectionPolicy(ctx, row any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertIntoActiveClusterSelectionPolicy", reflect.TypeOf((*MockTx)(nil).InsertIntoActiveClusterSelectionPolicy), ctx, row)
 }
 
 // InsertIntoBufferedEvents mocks base method.
@@ -3054,6 +3129,21 @@ func (mr *MockTxMockRecorder) Rollback() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rollback", reflect.TypeOf((*MockTx)(nil).Rollback))
 }
 
+// SelectFromActiveClusterSelectionPolicy mocks base method.
+func (m *MockTx) SelectFromActiveClusterSelectionPolicy(ctx context.Context, filter *ActiveClusterSelectionPolicyFilter) (*ActiveClusterSelectionPolicyRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SelectFromActiveClusterSelectionPolicy", ctx, filter)
+	ret0, _ := ret[0].(*ActiveClusterSelectionPolicyRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SelectFromActiveClusterSelectionPolicy indicates an expected call of SelectFromActiveClusterSelectionPolicy.
+func (mr *MockTxMockRecorder) SelectFromActiveClusterSelectionPolicy(ctx, filter any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectFromActiveClusterSelectionPolicy", reflect.TypeOf((*MockTx)(nil).SelectFromActiveClusterSelectionPolicy), ctx, filter)
+}
+
 // SelectFromActivityInfoMaps mocks base method.
 func (m *MockTx) SelectFromActivityInfoMaps(ctx context.Context, filter *ActivityInfoMapsFilter) ([]ActivityInfoMapsRow, error) {
 	m.ctrl.T.Helper()
@@ -3659,6 +3749,21 @@ func (mr *MockDBMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockDB)(nil).Close))
 }
 
+// DeleteFromActiveClusterSelectionPolicy mocks base method.
+func (m *MockDB) DeleteFromActiveClusterSelectionPolicy(ctx context.Context, filter *ActiveClusterSelectionPolicyFilter) (sql.Result, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteFromActiveClusterSelectionPolicy", ctx, filter)
+	ret0, _ := ret[0].(sql.Result)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteFromActiveClusterSelectionPolicy indicates an expected call of DeleteFromActiveClusterSelectionPolicy.
+func (mr *MockDBMockRecorder) DeleteFromActiveClusterSelectionPolicy(ctx, filter any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFromActiveClusterSelectionPolicy", reflect.TypeOf((*MockDB)(nil).DeleteFromActiveClusterSelectionPolicy), ctx, filter)
+}
+
 // DeleteFromActivityInfoMaps mocks base method.
 func (m *MockDB) DeleteFromActivityInfoMaps(ctx context.Context, filter *ActivityInfoMapsFilter) (sql.Result, error) {
 	m.ctrl.T.Helper()
@@ -4149,6 +4254,21 @@ func (m *MockDB) InsertConfig(ctx context.Context, row *persistence.InternalConf
 func (mr *MockDBMockRecorder) InsertConfig(ctx, row any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertConfig", reflect.TypeOf((*MockDB)(nil).InsertConfig), ctx, row)
+}
+
+// InsertIntoActiveClusterSelectionPolicy mocks base method.
+func (m *MockDB) InsertIntoActiveClusterSelectionPolicy(ctx context.Context, row *ActiveClusterSelectionPolicyRow) (sql.Result, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InsertIntoActiveClusterSelectionPolicy", ctx, row)
+	ret0, _ := ret[0].(sql.Result)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InsertIntoActiveClusterSelectionPolicy indicates an expected call of InsertIntoActiveClusterSelectionPolicy.
+func (mr *MockDBMockRecorder) InsertIntoActiveClusterSelectionPolicy(ctx, row any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertIntoActiveClusterSelectionPolicy", reflect.TypeOf((*MockDB)(nil).InsertIntoActiveClusterSelectionPolicy), ctx, row)
 }
 
 // InsertIntoBufferedEvents mocks base method.
@@ -4803,6 +4923,21 @@ func (m *MockDB) ReplaceIntoVisibility(ctx context.Context, row *VisibilityRow) 
 func (mr *MockDBMockRecorder) ReplaceIntoVisibility(ctx, row any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceIntoVisibility", reflect.TypeOf((*MockDB)(nil).ReplaceIntoVisibility), ctx, row)
+}
+
+// SelectFromActiveClusterSelectionPolicy mocks base method.
+func (m *MockDB) SelectFromActiveClusterSelectionPolicy(ctx context.Context, filter *ActiveClusterSelectionPolicyFilter) (*ActiveClusterSelectionPolicyRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SelectFromActiveClusterSelectionPolicy", ctx, filter)
+	ret0, _ := ret[0].(*ActiveClusterSelectionPolicyRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SelectFromActiveClusterSelectionPolicy indicates an expected call of SelectFromActiveClusterSelectionPolicy.
+func (mr *MockDBMockRecorder) SelectFromActiveClusterSelectionPolicy(ctx, filter any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectFromActiveClusterSelectionPolicy", reflect.TypeOf((*MockDB)(nil).SelectFromActiveClusterSelectionPolicy), ctx, filter)
 }
 
 // SelectFromActivityInfoMaps mocks base method.

--- a/common/persistence/sql/sqlplugin/interfaces.go
+++ b/common/persistence/sql/sqlplugin/interfaces.go
@@ -192,6 +192,25 @@ type (
 		RunID      serialization.UUID
 	}
 
+	// ActiveClusterSelectionPolicyRow represents a row in active_cluster_selection_policy table
+	ActiveClusterSelectionPolicyRow struct {
+		ShardID      int
+		DomainID     serialization.UUID
+		WorkflowID   string
+		RunID        serialization.UUID
+		Data         []byte
+		DataEncoding string
+	}
+
+	// ActiveClusterSelectionPolicyFilter contains the column names within
+	// active_cluster_selection_policy table that can be used to filter results
+	ActiveClusterSelectionPolicyFilter struct {
+		ShardID    int
+		DomainID   serialization.UUID
+		WorkflowID string
+		RunID      serialization.UUID
+	}
+
 	// TasksRow represents a row in tasks table
 	TasksRow struct {
 		ShardID      int // this is DBShardID, not historyShardID (TODO: maybe rename it for clarification)
@@ -728,6 +747,14 @@ type (
 		InsertIntoBufferedEvents(ctx context.Context, rows []BufferedEventsRow) (sql.Result, error)
 		SelectFromBufferedEvents(ctx context.Context, filter *BufferedEventsFilter) ([]BufferedEventsRow, error)
 		DeleteFromBufferedEvents(ctx context.Context, filter *BufferedEventsFilter) (sql.Result, error)
+
+		InsertIntoActiveClusterSelectionPolicy(ctx context.Context, row *ActiveClusterSelectionPolicyRow) (sql.Result, error)
+		// SelectFromActiveClusterSelectionPolicy returns 0 or 1 row from active_cluster_selection_policy table
+		// Required filter Params: {shardID, domainID, workflowID, runID}
+		SelectFromActiveClusterSelectionPolicy(ctx context.Context, filter *ActiveClusterSelectionPolicyFilter) (*ActiveClusterSelectionPolicyRow, error)
+		// DeleteFromActiveClusterSelectionPolicy deletes 0 or 1 row from active_cluster_selection_policy table
+		// Required filter Params: {shardID, domainID, workflowID, runID}
+		DeleteFromActiveClusterSelectionPolicy(ctx context.Context, filter *ActiveClusterSelectionPolicyFilter) (sql.Result, error)
 
 		InsertIntoReplicationTasks(ctx context.Context, rows []ReplicationTasksRow) (sql.Result, error)
 		// SelectFromReplicationTasks returns one or more rows from replication_tasks table

--- a/common/persistence/sql/sqlplugin/interfaces.go
+++ b/common/persistence/sql/sqlplugin/interfaces.go
@@ -37,6 +37,8 @@ import (
 var (
 	// ErrTTLNotSupported indicates the sql plugin does not support ttl
 	ErrTTLNotSupported = errors.New("plugin implementation does not support ttl")
+	// ErrNotImplemented indicates the sql database does not implement the method
+	ErrNotImplemented = errors.New("method not implemented for datastore")
 )
 
 type (

--- a/common/persistence/sql/sqlplugin/interfaces.go
+++ b/common/persistence/sql/sqlplugin/interfaces.go
@@ -194,12 +194,12 @@ type (
 
 	// ActiveClusterSelectionPolicyRow represents a row in active_cluster_selection_policy table
 	ActiveClusterSelectionPolicyRow struct {
-		ShardID      int
-		DomainID     serialization.UUID
-		WorkflowID   string
-		RunID        serialization.UUID
-		Data         []byte
-		DataEncoding string
+		ShardID      int                `db:"shard_id"`
+		DomainID     serialization.UUID `db:"domain_id"`
+		WorkflowID   string             `db:"workflow_id"`
+		RunID        serialization.UUID `db:"run_id"`
+		Data         []byte             `db:"data"`
+		DataEncoding string             `db:"data_encoding"`
 	}
 
 	// ActiveClusterSelectionPolicyFilter contains the column names within

--- a/common/persistence/sql/sqlplugin/mysql/active_cluster_selection_policy.go
+++ b/common/persistence/sql/sqlplugin/mysql/active_cluster_selection_policy.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package mysql
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
+)
+
+const (
+	// Insert is silently skipped if a row with the same (shard_id, domain_id, workflow_id, run_id) primary key already exists
+	insertActiveClusterSelectionPolicyQuery = `INSERT IGNORE INTO active_cluster_selection_policy
+		(shard_id, domain_id, workflow_id, run_id, data, data_encoding)
+		VALUES (?, ?, ?, ?, ?, ?)`
+
+	getActiveClusterSelectionPolicyQuery = `SELECT shard_id, domain_id, workflow_id, run_id, data, data_encoding
+		FROM active_cluster_selection_policy
+		WHERE shard_id = ? AND domain_id = ? AND workflow_id = ? AND run_id = ?`
+
+	deleteActiveClusterSelectionPolicyQuery = `DELETE FROM active_cluster_selection_policy
+		WHERE shard_id = ? AND domain_id = ? AND workflow_id = ? AND run_id = ?`
+)
+
+func (mdb *DB) InsertIntoActiveClusterSelectionPolicy(ctx context.Context, row *sqlplugin.ActiveClusterSelectionPolicyRow) (sql.Result, error) {
+	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(row.ShardID, mdb.GetTotalNumDBShards())
+	return mdb.driver.ExecContext(
+		ctx,
+		dbShardID,
+		insertActiveClusterSelectionPolicyQuery,
+		row.ShardID,
+		row.DomainID,
+		row.WorkflowID,
+		row.RunID,
+		row.Data,
+		row.DataEncoding,
+	)
+}
+
+func (mdb *DB) SelectFromActiveClusterSelectionPolicy(ctx context.Context, filter *sqlplugin.ActiveClusterSelectionPolicyFilter) (*sqlplugin.ActiveClusterSelectionPolicyRow, error) {
+	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(filter.ShardID, mdb.GetTotalNumDBShards())
+	var row sqlplugin.ActiveClusterSelectionPolicyRow
+	err := mdb.driver.GetContext(
+		ctx,
+		dbShardID,
+		&row,
+		getActiveClusterSelectionPolicyQuery,
+		filter.ShardID,
+		filter.DomainID,
+		filter.WorkflowID,
+		filter.RunID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+func (mdb *DB) DeleteFromActiveClusterSelectionPolicy(ctx context.Context, filter *sqlplugin.ActiveClusterSelectionPolicyFilter) (sql.Result, error) {
+	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(filter.ShardID, mdb.GetTotalNumDBShards())
+	return mdb.driver.ExecContext(
+		ctx,
+		dbShardID,
+		deleteActiveClusterSelectionPolicyQuery,
+		filter.ShardID,
+		filter.DomainID,
+		filter.WorkflowID,
+		filter.RunID,
+	)
+}

--- a/common/persistence/sql/sqlplugin/mysql/active_cluster_selection_policy_test.go
+++ b/common/persistence/sql/sqlplugin/mysql/active_cluster_selection_policy_test.go
@@ -1,0 +1,261 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/uber/cadence/common/persistence/serialization"
+	"github.com/uber/cadence/common/persistence/sql/sqldriver"
+	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
+)
+
+func TestInsertIntoActiveClusterSelectionPolicy(t *testing.T) {
+	domainID := serialization.UUID(uuid.NewRandom())
+	runID := serialization.UUID(uuid.NewRandom())
+
+	tests := []struct {
+		name      string
+		row       *sqlplugin.ActiveClusterSelectionPolicyRow
+		mockSetup func(*sqldriver.MockDriver)
+		wantErr   bool
+	}{
+		{
+			name: "successful insert",
+			row: &sqlplugin.ActiveClusterSelectionPolicyRow{
+				ShardID:      7,
+				DomainID:     domainID,
+				WorkflowID:   "wf-1",
+				RunID:        runID,
+				Data:         []byte("policy-bytes"),
+				DataEncoding: "thriftrw",
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().ExecContext(
+					gomock.Any(),
+					0,
+					insertActiveClusterSelectionPolicyQuery,
+					7,
+					domainID,
+					"wf-1",
+					runID,
+					[]byte("policy-bytes"),
+					"thriftrw",
+				).Return(nil, nil)
+			},
+		},
+		{
+			name: "exec error is returned",
+			row: &sqlplugin.ActiveClusterSelectionPolicyRow{
+				ShardID:      1,
+				DomainID:     domainID,
+				WorkflowID:   "wf-1",
+				RunID:        runID,
+				Data:         []byte("x"),
+				DataEncoding: "thriftrw",
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().ExecContext(
+					gomock.Any(),
+					gomock.Any(),
+					insertActiveClusterSelectionPolicyQuery,
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil, errors.New("boom"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDriver := sqldriver.NewMockDriver(ctrl)
+			tc.mockSetup(mockDriver)
+
+			mdb := &DB{
+				driver:      mockDriver,
+				converter:   &converter{},
+				numDBShards: 1,
+			}
+			_, err := mdb.InsertIntoActiveClusterSelectionPolicy(context.Background(), tc.row)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestSelectFromActiveClusterSelectionPolicy(t *testing.T) {
+	domainID := serialization.UUID(uuid.NewRandom())
+	runID := serialization.UUID(uuid.NewRandom())
+
+	tests := []struct {
+		name      string
+		filter    *sqlplugin.ActiveClusterSelectionPolicyFilter
+		mockSetup func(*sqldriver.MockDriver)
+		wantRow   *sqlplugin.ActiveClusterSelectionPolicyRow
+		wantErr   error
+	}{
+		{
+			name: "row found",
+			filter: &sqlplugin.ActiveClusterSelectionPolicyFilter{
+				ShardID: 7, DomainID: domainID, WorkflowID: "wf-1", RunID: runID,
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().GetContext(
+					gomock.Any(),
+					0,
+					gomock.Any(),
+					getActiveClusterSelectionPolicyQuery,
+					7, domainID, "wf-1", runID,
+				).DoAndReturn(func(_ context.Context, _ int, dest interface{}, _ string, _ ...interface{}) error {
+					row := dest.(*sqlplugin.ActiveClusterSelectionPolicyRow)
+					row.ShardID = 7
+					row.DomainID = domainID
+					row.WorkflowID = "wf-1"
+					row.RunID = runID
+					row.Data = []byte("policy-bytes")
+					row.DataEncoding = "thriftrw"
+					return nil
+				})
+			},
+			wantRow: &sqlplugin.ActiveClusterSelectionPolicyRow{
+				ShardID:      7,
+				DomainID:     domainID,
+				WorkflowID:   "wf-1",
+				RunID:        runID,
+				Data:         []byte("policy-bytes"),
+				DataEncoding: "thriftrw",
+			},
+		},
+		{
+			name: "no rows found propagates sql.ErrNoRows",
+			filter: &sqlplugin.ActiveClusterSelectionPolicyFilter{
+				ShardID: 1, DomainID: domainID, WorkflowID: "wf-1", RunID: runID,
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().GetContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+					getActiveClusterSelectionPolicyQuery,
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(sql.ErrNoRows)
+			},
+			wantErr: sql.ErrNoRows,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDriver := sqldriver.NewMockDriver(ctrl)
+			tc.mockSetup(mockDriver)
+
+			mdb := &DB{
+				driver:      mockDriver,
+				converter:   &converter{},
+				numDBShards: 1,
+			}
+			got, err := mdb.SelectFromActiveClusterSelectionPolicy(context.Background(), tc.filter)
+			if tc.wantErr != nil {
+				assert.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantRow, got)
+		})
+	}
+}
+
+func TestDeleteFromActiveClusterSelectionPolicy(t *testing.T) {
+	domainID := serialization.UUID(uuid.NewRandom())
+	runID := serialization.UUID(uuid.NewRandom())
+
+	tests := []struct {
+		name      string
+		filter    *sqlplugin.ActiveClusterSelectionPolicyFilter
+		mockSetup func(*sqldriver.MockDriver)
+		wantErr   bool
+	}{
+		{
+			name: "successful delete",
+			filter: &sqlplugin.ActiveClusterSelectionPolicyFilter{
+				ShardID: 7, DomainID: domainID, WorkflowID: "wf-1", RunID: runID,
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().ExecContext(
+					gomock.Any(),
+					0,
+					deleteActiveClusterSelectionPolicyQuery,
+					7, domainID, "wf-1", runID,
+				).Return(nil, nil)
+			},
+		},
+		{
+			name: "exec error is returned",
+			filter: &sqlplugin.ActiveClusterSelectionPolicyFilter{
+				ShardID: 1, DomainID: domainID, WorkflowID: "wf-1", RunID: runID,
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().ExecContext(
+					gomock.Any(), gomock.Any(),
+					deleteActiveClusterSelectionPolicyQuery,
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil, errors.New("boom"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDriver := sqldriver.NewMockDriver(ctrl)
+			tc.mockSetup(mockDriver)
+
+			mdb := &DB{
+				driver:      mockDriver,
+				converter:   &converter{},
+				numDBShards: 1,
+			}
+			_, err := mdb.DeleteFromActiveClusterSelectionPolicy(context.Background(), tc.filter)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/common/persistence/sql/sqlplugin/postgres/active_cluster_selection_policy.go
+++ b/common/persistence/sql/sqlplugin/postgres/active_cluster_selection_policy.go
@@ -28,14 +28,13 @@ import (
 )
 
 func (pdb *db) InsertIntoActiveClusterSelectionPolicy(ctx context.Context, row *sqlplugin.ActiveClusterSelectionPolicyRow) (sql.Result, error) {
-	// TODO(active-active): Implement postgres support for ActiveClusterSelectionPolicy
-	return nil, nil
+	return nil, sqlplugin.ErrNotImplemented
 }
 
 func (pdb *db) SelectFromActiveClusterSelectionPolicy(ctx context.Context, filter *sqlplugin.ActiveClusterSelectionPolicyFilter) (*sqlplugin.ActiveClusterSelectionPolicyRow, error) {
-	return nil, sql.ErrNoRows
+	return nil, sqlplugin.ErrNotImplemented
 }
 
 func (pdb *db) DeleteFromActiveClusterSelectionPolicy(ctx context.Context, filter *sqlplugin.ActiveClusterSelectionPolicyFilter) (sql.Result, error) {
-	return nil, nil
+	return nil, sqlplugin.ErrNotImplemented
 }

--- a/common/persistence/sql/sqlplugin/postgres/active_cluster_selection_policy.go
+++ b/common/persistence/sql/sqlplugin/postgres/active_cluster_selection_policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2026 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,12 +18,26 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package mysql
+package postgres
 
-// NOTE: whenever there is a new data base schema update, plz update the following versions
+import (
+	"context"
+	"database/sql"
+	"errors"
 
-// Version is the MySQL database release version
-const Version = "0.8"
+	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
+)
 
-// VisibilityVersion is the MySQL visibility database release version
-const VisibilityVersion = "0.8"
+var errActiveClusterSelectionPolicyNotImplemented = errors.New("ActiveClusterSelectionPolicy is not implemented for postgres")
+
+func (pdb *db) InsertIntoActiveClusterSelectionPolicy(ctx context.Context, row *sqlplugin.ActiveClusterSelectionPolicyRow) (sql.Result, error) {
+	return nil, errActiveClusterSelectionPolicyNotImplemented
+}
+
+func (pdb *db) SelectFromActiveClusterSelectionPolicy(ctx context.Context, filter *sqlplugin.ActiveClusterSelectionPolicyFilter) (*sqlplugin.ActiveClusterSelectionPolicyRow, error) {
+	return nil, errActiveClusterSelectionPolicyNotImplemented
+}
+
+func (pdb *db) DeleteFromActiveClusterSelectionPolicy(ctx context.Context, filter *sqlplugin.ActiveClusterSelectionPolicyFilter) (sql.Result, error) {
+	return nil, errActiveClusterSelectionPolicyNotImplemented
+}

--- a/common/persistence/sql/sqlplugin/postgres/active_cluster_selection_policy.go
+++ b/common/persistence/sql/sqlplugin/postgres/active_cluster_selection_policy.go
@@ -23,21 +23,19 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"errors"
 
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
 )
 
-var errActiveClusterSelectionPolicyNotImplemented = errors.New("ActiveClusterSelectionPolicy is not implemented for postgres")
-
 func (pdb *db) InsertIntoActiveClusterSelectionPolicy(ctx context.Context, row *sqlplugin.ActiveClusterSelectionPolicyRow) (sql.Result, error) {
-	return nil, errActiveClusterSelectionPolicyNotImplemented
+	// TODO(active-active): Implement postgres support for ActiveClusterSelectionPolicy
+	return nil, nil
 }
 
 func (pdb *db) SelectFromActiveClusterSelectionPolicy(ctx context.Context, filter *sqlplugin.ActiveClusterSelectionPolicyFilter) (*sqlplugin.ActiveClusterSelectionPolicyRow, error) {
-	return nil, errActiveClusterSelectionPolicyNotImplemented
+	return nil, sql.ErrNoRows
 }
 
 func (pdb *db) DeleteFromActiveClusterSelectionPolicy(ctx context.Context, filter *sqlplugin.ActiveClusterSelectionPolicyFilter) (sql.Result, error) {
-	return nil, errActiveClusterSelectionPolicyNotImplemented
+	return nil, nil
 }

--- a/common/persistence/sql/sqlplugin/sqlite/active_cluster_selection_policy.go
+++ b/common/persistence/sql/sqlplugin/sqlite/active_cluster_selection_policy.go
@@ -23,21 +23,19 @@ package sqlite
 import (
 	"context"
 	"database/sql"
-	"errors"
 
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
 )
 
-var errActiveClusterSelectionPolicyNotImplemented = errors.New("ActiveClusterSelectionPolicy is not implemented for sqlite")
-
 func (mdb *DB) InsertIntoActiveClusterSelectionPolicy(ctx context.Context, row *sqlplugin.ActiveClusterSelectionPolicyRow) (sql.Result, error) {
-	return nil, errActiveClusterSelectionPolicyNotImplemented
+	// TODO(active-active): Implement sqlite support for ActiveClusterSelectionPolicy
+	return nil, nil
 }
 
 func (mdb *DB) SelectFromActiveClusterSelectionPolicy(ctx context.Context, filter *sqlplugin.ActiveClusterSelectionPolicyFilter) (*sqlplugin.ActiveClusterSelectionPolicyRow, error) {
-	return nil, errActiveClusterSelectionPolicyNotImplemented
+	return nil, sql.ErrNoRows
 }
 
 func (mdb *DB) DeleteFromActiveClusterSelectionPolicy(ctx context.Context, filter *sqlplugin.ActiveClusterSelectionPolicyFilter) (sql.Result, error) {
-	return nil, errActiveClusterSelectionPolicyNotImplemented
+	return nil, nil
 }

--- a/common/persistence/sql/sqlplugin/sqlite/active_cluster_selection_policy.go
+++ b/common/persistence/sql/sqlplugin/sqlite/active_cluster_selection_policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2026 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,12 +18,26 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package mysql
+package sqlite
 
-// NOTE: whenever there is a new data base schema update, plz update the following versions
+import (
+	"context"
+	"database/sql"
+	"errors"
 
-// Version is the MySQL database release version
-const Version = "0.8"
+	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
+)
 
-// VisibilityVersion is the MySQL visibility database release version
-const VisibilityVersion = "0.8"
+var errActiveClusterSelectionPolicyNotImplemented = errors.New("ActiveClusterSelectionPolicy is not implemented for sqlite")
+
+func (mdb *DB) InsertIntoActiveClusterSelectionPolicy(ctx context.Context, row *sqlplugin.ActiveClusterSelectionPolicyRow) (sql.Result, error) {
+	return nil, errActiveClusterSelectionPolicyNotImplemented
+}
+
+func (mdb *DB) SelectFromActiveClusterSelectionPolicy(ctx context.Context, filter *sqlplugin.ActiveClusterSelectionPolicyFilter) (*sqlplugin.ActiveClusterSelectionPolicyRow, error) {
+	return nil, errActiveClusterSelectionPolicyNotImplemented
+}
+
+func (mdb *DB) DeleteFromActiveClusterSelectionPolicy(ctx context.Context, filter *sqlplugin.ActiveClusterSelectionPolicyFilter) (sql.Result, error) {
+	return nil, errActiveClusterSelectionPolicyNotImplemented
+}

--- a/common/persistence/sql/sqlplugin/sqlite/active_cluster_selection_policy.go
+++ b/common/persistence/sql/sqlplugin/sqlite/active_cluster_selection_policy.go
@@ -28,14 +28,13 @@ import (
 )
 
 func (mdb *DB) InsertIntoActiveClusterSelectionPolicy(ctx context.Context, row *sqlplugin.ActiveClusterSelectionPolicyRow) (sql.Result, error) {
-	// TODO(active-active): Implement sqlite support for ActiveClusterSelectionPolicy
-	return nil, nil
+	return nil, sqlplugin.ErrNotImplemented
 }
 
 func (mdb *DB) SelectFromActiveClusterSelectionPolicy(ctx context.Context, filter *sqlplugin.ActiveClusterSelectionPolicyFilter) (*sqlplugin.ActiveClusterSelectionPolicyRow, error) {
-	return nil, sql.ErrNoRows
+	return nil, sqlplugin.ErrNotImplemented
 }
 
 func (mdb *DB) DeleteFromActiveClusterSelectionPolicy(ctx context.Context, filter *sqlplugin.ActiveClusterSelectionPolicyFilter) (sql.Result, error) {
-	return nil, nil
+	return nil, sqlplugin.ErrNotImplemented
 }

--- a/common/persistence/sql/sqlplugin/sqlite/sqlite_persistence_test.go
+++ b/common/persistence/sql/sqlplugin/sqlite/sqlite_persistence_test.go
@@ -74,6 +74,14 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionWithWorkflowRequestsD
 	s.T().Skip("skip the test until we store workflow_request in sqlite")
 }
 
+func (s *ExecutionManagerSuite) TestGetActiveClusterSelectionPolicy() {
+	s.T().Skip("skip the test until we support ActiveClusterSelectionPolicy in sqlite")
+}
+
+func (s *ExecutionManagerSuite) TestDeleteActiveClusterSelectionPolicy() {
+	s.T().Skip("skip the test until we support ActiveClusterSelectionPolicy in sqlite")
+}
+
 func TestSQLiteExecutionManagerSuite(t *testing.T) {
 	s := new(ExecutionManagerSuite)
 	option := GetTestClusterOption()

--- a/host/persistence/postgres/postgres_persistence_test.go
+++ b/host/persistence/postgres/postgres_persistence_test.go
@@ -83,6 +83,14 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionWithWorkflowRequestsD
 	s.T().Skip("skip the test until we store workflow_request in postgres sql")
 }
 
+func (s *ExecutionManagerSuite) TestGetActiveClusterSelectionPolicy() {
+	s.T().Skip("skip the test until we support ActiveClusterSelectionPolicy in postgres sql")
+}
+
+func (s *ExecutionManagerSuite) TestDeleteActiveClusterSelectionPolicy() {
+	s.T().Skip("skip the test until we support ActiveClusterSelectionPolicy in postgres sql")
+}
+
 func TestPostgresSQLExecutionManagerSuite(t *testing.T) {
 	testflags.RequirePostgres(t)
 	s := new(ExecutionManagerSuite)

--- a/schema/mysql/v8/cadence/schema.sql
+++ b/schema/mysql/v8/cadence/schema.sql
@@ -292,3 +292,14 @@ CREATE TABLE domain_audit_log (
   comment                 VARCHAR(255) NOT NULL DEFAULT '',
   PRIMARY KEY (domain_id, operation_type, created_time, event_id)
 );
+
+CREATE TABLE active_cluster_selection_policy (
+  shard_id      INT          NOT NULL,
+  domain_id     BINARY(16)   NOT NULL,
+  workflow_id   VARCHAR(255) NOT NULL,
+  run_id        BINARY(16)   NOT NULL,
+  --
+  data          MEDIUMBLOB   NOT NULL,
+  data_encoding VARCHAR(16)  NOT NULL,
+  PRIMARY KEY (shard_id, domain_id, workflow_id, run_id)
+);

--- a/schema/mysql/v8/cadence/versioned/v0.8/active_cluster_selection_policy.sql
+++ b/schema/mysql/v8/cadence/versioned/v0.8/active_cluster_selection_policy.sql
@@ -1,0 +1,10 @@
+CREATE TABLE active_cluster_selection_policy (
+  shard_id      INT          NOT NULL,
+  domain_id     BINARY(16)   NOT NULL,
+  workflow_id   VARCHAR(255) NOT NULL,
+  run_id        BINARY(16)   NOT NULL,
+  --
+  data          MEDIUMBLOB   NOT NULL,
+  data_encoding VARCHAR(16)  NOT NULL,
+  PRIMARY KEY (shard_id, domain_id, workflow_id, run_id)
+);

--- a/schema/mysql/v8/cadence/versioned/v0.8/manifest.json
+++ b/schema/mysql/v8/cadence/versioned/v0.8/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.8",
+  "MinCompatibleVersion": "0.8",
+  "Description": "Add active_cluster_selection_policy table for active-active domain workflows",
+  "SchemaUpdateCqlFiles": [
+    "active_cluster_selection_policy.sql"
+  ]
+}

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -129,7 +129,7 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDirFromEmbeddings() {
 	s.NoError(err)
 	ans, err = readSchemaDir(fsys, "0.3", "")
 	s.NoError(err)
-	s.Equal([]string{"v0.4", "v0.5", "v0.6", "v0.7"}, ans)
+	s.Equal([]string{"v0.4", "v0.5", "v0.6", "v0.7", "v0.8"}, ans)
 
 	fsys, err = fs.Sub(mysql.SchemaFS, "v8/visibility/versioned")
 	s.NoError(err)


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Added MySQL support for cluster selection policy
- Added active_cluster_selection_policy table in MySQL database
- Implemented CRUD methods for MySQL database updates (insert, select, delete)
- Implemented `GetActiveClusterSelectionPolicy` and `DeleteActiveClusterSelectionPolicy` for sql stores
- Runs `insertActiveClusterSelectionPolicy` when new workflow is created

Fixes: #7600 

**Why?**
Implement MySQL support for active-active domains

**How did you test it?**
Unit tests: `go test ./common/persistence/sql/sqlplugin/mysql ./common/persistence/sql/`
Persistence tests (locally): `go test -run 'TestMySQLExecutionManagerSuite/TestGetActiveClusterSelectionPolicy|TestMySQLExecutionManagerSuite/TestDeleteActiveClusterSelectionPolicy' ./host/persistence/mysql`
Integration tests: `make test_e2e`

**Potential risks**
Low risk, because changes don't affect existing MySQL tables

**Release notes**
MySQL supports active-active cluster selection policy

**Documentation Changes**

---
**Detailed Description**
[In-depth description of the changes made to the schema or interfaces, specifying new fields, removed fields, or modified data structures]
Added MySQL support for cluster selection policy
- Added active_cluster_selection_policy table in MySQL database
- Implemented CRUD methods for MySQL database updates (insert, select, delete)
- Implemented `GetActiveClusterSelectionPolicy` and `DeleteActiveClusterSelectionPolicy` for sql stores
- Runs `insertActiveClusterSelectionPolicy` when new workflow is created

**Impact Analysis**
- **Backward Compatibility**: Doesn't change existing MySQL tables, and hence doesn't affect features that MySQL already supports
- **Forward Compatibility**: Interface layer for row structure and CRUD methods allow more SQL database to be supported in the future

**Testing Plan**
- **Unit Tests**: `go test ./common/persistence/sql/sqlplugin/mysql ./common/persistence/sql/`
- **Persistence Tests**: `go test -run 'TestMySQLExecutionManagerSuite/TestGetActiveClusterSelectionPolicy|TestMySQLExecutionManagerSuite/TestDeleteActiveClusterSelectionPolicy' ./host/persistence/mysql`
- **Integration Tests**: `make test_e2e`
- **Compatibility Tests**: [Have we done tests to test the backward and forward compatibility?]

**Rollout Plan**
- What is the rollout plan?
- Does the order of deployment matter?
- Is it safe to rollback? Does the order of rollback matter?
- Is there a kill switch to mitigate the impact immediately?
---
