### PR TITLE
fix(shard-distributor): get all executors in buildAssignedCounts

### DIFF
--- a/service/sharddistributor/handler/ephemeral_assigner.go
+++ b/service/sharddistributor/handler/ephemeral_assigner.go
@@ -82,13 +82,12 @@ func (h *handlerImpl) assignEphemeralBatch(ctx context.Context, namespace string
 // buildAssignedCounts returns a map of executorID -> current shard count for
 // all ACTIVE executors in the given namespace state.
 func buildAssignedCounts(state *store.NamespaceState) (map[string]int, error) {
-	counts := make(map[string]int, len(state.ShardAssignments))
-	for executorID, assignment := range state.ShardAssignments {
-		executorState, ok := state.Executors[executorID]
-		if !ok || executorState.Status != types.ExecutorStatusACTIVE {
+	counts := make(map[string]int, len(state.Executors))
+	for executorID, executorState := range state.Executors {
+		if executorState.Status != types.ExecutorStatusACTIVE {
 			continue
 		}
-		counts[executorID] = len(assignment.AssignedShards)
+		counts[executorID] = len(state.ShardAssignments[executorID].AssignedShards)
 	}
 	return counts, nil
 }

--- a/service/sharddistributor/handler/ephemeral_assigner_test.go
+++ b/service/sharddistributor/handler/ephemeral_assigner_test.go
@@ -163,6 +163,30 @@ func TestAssignEphemeralBatch(t *testing.T) {
 			expectedErrMsg: "no active executors available for namespace",
 		},
 		{
+			// An executor that has heartbeated (ACTIVE in state.Executors) but has
+			// never been assigned a shard yet (absent from state.ShardAssignments)
+			// must still be eligible for assignment. This covers the bootstrap case
+			// where the very first shard creation would otherwise always fail.
+			name:      "AssignsToExecutorWithNoExistingAssignments",
+			namespace: _testNamespaceEphemeral,
+			shardKeys: []string{"NEW-SHARD"},
+			setupMocks: func(mockStore *store.MockStore) {
+				mockStore.EXPECT().GetState(gomock.Any(), _testNamespaceEphemeral).Return(&store.NamespaceState{
+					Executors: map[string]store.HeartbeatState{
+						"owner1": {Status: types.ExecutorStatusACTIVE},
+					},
+					// No ShardAssignments entry for owner1 — fresh executor.
+					ShardAssignments: map[string]store.AssignedState{},
+				}, nil)
+				mockStore.EXPECT().AssignShards(gomock.Any(), _testNamespaceEphemeral, gomock.Any(), gomock.Any()).Return(nil)
+				mockStore.EXPECT().GetExecutor(gomock.Any(), _testNamespaceEphemeral, "owner1").Return(&store.ShardOwner{
+					ExecutorID: "owner1",
+					Metadata:   map[string]string{"ip": "127.0.0.1", "port": "1234"},
+				}, nil)
+			},
+			expectedOwners: map[string]string{"NEW-SHARD": "owner1"},
+		},
+		{
 			name:      "AssignShardsFailure",
 			namespace: _testNamespaceEphemeral,
 			shardKeys: []string{"NON-EXISTING-SHARD"},


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
 1. buildAssignedCounts now iterates state.Executors instead of state.ShardAssignments. For executors that have no prior assignments, state.ShardAssignments[executorID].AssignedShards returns a nil map, so len evaluates to 0.                                                                                 
  2. A new test case AssignsToExecutorWithNoExistingAssignments covers the bootstrap scenario.
part of https://github.com/cadence-workflow/cadence/issues/6862

**Why?**
buildAssignedCounts was iterating state.ShardAssignments to find eligible executors, but a fresh executor only writes to state.Executors via heartbeat — it has no entry in state.ShardAssignments until it has been assigned at least one shard. So new executors receive a new shards only from the rebalancing loop and not in this case since assignment requires being in ShardAssignments. The fix iterates state.Executors directly so any ACTIVE executor is eligible regardless of prior assignment history.

**How did you test it?**
go test -run TestAssignEphemeralBatch ./service/sharddistributor/handler/ 2>&1

plus:
etcd
make cadence-server; ./cadence-server start --services shard-distributor
make start-sharddistributor-canary

and inspecting the new assignments in etcd

**Potential risks**
it is a fix, so it should improve the assignments to new executors

**Release notes**
N/A

**Documentation Changes**
N/A
