### PR TITLE
feat(history): add shard-id to persistence error logs

### DIFF
--- a/service/history/decision/handler_test.go
+++ b/service/history/decision/handler_test.go
@@ -170,7 +170,6 @@ func TestHandleDecisionTaskScheduled(t *testing.T) {
 					GetEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Times(1).
 					Return(nil, &persistence.TimeoutError{Msg: "failed to get start event: request timeout"})
-				shardContext.EXPECT().GetShardID().Return(testShardID).Times(1)
 			},
 			expectErr: true,
 		},
@@ -191,7 +190,6 @@ func TestHandleDecisionTaskScheduled(t *testing.T) {
 					GetEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Times(1).
 					Return(&types.HistoryEvent{}, nil)
-				shardContext.EXPECT().GetShardID().Return(testShardID).Times(1)
 				shardContext.EXPECT().GenerateTaskIDs(gomock.Any()).Times(1).Return([]int64{}, errors.New("some random error to avoid going too deep in call stack unrelated to this unit"))
 			},
 			expectErr:       true,
@@ -213,7 +211,6 @@ func TestHandleDecisionTaskScheduled(t *testing.T) {
 					GetEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Times(1).
 					Return(&types.HistoryEvent{}, nil)
-				shardContext.EXPECT().GetShardID().Return(testShardID).Times(1)
 				shardContext.EXPECT().GenerateTaskIDs(gomock.Any()).Times(1).Return([]int64{}, errors.New("some random error to avoid going too deep in call stack unrelated to this unit"))
 			},
 			expectErr:       true,
@@ -248,6 +245,7 @@ func TestHandleDecisionTaskScheduled(t *testing.T) {
 			if test.expectCalls != nil {
 				test.expectCalls(ctrl, decisionHandler.shard.(*shard.MockContext))
 			}
+			expectGetShardIDAnyTimes(decisionHandler)
 			decisionHandler.executionCache = execution.NewCache(decisionHandler.shard)
 			err := decisionHandler.HandleDecisionTaskScheduled(context.Background(), request)
 			assert.Equal(t, test.expectErr, err != nil)
@@ -294,7 +292,6 @@ func TestHandleDecisionTaskFailed(t *testing.T) {
 					RunID:      constants.TestRunID,
 				}).Return(&persistence.AppendHistoryNodesResponse{}, nil)
 				h.shard.(*shard.MockContext).EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil)
-				h.shard.(*shard.MockContext).EXPECT().GetShardID().Return(testShardID)
 				engine := engine.NewMockEngine(ctrl)
 				h.shard.(*shard.MockContext).EXPECT().GetEngine().Times(3).Return(engine)
 				engine.EXPECT().NotifyNewHistoryEvent(gomock.Any())
@@ -377,6 +374,7 @@ func TestHandleDecisionTaskFailed(t *testing.T) {
 				expectDefaultDomainCache(decisionHandler, test.domainID)
 			}
 			expectGetWorkflowExecution(decisionHandler, test.domainID, test.mutablestate)
+			expectGetShardIDAnyTimes(decisionHandler)
 			decisionHandler.executionCache = execution.NewCache(shardContext)
 			if test.expectCalls != nil {
 				test.expectCalls(ctrl, decisionHandler)
@@ -481,7 +479,6 @@ func TestHandleDecisionTaskStarted(t *testing.T) {
 					AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, types.WorkflowExecution{WorkflowID: constants.TestWorkflowID, RunID: constants.TestRunID}).
 					Return(&persistence.AppendHistoryNodesResponse{}, nil)
 				h.shard.(*shard.MockContext).EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil)
-				h.shard.(*shard.MockContext).EXPECT().GetShardID().Return(testShardID)
 				engine := engine.NewMockEngine(ctrl)
 				h.shard.(*shard.MockContext).EXPECT().GetEngine().Times(3).Return(engine)
 				engine.EXPECT().NotifyNewHistoryEvent(gomock.Any())
@@ -536,6 +533,7 @@ func TestHandleDecisionTaskStarted(t *testing.T) {
 			expectCommonCalls(decisionHandler, test.domainID)
 			expectDefaultDomainCache(decisionHandler, test.domainID)
 			expectGetWorkflowExecution(decisionHandler, test.domainID, test.mutablestate)
+			expectGetShardIDAnyTimes(decisionHandler)
 			decisionHandler.executionCache = execution.NewCache(shardContext)
 			if test.expectCalls != nil {
 				test.expectCalls(ctrl, decisionHandler)
@@ -618,7 +616,6 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 				eventsCache := events.NewMockCache(ctrl)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetEventsCache().Times(1).Return(eventsCache)
 				eventsCache.EXPECT().PutEvent(constants.TestDomainID, constants.TestWorkflowID, constants.TestRunID, int64(1), gomock.Any())
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GetShardID().Times(1).Return(testShardID)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(4).Return([]int64{0, 1, 2, 3}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(6).Return([]int64{0, 1, 2, 3, 4, 5}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, types.WorkflowExecution{
@@ -748,7 +745,6 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 
 				eventsCache := events.NewMockCache(ctrl)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetEventsCache().Times(1).Return(eventsCache)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GetShardID().Times(1).Return(testShardID)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(1).Return([]int64{0}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, types.WorkflowExecution{
 					WorkflowID: constants.TestWorkflowID,
@@ -801,7 +797,6 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetEventsCache().Times(3).Return(eventsCache)
 				eventsCache.EXPECT().GetEvent(context.Background(), testShardID, constants.TestDomainID, constants.TestWorkflowID, constants.TestRunID, commonconstants.FirstEventID, commonconstants.FirstEventID, nil).Return(&types.HistoryEvent{}, nil)
 				eventsCache.EXPECT().PutEvent(constants.TestDomainID, constants.TestWorkflowID, gomock.Any(), int64(1), gomock.Any()).Times(2)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GetShardID().Times(1).Return(testShardID)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(2).Times(1).Return([]int64{0, 1}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, gomock.Any()).Return(nil, &persistence.TransactionSizeLimitError{Msg: fmt.Sprintf("transaction size exceeds limit")})
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetExecutionManager().Times(1)
@@ -843,7 +838,6 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 						WorkflowExecutionStartedEventAttributes: &types.WorkflowExecutionStartedEventAttributes{},
 					}, nil).Times(3)
 				eventsCache.EXPECT().PutEvent(constants.TestDomainID, constants.TestWorkflowID, gomock.Any(), int64(1), gomock.Any()).Times(2)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GetShardID().Times(3).Return(testShardID)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(2).Times(1).Return([]int64{0, 1}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, gomock.Any()).Return(nil, execution.NewConflictError(new(testing.T), errors.New("some random conflict error")))
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetExecutionManager().Times(1)
@@ -885,7 +879,6 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 						WorkflowExecutionStartedEventAttributes: &types.WorkflowExecutionStartedEventAttributes{},
 					}, nil).Times(3)
 				eventsCache.EXPECT().PutEvent(constants.TestDomainID, constants.TestWorkflowID, gomock.Any(), int64(1), gomock.Any()).Times(2)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GetShardID().Times(3).Return(testShardID)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(2).Times(1).Return([]int64{0, 1}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, gomock.Any()).Return(nil, &persistence.TransactionSizeLimitError{Msg: fmt.Sprintf("transaction size exceeds limit")})
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetExecutionManager().Times(1)
@@ -938,7 +931,6 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 						WorkflowExecutionStartedEventAttributes: &types.WorkflowExecutionStartedEventAttributes{},
 					}, nil).Times(3)
 				eventsCache.EXPECT().PutEvent(constants.TestDomainID, constants.TestWorkflowID, gomock.Any(), int64(1), gomock.Any()).Times(3)
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GetShardID().Times(3).Return(testShardID)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(2).Times(2).Return([]int64{0, 1}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(1).Times(1).Return([]int64{0}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, gomock.Any()).Return(nil, &persistence.TransactionSizeLimitError{Msg: fmt.Sprintf("transaction size exceeds limit")})
@@ -1134,7 +1126,6 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 				}
 				decisionHandler.tokenSerializer.(*common.MockTaskTokenSerializer).EXPECT().Deserialize(serializedTestToken).Return(deserializedTestToken, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetEventsCache().Times(1).Return(events.NewMockCache(ctrl))
-				decisionHandler.shard.(*shard.MockContext).EXPECT().GetShardID().Times(1).Return(testShardID)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GenerateTaskIDs(3).Return([]int64{0, 1, 2}, nil)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().AppendHistoryV2Events(gomock.Any(), gomock.Any(), constants.TestDomainID, types.WorkflowExecution{
 					WorkflowID: constants.TestWorkflowID,
@@ -1191,6 +1182,7 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 			if test.expectGetWorkflowExecution {
 				expectGetWorkflowExecution(decisionHandler, test.domainID, test.mutableState)
 			}
+			expectGetShardIDAnyTimes(decisionHandler)
 			decisionHandler.executionCache = execution.NewCache(shard)
 
 			request := &types.HistoryRespondDecisionTaskCompletedRequest{
@@ -1450,8 +1442,14 @@ func expectCommonCalls(handler *handlerImpl, domainID string) {
 	handler.shard.(*shard.MockContext).EXPECT().GetMetricsClient().AnyTimes().Return(handler.metricsClient)
 	handler.domainCache.(*cache.MockDomainCache).EXPECT().GetDomainName(domainID).AnyTimes().Return(constants.TestDomainName, nil)
 	handler.shard.(*shard.MockContext).EXPECT().GetExecutionManager().Times(1)
-	handler.shard.(*shard.MockContext).EXPECT().GetShardID().Return(testShardID).Times(1)
 	handler.shard.(*shard.MockContext).EXPECT().GetActiveClusterManager().Return(handler.activeClusterManager).AnyTimes()
+}
+
+// expectGetShardIDAnyTimes covers execution.NewCache and persistence retry logging; register it before
+// execution.NewCache. Add any stricter GetShardID().Times(n) expectations after this call so gomock
+// matches them first (newer expectations take precedence).
+func expectGetShardIDAnyTimes(handler *handlerImpl) {
+	handler.shard.(*shard.MockContext).EXPECT().GetShardID().Return(testShardID).AnyTimes()
 }
 
 func expectGetWorkflowExecution(handler *handlerImpl, domainID string, state *persistence.WorkflowMutableState) {

--- a/service/history/events/cache.go
+++ b/service/history/events/cache.go
@@ -213,12 +213,15 @@ func (e *cacheImpl) GetEvent(
 
 	if err != nil {
 		e.metricsClient.IncCounter(metrics.EventsCacheGetEventScope, metrics.CacheFailures)
-		e.logger.Error("EventsCache unable to retrieve event from store",
+		logTags := []tag.Tag{
+			tag.ShardID(shardID),
 			tag.Error(err),
 			tag.WorkflowID(workflowID),
 			tag.WorkflowRunID(runID),
 			tag.WorkflowDomainID(domainID),
-			tag.WorkflowEventID(eventID))
+			tag.WorkflowEventID(eventID),
+		}
+		e.logger.Error("EventsCache unable to retrieve event from store", logTags...)
 		return nil, err
 	}
 

--- a/service/history/execution/context.go
+++ b/service/history/execution/context.go
@@ -1225,6 +1225,7 @@ func createWorkflowExecutionWithRetry(
 	default:
 		logger.Error(
 			"Persistent store operation failure",
+			tag.ShardID(shardContext.GetShardID()),
 			tag.StoreOperationCreateWorkflowExecution,
 			tag.Error(err),
 		)
@@ -1264,7 +1265,10 @@ func getWorkflowExecutionWithRetry(
 		// otherwise always log
 		var shardClosedError *shard.ErrShardClosed
 		if !errors.As(err, &shardClosedError) || shardContext.GetTimeSource().Since(shardClosedError.ClosedAt) > shard.TimeBeforeShardClosedIsError {
-			logger.Error("Persistent fetch operation failure", tag.StoreOperationGetWorkflowExecution, tag.Error(err))
+			logger.Error("Persistent fetch operation failure",
+				tag.ShardID(shardContext.GetShardID()),
+				tag.StoreOperationGetWorkflowExecution,
+				tag.Error(err))
 		}
 
 		return nil, err
@@ -1315,6 +1319,7 @@ func updateWorkflowExecutionWithRetry(
 	default:
 		logger.Error(
 			"Persistent store operation failure",
+			tag.ShardID(shardContext.GetShardID()),
 			tag.StoreOperationUpdateWorkflowExecution,
 			tag.Error(err),
 			tag.Number(request.UpdateWorkflowMutation.Condition),

--- a/service/history/execution/context_test.go
+++ b/service/history/execution/context_test.go
@@ -597,6 +597,7 @@ func TestCreateWorkflowExecutionWithRetry(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			mockShard := shard.NewMockContext(mockCtrl)
+			mockShard.EXPECT().GetShardID().Return(7).AnyTimes()
 			policy := backoff.NewExponentialRetryPolicy(time.Millisecond)
 			policy.SetMaximumAttempts(1)
 			if tc.mockSetup != nil {
@@ -698,6 +699,7 @@ func TestUpdateWorkflowExecutionWithRetry(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			mockShard := shard.NewMockContext(mockCtrl)
+			mockShard.EXPECT().GetShardID().Return(7).AnyTimes()
 			policy := backoff.NewExponentialRetryPolicy(time.Millisecond)
 			policy.SetMaximumAttempts(1)
 			if tc.mockSetup != nil {
@@ -3185,6 +3187,7 @@ func TestGetWorkflowExecutionWithRetry(t *testing.T) {
 			mockLogger.EXPECT().Helper().Return(mockLogger)
 			timeSource := clock.NewMockedTimeSource()
 			mockShard.EXPECT().GetTimeSource().Return(timeSource).AnyTimes()
+			mockShard.EXPECT().GetShardID().Return(7).AnyTimes()
 			policy := backoff.NewExponentialRetryPolicy(time.Millisecond)
 			policy.SetMaximumAttempts(1)
 			if tc.mockSetup != nil {
@@ -3208,6 +3211,7 @@ func expectLog(mockLogger *log.MockLogger, err error) *gomock.Call {
 	return mockLogger.EXPECT().Error(
 		"Persistent fetch operation failure",
 		[]tag.Tag{
+			tag.ShardID(7),
 			tag.StoreOperationGetWorkflowExecution,
 			tag.Error(err),
 		})

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -62,6 +62,8 @@ type (
 		GetClusterMetadata() cluster.Metadata
 		GetConfig() *config.Config
 		GetEventsCache() events.Cache
+		// GetLogger returns a logger tagged with this shard (history item includes shard-id).
+		// Prefer it for work scoped to a shard so logs remain attributable when downstream adds tags.
 		GetLogger() log.Logger
 		GetThrottledLogger() log.Logger
 		GetMetricsClient() metrics.Client


### PR DESCRIPTION
**What changed?**
History service now adds tag.ShardID on the same log line as tag.Error for:

getWorkflowExecutionWithRetry, createWorkflowExecutionWithRetry, and updateWorkflowExecutionWithRetry in service/history/execution/context.go (the generic “Persistent fetch/store operation failure” paths).
Per-shard events cache: when GetEvent fails after ReadHistoryBranch, the EventsCache unable to retrieve event from store line includes shard-id when the cache was constructed with a shard (global cache unchanged).
shard.Context’s GetLogger() is documented as already being shard-tagged at construction.

Fixes #8016.

**Why?**
For failures that are not typed persistence errors—especially context.Canceled and context.DeadlineExceeded—operators need shard-id on the log line they search (next to the error), not only on separate persistence/metrics paths. History shard loggers already carry shard context via WithTags, but this makes shard attribution explicit on these high-traffic error messages.

**How did you test it?**
go test ./service/history/execution/... ./service/history/events/... ./service/history/shard/...


**Potential risks**
None for behavior: logging and a small interface comment only.

**Release notes**
N/A — internal observability / logging only.


**Documentation Changes**
N/A — no Cadence-Docs or user-facing doc updates. 
