### PR TITLE
feat(archival): add support for region specific s3 access point

### DIFF
--- a/common/archiver/provider/init.go
+++ b/common/archiver/provider/init.go
@@ -51,13 +51,17 @@ func init() {
 		}
 		return filestore.NewHistoryArchiver(container, out)
 	}))
-	must(RegisterHistoryArchiver(s3store.URIScheme, config.S3storeConfig, func(cfg *config.YamlNode, container *archiver.HistoryBootstrapContainer) (archiver.HistoryArchiver, error) {
+	// s3store handles both the plain bucket scheme ("s3") and the access point scheme ("s3-ap").
+	// Both register under the same S3storeConfig YAML node.
+	s3HistoryConstructor := func(cfg *config.YamlNode, container *archiver.HistoryBootstrapContainer) (archiver.HistoryArchiver, error) {
 		var out *config.S3Archiver
 		if err := cfg.Decode(&out); err != nil {
 			return nil, fmt.Errorf("bad config: %w", err)
 		}
 		return s3store.NewHistoryArchiver(container, out)
-	}))
+	}
+	must(RegisterHistoryArchiver(s3store.URIScheme, config.S3storeConfig, s3HistoryConstructor))
+	must(RegisterHistoryArchiver(s3store.URISchemeAccessPoint, config.S3storeConfig, s3HistoryConstructor))
 
 	must(RegisterVisibilityArchiver(filestore.URIScheme, config.FilestoreConfig, func(cfg *config.YamlNode, container *archiver.VisibilityBootstrapContainer) (archiver.VisibilityArchiver, error) {
 		var out *config.FilestoreArchiver
@@ -66,11 +70,13 @@ func init() {
 		}
 		return filestore.NewVisibilityArchiver(container, out)
 	}))
-	must(RegisterVisibilityArchiver(s3store.URIScheme, config.S3storeConfig, func(cfg *config.YamlNode, container *archiver.VisibilityBootstrapContainer) (archiver.VisibilityArchiver, error) {
+	s3VisibilityConstructor := func(cfg *config.YamlNode, container *archiver.VisibilityBootstrapContainer) (archiver.VisibilityArchiver, error) {
 		var out *config.S3Archiver
 		if err := cfg.Decode(&out); err != nil {
 			return nil, fmt.Errorf("bad config: %w", err)
 		}
 		return s3store.NewVisibilityArchiver(container, out)
-	}))
+	}
+	must(RegisterVisibilityArchiver(s3store.URIScheme, config.S3storeConfig, s3VisibilityConstructor))
+	must(RegisterVisibilityArchiver(s3store.URISchemeAccessPoint, config.S3storeConfig, s3VisibilityConstructor))
 }

--- a/common/archiver/s3store/README.md
+++ b/common/archiver/s3store/README.md
@@ -28,6 +28,59 @@ domainDefaults:
       URI: "s3://<bucket-name>"
 ```
 
+## URI schemes
+Two URI schemes are supported:
+
+- `s3://<bucket-name>[/<path>]` — plain S3 bucket. The hostname is the bucket
+  name and is passed directly to the AWS SDK. This is the original scheme.
+- `s3-ap://<account-id>/<access-point-name>[/<path>]` — S3
+  [access point](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points.html).
+  The region is taken from the archiver's configured `region`, so the **same URI
+  works in every region**. This is useful for global domains where the archival
+  URI must be identical across clusters.
+
+At request time, an `s3-ap` URI is reconstructed into an access point ARN of
+the form `arn:aws:s3:<region>:<account-id>:accesspoint/<access-point-name>` and
+passed as the `Bucket` parameter to S3 SDK calls. Each cluster contributes its
+own region to the ARN.
+
+Example — registering a global domain with an access point archival URI:
+
+```
+cadence --do my-domain domain register \
+  --history_uri    "s3-ap://710914175400/cadence-archival/prod" \
+  --visibility_uri "s3-ap://710914175400/cadence-archival/prod" \
+  --history_archival_status enabled \
+  --visibility_archival_status enabled \
+  --gd true --cl primary,secondary --ac primary --rd 7
+```
+
+In `us-east-1` this resolves to the bucket
+`arn:aws:s3:us-east-1:710914175400:accesspoint/cadence-archival`; in
+`eu-west-1` the same URI resolves to
+`arn:aws:s3:eu-west-1:710914175400:accesspoint/cadence-archival`.
+
+### Access point IAM and `HeadBucket`
+At domain-registration time the frontend calls `HeadBucket` against the
+constructed ARN to verify the URI. `HeadBucket` on an access point is evaluated
+against the **underlying bucket's** policy, not the access point policy — so
+granting `s3:*` on the access point alone is not enough. The role used by the
+Cadence services needs `s3:ListBucket` on the underlying bucket
+(`arn:aws:s3:::<underlying-bucket-name>`) for the validation check to pass.
+
+The ARN partition is inferred from the region prefix, so the same URI works
+across `aws`, `aws-cn` (China), `aws-us-gov` (GovCloud), and `aws-iso`/
+`aws-iso-b` (Secret/Top-Secret) partitions.
+
+### Limitations
+- The `s3-ap` scheme requires the archiver's `region` config to be set. Plain
+  `s3://` URIs work without it (the SDK falls back to environment / instance
+  metadata).
+- `s3ForcePathStyle: true` is incompatible with access points. Leave it unset
+  (the default) when using `s3-ap://`.
+- Multi-Region Access Points (MRAP) are not currently supported. MRAP ARNs have
+  no region component and require SigV4A signing, which is a separate scheme.
+
 ## Visibility query syntax
 You can query the visibility store by using the `cadence workflow listarchived` command
 
@@ -69,6 +122,11 @@ s3://<bucket-name>/<domain-id>/
                 startTimeout/2020-01-21T16:16:11Z/<run-id>
                 closeTimeout/2020-01-21T16:16:11Z/<run-id>
 ```
+
+For `s3-ap://` URIs, the path component after the access point name plays the
+same role as the path under a bucket name. For example,
+`s3-ap://710914175400/cadence-archival/prod` produces objects under
+`prod/<domain-id>/history/...` inside the underlying bucket.
 
 ## Using localstack for local development
 1. Install awscli from [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)

--- a/common/archiver/s3store/historyArchiver.go
+++ b/common/archiver/s3store/historyArchiver.go
@@ -48,8 +48,13 @@ import (
 )
 
 const (
-	// URIScheme is the scheme for the s3 implementation
-	URIScheme               = "s3"
+	// URIScheme is the scheme for the s3 implementation using a plain bucket name.
+	URIScheme = "s3"
+	// URISchemeAccessPoint is the scheme for S3 access point URIs.
+	// Format: s3-ap://<account-id>/<access-point-name>[/<path>]
+	// The region is injected from the archiver's configured AWS region,
+	// so the same URI works across all regions (useful for global domains).
+	URISchemeAccessPoint    = "s3-ap"
 	errEncodeHistory        = "failed to encode history batches"
 	errWriteKey             = "failed to write history to s3"
 	defaultBlobstoreTimeout = 60 * time.Second
@@ -57,15 +62,18 @@ const (
 )
 
 var (
-	errNoBucketSpecified = errors.New("no bucket specified")
-	errBucketNotExists   = errors.New("requested bucket does not exist")
-	errEmptyAwsRegion    = errors.New("empty aws region")
+	errNoBucketSpecified      = errors.New("no bucket specified")
+	errBucketNotExists        = errors.New("requested bucket does not exist")
+	errEmptyAwsRegion         = errors.New("empty aws region")
+	errInvalidAccessPointURI  = errors.New("invalid s3-ap URI: expected s3-ap://<account-id>/<access-point-name>[/<path>]")
+	errInvalidAccessPointAcct = errors.New("invalid s3-ap URI: account id must be 12 digits")
 )
 
 type (
 	historyArchiver struct {
 		container *archiver.HistoryBootstrapContainer
 		s3cli     s3iface.S3API
+		region    string
 		// only set in test code
 		historyIterator archiver.HistoryIterator
 	}
@@ -112,6 +120,7 @@ func newHistoryArchiver(
 	return &historyArchiver{
 		container:       container,
 		s3cli:           s3.New(sess),
+		region:          config.Region,
 		historyIterator: historyIterator,
 	}, nil
 }
@@ -188,9 +197,9 @@ func (h *historyArchiver) Archive(
 			return err
 		}
 
-		key := constructHistoryKey(URI.Path(), request.DomainID, request.WorkflowID, request.RunID, request.CloseFailoverVersion, progress.BatchIdx)
+		key := constructHistoryKey(s3KeyPath(URI), request.DomainID, request.WorkflowID, request.RunID, request.CloseFailoverVersion, progress.BatchIdx)
 
-		exists, err := keyExists(ctx, h.s3cli, URI, key)
+		exists, err := keyExists(ctx, h.s3cli, URI, key, h.region)
 		if err != nil {
 			logger := logger.WithTags(tag.ArchivalArchiveFailReason(errWriteKey), tag.Error(err))
 			if isRetryableError(err) {
@@ -204,7 +213,7 @@ func (h *historyArchiver) Archive(
 		if exists {
 			scope.IncCounter(metrics.HistoryArchiverBlobExistsCount)
 		} else {
-			if err := upload(ctx, h.s3cli, URI, key, encodedHistoryBlob); err != nil {
+			if err := upload(ctx, h.s3cli, URI, h.region, key, encodedHistoryBlob); err != nil {
 				logger := logger.WithTags(tag.ArchivalArchiveFailReason(errWriteKey), tag.Error(err))
 				if isRetryableError(err) {
 					logger.Error(archiver.ArchiveTransientErrorMsg)
@@ -304,9 +313,9 @@ func (h *historyArchiver) Get(
 			isTruncated = true
 			break
 		}
-		key := constructHistoryKey(URI.Path(), request.DomainID, request.WorkflowID, request.RunID, token.CloseFailoverVersion, token.BatchIdx)
+		key := constructHistoryKey(s3KeyPath(URI), request.DomainID, request.WorkflowID, request.RunID, token.CloseFailoverVersion, token.BatchIdx)
 
-		encodedRecord, err := download(ctx, h.s3cli, URI, key)
+		encodedRecord, err := download(ctx, h.s3cli, URI, h.region, key)
 		if err != nil {
 			if isRetryableError(err) {
 				return nil, &types.InternalServiceError{Message: err.Error()}
@@ -351,7 +360,7 @@ func (h *historyArchiver) ValidateURI(URI archiver.URI) error {
 	if err != nil {
 		return err
 	}
-	return bucketExists(context.TODO(), h.s3cli, URI)
+	return bucketExists(context.TODO(), h.s3cli, URI, h.region)
 }
 
 func getNextHistoryBlob(ctx context.Context, historyIterator archiver.HistoryIterator) (*archiver.HistoryBlob, error) {
@@ -382,9 +391,13 @@ func getNextHistoryBlob(ctx context.Context, historyIterator archiver.HistoryIte
 func (h *historyArchiver) getHighestVersion(ctx context.Context, URI archiver.URI, request *archiver.GetHistoryRequest) (*int64, error) {
 	ctx, cancel := ensureContextTimeout(ctx)
 	defer cancel()
-	var prefix = constructHistoryKeyPrefix(URI.Path(), request.DomainID, request.WorkflowID, request.RunID) + "/"
+	bucket, err := s3Bucket(URI, h.region)
+	if err != nil {
+		return nil, err
+	}
+	var prefix = constructHistoryKeyPrefix(s3KeyPath(URI), request.DomainID, request.WorkflowID, request.RunID) + "/"
 	results, err := h.s3cli.ListObjectsV2WithContext(ctx, &s3.ListObjectsV2Input{
-		Bucket:    aws.String(URI.Hostname()),
+		Bucket:    aws.String(bucket),
 		Prefix:    aws.String(prefix),
 		Delimiter: aws.String("/"),
 	})

--- a/common/archiver/s3store/uri_test.go
+++ b/common/archiver/s3store/uri_test.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package s3store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/uber/cadence/common/archiver"
+)
+
+func TestSoftValidateURI(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		wantErr error
+	}{
+		{"wrong scheme", "wrongscheme:///a/b/c", archiver.ErrURISchemeMismatch},
+		{"s3 no bucket", "s3://", errNoBucketSpecified},
+		{"s3 valid bucket", "s3://bucket", nil},
+		{"s3 valid bucket with path", "s3://bucket/a/b/c", nil},
+
+		{"s3-ap valid no path", "s3-ap://710914175400/dummy-accesspoint", nil},
+		{"s3-ap valid with path", "s3-ap://710914175400/dummy-accesspoint/foo/bar", nil},
+		{"s3-ap missing account", "s3-ap:///dummy-accesspoint", errInvalidAccessPointAcct},
+		{"s3-ap account too short", "s3-ap://12345/dummy-accesspoint", errInvalidAccessPointAcct},
+		{"s3-ap account too long", "s3-ap://1234567890123/dummy-accesspoint", errInvalidAccessPointAcct},
+		{"s3-ap account non-numeric", "s3-ap://abcdefghijkl/dummy-accesspoint", errInvalidAccessPointAcct},
+		{"s3-ap missing access point name", "s3-ap://710914175400", errInvalidAccessPointURI},
+		{"s3-ap empty access point name", "s3-ap://710914175400/", errInvalidAccessPointURI},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := archiver.NewURI(tc.uri)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantErr, softValidateURI(u))
+		})
+	}
+}
+
+func TestS3Bucket(t *testing.T) {
+	tests := []struct {
+		name       string
+		uri        string
+		region     string
+		wantBucket string
+		wantErr    error
+	}{
+		{
+			name:       "plain bucket",
+			uri:        "s3://test-bucket/some/path",
+			region:     "us-east-1",
+			wantBucket: "test-bucket",
+		},
+		{
+			name:       "plain bucket empty region",
+			uri:        "s3://test-bucket",
+			region:     "",
+			wantBucket: "test-bucket",
+		},
+		{
+			name:       "access point us-east-1",
+			uri:        "s3-ap://710914175400/dummy-accesspoint",
+			region:     "us-east-1",
+			wantBucket: "arn:aws:s3:us-east-1:710914175400:accesspoint/dummy-accesspoint",
+		},
+		{
+			name:       "access point eu-west-1 same URI",
+			uri:        "s3-ap://710914175400/dummy-accesspoint/ignored/path",
+			region:     "eu-west-1",
+			wantBucket: "arn:aws:s3:eu-west-1:710914175400:accesspoint/dummy-accesspoint",
+		},
+		{
+			name:       "access point GovCloud uses aws-us-gov partition",
+			uri:        "s3-ap://710914175400/dummy-accesspoint",
+			region:     "us-gov-west-1",
+			wantBucket: "arn:aws-us-gov:s3:us-gov-west-1:710914175400:accesspoint/dummy-accesspoint",
+		},
+		{
+			name:       "access point China uses aws-cn partition",
+			uri:        "s3-ap://710914175400/dummy-accesspoint",
+			region:     "cn-north-1",
+			wantBucket: "arn:aws-cn:s3:cn-north-1:710914175400:accesspoint/dummy-accesspoint",
+		},
+		{
+			name:    "access point empty region",
+			uri:     "s3-ap://710914175400/dummy-accesspoint",
+			region:  "",
+			wantErr: errEmptyAwsRegion,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := archiver.NewURI(tc.uri)
+			require.NoError(t, err)
+			got, err := s3Bucket(u, tc.region)
+			if tc.wantErr != nil {
+				require.Equal(t, tc.wantErr, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantBucket, got)
+		})
+	}
+}
+
+func TestS3KeyPath(t *testing.T) {
+	tests := []struct {
+		name string
+		uri  string
+		want string
+	}{
+		{"plain bucket no path", "s3://test-bucket", ""},
+		{"plain bucket with path", "s3://test-bucket/a/b/c", "/a/b/c"},
+		{"access point no sub-path", "s3-ap://710914175400/dummy-accesspoint", ""},
+		{"access point with sub-path", "s3-ap://710914175400/dummy-accesspoint/a/b/c", "/a/b/c"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := archiver.NewURI(tc.uri)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, s3KeyPath(u))
+		})
+	}
+}
+
+func TestPartitionForRegion(t *testing.T) {
+	tests := []struct {
+		region string
+		want   string
+	}{
+		{"us-east-1", "aws"},
+		{"eu-west-1", "aws"},
+		{"ap-south-1", "aws"},
+		{"us-gov-west-1", "aws-us-gov"},
+		{"us-gov-east-1", "aws-us-gov"},
+		{"cn-north-1", "aws-cn"},
+		{"cn-northwest-1", "aws-cn"},
+		{"us-iso-east-1", "aws-iso"},
+		{"us-isob-east-1", "aws-iso-b"},
+		{"", "aws"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.region, func(t *testing.T) {
+			require.Equal(t, tc.want, partitionForRegion(tc.region))
+		})
+	}
+}

--- a/common/archiver/s3store/util.go
+++ b/common/archiver/s3store/util.go
@@ -86,20 +86,110 @@ func serializeQueryVisibilityToken(token string) []byte {
 
 // Only validates the scheme and buckets are passed
 func softValidateURI(URI archiver.URI) error {
-	if URI.Scheme() != URIScheme {
+	switch URI.Scheme() {
+	case URIScheme:
+		if len(URI.Hostname()) == 0 {
+			return errNoBucketSpecified
+		}
+		return nil
+	case URISchemeAccessPoint:
+		return validateAccessPointURI(URI)
+	default:
 		return archiver.ErrURISchemeMismatch
 	}
-	if len(URI.Hostname()) == 0 {
-		return errNoBucketSpecified
+}
+
+// validateAccessPointURI checks that an s3-ap URI has a 12-digit account id
+// and a non-empty access point name. The region is not validated here because
+// it is supplied by the archiver's configuration at request time.
+func validateAccessPointURI(URI archiver.URI) error {
+	account := URI.Hostname()
+	if len(account) != 12 {
+		return errInvalidAccessPointAcct
+	}
+	for _, r := range account {
+		if r < '0' || r > '9' {
+			return errInvalidAccessPointAcct
+		}
+	}
+	if _, _, ok := splitAccessPointPath(URI.Path()); !ok {
+		return errInvalidAccessPointURI
 	}
 	return nil
 }
 
-func bucketExists(ctx context.Context, s3cli s3iface.S3API, URI archiver.URI) error {
+// splitAccessPointPath splits the URL path of an s3-ap URI into the access
+// point name and the remaining object-key prefix. Returns ok=false when no
+// non-empty access point name is present.
+func splitAccessPointPath(p string) (name, keyPath string, ok bool) {
+	p = strings.TrimPrefix(p, "/")
+	if p == "" {
+		return "", "", false
+	}
+	if idx := strings.Index(p, "/"); idx >= 0 {
+		return p[:idx], p[idx:], p[:idx] != ""
+	}
+	return p, "", true
+}
+
+// s3Bucket returns the string to pass as the S3 SDK Bucket parameter.
+// For s3:// URIs this is the hostname. For s3-ap:// URIs this is a full
+// access point ARN constructed from the configured region.
+// An empty region for an s3-ap URI returns errEmptyAwsRegion.
+func s3Bucket(URI archiver.URI, region string) (string, error) {
+	switch URI.Scheme() {
+	case URISchemeAccessPoint:
+		name, _, ok := splitAccessPointPath(URI.Path())
+		if !ok {
+			return "", errInvalidAccessPointURI
+		}
+		if region == "" {
+			return "", errEmptyAwsRegion
+		}
+		return fmt.Sprintf("arn:%s:s3:%s:%s:accesspoint/%s", partitionForRegion(region), region, URI.Hostname(), name), nil
+	default:
+		return URI.Hostname(), nil
+	}
+}
+
+// partitionForRegion returns the AWS ARN partition for the given region.
+// AWS partitions an account's resources by jurisdiction; ARNs in different
+// partitions use different prefixes. Defaults to the standard "aws" partition.
+func partitionForRegion(region string) string {
+	switch {
+	case strings.HasPrefix(region, "cn-"):
+		return "aws-cn"
+	case strings.HasPrefix(region, "us-gov-"):
+		return "aws-us-gov"
+	case strings.HasPrefix(region, "us-iso-"):
+		return "aws-iso"
+	case strings.HasPrefix(region, "us-isob-"):
+		return "aws-iso-b"
+	default:
+		return "aws"
+	}
+}
+
+// s3KeyPath returns the path component used for object-key construction.
+// For s3-ap URIs, the access point name is stripped from the URL path so the
+// remainder matches what users would get from an s3:// URI.
+func s3KeyPath(URI archiver.URI) string {
+	if URI.Scheme() == URISchemeAccessPoint {
+		_, keyPath, _ := splitAccessPointPath(URI.Path())
+		return keyPath
+	}
+	return URI.Path()
+}
+
+func bucketExists(ctx context.Context, s3cli s3iface.S3API, URI archiver.URI, region string) error {
 	ctx, cancel := ensureContextTimeout(ctx)
 	defer cancel()
-	_, err := s3cli.HeadBucketWithContext(ctx, &s3.HeadBucketInput{
-		Bucket: aws.String(URI.Hostname()),
+	bucket, err := s3Bucket(URI, region)
+	if err != nil {
+		return err
+	}
+	_, err = s3cli.HeadBucketWithContext(ctx, &s3.HeadBucketInput{
+		Bucket: aws.String(bucket),
 	})
 	if err == nil {
 		return nil
@@ -110,11 +200,15 @@ func bucketExists(ctx context.Context, s3cli s3iface.S3API, URI archiver.URI) er
 	return err
 }
 
-func keyExists(ctx context.Context, s3cli s3iface.S3API, URI archiver.URI, key string) (bool, error) {
+func keyExists(ctx context.Context, s3cli s3iface.S3API, URI archiver.URI, key, region string) (bool, error) {
 	ctx, cancel := ensureContextTimeout(ctx)
 	defer cancel()
-	_, err := s3cli.HeadObjectWithContext(ctx, &s3.HeadObjectInput{
-		Bucket: aws.String(URI.Hostname()),
+	bucket, err := s3Bucket(URI, region)
+	if err != nil {
+		return false, err
+	}
+	_, err = s3cli.HeadObjectWithContext(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
 	})
 	if err != nil {
@@ -181,12 +275,16 @@ func ensureContextTimeout(ctx context.Context) (context.Context, context.CancelF
 	}
 	return context.WithTimeout(ctx, defaultBlobstoreTimeout)
 }
-func upload(ctx context.Context, s3cli s3iface.S3API, URI archiver.URI, key string, data []byte) error {
+func upload(ctx context.Context, s3cli s3iface.S3API, URI archiver.URI, region, key string, data []byte) error {
 	ctx, cancel := ensureContextTimeout(ctx)
 	defer cancel()
 
-	_, err := s3cli.PutObjectWithContext(ctx, &s3.PutObjectInput{
-		Bucket: aws.String(URI.Hostname()),
+	bucket, err := s3Bucket(URI, region)
+	if err != nil {
+		return err
+	}
+	_, err = s3cli.PutObjectWithContext(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
 		Body:   bytes.NewReader(data),
 	})
@@ -201,11 +299,15 @@ func upload(ctx context.Context, s3cli s3iface.S3API, URI archiver.URI, key stri
 	return nil
 }
 
-func download(ctx context.Context, s3cli s3iface.S3API, URI archiver.URI, key string) ([]byte, error) {
+func download(ctx context.Context, s3cli s3iface.S3API, URI archiver.URI, region, key string) ([]byte, error) {
 	ctx, cancel := ensureContextTimeout(ctx)
 	defer cancel()
+	bucket, err := s3Bucket(URI, region)
+	if err != nil {
+		return nil, err
+	}
 	result, err := s3cli.GetObjectWithContext(ctx, &s3.GetObjectInput{
-		Bucket: aws.String(URI.Hostname()),
+		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
 	})
 

--- a/common/archiver/s3store/visibilityArchiver.go
+++ b/common/archiver/s3store/visibilityArchiver.go
@@ -39,6 +39,7 @@ type (
 	visibilityArchiver struct {
 		container   *archiver.VisibilityBootstrapContainer
 		s3cli       s3iface.S3API
+		region      string
 		queryParser QueryParser
 	}
 
@@ -90,6 +91,7 @@ func newVisibilityArchiver(
 	return &visibilityArchiver{
 		container:   container,
 		s3cli:       s3.New(sess),
+		region:      config.Region,
 		queryParser: NewQueryParser(),
 	}, nil
 }
@@ -139,8 +141,8 @@ func (v *visibilityArchiver) Archive(
 	indexes := createIndexesToArchive(request)
 	// Upload archive to all indexes
 	for _, element := range indexes {
-		key := constructTimestampIndex(URI.Path(), request.DomainID, element.primaryIndex, element.primaryIndexValue, element.secondaryIndex, element.secondaryIndexTimestamp, request.RunID)
-		if err := upload(ctx, v.s3cli, URI, key, encodedVisibilityRecord); err != nil {
+		key := constructTimestampIndex(s3KeyPath(URI), request.DomainID, element.primaryIndex, element.primaryIndexValue, element.secondaryIndex, element.secondaryIndexTimestamp, request.RunID)
+		if err := upload(ctx, v.s3cli, URI, v.region, key, encodedVisibilityRecord); err != nil {
 			archiveFailReason = errWriteKey
 			return err
 		}
@@ -200,16 +202,21 @@ func (v *visibilityArchiver) query(
 		primaryIndex = primaryIndexKeyWorkflowID
 		primaryIndexValue = request.parsedQuery.workflowID
 	}
-	var prefix = constructVisibilitySearchPrefix(URI.Path(), request.domainID, primaryIndex, *primaryIndexValue, secondaryIndexKeyCloseTimeout) + "/"
+	keyPath := s3KeyPath(URI)
+	var prefix = constructVisibilitySearchPrefix(keyPath, request.domainID, primaryIndex, *primaryIndexValue, secondaryIndexKeyCloseTimeout) + "/"
 	if request.parsedQuery.closeTime != nil {
-		prefix = constructTimeBasedSearchKey(URI.Path(), request.domainID, primaryIndex, *primaryIndexValue, secondaryIndexKeyCloseTimeout, *request.parsedQuery.closeTime, *request.parsedQuery.searchPrecision)
+		prefix = constructTimeBasedSearchKey(keyPath, request.domainID, primaryIndex, *primaryIndexValue, secondaryIndexKeyCloseTimeout, *request.parsedQuery.closeTime, *request.parsedQuery.searchPrecision)
 	}
 	if request.parsedQuery.startTime != nil {
-		prefix = constructTimeBasedSearchKey(URI.Path(), request.domainID, primaryIndex, *primaryIndexValue, secondaryIndexKeyStartTimeout, *request.parsedQuery.startTime, *request.parsedQuery.searchPrecision)
+		prefix = constructTimeBasedSearchKey(keyPath, request.domainID, primaryIndex, *primaryIndexValue, secondaryIndexKeyStartTimeout, *request.parsedQuery.startTime, *request.parsedQuery.searchPrecision)
 	}
 
+	bucket, err := s3Bucket(URI, v.region)
+	if err != nil {
+		return nil, &types.BadRequestError{Message: err.Error()}
+	}
 	results, err := v.s3cli.ListObjectsV2WithContext(ctx, &s3.ListObjectsV2Input{
-		Bucket:            aws.String(URI.Hostname()),
+		Bucket:            aws.String(bucket),
 		Prefix:            aws.String(prefix),
 		MaxKeys:           aws.Int64(int64(request.pageSize)),
 		ContinuationToken: token,
@@ -229,7 +236,7 @@ func (v *visibilityArchiver) query(
 		response.NextPageToken = serializeQueryVisibilityToken(*results.NextContinuationToken)
 	}
 	for _, item := range results.Contents {
-		encodedRecord, err := download(ctx, v.s3cli, URI, *item.Key)
+		encodedRecord, err := download(ctx, v.s3cli, URI, v.region, *item.Key)
 		if err != nil {
 			return nil, &types.InternalServiceError{Message: err.Error()}
 		}
@@ -248,5 +255,5 @@ func (v *visibilityArchiver) ValidateURI(URI archiver.URI) error {
 	if err != nil {
 		return err
 	}
-	return bucketExists(context.TODO(), v.s3cli, URI)
+	return bucketExists(context.TODO(), v.s3cli, URI, v.region)
 }

--- a/common/archiver/s3store/visibilityArchiver_test.go
+++ b/common/archiver/s3store/visibilityArchiver_test.go
@@ -210,7 +210,7 @@ func (s *visibilityArchiverSuite) TestArchive_Success() {
 	s.NoError(err)
 
 	expectedKey := constructTimestampIndex(URI.Path(), testDomainID, primaryIndexKeyWorkflowID, testWorkflowID, secondaryIndexKeyCloseTimeout, closeTimestamp.UnixNano(), testRunID)
-	data, err := download(context.Background(), visibilityArchiver.s3cli, URI, expectedKey)
+	data, err := download(context.Background(), visibilityArchiver.s3cli, URI, visibilityArchiver.region, expectedKey)
 	s.NoError(err, expectedKey)
 
 	archivedRecord := &archiver.ArchiveVisibilityRequest{}


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->

**What changed?**

Added a new URI scheme `s3-ap://` to the S3 archiver, alongside the existing `s3://` scheme. The new scheme accepts an account ID and access point name and reconstructs a regional access point ARN at request time from the archiver's configured AWS region.

URI format: `s3-ap://<account-id>/<access-point-name>[/<path>]`
Resolved bucket parameter (passed to the AWS SDK): `arn:aws:s3:<region>:<account-id>:accesspoint/<access-point-name>`

Changes are confined to `common/archiver/s3store/` and the provider registration:
- New constant `s3store.URISchemeAccessPoint = "s3-ap"` and validation for the new shape (12-digit account, non-empty access point name).
- `s3Bucket(URI, region)` and `s3KeyPath(URI)` helpers used by every S3 SDK call site (`upload`, `download`, `keyExists`, `bucketExists`, `ListObjectsV2`).
- Region threaded onto `historyArchiver` and `visibilityArchiver` so it's available where the ARN is built.
- `s3-ap` registered as both a history and visibility archiver scheme in `common/archiver/provider/init.go`, sharing the existing `S3storeConfig` YAML node.
- Plain Go table tests in `uri_test.go` covering scheme validation, ARN construction across regions, and key-path extraction.
- README updates documenting the new scheme, IAM/`HeadBucket` caveat, and limitations.

**Why?**

Today the S3 archiver only accepts plain bucket URIs (`s3://<bucket>`). For global domains, the archival URI is shared across regions, but a regional access point ARN or alias hostname is region-specific — so there's no single URI that can route to the local access point in each cluster. Operators who want to enforce S3 access via access points (account/VPC isolation, scoped policies, etc.) end up unable to configure archival for a global domain without giving up the access point pattern.

`s3-ap://<account>/<name>` is region-agnostic by construction: the same URI works in every cluster, and each cluster's archiver fills in its own configured region when building the ARN that gets passed to the SDK. The AWS SDK accepts an access point ARN as the `Bucket` parameter for all S3 operations the archiver uses, so no change is needed to the call paths beyond constructing the right string.

This is reported in issue #8010

**How did you test it?**

- New plain Go table tests in `common/archiver/s3store/uri_test.go`:
  - `TestSoftValidateURI` — 12 cases covering both schemes (wrong scheme, empty bucket, valid bucket, valid s3-ap, missing/short/long/non-numeric account, missing access point name).
  - `TestS3Bucket` — 5 cases including the same `s3-ap` URI resolving to different ARNs under `us-east-1` and `eu-west-1`, and the empty-region failure path.
  - `TestS3KeyPath` — 4 cases verifying path-after-bucket and path-after-access-point-name extraction.
- Existing `historyArchiver`/`visibilityArchiver` test suites continue to pass with the new helper signatures.
- `go test -race -count=1 ./common/archiver/s3store/...` passes locally.
- End-to-end manual test on a deployed cluster: registered a global domain with an `s3-ap://` history and visibility URI; confirmed the frontend constructs the ARN correctly and `validateHistoryArchivalURI`/`validateVisibilityArchivalURI` succeed once the access point's underlying bucket grants `s3:ListBucket` to the Cadence role (necessary for the existing `HeadBucket` validation).

**Potential risks**

- **Behavior for existing `s3://` URIs is unchanged.** Validation, bucket extraction, and key construction take the same code paths as before; the new scheme is opt-in by URI.
- **Helper signatures changed** (`upload`, `download`, `keyExists`, `bucketExists` now take a `region` parameter). All in-tree callers were updated; one test file required a one-line signature update. The package isn't a public API surface, but downstream forks that call into `s3store` directly will need the same one-line change.
- **`HeadBucket` semantics with access points.** `ValidateURI` still calls `HeadBucket` on the constructed ARN. AWS evaluates `HeadBucket` against the underlying bucket policy, not the access point policy — so granting `s3:*` on the access point alone is not sufficient for the validation step. The README documents this; users who don't want to grant `s3:ListBucket` on the underlying bucket will hit a 403 at domain registration.
- **`s3ForcePathStyle: true` is incompatible with access points.** Documented as a limitation; the existing default (`false`) is correct for the new scheme.
- **No new dependencies; no schema or wire-format changes; no migration required.**

**Release notes**

Added `s3-ap://<account>/<access-point-name>[/<path>]` URI scheme to the S3 history and visibility archivers. The same URI works across all regions of a global domain — each cluster's configured AWS region is injected when constructing the access point ARN passed to the AWS SDK. Existing `s3://<bucket>` URIs continue to work unchanged.

**Documentation Changes**

Updated `common/archiver/s3store/README.md` with:
- A "URI schemes" section comparing `s3://` and `s3-ap://`, including a `cadence domain register` example for a global domain.
- An "Access point IAM and `HeadBucket`" note explaining the underlying-bucket policy requirement.
- A limitations subsection (region required, `s3ForcePathStyle` incompatible, MRAP not supported).
- A note on how the `s3-ap://` path component maps to object keys under the underlying bucket.

