### PR TITLE
chore(shard-distirbutor): reuse the state for assignephemeral shards

### DIFF
--- a/service/sharddistributor/handler/ephemeral_assigner.go
+++ b/service/sharddistributor/handler/ephemeral_assigner.go
@@ -38,9 +38,8 @@ import (
 //  1. GetState     — read current namespace state once for the whole batch.
 //  2. AssignShards — write all new assignments atomically in one operation.
 //
-// After the write, GetExecutor is called once per unique chosen executor (not
-// per shard) to fetch metadata for the response, since metadata is stored
-// separately in the shard cache and is not returned by GetState.
+// Executor metadata for the response is derived directly from the HeartbeatState
+// already present in the GetState result, avoiding an extra storage round-trip.
 //
 // Within the batch the least-loaded ACTIVE executor is chosen per shard, with
 // the in-batch running count updated after each pick so load is spread evenly.
@@ -71,10 +70,7 @@ func (h *handlerImpl) assignEphemeralBatch(ctx context.Context, namespace string
 		return nil, &types.InternalServiceError{Message: fmt.Sprintf("assign ephemeral shards: %v", err)}
 	}
 
-	executorOwners, err := h.fetchExecutorMetadata(ctx, namespace, chosenExecutors)
-	if err != nil {
-		return nil, err
-	}
+	executorOwners := buildExecutorOwners(state, chosenExecutors)
 
 	return buildResults(namespace, shardKeys, chosenExecutors, executorOwners), nil
 }
@@ -134,22 +130,22 @@ func mergeAssignments(state *store.NamespaceState, chosenExecutors map[string]st
 	}
 }
 
-// fetchExecutorMetadata calls GetExecutor once per unique chosen executor to
-// retrieve metadata. Metadata is stored separately from HeartbeatState and is
-// not returned by GetState.
-func (h *handlerImpl) fetchExecutorMetadata(ctx context.Context, namespace string, chosenExecutors map[string]string) (map[string]*store.ShardOwner, error) {
-	executorOwners := make(map[string]*store.ShardOwner, len(chosenExecutors))
+// buildExecutorOwners derives ShardOwner metadata for each chosen executor
+// directly from the HeartbeatState already present in state, avoiding an
+// extra storage round-trip.
+func buildExecutorOwners(state *store.NamespaceState, chosenExecutors map[string]string) map[string]*store.ShardOwner {
+	owners := make(map[string]*store.ShardOwner, len(chosenExecutors))
 	for _, executorID := range chosenExecutors {
-		if _, already := executorOwners[executorID]; already {
+		if _, already := owners[executorID]; already {
 			continue
 		}
-		owner, err := h.storage.GetExecutor(ctx, namespace, executorID)
-		if err != nil {
-			return nil, &types.InternalServiceError{Message: fmt.Sprintf("get executor %q: %v", executorID, err)}
+		heartbeat := state.Executors[executorID]
+		owners[executorID] = &store.ShardOwner{
+			ExecutorID: executorID,
+			Metadata:   heartbeat.Metadata,
 		}
-		executorOwners[executorID] = owner
 	}
-	return executorOwners, nil
+	return owners
 }
 
 // buildResults constructs the shardKey -> GetShardOwnerResponse map from the

--- a/service/sharddistributor/handler/ephemeral_assigner_test.go
+++ b/service/sharddistributor/handler/ephemeral_assigner_test.go
@@ -53,7 +53,7 @@ func TestAssignEphemeralBatch(t *testing.T) {
 				mockStore.EXPECT().GetState(gomock.Any(), _testNamespaceEphemeral).Return(&store.NamespaceState{
 					Executors: map[string]store.HeartbeatState{
 						"owner1": {Status: types.ExecutorStatusACTIVE},
-						"owner2": {Status: types.ExecutorStatusACTIVE},
+						"owner2": {Status: types.ExecutorStatusACTIVE, Metadata: map[string]string{"ip": "127.0.0.1", "port": "1234"}},
 					},
 					ShardAssignments: map[string]store.AssignedState{
 						"owner1": {
@@ -72,10 +72,6 @@ func TestAssignEphemeralBatch(t *testing.T) {
 				}, nil)
 				// owner2 has the fewest shards; expect a single batch AssignShards call.
 				mockStore.EXPECT().AssignShards(gomock.Any(), _testNamespaceEphemeral, gomock.Any(), gomock.Any()).Return(nil)
-				mockStore.EXPECT().GetExecutor(gomock.Any(), _testNamespaceEphemeral, "owner2").Return(&store.ShardOwner{
-					ExecutorID: "owner2",
-					Metadata:   map[string]string{"ip": "127.0.0.1", "port": "1234"},
-				}, nil)
 			},
 			expectedOwners: map[string]string{"NON-EXISTING-SHARD": "owner2"},
 		},
@@ -86,7 +82,7 @@ func TestAssignEphemeralBatch(t *testing.T) {
 			setupMocks: func(mockStore *store.MockStore) {
 				mockStore.EXPECT().GetState(gomock.Any(), _testNamespaceEphemeral).Return(&store.NamespaceState{
 					Executors: map[string]store.HeartbeatState{
-						"owner1": {Status: types.ExecutorStatusACTIVE},
+						"owner1": {Status: types.ExecutorStatusACTIVE, Metadata: map[string]string{"ip": "127.0.0.1", "port": "1234"}},
 						// owner2 is DRAINING, should be skipped even though it has fewer shards
 						"owner2": {Status: types.ExecutorStatusDRAINING},
 					},
@@ -108,10 +104,6 @@ func TestAssignEphemeralBatch(t *testing.T) {
 				}, nil)
 				// owner1 should be selected; single batch write
 				mockStore.EXPECT().AssignShards(gomock.Any(), _testNamespaceEphemeral, gomock.Any(), gomock.Any()).Return(nil)
-				mockStore.EXPECT().GetExecutor(gomock.Any(), _testNamespaceEphemeral, "owner1").Return(&store.ShardOwner{
-					ExecutorID: "owner1",
-					Metadata:   map[string]string{"ip": "127.0.0.1", "port": "1234"},
-				}, nil)
 			},
 			expectedOwners: map[string]string{"NON-EXISTING-SHARD": "owner1"},
 		},
@@ -205,6 +197,53 @@ func TestAssignEphemeralBatch(t *testing.T) {
 					require.Equal(t, map[string]string{"ip": "127.0.0.1", "port": "1234"}, results[shardKey].Metadata)
 				}
 			}
+		})
+	}
+}
+
+func TestBuildExecutorOwners(t *testing.T) {
+	tests := []struct {
+		name            string
+		state           *store.NamespaceState
+		chosenExecutors map[string]string
+		expected        map[string]*store.ShardOwner
+	}{
+		{
+			name: "DerivesMetadataFromHeartbeatState",
+			state: &store.NamespaceState{
+				Executors: map[string]store.HeartbeatState{
+					"exec1": {Metadata: map[string]string{"ip": "10.0.0.1"}},
+					"exec2": {Metadata: map[string]string{"ip": "10.0.0.2"}},
+				},
+			},
+			chosenExecutors: map[string]string{
+				"shard1": "exec1",
+				"shard2": "exec2",
+				"shard3": "exec1", // duplicate — should not produce a second ShardOwner
+			},
+			expected: map[string]*store.ShardOwner{
+				"exec1": {ExecutorID: "exec1", Metadata: map[string]string{"ip": "10.0.0.1"}},
+				"exec2": {ExecutorID: "exec2", Metadata: map[string]string{"ip": "10.0.0.2"}},
+			},
+		},
+		{
+			name: "NilMetadataWhenExecutorHasNone",
+			state: &store.NamespaceState{
+				Executors: map[string]store.HeartbeatState{
+					"exec1": {Status: types.ExecutorStatusACTIVE},
+				},
+			},
+			chosenExecutors: map[string]string{"shard1": "exec1"},
+			expected: map[string]*store.ShardOwner{
+				"exec1": {ExecutorID: "exec1", Metadata: nil},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildExecutorOwners(tt.state, tt.chosenExecutors)
+			require.Equal(t, tt.expected, got)
 		})
 	}
 }

--- a/service/sharddistributor/handler/handler_test.go
+++ b/service/sharddistributor/handler/handler_test.go
@@ -159,14 +159,10 @@ func TestGetShardOwner(t *testing.T) {
 			setupMocks: func(mockStore *store.MockStore) {
 				mockStore.EXPECT().GetShardOwner(gomock.Any(), _testNamespaceEphemeral, "NON-EXISTING-SHARD").Return(nil, store.ErrShardNotFound)
 				mockStore.EXPECT().GetState(gomock.Any(), _testNamespaceEphemeral).Return(&store.NamespaceState{
-					Executors:        map[string]store.HeartbeatState{"owner1": {Status: types.ExecutorStatusACTIVE}},
+					Executors:        map[string]store.HeartbeatState{"owner1": {Status: types.ExecutorStatusACTIVE, Metadata: map[string]string{"ip": "127.0.0.1", "port": "1234"}}},
 					ShardAssignments: map[string]store.AssignedState{"owner1": {AssignedShards: map[string]*types.ShardAssignment{}}},
 				}, nil)
 				mockStore.EXPECT().AssignShards(gomock.Any(), _testNamespaceEphemeral, gomock.Any(), gomock.Any()).Return(nil)
-				mockStore.EXPECT().GetExecutor(gomock.Any(), _testNamespaceEphemeral, "owner1").Return(&store.ShardOwner{
-					ExecutorID: "owner1",
-					Metadata:   map[string]string{"ip": "127.0.0.1", "port": "1234"},
-				}, nil)
 			},
 			expectedOwner: "owner1",
 			expectedError: false,
@@ -233,14 +229,10 @@ func TestGetShardOwner(t *testing.T) {
 
 				// Second batcher attempt: succeeds.
 				mockStore.EXPECT().GetState(gomock.Any(), _testNamespaceEphemeral).Return(&store.NamespaceState{
-					Executors:        map[string]store.HeartbeatState{"owner1": {Status: types.ExecutorStatusACTIVE}},
+					Executors:        map[string]store.HeartbeatState{"owner1": {Status: types.ExecutorStatusACTIVE, Metadata: map[string]string{"ip": "127.0.0.1", "port": "1234"}}},
 					ShardAssignments: map[string]store.AssignedState{"owner1": {AssignedShards: map[string]*types.ShardAssignment{}}},
 				}, nil)
 				mockStore.EXPECT().AssignShards(gomock.Any(), _testNamespaceEphemeral, gomock.Any(), gomock.Any()).Return(nil)
-				mockStore.EXPECT().GetExecutor(gomock.Any(), _testNamespaceEphemeral, "owner1").Return(&store.ShardOwner{
-					ExecutorID: "owner1",
-					Metadata:   map[string]string{"ip": "127.0.0.1", "port": "1234"},
-				}, nil)
 			},
 			expectedOwner: "owner1",
 			expectedError: false,


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
The fetchExecutorMetadata method (which made one GetExecutor storage call per unique assigned executor after writing new shard assignments) was replaced with a pure in-memory function       
  buildExecutorOwners. Instead of going back to storage, it now derives the executor metadata directly from the HeartbeatState already loaded by the preceding GetState call.
part of https://github.com/cadence-workflow/cadence/issues/6862

**Why?**
 The GetState call already fetches the full executor heartbeat state, including the metadata needed for the response. The previous code discarded that data and then re-fetched it from storage
   once per executor — wasting N extra round-trips per assignEphemeralBatch invocation. This change eliminates those redundant reads: fewer storage calls means lower latency, less load on etcd.

**How did you test it?**
go test -race ./service/sharddistributor/handler/...

**Potential risks**
tested in local development, do not expect any issue

**Release notes**
N/A

**Documentation Changes**
N/A
