### PR TITLE
feat(replication): persist dlq task in standby cluster

### DIFF
--- a/common/mocks/ExecutionManager.go
+++ b/common/mocks/ExecutionManager.go
@@ -258,19 +258,19 @@ func (_m *ExecutionManager) GetReplicationDLQSize(ctx context.Context, request *
 }
 
 // GetReplicationTasksFromDLQ provides a mock function with given fields: ctx, request
-func (_m *ExecutionManager) GetReplicationTasksFromDLQ(ctx context.Context, request *persistence.GetReplicationTasksFromDLQRequest) (*persistence.GetHistoryTasksResponse, error) {
+func (_m *ExecutionManager) GetReplicationTasksFromDLQ(ctx context.Context, request *persistence.GetReplicationTasksFromDLQRequest) (*persistence.GetReplicationDLQTasksResponse, error) {
 	ret := _m.Called(ctx, request)
 
-	var r0 *persistence.GetHistoryTasksResponse
+	var r0 *persistence.GetReplicationDLQTasksResponse
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *persistence.GetReplicationTasksFromDLQRequest) (*persistence.GetHistoryTasksResponse, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *persistence.GetReplicationTasksFromDLQRequest) (*persistence.GetReplicationDLQTasksResponse, error)); ok {
 		return rf(ctx, request)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *persistence.GetReplicationTasksFromDLQRequest) *persistence.GetHistoryTasksResponse); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *persistence.GetReplicationTasksFromDLQRequest) *persistence.GetReplicationDLQTasksResponse); ok {
 		r0 = rf(ctx, request)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*persistence.GetHistoryTasksResponse)
+			r0 = ret.Get(0).(*persistence.GetReplicationDLQTasksResponse)
 		}
 	}
 

--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -972,6 +972,7 @@ type (
 		SourceClusterName string
 		TaskInfo          *ReplicationTaskInfo
 		DomainName        string
+		Task              *DataBlob
 	}
 
 	// GetReplicationTasksFromDLQRequest is used to get replication tasks from dlq
@@ -982,6 +983,19 @@ type (
 		MaxReadLevel      int64
 		BatchSize         int
 		NextPageToken     []byte
+	}
+
+	// ReplicationDLQTask pairs DLQ task metadata with its stored full task payload.
+	// Task may be nil for entries written before payload storage was implemented.
+	ReplicationDLQTask struct {
+		Info *ReplicationTaskInfo
+		Task *DataBlob
+	}
+
+	// GetReplicationDLQTasksResponse is returned by GetReplicationDLQTasks.
+	GetReplicationDLQTasksResponse struct {
+		Tasks         []*ReplicationDLQTask
+		NextPageToken []byte
 	}
 
 	// GetReplicationDLQSizeRequest is used to get one replication task from dlq
@@ -1648,7 +1662,7 @@ type (
 		// Replication task related methods
 
 		PutReplicationTaskToDLQ(ctx context.Context, request *PutReplicationTaskToDLQRequest) error
-		GetReplicationTasksFromDLQ(ctx context.Context, request *GetReplicationTasksFromDLQRequest) (*GetHistoryTasksResponse, error)
+		GetReplicationTasksFromDLQ(ctx context.Context, request *GetReplicationTasksFromDLQRequest) (*GetReplicationDLQTasksResponse, error)
 		GetReplicationDLQSize(ctx context.Context, request *GetReplicationDLQSizeRequest) (*GetReplicationDLQSizeResponse, error)
 		DeleteReplicationTaskFromDLQ(ctx context.Context, request *DeleteReplicationTaskFromDLQRequest) error
 		RangeDeleteReplicationTaskFromDLQ(ctx context.Context, request *RangeDeleteReplicationTaskFromDLQRequest) (*RangeDeleteReplicationTaskFromDLQResponse, error)

--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -985,11 +985,11 @@ type (
 		NextPageToken     []byte
 	}
 
-	// ReplicationDLQTask pairs DLQ task metadata with its stored full task payload.
-	// Task may be nil for entries written before payload storage was implemented.
+	// ReplicationDLQTask pairs DLQ task metadata with its hydrated full task payload.
+	// Task may be nil for entries with no stored payload or whose payload could not be hydrated.
 	ReplicationDLQTask struct {
 		Info *ReplicationTaskInfo
-		Task *DataBlob
+		Task *types.ReplicationTask
 	}
 
 	// GetReplicationDLQTasksResponse is returned by GetReplicationDLQTasks.

--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -972,7 +972,7 @@ type (
 		SourceClusterName string
 		TaskInfo          *ReplicationTaskInfo
 		DomainName        string
-		Task              *DataBlob
+		Task              *types.ReplicationTask
 	}
 
 	// GetReplicationTasksFromDLQRequest is used to get replication tasks from dlq

--- a/common/persistence/data_manager_interfaces_mock.go
+++ b/common/persistence/data_manager_interfaces_mock.go
@@ -624,10 +624,10 @@ func (mr *MockExecutionManagerMockRecorder) GetReplicationDLQSize(ctx, request a
 }
 
 // GetReplicationTasksFromDLQ mocks base method.
-func (m *MockExecutionManager) GetReplicationTasksFromDLQ(ctx context.Context, request *GetReplicationTasksFromDLQRequest) (*GetHistoryTasksResponse, error) {
+func (m *MockExecutionManager) GetReplicationTasksFromDLQ(ctx context.Context, request *GetReplicationTasksFromDLQRequest) (*GetReplicationDLQTasksResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetReplicationTasksFromDLQ", ctx, request)
-	ret0, _ := ret[0].(*GetHistoryTasksResponse)
+	ret0, _ := ret[0].(*GetReplicationDLQTasksResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/common/persistence/data_store_interfaces.go
+++ b/common/persistence/data_store_interfaces.go
@@ -120,7 +120,7 @@ type (
 
 		// Replication task related methods
 		PutReplicationTaskToDLQ(ctx context.Context, request *InternalPutReplicationTaskToDLQRequest) error
-		GetReplicationTasksFromDLQ(ctx context.Context, request *GetReplicationTasksFromDLQRequest) (*GetHistoryTasksResponse, error)
+		GetReplicationTasksFromDLQ(ctx context.Context, request *GetReplicationTasksFromDLQRequest) (*GetReplicationDLQTasksResponse, error)
 		GetReplicationDLQSize(ctx context.Context, request *GetReplicationDLQSizeRequest) (*GetReplicationDLQSizeResponse, error)
 		DeleteReplicationTaskFromDLQ(ctx context.Context, request *DeleteReplicationTaskFromDLQRequest) error
 		RangeDeleteReplicationTaskFromDLQ(ctx context.Context, request *RangeDeleteReplicationTaskFromDLQRequest) (*RangeDeleteReplicationTaskFromDLQResponse, error)
@@ -326,6 +326,7 @@ type (
 		ShardID           ShardID
 		SourceClusterName string
 		TaskInfo          *InternalReplicationTaskInfo
+		Task              *DataBlob
 	}
 
 	// InternalReplicationTaskInfo describes the replication task created for replication of history events

--- a/common/persistence/data_store_interfaces.go
+++ b/common/persistence/data_store_interfaces.go
@@ -120,7 +120,7 @@ type (
 
 		// Replication task related methods
 		PutReplicationTaskToDLQ(ctx context.Context, request *InternalPutReplicationTaskToDLQRequest) error
-		GetReplicationTasksFromDLQ(ctx context.Context, request *GetReplicationTasksFromDLQRequest) (*GetReplicationDLQTasksResponse, error)
+		GetReplicationTasksFromDLQ(ctx context.Context, request *GetReplicationTasksFromDLQRequest) (*InternalGetReplicationDLQTasksResponse, error)
 		GetReplicationDLQSize(ctx context.Context, request *GetReplicationDLQSizeRequest) (*GetReplicationDLQSizeResponse, error)
 		DeleteReplicationTaskFromDLQ(ctx context.Context, request *DeleteReplicationTaskFromDLQRequest) error
 		RangeDeleteReplicationTaskFromDLQ(ctx context.Context, request *RangeDeleteReplicationTaskFromDLQRequest) (*RangeDeleteReplicationTaskFromDLQResponse, error)
@@ -327,6 +327,18 @@ type (
 		SourceClusterName string
 		TaskInfo          *InternalReplicationTaskInfo
 		Task              *DataBlob
+	}
+
+	// InternalReplicationDLQTask is the store-layer ReplicationDLQTask: payload is a raw blob.
+	InternalReplicationDLQTask struct {
+		Info *ReplicationTaskInfo
+		Task *DataBlob
+	}
+
+	// InternalGetReplicationDLQTasksResponse is the store-layer GetReplicationDLQTasksResponse.
+	InternalGetReplicationDLQTasksResponse struct {
+		Tasks         []*InternalReplicationDLQTask
+		NextPageToken []byte
 	}
 
 	// InternalReplicationTaskInfo describes the replication task created for replication of history events

--- a/common/persistence/data_store_interfaces_mock.go
+++ b/common/persistence/data_store_interfaces_mock.go
@@ -240,10 +240,10 @@ func (mr *MockExecutionStoreMockRecorder) GetReplicationDLQSize(ctx, request any
 }
 
 // GetReplicationTasksFromDLQ mocks base method.
-func (m *MockExecutionStore) GetReplicationTasksFromDLQ(ctx context.Context, request *GetReplicationTasksFromDLQRequest) (*GetHistoryTasksResponse, error) {
+func (m *MockExecutionStore) GetReplicationTasksFromDLQ(ctx context.Context, request *GetReplicationTasksFromDLQRequest) (*GetReplicationDLQTasksResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetReplicationTasksFromDLQ", ctx, request)
-	ret0, _ := ret[0].(*GetHistoryTasksResponse)
+	ret0, _ := ret[0].(*GetReplicationDLQTasksResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/common/persistence/data_store_interfaces_mock.go
+++ b/common/persistence/data_store_interfaces_mock.go
@@ -240,10 +240,10 @@ func (mr *MockExecutionStoreMockRecorder) GetReplicationDLQSize(ctx, request any
 }
 
 // GetReplicationTasksFromDLQ mocks base method.
-func (m *MockExecutionStore) GetReplicationTasksFromDLQ(ctx context.Context, request *GetReplicationTasksFromDLQRequest) (*GetReplicationDLQTasksResponse, error) {
+func (m *MockExecutionStore) GetReplicationTasksFromDLQ(ctx context.Context, request *GetReplicationTasksFromDLQRequest) (*InternalGetReplicationDLQTasksResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetReplicationTasksFromDLQ", ctx, request)
-	ret0, _ := ret[0].(*GetReplicationDLQTasksResponse)
+	ret0, _ := ret[0].(*InternalGetReplicationDLQTasksResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -873,6 +873,7 @@ func (m *executionManagerImpl) PutReplicationTaskToDLQ(
 	internalRequest := &InternalPutReplicationTaskToDLQRequest{
 		SourceClusterName: request.SourceClusterName,
 		TaskInfo:          m.toInternalReplicationTaskInfo(request.TaskInfo),
+		Task:              request.Task,
 	}
 	return m.persistence.PutReplicationTaskToDLQ(ctx, internalRequest)
 }
@@ -880,7 +881,7 @@ func (m *executionManagerImpl) PutReplicationTaskToDLQ(
 func (m *executionManagerImpl) GetReplicationTasksFromDLQ(
 	ctx context.Context,
 	request *GetReplicationTasksFromDLQRequest,
-) (*GetHistoryTasksResponse, error) {
+) (*GetReplicationDLQTasksResponse, error) {
 	return m.persistence.GetReplicationTasksFromDLQ(ctx, request)
 }
 

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -29,6 +29,7 @@ import (
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/types"
 )
 
@@ -886,7 +887,33 @@ func (m *executionManagerImpl) GetReplicationTasksFromDLQ(
 	ctx context.Context,
 	request *GetReplicationTasksFromDLQRequest,
 ) (*GetReplicationDLQTasksResponse, error) {
-	return m.persistence.GetReplicationTasksFromDLQ(ctx, request)
+	internalResp, err := m.persistence.GetReplicationTasksFromDLQ(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	tasks := make([]*ReplicationDLQTask, len(internalResp.Tasks))
+	for i, internalTask := range internalResp.Tasks {
+		hydrated := &ReplicationDLQTask{Info: internalTask.Info}
+		if internalTask.Task != nil {
+			task, err := m.serializer.DeserializeReplicationDLQTask(internalTask.Task)
+			if err != nil {
+				// Surface a nil hydrated task so the caller can fall back to cross-cluster hydration.
+				m.logger.Warn("failed to deserialize DLQ task blob",
+					tag.WorkflowDomainID(internalTask.Info.DomainID),
+					tag.WorkflowID(internalTask.Info.WorkflowID),
+					tag.WorkflowRunID(internalTask.Info.RunID),
+					tag.TaskID(internalTask.Info.TaskID),
+					tag.Error(err))
+			} else {
+				hydrated.Task = task
+			}
+		}
+		tasks[i] = hydrated
+	}
+	return &GetReplicationDLQTasksResponse{
+		Tasks:         tasks,
+		NextPageToken: internalResp.NextPageToken,
+	}, nil
 }
 
 func (m *executionManagerImpl) GetReplicationDLQSize(

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -870,10 +870,14 @@ func (m *executionManagerImpl) PutReplicationTaskToDLQ(
 	ctx context.Context,
 	request *PutReplicationTaskToDLQRequest,
 ) error {
+	taskBlob, err := m.serializer.SerializeReplicationDLQTask(request.Task, constants.EncodingTypeThriftRW)
+	if err != nil {
+		return err
+	}
 	internalRequest := &InternalPutReplicationTaskToDLQRequest{
 		SourceClusterName: request.SourceClusterName,
 		TaskInfo:          m.toInternalReplicationTaskInfo(request.TaskInfo),
-		Task:              request.Task,
+		Task:              taskBlob,
 	}
 	return m.persistence.PutReplicationTaskToDLQ(ctx, internalRequest)
 }

--- a/common/persistence/execution_manager_test.go
+++ b/common/persistence/execution_manager_test.go
@@ -621,6 +621,7 @@ func TestGetReplicationTasksFromDLQ(t *testing.T) {
 					TaskID:     1,
 					TaskType:   ReplicationTaskTypeHistory,
 				},
+				Task: nil,
 			},
 		},
 		NextPageToken: []byte("test-token"),
@@ -631,6 +632,7 @@ func TestGetReplicationTasksFromDLQ(t *testing.T) {
 	res, err := manager.GetReplicationTasksFromDLQ(context.Background(), request)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, res)
+	assert.Nil(t, res.Tasks[0].Task)
 }
 
 func TestGetReplicationTasksFromDLQ_WithBlob(t *testing.T) {

--- a/common/persistence/execution_manager_test.go
+++ b/common/persistence/execution_manager_test.go
@@ -612,42 +612,25 @@ func TestGetReplicationTasksFromDLQ(t *testing.T) {
 		NextPageToken:     nil,
 	}
 
-	now := time.Now().UTC().Round(time.Second)
-
-	mockedStore.EXPECT().GetReplicationTasksFromDLQ(gomock.Any(), request).Return(
-		&GetHistoryTasksResponse{
-			Tasks: []Task{
-				&HistoryReplicationTask{
-					WorkflowIdentifier: WorkflowIdentifier{
-						DomainID:   testDomainID,
-						WorkflowID: testWorkflowID,
-					},
-					TaskData: TaskData{
-						TaskID:              1,
-						VisibilityTimestamp: now,
-					},
-				},
-			},
-			NextPageToken: []byte("test-token"),
-		}, nil)
-
-	res, err := manager.GetReplicationTasksFromDLQ(context.Background(), request)
-	assert.NoError(t, err)
-	assert.Equal(t, &GetHistoryTasksResponse{
-		Tasks: []Task{
-			&HistoryReplicationTask{
-				WorkflowIdentifier: WorkflowIdentifier{
+	expected := &GetReplicationDLQTasksResponse{
+		Tasks: []*ReplicationDLQTask{
+			{
+				Info: &ReplicationTaskInfo{
 					DomainID:   testDomainID,
 					WorkflowID: testWorkflowID,
-				},
-				TaskData: TaskData{
-					TaskID:              1,
-					VisibilityTimestamp: now,
+					TaskID:     1,
+					TaskType:   ReplicationTaskTypeHistory,
 				},
 			},
 		},
 		NextPageToken: []byte("test-token"),
-	}, res)
+	}
+
+	mockedStore.EXPECT().GetReplicationTasksFromDLQ(gomock.Any(), request).Return(expected, nil)
+
+	res, err := manager.GetReplicationTasksFromDLQ(context.Background(), request)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, res)
 }
 
 func TestDeserializeChildExecutionInfos(t *testing.T) {

--- a/common/persistence/execution_manager_test.go
+++ b/common/persistence/execution_manager_test.go
@@ -633,6 +633,45 @@ func TestGetReplicationTasksFromDLQ(t *testing.T) {
 	assert.Equal(t, expected, res)
 }
 
+func TestGetReplicationTasksFromDLQ_WithBlob(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockedStore := NewMockExecutionStore(ctrl)
+	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), nil, &DynamicConfiguration{
+		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
+	})
+
+	request := &GetReplicationTasksFromDLQRequest{
+		SourceClusterName: "test-cluster",
+		ReadLevel:         1,
+		MaxReadLevel:      2,
+		BatchSize:         10,
+		NextPageToken:     nil,
+	}
+
+	blob := &DataBlob{Data: []byte("serialized-task"), Encoding: constants.EncodingTypeThriftRW}
+	expected := &GetReplicationDLQTasksResponse{
+		Tasks: []*ReplicationDLQTask{
+			{
+				Info: &ReplicationTaskInfo{
+					DomainID:   testDomainID,
+					WorkflowID: testWorkflowID,
+					TaskID:     1,
+					TaskType:   ReplicationTaskTypeHistory,
+				},
+				Task: blob,
+			},
+		},
+		NextPageToken: []byte("test-token"),
+	}
+
+	mockedStore.EXPECT().GetReplicationTasksFromDLQ(gomock.Any(), request).Return(expected, nil)
+
+	res, err := manager.GetReplicationTasksFromDLQ(context.Background(), request)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, res)
+	assert.Equal(t, blob, res.Tasks[0].Task)
+}
+
 func TestDeserializeChildExecutionInfos(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/common/persistence/execution_manager_test.go
+++ b/common/persistence/execution_manager_test.go
@@ -567,7 +567,7 @@ func TestDeserializeBufferedEvents(t *testing.T) {
 func TestPutReplicationTaskToDLQ(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockedStore := NewMockExecutionStore(ctrl)
-	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), nil, &DynamicConfiguration{
+	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), NewPayloadSerializer(), &DynamicConfiguration{
 		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
 	})
 
@@ -581,6 +581,7 @@ func TestPutReplicationTaskToDLQ(t *testing.T) {
 			CreationTime: now.UnixNano(),
 		},
 		DomainName: testDomain,
+		Task:       &types.ReplicationTask{},
 	}
 
 	mockedStore.EXPECT().PutReplicationTaskToDLQ(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req *InternalPutReplicationTaskToDLQRequest) error {

--- a/common/persistence/execution_manager_test.go
+++ b/common/persistence/execution_manager_test.go
@@ -24,6 +24,7 @@ package persistence
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -601,7 +602,7 @@ func TestPutReplicationTaskToDLQ(t *testing.T) {
 func TestGetReplicationTasksFromDLQ(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockedStore := NewMockExecutionStore(ctrl)
-	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), nil, &DynamicConfiguration{
+	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), NewPayloadSerializer(), &DynamicConfiguration{
 		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
 	})
 
@@ -613,8 +614,8 @@ func TestGetReplicationTasksFromDLQ(t *testing.T) {
 		NextPageToken:     nil,
 	}
 
-	expected := &GetReplicationDLQTasksResponse{
-		Tasks: []*ReplicationDLQTask{
+	storeResp := &InternalGetReplicationDLQTasksResponse{
+		Tasks: []*InternalReplicationDLQTask{
 			{
 				Info: &ReplicationTaskInfo{
 					DomainID:   testDomainID,
@@ -628,18 +629,21 @@ func TestGetReplicationTasksFromDLQ(t *testing.T) {
 		NextPageToken: []byte("test-token"),
 	}
 
-	mockedStore.EXPECT().GetReplicationTasksFromDLQ(gomock.Any(), request).Return(expected, nil)
+	mockedStore.EXPECT().GetReplicationTasksFromDLQ(gomock.Any(), request).Return(storeResp, nil)
 
 	res, err := manager.GetReplicationTasksFromDLQ(context.Background(), request)
 	assert.NoError(t, err)
-	assert.Equal(t, expected, res)
+	assert.Len(t, res.Tasks, 1)
+	assert.Equal(t, storeResp.Tasks[0].Info, res.Tasks[0].Info)
 	assert.Nil(t, res.Tasks[0].Task)
+	assert.Equal(t, storeResp.NextPageToken, res.NextPageToken)
 }
 
 func TestGetReplicationTasksFromDLQ_WithBlob(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockedStore := NewMockExecutionStore(ctrl)
-	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), nil, &DynamicConfiguration{
+	mockedSerializer := NewMockPayloadSerializer(ctrl)
+	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
 		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
 	})
 
@@ -652,8 +656,12 @@ func TestGetReplicationTasksFromDLQ_WithBlob(t *testing.T) {
 	}
 
 	blob := &DataBlob{Data: []byte("serialized-task"), Encoding: constants.EncodingTypeThriftRW}
-	expected := &GetReplicationDLQTasksResponse{
-		Tasks: []*ReplicationDLQTask{
+	hydrated := &types.ReplicationTask{
+		TaskType:     types.ReplicationTaskTypeHistory.Ptr(),
+		SourceTaskID: 1,
+	}
+	storeResp := &InternalGetReplicationDLQTasksResponse{
+		Tasks: []*InternalReplicationDLQTask{
 			{
 				Info: &ReplicationTaskInfo{
 					DomainID:   testDomainID,
@@ -667,12 +675,58 @@ func TestGetReplicationTasksFromDLQ_WithBlob(t *testing.T) {
 		NextPageToken: []byte("test-token"),
 	}
 
-	mockedStore.EXPECT().GetReplicationTasksFromDLQ(gomock.Any(), request).Return(expected, nil)
+	mockedStore.EXPECT().GetReplicationTasksFromDLQ(gomock.Any(), request).Return(storeResp, nil)
+	mockedSerializer.EXPECT().DeserializeReplicationDLQTask(blob).Return(hydrated, nil)
 
 	res, err := manager.GetReplicationTasksFromDLQ(context.Background(), request)
 	assert.NoError(t, err)
-	assert.Equal(t, expected, res)
-	assert.Equal(t, blob, res.Tasks[0].Task)
+	assert.Len(t, res.Tasks, 1)
+	assert.Equal(t, storeResp.Tasks[0].Info, res.Tasks[0].Info)
+	assert.Equal(t, hydrated, res.Tasks[0].Task)
+	assert.Equal(t, storeResp.NextPageToken, res.NextPageToken)
+}
+
+func TestGetReplicationTasksFromDLQ_CorruptBlob(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockedStore := NewMockExecutionStore(ctrl)
+	mockedSerializer := NewMockPayloadSerializer(ctrl)
+	manager := NewExecutionManagerImpl(mockedStore, testlogger.New(t), mockedSerializer, &DynamicConfiguration{
+		SerializationEncoding: dynamicproperties.GetStringPropertyFn(string(constants.EncodingTypeThriftRW)),
+	})
+
+	request := &GetReplicationTasksFromDLQRequest{
+		SourceClusterName: "test-cluster",
+		ReadLevel:         1,
+		MaxReadLevel:      2,
+		BatchSize:         10,
+		NextPageToken:     nil,
+	}
+
+	blob := &DataBlob{Data: []byte("corrupt"), Encoding: constants.EncodingTypeThriftRW}
+	storeResp := &InternalGetReplicationDLQTasksResponse{
+		Tasks: []*InternalReplicationDLQTask{
+			{
+				Info: &ReplicationTaskInfo{
+					DomainID:   testDomainID,
+					WorkflowID: testWorkflowID,
+					TaskID:     1,
+					TaskType:   ReplicationTaskTypeHistory,
+				},
+				Task: blob,
+			},
+		},
+		NextPageToken: []byte("test-token"),
+	}
+
+	mockedStore.EXPECT().GetReplicationTasksFromDLQ(gomock.Any(), request).Return(storeResp, nil)
+	mockedSerializer.EXPECT().DeserializeReplicationDLQTask(blob).Return(nil, errors.New("deser failed"))
+
+	res, err := manager.GetReplicationTasksFromDLQ(context.Background(), request)
+	assert.NoError(t, err)
+	assert.Len(t, res.Tasks, 1)
+	assert.Equal(t, storeResp.Tasks[0].Info, res.Tasks[0].Info)
+	assert.Nil(t, res.Tasks[0].Task)
+	assert.Equal(t, storeResp.NextPageToken, res.NextPageToken)
 }
 
 func TestDeserializeChildExecutionInfos(t *testing.T) {

--- a/common/persistence/nosql/nosql_execution_store.go
+++ b/common/persistence/nosql/nosql_execution_store.go
@@ -624,7 +624,7 @@ func (d *nosqlExecutionStore) PutReplicationTaskToDLQ(
 ) error {
 	err := d.db.InsertReplicationDLQTask(ctx, d.shardID, request.SourceClusterName, &nosqlplugin.HistoryMigrationTask{
 		Replication: request.TaskInfo,
-		Task:        nil, // TODO: encode task infor into datablob
+		Task:        request.Task,
 	})
 	if err != nil {
 		return convertCommonErrors(d.db, "PutReplicationTaskToDLQ", err)
@@ -636,7 +636,7 @@ func (d *nosqlExecutionStore) PutReplicationTaskToDLQ(
 func (d *nosqlExecutionStore) GetReplicationTasksFromDLQ(
 	ctx context.Context,
 	request *persistence.GetReplicationTasksFromDLQRequest,
-) (*persistence.GetHistoryTasksResponse, error) {
+) (*persistence.GetReplicationDLQTasksResponse, error) {
 	if request.ReadLevel > request.MaxReadLevel {
 		return nil, &types.BadRequestError{Message: "ReadLevel cannot be higher than MaxReadLevel"}
 	}
@@ -644,16 +644,29 @@ func (d *nosqlExecutionStore) GetReplicationTasksFromDLQ(
 	if err != nil {
 		return nil, convertCommonErrors(d.db, "GetReplicationTasksFromDLQ", err)
 	}
-	var tTasks []persistence.Task
+	var dlqTasks []*persistence.ReplicationDLQTask
 	for _, t := range tasks {
-		task, err := t.Replication.ToTask()
-		if err != nil {
-			return nil, convertCommonErrors(d.db, "GetReplicationTasksFromDLQ", err)
-		}
-		tTasks = append(tTasks, task)
+		r := t.Replication
+		dlqTasks = append(dlqTasks, &persistence.ReplicationDLQTask{
+			Info: &persistence.ReplicationTaskInfo{
+				DomainID:          r.DomainID,
+				WorkflowID:        r.WorkflowID,
+				RunID:             r.RunID,
+				TaskID:            r.TaskID,
+				TaskType:          r.TaskType,
+				FirstEventID:      r.FirstEventID,
+				NextEventID:       r.NextEventID,
+				Version:           r.Version,
+				ScheduledID:       r.ScheduledID,
+				BranchToken:       r.BranchToken,
+				NewRunBranchToken: r.NewRunBranchToken,
+				CreationTime:      r.CreationTime.UnixNano(),
+			},
+			Task: t.Task,
+		})
 	}
-	return &persistence.GetHistoryTasksResponse{
-		Tasks:         tTasks,
+	return &persistence.GetReplicationDLQTasksResponse{
+		Tasks:         dlqTasks,
 		NextPageToken: nextPageToken,
 	}, nil
 }

--- a/common/persistence/nosql/nosql_execution_store.go
+++ b/common/persistence/nosql/nosql_execution_store.go
@@ -636,7 +636,7 @@ func (d *nosqlExecutionStore) PutReplicationTaskToDLQ(
 func (d *nosqlExecutionStore) GetReplicationTasksFromDLQ(
 	ctx context.Context,
 	request *persistence.GetReplicationTasksFromDLQRequest,
-) (*persistence.GetReplicationDLQTasksResponse, error) {
+) (*persistence.InternalGetReplicationDLQTasksResponse, error) {
 	if request.ReadLevel > request.MaxReadLevel {
 		return nil, &types.BadRequestError{Message: "ReadLevel cannot be higher than MaxReadLevel"}
 	}
@@ -644,10 +644,10 @@ func (d *nosqlExecutionStore) GetReplicationTasksFromDLQ(
 	if err != nil {
 		return nil, convertCommonErrors(d.db, "GetReplicationTasksFromDLQ", err)
 	}
-	var dlqTasks []*persistence.ReplicationDLQTask
+	var dlqTasks []*persistence.InternalReplicationDLQTask
 	for _, t := range tasks {
 		r := t.Replication
-		dlqTasks = append(dlqTasks, &persistence.ReplicationDLQTask{
+		dlqTasks = append(dlqTasks, &persistence.InternalReplicationDLQTask{
 			Info: &persistence.ReplicationTaskInfo{
 				DomainID:          r.DomainID,
 				WorkflowID:        r.WorkflowID,
@@ -665,7 +665,7 @@ func (d *nosqlExecutionStore) GetReplicationTasksFromDLQ(
 			Task: t.Task,
 		})
 	}
-	return &persistence.GetReplicationDLQTasksResponse{
+	return &persistence.InternalGetReplicationDLQTasksResponse{
 		Tasks:         dlqTasks,
 		NextPageToken: nextPageToken,
 	}, nil

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -1542,7 +1542,7 @@ func (s *TestBase) GetReplicationTasksFromDLQ(
 	maxReadLevel int64,
 	pageSize int,
 	pageToken []byte,
-) (*persistence.GetHistoryTasksResponse, error) {
+) (*persistence.GetReplicationDLQTasksResponse, error) {
 
 	return s.ExecutionManager.GetReplicationTasksFromDLQ(ctx, &persistence.GetReplicationTasksFromDLQRequest{
 		SourceClusterName: sourceCluster,

--- a/common/persistence/serializer.go
+++ b/common/persistence/serializer.go
@@ -98,6 +98,10 @@ type (
 		// serialize/deserialize active cluster selection policy
 		SerializeActiveClusterSelectionPolicy(policy *types.ActiveClusterSelectionPolicy, encodingType constants.EncodingType) (*DataBlob, error)
 		DeserializeActiveClusterSelectionPolicy(data *DataBlob) (*types.ActiveClusterSelectionPolicy, error)
+
+		// serialize/deserialize replication task
+		SerializeReplicationTask(task *types.ReplicationTask, encodingType constants.EncodingType) (*DataBlob, error)
+		DeserializeReplicationTask(data *DataBlob) (*types.ReplicationTask, error)
 	}
 
 	// CadenceSerializationError is an error type for cadence serialization
@@ -376,6 +380,22 @@ func (t *serializerImpl) DeserializeActiveClusterSelectionPolicy(data *DataBlob)
 	return &policy, err
 }
 
+func (t *serializerImpl) SerializeReplicationTask(task *types.ReplicationTask, encodingType constants.EncodingType) (*DataBlob, error) {
+	if task == nil {
+		return nil, nil
+	}
+	return t.serialize(task, encodingType)
+}
+
+func (t *serializerImpl) DeserializeReplicationTask(data *DataBlob) (*types.ReplicationTask, error) {
+	if data == nil {
+		return nil, nil
+	}
+	var task types.ReplicationTask
+	err := t.deserialize(data, &task)
+	return &task, err
+}
+
 func (t *serializerImpl) serialize(input interface{}, encodingType constants.EncodingType) (*DataBlob, error) {
 	if input == nil {
 		return nil, nil
@@ -431,6 +451,8 @@ func (t *serializerImpl) thriftrwEncode(input interface{}) ([]byte, error) {
 		return t.thriftrwEncoder.Encode(thrift.FromActiveClusters(input))
 	case *types.ActiveClusterSelectionPolicy:
 		return t.thriftrwEncoder.Encode(thrift.FromActiveClusterSelectionPolicy(input))
+	case *types.ReplicationTask:
+		return t.thriftrwEncoder.Encode(thrift.FromReplicationTask(input))
 	default:
 		return nil, nil
 	}
@@ -554,6 +576,13 @@ func (t *serializerImpl) thriftrwDecode(data []byte, target interface{}) error {
 			return err
 		}
 		*target = *thrift.ToActiveClusterSelectionPolicy(&thriftTarget)
+		return nil
+	case *types.ReplicationTask:
+		thriftTarget := replicator.ReplicationTask{}
+		if err := t.thriftrwEncoder.Decode(data, &thriftTarget); err != nil {
+			return err
+		}
+		*target = *thrift.ToReplicationTask(&thriftTarget)
 		return nil
 	default:
 		return nil

--- a/common/persistence/serializer.go
+++ b/common/persistence/serializer.go
@@ -99,9 +99,9 @@ type (
 		SerializeActiveClusterSelectionPolicy(policy *types.ActiveClusterSelectionPolicy, encodingType constants.EncodingType) (*DataBlob, error)
 		DeserializeActiveClusterSelectionPolicy(data *DataBlob) (*types.ActiveClusterSelectionPolicy, error)
 
-		// serialize/deserialize replication task
-		SerializeReplicationTask(task *types.ReplicationTask, encodingType constants.EncodingType) (*DataBlob, error)
-		DeserializeReplicationTask(data *DataBlob) (*types.ReplicationTask, error)
+		// serialize/deserialize full replication task payload for DLQ storage
+		SerializeReplicationDLQTask(task *types.ReplicationTask, encodingType constants.EncodingType) (*DataBlob, error)
+		DeserializeReplicationDLQTask(data *DataBlob) (*types.ReplicationTask, error)
 	}
 
 	// CadenceSerializationError is an error type for cadence serialization
@@ -380,14 +380,14 @@ func (t *serializerImpl) DeserializeActiveClusterSelectionPolicy(data *DataBlob)
 	return &policy, err
 }
 
-func (t *serializerImpl) SerializeReplicationTask(task *types.ReplicationTask, encodingType constants.EncodingType) (*DataBlob, error) {
+func (t *serializerImpl) SerializeReplicationDLQTask(task *types.ReplicationTask, encodingType constants.EncodingType) (*DataBlob, error) {
 	if task == nil {
 		return nil, nil
 	}
 	return t.serialize(task, encodingType)
 }
 
-func (t *serializerImpl) DeserializeReplicationTask(data *DataBlob) (*types.ReplicationTask, error) {
+func (t *serializerImpl) DeserializeReplicationDLQTask(data *DataBlob) (*types.ReplicationTask, error) {
 	if data == nil {
 		return nil, nil
 	}

--- a/common/persistence/serializer_mock.go
+++ b/common/persistence/serializer_mock.go
@@ -208,6 +208,21 @@ func (mr *MockPayloadSerializerMockRecorder) DeserializeProcessingQueueStates(da
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeserializeProcessingQueueStates", reflect.TypeOf((*MockPayloadSerializer)(nil).DeserializeProcessingQueueStates), data)
 }
 
+// DeserializeReplicationTask mocks base method.
+func (m *MockPayloadSerializer) DeserializeReplicationTask(data *DataBlob) (*types.ReplicationTask, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeserializeReplicationTask", data)
+	ret0, _ := ret[0].(*types.ReplicationTask)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeserializeReplicationTask indicates an expected call of DeserializeReplicationTask.
+func (mr *MockPayloadSerializerMockRecorder) DeserializeReplicationTask(data any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeserializeReplicationTask", reflect.TypeOf((*MockPayloadSerializer)(nil).DeserializeReplicationTask), data)
+}
+
 // DeserializeResetPoints mocks base method.
 func (m *MockPayloadSerializer) DeserializeResetPoints(data *DataBlob) (*types.ResetPoints, error) {
 	m.ctrl.T.Helper()
@@ -416,6 +431,21 @@ func (m *MockPayloadSerializer) SerializeProcessingQueueStates(states *types.Pro
 func (mr *MockPayloadSerializerMockRecorder) SerializeProcessingQueueStates(states, encodingType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SerializeProcessingQueueStates", reflect.TypeOf((*MockPayloadSerializer)(nil).SerializeProcessingQueueStates), states, encodingType)
+}
+
+// SerializeReplicationTask mocks base method.
+func (m *MockPayloadSerializer) SerializeReplicationTask(task *types.ReplicationTask, encodingType constants.EncodingType) (*DataBlob, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SerializeReplicationTask", task, encodingType)
+	ret0, _ := ret[0].(*DataBlob)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SerializeReplicationTask indicates an expected call of SerializeReplicationTask.
+func (mr *MockPayloadSerializerMockRecorder) SerializeReplicationTask(task, encodingType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SerializeReplicationTask", reflect.TypeOf((*MockPayloadSerializer)(nil).SerializeReplicationTask), task, encodingType)
 }
 
 // SerializeResetPoints mocks base method.

--- a/common/persistence/serializer_mock.go
+++ b/common/persistence/serializer_mock.go
@@ -208,19 +208,19 @@ func (mr *MockPayloadSerializerMockRecorder) DeserializeProcessingQueueStates(da
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeserializeProcessingQueueStates", reflect.TypeOf((*MockPayloadSerializer)(nil).DeserializeProcessingQueueStates), data)
 }
 
-// DeserializeReplicationTask mocks base method.
-func (m *MockPayloadSerializer) DeserializeReplicationTask(data *DataBlob) (*types.ReplicationTask, error) {
+// DeserializeReplicationDLQTask mocks base method.
+func (m *MockPayloadSerializer) DeserializeReplicationDLQTask(data *DataBlob) (*types.ReplicationTask, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeserializeReplicationTask", data)
+	ret := m.ctrl.Call(m, "DeserializeReplicationDLQTask", data)
 	ret0, _ := ret[0].(*types.ReplicationTask)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DeserializeReplicationTask indicates an expected call of DeserializeReplicationTask.
-func (mr *MockPayloadSerializerMockRecorder) DeserializeReplicationTask(data any) *gomock.Call {
+// DeserializeReplicationDLQTask indicates an expected call of DeserializeReplicationDLQTask.
+func (mr *MockPayloadSerializerMockRecorder) DeserializeReplicationDLQTask(data any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeserializeReplicationTask", reflect.TypeOf((*MockPayloadSerializer)(nil).DeserializeReplicationTask), data)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeserializeReplicationDLQTask", reflect.TypeOf((*MockPayloadSerializer)(nil).DeserializeReplicationDLQTask), data)
 }
 
 // DeserializeResetPoints mocks base method.
@@ -433,19 +433,19 @@ func (mr *MockPayloadSerializerMockRecorder) SerializeProcessingQueueStates(stat
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SerializeProcessingQueueStates", reflect.TypeOf((*MockPayloadSerializer)(nil).SerializeProcessingQueueStates), states, encodingType)
 }
 
-// SerializeReplicationTask mocks base method.
-func (m *MockPayloadSerializer) SerializeReplicationTask(task *types.ReplicationTask, encodingType constants.EncodingType) (*DataBlob, error) {
+// SerializeReplicationDLQTask mocks base method.
+func (m *MockPayloadSerializer) SerializeReplicationDLQTask(task *types.ReplicationTask, encodingType constants.EncodingType) (*DataBlob, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SerializeReplicationTask", task, encodingType)
+	ret := m.ctrl.Call(m, "SerializeReplicationDLQTask", task, encodingType)
 	ret0, _ := ret[0].(*DataBlob)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// SerializeReplicationTask indicates an expected call of SerializeReplicationTask.
-func (mr *MockPayloadSerializerMockRecorder) SerializeReplicationTask(task, encodingType any) *gomock.Call {
+// SerializeReplicationDLQTask indicates an expected call of SerializeReplicationDLQTask.
+func (mr *MockPayloadSerializerMockRecorder) SerializeReplicationDLQTask(task, encodingType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SerializeReplicationTask", reflect.TypeOf((*MockPayloadSerializer)(nil).SerializeReplicationTask), task, encodingType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SerializeReplicationDLQTask", reflect.TypeOf((*MockPayloadSerializer)(nil).SerializeReplicationDLQTask), task, encodingType)
 }
 
 // SerializeResetPoints mocks base method.

--- a/common/persistence/serializer_test.go
+++ b/common/persistence/serializer_test.go
@@ -251,16 +251,16 @@ func TestSerializers(t *testing.T) {
 			},
 		},
 		{
-			name: "replication task",
+			name: "replication DLQ task",
 			payloads: map[string]any{
 				"nil":    (*types.ReplicationTask)(nil),
 				"normal": generateReplicationTask(),
 			},
 			serializeFn: func(payload any, encoding constants.EncodingType) (*DataBlob, error) {
-				return serializer.SerializeReplicationTask(payload.(*types.ReplicationTask), encoding)
+				return serializer.SerializeReplicationDLQTask(payload.(*types.ReplicationTask), encoding)
 			},
 			deserializeFn: func(data *DataBlob) (any, error) {
-				return serializer.DeserializeReplicationTask(data)
+				return serializer.DeserializeReplicationDLQTask(data)
 			},
 		},
 	}

--- a/common/persistence/serializer_test.go
+++ b/common/persistence/serializer_test.go
@@ -250,6 +250,19 @@ func TestSerializers(t *testing.T) {
 				return serializer.DeserializeActiveClusterSelectionPolicy(data)
 			},
 		},
+		{
+			name: "replication task",
+			payloads: map[string]any{
+				"nil":    (*types.ReplicationTask)(nil),
+				"normal": generateReplicationTask(),
+			},
+			serializeFn: func(payload any, encoding constants.EncodingType) (*DataBlob, error) {
+				return serializer.SerializeReplicationTask(payload.(*types.ReplicationTask), encoding)
+			},
+			deserializeFn: func(data *DataBlob) (any, error) {
+				return serializer.DeserializeReplicationTask(data)
+			},
+		},
 	}
 
 	// generate runnable test cases here so actual test body is not 3 level nested
@@ -543,5 +556,24 @@ func generateActiveClusterSelectionPolicy() *types.ActiveClusterSelectionPolicy 
 		StickyRegion:                   "region1",
 		ExternalEntityType:             "externalEntityType1",
 		ExternalEntityKey:              "externalEntityKey1",
+	}
+}
+
+func generateReplicationTask() *types.ReplicationTask {
+	return &types.ReplicationTask{
+		TaskType:     types.ReplicationTaskTypeHistoryV2.Ptr(),
+		SourceTaskID: 42,
+		HistoryTaskV2Attributes: &types.HistoryTaskV2Attributes{
+			DomainID:   "test-domain-id",
+			WorkflowID: "test-workflow-id",
+			RunID:      "test-run-id",
+			VersionHistoryItems: []*types.VersionHistoryItem{
+				{EventID: 10, Version: 1},
+			},
+			Events: &types.DataBlob{
+				EncodingType: types.EncodingTypeThriftRW.Ptr(),
+				Data:         []byte("test-events-data"),
+			},
+		},
 	}
 }

--- a/common/persistence/sql/sql_execution_store.go
+++ b/common/persistence/sql/sql_execution_store.go
@@ -1058,6 +1058,9 @@ func (m *sqlExecutionStore) PutReplicationTaskToDLQ(
 		return err
 	}
 
+	// TODO: The SQL schema does not yet have a column for the full replication task blob.
+	// request.Task is intentionally not persisted here. A schema migration is needed to
+	// support skipping the cross-cluster GetDLQReplicationMessages RPC for SQL backends.
 	row := &sqlplugin.ReplicationTaskDLQRow{
 		SourceClusterName: request.SourceClusterName,
 		ShardID:           m.shardID,

--- a/common/persistence/sql/sql_execution_store.go
+++ b/common/persistence/sql/sql_execution_store.go
@@ -852,7 +852,7 @@ func getReadLevels(request *p.GetReplicationTasksFromDLQRequest) (readLevel int6
 func (m *sqlExecutionStore) GetReplicationTasksFromDLQ(
 	ctx context.Context,
 	request *p.GetReplicationTasksFromDLQRequest,
-) (*p.GetHistoryTasksResponse, error) {
+) (*p.GetReplicationDLQTasksResponse, error) {
 
 	readLevel, maxReadLevel, err := getReadLevels(request)
 	if err != nil {
@@ -874,16 +874,31 @@ func (m *sqlExecutionStore) GetReplicationTasksFromDLQ(
 			return nil, convertCommonErrors(m.db, "GetReplicationTasksFromDLQ", "", err)
 		}
 	}
-	var tasks []p.Task
+	var dlqTasks []*p.ReplicationDLQTask
 	for _, row := range rows {
-		task, err := m.taskSerializer.DeserializeTask(p.HistoryTaskCategoryReplication, p.NewDataBlob(row.Data, constants.EncodingType(row.DataEncoding)))
+		info, err := m.parser.ReplicationTaskInfoFromBlob(row.Data, row.DataEncoding)
 		if err != nil {
 			return nil, convertCommonErrors(m.db, "GetReplicationTasksFromDLQ", "", err)
 		}
-		task.SetTaskID(row.TaskID)
-		tasks = append(tasks, task)
+		dlqTasks = append(dlqTasks, &p.ReplicationDLQTask{
+			Info: &p.ReplicationTaskInfo{
+				DomainID:          info.DomainID.String(),
+				WorkflowID:        info.GetWorkflowID(),
+				RunID:             info.RunID.String(),
+				TaskID:            row.TaskID,
+				TaskType:          int(info.GetTaskType()),
+				FirstEventID:      info.GetFirstEventID(),
+				NextEventID:       info.GetNextEventID(),
+				Version:           info.GetVersion(),
+				ScheduledID:       info.GetScheduledID(),
+				BranchToken:       info.BranchToken,
+				NewRunBranchToken: info.NewRunBranchToken,
+				CreationTime:      info.GetCreationTimestamp().UnixNano(),
+			},
+			// SQL has no separate column for the full task blob; Task is nil here.
+		})
 	}
-	resp := &p.GetHistoryTasksResponse{Tasks: tasks}
+	resp := &p.GetReplicationDLQTasksResponse{Tasks: dlqTasks}
 	if len(rows) > 0 {
 		nextTaskID := rows[len(rows)-1].TaskID + 1
 		if nextTaskID < maxReadLevel {

--- a/common/persistence/sql/sql_execution_store.go
+++ b/common/persistence/sql/sql_execution_store.go
@@ -852,7 +852,7 @@ func getReadLevels(request *p.GetReplicationTasksFromDLQRequest) (readLevel int6
 func (m *sqlExecutionStore) GetReplicationTasksFromDLQ(
 	ctx context.Context,
 	request *p.GetReplicationTasksFromDLQRequest,
-) (*p.GetReplicationDLQTasksResponse, error) {
+) (*p.InternalGetReplicationDLQTasksResponse, error) {
 
 	readLevel, maxReadLevel, err := getReadLevels(request)
 	if err != nil {
@@ -874,13 +874,13 @@ func (m *sqlExecutionStore) GetReplicationTasksFromDLQ(
 			return nil, convertCommonErrors(m.db, "GetReplicationTasksFromDLQ", "", err)
 		}
 	}
-	var dlqTasks []*p.ReplicationDLQTask
+	var dlqTasks []*p.InternalReplicationDLQTask
 	for _, row := range rows {
 		info, err := m.parser.ReplicationTaskInfoFromBlob(row.Data, row.DataEncoding)
 		if err != nil {
 			return nil, convertCommonErrors(m.db, "GetReplicationTasksFromDLQ", "", err)
 		}
-		dlqTasks = append(dlqTasks, &p.ReplicationDLQTask{
+		dlqTasks = append(dlqTasks, &p.InternalReplicationDLQTask{
 			Info: &p.ReplicationTaskInfo{
 				DomainID:          info.DomainID.String(),
 				WorkflowID:        info.GetWorkflowID(),
@@ -898,7 +898,7 @@ func (m *sqlExecutionStore) GetReplicationTasksFromDLQ(
 			// SQL has no separate column for the full task blob; Task is nil here.
 		})
 	}
-	resp := &p.GetReplicationDLQTasksResponse{Tasks: dlqTasks}
+	resp := &p.InternalGetReplicationDLQTasksResponse{Tasks: dlqTasks}
 	if len(rows) > 0 {
 		nextTaskID := rows[len(rows)-1].TaskID + 1
 		if nextTaskID < maxReadLevel {

--- a/common/persistence/sql/sql_execution_store_test.go
+++ b/common/persistence/sql/sql_execution_store_test.go
@@ -252,6 +252,8 @@ func TestGetReplicationTasksFromDLQ(t *testing.T) {
 							NewRunBranchToken: []byte(`nbt`),
 							CreationTime:      time.Time{}.UnixNano(),
 						},
+						// SQL has no column for the full task blob; Task is always nil for SQL backends.
+						Task: nil,
 					},
 				},
 				NextPageToken: serializePageToken(101),

--- a/common/persistence/sql/sql_execution_store_test.go
+++ b/common/persistence/sql/sql_execution_store_test.go
@@ -193,8 +193,8 @@ func TestGetReplicationTasksFromDLQ(t *testing.T) {
 	testCases := []struct {
 		name      string
 		req       *persistence.GetReplicationTasksFromDLQRequest
-		mockSetup func(*sqlplugin.MockDB, *serialization.MockTaskSerializer)
-		want      *persistence.GetHistoryTasksResponse
+		mockSetup func(*sqlplugin.MockDB, *serialization.MockParser)
+		want      *persistence.GetReplicationDLQTasksResponse
 		wantErr   bool
 	}{
 		{
@@ -205,7 +205,7 @@ func TestGetReplicationTasksFromDLQ(t *testing.T) {
 				MaxReadLevel:      199,
 				BatchSize:         1000,
 			},
-			mockSetup: func(mockDB *sqlplugin.MockDB, mockParser *serialization.MockTaskSerializer) {
+			mockSetup: func(mockDB *sqlplugin.MockDB, mockParser *serialization.MockParser) {
 				mockDB.EXPECT().SelectFromReplicationTasksDLQ(gomock.Any(), &sqlplugin.ReplicationTasksDLQFilter{
 					ReplicationTasksFilter: sqlplugin.ReplicationTasksFilter{
 						ShardID:            shardID,
@@ -219,42 +219,39 @@ func TestGetReplicationTasksFromDLQ(t *testing.T) {
 						ShardID:      shardID,
 						TaskID:       100,
 						Data:         []byte(`replication`),
-						DataEncoding: "replication",
+						DataEncoding: "thriftrw",
 					},
 				}, nil)
-				mockParser.EXPECT().DeserializeTask(persistence.HistoryTaskCategoryReplication, persistence.NewDataBlob([]byte(`replication`), "replication")).Return(&persistence.HistoryReplicationTask{
-					WorkflowIdentifier: persistence.WorkflowIdentifier{
-						DomainID:   "abdcea69-61d5-44c3-9d55-afe23505a542",
-						WorkflowID: "test",
-						RunID:      "abdcea69-61d5-44c3-9d55-afe23505a54a",
-					},
-					TaskData: persistence.TaskData{
-						Version:             202,
-						VisibilityTimestamp: time.Unix(1, 1),
-					},
+				domainID := serialization.MustParseUUID("abdcea69-61d5-44c3-9d55-afe23505a542")
+				runID := serialization.MustParseUUID("abdcea69-61d5-44c3-9d55-afe23505a54a")
+				mockParser.EXPECT().ReplicationTaskInfoFromBlob([]byte(`replication`), "thriftrw").Return(&serialization.ReplicationTaskInfo{
+					DomainID:          domainID,
+					WorkflowID:        "test",
+					RunID:             runID,
+					TaskType:          persistence.ReplicationTaskTypeHistory,
+					Version:           202,
 					FirstEventID:      10,
 					NextEventID:       101,
 					BranchToken:       []byte(`bt`),
 					NewRunBranchToken: []byte(`nbt`),
 				}, nil)
 			},
-			want: &persistence.GetHistoryTasksResponse{
-				Tasks: []persistence.Task{
-					&persistence.HistoryReplicationTask{
-						WorkflowIdentifier: persistence.WorkflowIdentifier{
-							DomainID:   "abdcea69-61d5-44c3-9d55-afe23505a542",
-							WorkflowID: "test",
-							RunID:      "abdcea69-61d5-44c3-9d55-afe23505a54a",
+			want: &persistence.GetReplicationDLQTasksResponse{
+				Tasks: []*persistence.ReplicationDLQTask{
+					{
+						Info: &persistence.ReplicationTaskInfo{
+							DomainID:          "abdcea69-61d5-44c3-9d55-afe23505a542",
+							WorkflowID:        "test",
+							RunID:             "abdcea69-61d5-44c3-9d55-afe23505a54a",
+							TaskID:            100,
+							TaskType:          persistence.ReplicationTaskTypeHistory,
+							Version:           202,
+							FirstEventID:      10,
+							NextEventID:       101,
+							BranchToken:       []byte(`bt`),
+							NewRunBranchToken: []byte(`nbt`),
+							CreationTime:      time.Time{}.UnixNano(),
 						},
-						TaskData: persistence.TaskData{
-							TaskID:              100,
-							Version:             202,
-							VisibilityTimestamp: time.Unix(1, 1),
-						},
-						FirstEventID:      10,
-						NextEventID:       101,
-						BranchToken:       []byte(`bt`),
-						NewRunBranchToken: []byte(`nbt`),
 					},
 				},
 				NextPageToken: serializePageToken(101),
@@ -269,7 +266,7 @@ func TestGetReplicationTasksFromDLQ(t *testing.T) {
 				MaxReadLevel:      199,
 				BatchSize:         1000,
 			},
-			mockSetup: func(mockDB *sqlplugin.MockDB, mockParser *serialization.MockTaskSerializer) {
+			mockSetup: func(mockDB *sqlplugin.MockDB, mockParser *serialization.MockParser) {
 				err := errors.New("some error")
 				mockDB.EXPECT().SelectFromReplicationTasksDLQ(gomock.Any(), &sqlplugin.ReplicationTasksDLQFilter{
 					ReplicationTasksFilter: sqlplugin.ReplicationTasksFilter{
@@ -292,7 +289,7 @@ func TestGetReplicationTasksFromDLQ(t *testing.T) {
 				MaxReadLevel:      199,
 				BatchSize:         1000,
 			},
-			mockSetup: func(mockDB *sqlplugin.MockDB, mockParser *serialization.MockTaskSerializer) {
+			mockSetup: func(mockDB *sqlplugin.MockDB, mockParser *serialization.MockParser) {
 				mockDB.EXPECT().SelectFromReplicationTasksDLQ(gomock.Any(), &sqlplugin.ReplicationTasksDLQFilter{
 					ReplicationTasksFilter: sqlplugin.ReplicationTasksFilter{
 						ShardID:            shardID,
@@ -309,7 +306,7 @@ func TestGetReplicationTasksFromDLQ(t *testing.T) {
 						DataEncoding: "replication",
 					},
 				}, nil)
-				mockParser.EXPECT().DeserializeTask(persistence.HistoryTaskCategoryReplication, persistence.NewDataBlob([]byte(`replication`), "replication")).Return(nil, errors.New("some error"))
+				mockParser.EXPECT().ReplicationTaskInfoFromBlob([]byte(`replication`), "replication").Return(nil, errors.New("some error"))
 				mockDB.EXPECT().IsNotFoundError(gomock.Any()).Return(true)
 			},
 			wantErr: true,
@@ -322,8 +319,8 @@ func TestGetReplicationTasksFromDLQ(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockDB := sqlplugin.NewMockDB(ctrl)
-			mockParser := serialization.NewMockTaskSerializer(ctrl)
-			store, err := NewSQLExecutionStore(mockDB, nil, int(shardID), nil, mockParser, nil)
+			mockParser := serialization.NewMockParser(ctrl)
+			store, err := NewSQLExecutionStore(mockDB, nil, int(shardID), mockParser, nil, nil)
 			require.NoError(t, err, "failed to create execution store")
 
 			tc.mockSetup(mockDB, mockParser)

--- a/common/persistence/sql/sql_execution_store_test.go
+++ b/common/persistence/sql/sql_execution_store_test.go
@@ -194,7 +194,7 @@ func TestGetReplicationTasksFromDLQ(t *testing.T) {
 		name      string
 		req       *persistence.GetReplicationTasksFromDLQRequest
 		mockSetup func(*sqlplugin.MockDB, *serialization.MockParser)
-		want      *persistence.GetReplicationDLQTasksResponse
+		want      *persistence.InternalGetReplicationDLQTasksResponse
 		wantErr   bool
 	}{
 		{
@@ -236,8 +236,8 @@ func TestGetReplicationTasksFromDLQ(t *testing.T) {
 					NewRunBranchToken: []byte(`nbt`),
 				}, nil)
 			},
-			want: &persistence.GetReplicationDLQTasksResponse{
-				Tasks: []*persistence.ReplicationDLQTask{
+			want: &persistence.InternalGetReplicationDLQTasksResponse{
+				Tasks: []*persistence.InternalReplicationDLQTask{
 					{
 						Info: &persistence.ReplicationTaskInfo{
 							DomainID:          "abdcea69-61d5-44c3-9d55-afe23505a542",

--- a/common/persistence/wrappers/errorinjectors/execution_generated.go
+++ b/common/persistence/wrappers/errorinjectors/execution_generated.go
@@ -225,7 +225,7 @@ func (c *injectorExecutionManager) GetReplicationDLQSize(ctx context.Context, re
 	return
 }
 
-func (c *injectorExecutionManager) GetReplicationTasksFromDLQ(ctx context.Context, request *persistence.GetReplicationTasksFromDLQRequest) (gp1 *persistence.GetHistoryTasksResponse, err error) {
+func (c *injectorExecutionManager) GetReplicationTasksFromDLQ(ctx context.Context, request *persistence.GetReplicationTasksFromDLQRequest) (gp1 *persistence.GetReplicationDLQTasksResponse, err error) {
 	fakeErr := generateFakeError(c.errorRate, c.starttime)
 	var forwardCall bool
 	if forwardCall = shouldForwardCallToPersistence(fakeErr); forwardCall {

--- a/common/persistence/wrappers/errorinjectors/injectors_test.go
+++ b/common/persistence/wrappers/errorinjectors/injectors_test.go
@@ -288,7 +288,7 @@ func builderForPassThrough(t *testing.T, injector any, errorRate float64, logger
 			mocked.EXPECT().CreateFailoverMarkerTasks(gomock.Any(), gomock.Any()).Return(expectedErr)
 			mocked.EXPECT().DeleteReplicationTaskFromDLQ(gomock.Any(), gomock.Any()).Return(expectedErr)
 			mocked.EXPECT().GetReplicationDLQSize(gomock.Any(), gomock.Any()).Return(&persistence.GetReplicationDLQSizeResponse{}, expectedErr)
-			mocked.EXPECT().GetReplicationTasksFromDLQ(gomock.Any(), gomock.Any()).Return(&persistence.GetHistoryTasksResponse{}, expectedErr)
+			mocked.EXPECT().GetReplicationTasksFromDLQ(gomock.Any(), gomock.Any()).Return(&persistence.GetReplicationDLQTasksResponse{}, expectedErr)
 			mocked.EXPECT().IsWorkflowExecutionExists(gomock.Any(), gomock.Any()).Return(&persistence.IsWorkflowExecutionExistsResponse{}, expectedErr)
 			mocked.EXPECT().ListConcreteExecutions(gomock.Any(), gomock.Any()).Return(&persistence.ListConcreteExecutionsResponse{}, expectedErr)
 			mocked.EXPECT().ListCurrentExecutions(gomock.Any(), gomock.Any()).Return(&persistence.ListCurrentExecutionsResponse{}, expectedErr)

--- a/common/persistence/wrappers/metered/execution_generated.go
+++ b/common/persistence/wrappers/metered/execution_generated.go
@@ -345,7 +345,7 @@ func (c *meteredExecutionManager) GetReplicationDLQSize(ctx context.Context, req
 	return
 }
 
-func (c *meteredExecutionManager) GetReplicationTasksFromDLQ(ctx context.Context, request *persistence.GetReplicationTasksFromDLQRequest) (gp1 *persistence.GetHistoryTasksResponse, err error) {
+func (c *meteredExecutionManager) GetReplicationTasksFromDLQ(ctx context.Context, request *persistence.GetReplicationTasksFromDLQRequest) (gp1 *persistence.GetReplicationDLQTasksResponse, err error) {
 	op := func() error {
 		gp1, err = c.wrapped.GetReplicationTasksFromDLQ(ctx, request)
 		c.emptyMetric("ExecutionManager.GetReplicationTasksFromDLQ", request, gp1, err)

--- a/common/persistence/wrappers/metered/metered_test.go
+++ b/common/persistence/wrappers/metered/metered_test.go
@@ -266,7 +266,7 @@ func prepareMockForTest(t *testing.T, input interface{}, expectedErr error) {
 		mocked.EXPECT().CreateFailoverMarkerTasks(gomock.Any(), gomock.Any()).Return(expectedErr).Times(1)
 		mocked.EXPECT().DeleteReplicationTaskFromDLQ(gomock.Any(), gomock.Any()).Return(expectedErr).Times(1)
 		mocked.EXPECT().GetReplicationDLQSize(gomock.Any(), gomock.Any()).Return(&persistence.GetReplicationDLQSizeResponse{}, expectedErr).Times(1)
-		mocked.EXPECT().GetReplicationTasksFromDLQ(gomock.Any(), gomock.Any()).Return(&persistence.GetHistoryTasksResponse{}, expectedErr).Times(1)
+		mocked.EXPECT().GetReplicationTasksFromDLQ(gomock.Any(), gomock.Any()).Return(&persistence.GetReplicationDLQTasksResponse{}, expectedErr).Times(1)
 		mocked.EXPECT().IsWorkflowExecutionExists(gomock.Any(), gomock.Any()).Return(&persistence.IsWorkflowExecutionExistsResponse{}, expectedErr).Times(1)
 		mocked.EXPECT().ListConcreteExecutions(gomock.Any(), gomock.Any()).Return(&persistence.ListConcreteExecutionsResponse{}, expectedErr).Times(1)
 		mocked.EXPECT().ListCurrentExecutions(gomock.Any(), gomock.Any()).Return(&persistence.ListCurrentExecutionsResponse{}, expectedErr).Times(1)

--- a/common/persistence/wrappers/ratelimited/execution_generated.go
+++ b/common/persistence/wrappers/ratelimited/execution_generated.go
@@ -137,7 +137,7 @@ func (c *ratelimitedExecutionManager) GetReplicationDLQSize(ctx context.Context,
 	return c.wrapped.GetReplicationDLQSize(ctx, request)
 }
 
-func (c *ratelimitedExecutionManager) GetReplicationTasksFromDLQ(ctx context.Context, request *persistence.GetReplicationTasksFromDLQRequest) (gp1 *persistence.GetHistoryTasksResponse, err error) {
+func (c *ratelimitedExecutionManager) GetReplicationTasksFromDLQ(ctx context.Context, request *persistence.GetReplicationTasksFromDLQRequest) (gp1 *persistence.GetReplicationDLQTasksResponse, err error) {
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return

--- a/common/persistence/wrappers/ratelimited/wrappers_test.go
+++ b/common/persistence/wrappers/ratelimited/wrappers_test.go
@@ -269,7 +269,7 @@ func builderForPassThrough(t *testing.T, injector any, limiter quotas.Limiter, e
 			mocked.EXPECT().CreateFailoverMarkerTasks(gomock.Any(), gomock.Any()).Return(expectedErr)
 			mocked.EXPECT().DeleteReplicationTaskFromDLQ(gomock.Any(), gomock.Any()).Return(expectedErr)
 			mocked.EXPECT().GetReplicationDLQSize(gomock.Any(), gomock.Any()).Return(&persistence.GetReplicationDLQSizeResponse{}, expectedErr)
-			mocked.EXPECT().GetReplicationTasksFromDLQ(gomock.Any(), gomock.Any()).Return(&persistence.GetHistoryTasksResponse{}, expectedErr)
+			mocked.EXPECT().GetReplicationTasksFromDLQ(gomock.Any(), gomock.Any()).Return(&persistence.GetReplicationDLQTasksResponse{}, expectedErr)
 			mocked.EXPECT().IsWorkflowExecutionExists(gomock.Any(), gomock.Any()).Return(&persistence.IsWorkflowExecutionExistsResponse{}, expectedErr)
 			mocked.EXPECT().ListConcreteExecutions(gomock.Any(), gomock.Any()).Return(&persistence.ListConcreteExecutionsResponse{}, expectedErr)
 			mocked.EXPECT().ListCurrentExecutions(gomock.Any(), gomock.Any()).Return(&persistence.ListCurrentExecutionsResponse{}, expectedErr)

--- a/host/ndc/replication_integration_test.go
+++ b/host/ndc/replication_integration_test.go
@@ -145,7 +145,6 @@ Loop:
 
 			for _, task := range response.Tasks {
 				s.NotNil(task.Info)
-				s.Equal(persistence.ReplicationTaskTypeHistory, task.Info.TaskType)
 				firstEventID := task.Info.FirstEventID
 				actualDLQMsgs[firstEventID] = true
 			}

--- a/host/ndc/replication_integration_test.go
+++ b/host/ndc/replication_integration_test.go
@@ -144,9 +144,7 @@ Loop:
 			token = response.NextPageToken
 
 			for _, task := range response.Tasks {
-				t, ok := task.(*persistence.HistoryReplicationTask)
-				s.True(ok, "task is not a HistoryReplicationTask")
-				firstEventID := t.FirstEventID
+				firstEventID := task.Info.FirstEventID
 				actualDLQMsgs[firstEventID] = true
 			}
 		}

--- a/host/ndc/replication_integration_test.go
+++ b/host/ndc/replication_integration_test.go
@@ -144,6 +144,8 @@ Loop:
 			token = response.NextPageToken
 
 			for _, task := range response.Tasks {
+				s.NotNil(task.Info)
+				s.Equal(persistence.ReplicationTaskTypeHistory, task.Info.TaskType)
 				firstEventID := task.Info.FirstEventID
 				actualDLQMsgs[firstEventID] = true
 			}

--- a/service/history/replication/dlq_handler.go
+++ b/service/history/replication/dlq_handler.go
@@ -152,7 +152,7 @@ func (r *dlqHandlerImpl) fetchAndEmitMessageCount(ctx context.Context) error {
 		request := persistence.GetReplicationDLQSizeRequest{SourceClusterName: sourceCluster, ShardID: common.Ptr(r.shard.GetShardID())}
 		response, err := r.shard.GetExecutionManager().GetReplicationDLQSize(ctx, &request)
 		if err != nil {
-			r.logger.Error("failed to get replication DLQ size", tag.Error(err))
+			r.logger.Error("failed to get replication DLQ size", tag.SourceCluster(sourceCluster), tag.Error(err))
 			r.metricsClient.Scope(metrics.ReplicationDLQStatsScope).IncCounter(metrics.ReplicationDLQProbeFailed)
 			return err
 		}
@@ -262,7 +262,7 @@ func (r *dlqHandlerImpl) readMessagesWithAckLevel(
 			replicationTask, err := r.serializer.DeserializeReplicationDLQTask(task.Task)
 			if err != nil {
 				r.logger.Warn("failed to deserialize DLQ task blob, falling back to cross-cluster hydration",
-					tag.TaskID(info.TaskID), tag.Error(err))
+					tag.WorkflowDomainID(info.DomainID), tag.WorkflowID(info.WorkflowID), tag.WorkflowRunID(info.RunID), tag.TaskID(info.TaskID), tag.Error(err))
 				needHydration = append(needHydration, ti)
 			} else {
 				hydrated[info.TaskID] = replicationTask
@@ -295,7 +295,8 @@ func (r *dlqHandlerImpl) readMessagesWithAckLevel(
 	for _, task := range resp.Tasks {
 		rt, ok := hydrated[task.Info.TaskID]
 		if !ok {
-			r.logger.Warn("replication task not found after hydration", tag.TaskID(task.Info.TaskID))
+			r.logger.Warn("replication task not found after hydration",
+				tag.WorkflowDomainID(task.Info.DomainID), tag.WorkflowID(task.Info.WorkflowID), tag.WorkflowRunID(task.Info.RunID), tag.TaskID(task.Info.TaskID))
 			continue
 		}
 		replicationTasks = append(replicationTasks, rt)

--- a/service/history/replication/dlq_handler.go
+++ b/service/history/replication/dlq_handler.go
@@ -247,8 +247,8 @@ func (r *dlqHandlerImpl) readMessagesWithAckLevel(
 // hydrateDLQTasks resolves the full replication task payload for each raw DLQ entry.
 // It first attempts local deserialization from the stored blob; tasks without a blob
 // or with a corrupt blob are fetched from the source cluster via GetDLQReplicationMessages.
-// Both returned slices are parallel and always have the same length — tasks that cannot
-// be resolved (source workflow deleted) are omitted from both.
+// Both returned slices are always the same length and parallel — replicationTasks[i] is nil
+// when the task could not be resolved (e.g. source workflow deleted).
 func (r *dlqHandlerImpl) hydrateDLQTasks(
 	ctx context.Context,
 	sourceCluster string,
@@ -310,22 +310,19 @@ func (r *dlqHandlerImpl) hydrateDLQTasks(
 		}
 	}
 
-	// Assemble both slices together so they always have equal length and matching order.
-	// Tasks missing from hydration (e.g. source workflow deleted) are omitted from both.
-	replicationTasks := make([]*types.ReplicationTask, 0, len(rawTasks))
-	taskInfo := make([]*types.ReplicationTaskInfo, 0, len(rawTasks))
-	for _, ti := range taskInfos {
+	// Build parallel slices of equal length. replicationTasks[i] is nil when the task
+	// could not be hydrated (e.g. source workflow deleted) — callers must check for nil.
+	replicationTasks := make([]*types.ReplicationTask, len(taskInfos))
+	for i, ti := range taskInfos {
 		rt, ok := hydrated[ti.TaskID]
 		if !ok {
 			r.logger.Warn("replication task not found after hydration",
 				tag.WorkflowDomainID(ti.DomainID), tag.WorkflowID(ti.WorkflowID), tag.WorkflowRunID(ti.RunID), tag.TaskID(ti.TaskID))
-			continue
 		}
-		replicationTasks = append(replicationTasks, rt)
-		taskInfo = append(taskInfo, ti)
+		replicationTasks[i] = rt // nil when not found
 	}
 
-	return replicationTasks, taskInfo, nil
+	return replicationTasks, taskInfos, nil
 }
 
 func (r *dlqHandlerImpl) PurgeMessages(
@@ -374,7 +371,9 @@ func (r *dlqHandlerImpl) MergeMessages(
 
 	replicationTasks := map[int64]*types.ReplicationTask{}
 	for _, task := range tasks {
-		replicationTasks[task.SourceTaskID] = task
+		if task != nil {
+			replicationTasks[task.SourceTaskID] = task
+		}
 	}
 
 	lastMessageID = defaultBeginningMessageID

--- a/service/history/replication/dlq_handler.go
+++ b/service/history/replication/dlq_handler.go
@@ -236,8 +236,8 @@ func (r *dlqHandlerImpl) readMessagesWithAckLevel(
 		return nil, nil, nil, err
 	}
 
-	taskInfo := make([]*types.ReplicationTaskInfo, 0, len(resp.Tasks))
 	hydrated := make(map[int64]*types.ReplicationTask, len(resp.Tasks))
+	taskInfos := make([]*types.ReplicationTaskInfo, 0, len(resp.Tasks)) // parallel to resp.Tasks
 	var needHydration []*types.ReplicationTaskInfo
 
 	for _, task := range resp.Tasks {
@@ -256,7 +256,7 @@ func (r *dlqHandlerImpl) readMessagesWithAckLevel(
 			NextEventID:  info.NextEventID,
 			ScheduledID:  info.ScheduledID,
 		}
-		taskInfo = append(taskInfo, ti)
+		taskInfos = append(taskInfos, ti)
 
 		if task.Task != nil {
 			replicationTask, err := r.serializer.DeserializeReplicationDLQTask(task.Task)
@@ -291,8 +291,11 @@ func (r *dlqHandlerImpl) readMessagesWithAckLevel(
 		}
 	}
 
+	// Assemble both slices in the same loop so they always have equal length and matching order.
+	// Tasks missing from hydration (source workflow deleted) are skipped from both.
 	replicationTasks := make([]*types.ReplicationTask, 0, len(resp.Tasks))
-	for _, task := range resp.Tasks {
+	taskInfo := make([]*types.ReplicationTaskInfo, 0, len(resp.Tasks))
+	for i, task := range resp.Tasks {
 		rt, ok := hydrated[task.Info.TaskID]
 		if !ok {
 			r.logger.Warn("replication task not found after hydration",
@@ -300,6 +303,7 @@ func (r *dlqHandlerImpl) readMessagesWithAckLevel(
 			continue
 		}
 		replicationTasks = append(replicationTasks, rt)
+		taskInfo = append(taskInfo, taskInfos[i])
 	}
 
 	return replicationTasks, taskInfo, resp.NextPageToken, nil

--- a/service/history/replication/dlq_handler.go
+++ b/service/history/replication/dlq_handler.go
@@ -290,7 +290,12 @@ func (r *dlqHandlerImpl) readMessagesWithAckLevel(
 
 	replicationTasks := make([]*types.ReplicationTask, 0, len(resp.Tasks))
 	for _, task := range resp.Tasks {
-		replicationTasks = append(replicationTasks, hydrated[task.Info.TaskID])
+		rt, ok := hydrated[task.Info.TaskID]
+		if !ok {
+			r.logger.Warn("replication task not found after hydration", tag.TaskID(task.Info.TaskID))
+			continue
+		}
+		replicationTasks = append(replicationTasks, rt)
 	}
 
 	return replicationTasks, taskInfo, resp.NextPageToken, nil

--- a/service/history/replication/dlq_handler.go
+++ b/service/history/replication/dlq_handler.go
@@ -261,9 +261,12 @@ func (r *dlqHandlerImpl) readMessagesWithAckLevel(
 		if task.Task != nil {
 			replicationTask, err := r.serializer.DeserializeReplicationDLQTask(task.Task)
 			if err != nil {
-				return nil, nil, nil, err
+				r.logger.Warn("failed to deserialize DLQ task blob, falling back to cross-cluster hydration",
+					tag.TaskID(info.TaskID), tag.Error(err))
+				needHydration = append(needHydration, ti)
+			} else {
+				hydrated[info.TaskID] = replicationTask
 			}
-			hydrated[info.TaskID] = replicationTask
 		} else {
 			needHydration = append(needHydration, ti)
 		}

--- a/service/history/replication/dlq_handler.go
+++ b/service/history/replication/dlq_handler.go
@@ -236,14 +236,33 @@ func (r *dlqHandlerImpl) readMessagesWithAckLevel(
 		return nil, nil, nil, err
 	}
 
-	hydrated := make(map[int64]*types.ReplicationTask, len(resp.Tasks))
-	taskInfos := make([]*types.ReplicationTaskInfo, 0, len(resp.Tasks)) // parallel to resp.Tasks
+	replicationTasks, taskInfo, err := r.hydrateDLQTasks(ctx, sourceCluster, resp.Tasks)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return replicationTasks, taskInfo, resp.NextPageToken, nil
+}
+
+// hydrateDLQTasks resolves the full replication task payload for each raw DLQ entry.
+// It first attempts local deserialization from the stored blob; tasks without a blob
+// or with a corrupt blob are fetched from the source cluster via GetDLQReplicationMessages.
+// Both returned slices are parallel and always have the same length — tasks that cannot
+// be resolved (source workflow deleted) are omitted from both.
+func (r *dlqHandlerImpl) hydrateDLQTasks(
+	ctx context.Context,
+	sourceCluster string,
+	rawTasks []*persistence.ReplicationDLQTask,
+) ([]*types.ReplicationTask, []*types.ReplicationTaskInfo, error) {
+
+	hydrated := make(map[int64]*types.ReplicationTask, len(rawTasks))
+	taskInfos := make([]*types.ReplicationTaskInfo, 0, len(rawTasks)) // parallel to rawTasks
 	var needHydration []*types.ReplicationTaskInfo
 
-	for _, task := range resp.Tasks {
+	for _, task := range rawTasks {
 		info := task.Info
 		if info == nil {
-			return nil, nil, nil, fmt.Errorf("nil task info in DLQ response")
+			return nil, nil, fmt.Errorf("nil task info in DLQ response")
 		}
 		ti := &types.ReplicationTaskInfo{
 			DomainID:     info.DomainID,
@@ -275,7 +294,7 @@ func (r *dlqHandlerImpl) readMessagesWithAckLevel(
 	if len(needHydration) > 0 {
 		remoteAdminClient, err := r.shard.GetService().GetClientBean().GetRemoteAdminClient(sourceCluster)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, err
 		}
 		response, err := remoteAdminClient.GetDLQReplicationMessages(
 			ctx,
@@ -284,18 +303,18 @@ func (r *dlqHandlerImpl) readMessagesWithAckLevel(
 			},
 		)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, err
 		}
 		for _, task := range response.ReplicationTasks {
 			hydrated[task.SourceTaskID] = task
 		}
 	}
 
-	// Assemble both slices in the same loop so they always have equal length and matching order.
-	// Tasks missing from hydration (source workflow deleted) are skipped from both.
-	replicationTasks := make([]*types.ReplicationTask, 0, len(resp.Tasks))
-	taskInfo := make([]*types.ReplicationTaskInfo, 0, len(resp.Tasks))
-	for i, task := range resp.Tasks {
+	// Assemble both slices together so they always have equal length and matching order.
+	// Tasks missing from hydration (e.g. source workflow deleted) are omitted from both.
+	replicationTasks := make([]*types.ReplicationTask, 0, len(rawTasks))
+	taskInfo := make([]*types.ReplicationTaskInfo, 0, len(rawTasks))
+	for i, task := range rawTasks {
 		rt, ok := hydrated[task.Info.TaskID]
 		if !ok {
 			r.logger.Warn("replication task not found after hydration",
@@ -306,7 +325,7 @@ func (r *dlqHandlerImpl) readMessagesWithAckLevel(
 		taskInfo = append(taskInfo, taskInfos[i])
 	}
 
-	return replicationTasks, taskInfo, resp.NextPageToken, nil
+	return replicationTasks, taskInfo, nil
 }
 
 func (r *dlqHandlerImpl) PurgeMessages(

--- a/service/history/replication/dlq_handler.go
+++ b/service/history/replication/dlq_handler.go
@@ -256,7 +256,7 @@ func (r *dlqHandlerImpl) hydrateDLQTasks(
 ) ([]*types.ReplicationTask, []*types.ReplicationTaskInfo, error) {
 
 	hydrated := make(map[int64]*types.ReplicationTask, len(rawTasks))
-	taskInfos := make([]*types.ReplicationTaskInfo, 0, len(rawTasks)) // parallel to rawTasks
+	taskInfos := make([]*types.ReplicationTaskInfo, 0, len(rawTasks))
 	var needHydration []*types.ReplicationTaskInfo
 
 	for _, task := range rawTasks {
@@ -314,15 +314,15 @@ func (r *dlqHandlerImpl) hydrateDLQTasks(
 	// Tasks missing from hydration (e.g. source workflow deleted) are omitted from both.
 	replicationTasks := make([]*types.ReplicationTask, 0, len(rawTasks))
 	taskInfo := make([]*types.ReplicationTaskInfo, 0, len(rawTasks))
-	for i, task := range rawTasks {
-		rt, ok := hydrated[task.Info.TaskID]
+	for _, ti := range taskInfos {
+		rt, ok := hydrated[ti.TaskID]
 		if !ok {
 			r.logger.Warn("replication task not found after hydration",
-				tag.WorkflowDomainID(task.Info.DomainID), tag.WorkflowID(task.Info.WorkflowID), tag.WorkflowRunID(task.Info.RunID), tag.TaskID(task.Info.TaskID))
+				tag.WorkflowDomainID(ti.DomainID), tag.WorkflowID(ti.WorkflowID), tag.WorkflowRunID(ti.RunID), tag.TaskID(ti.TaskID))
 			continue
 		}
 		replicationTasks = append(replicationTasks, rt)
-		taskInfo = append(taskInfo, taskInfos[i])
+		taskInfo = append(taskInfo, ti)
 	}
 
 	return replicationTasks, taskInfo, nil

--- a/service/history/replication/dlq_handler.go
+++ b/service/history/replication/dlq_handler.go
@@ -22,6 +22,7 @@ package replication
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -79,6 +80,7 @@ type (
 	dlqHandlerImpl struct {
 		taskExecutors map[string]TaskExecutor
 		shard         shard.Context
+		serializer    persistence.PayloadSerializer
 		logger        log.Logger
 		metricsClient metrics.Client
 		done          chan struct{}
@@ -105,6 +107,7 @@ func NewDLQHandler(
 	return &dlqHandlerImpl{
 		shard:         shard,
 		taskExecutors: taskExecutors,
+		serializer:    persistence.NewPayloadSerializer(),
 		logger:        shard.GetLogger(),
 		metricsClient: shard.GetMetricsClient(),
 		done:          make(chan struct{}),
@@ -233,15 +236,16 @@ func (r *dlqHandlerImpl) readMessagesWithAckLevel(
 		return nil, nil, nil, err
 	}
 
-	remoteAdminClient, err := r.shard.GetService().GetClientBean().GetRemoteAdminClient(sourceCluster)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
 	taskInfo := make([]*types.ReplicationTaskInfo, 0, len(resp.Tasks))
+	hydrated := make(map[int64]*types.ReplicationTask, len(resp.Tasks))
+	var needHydration []*types.ReplicationTaskInfo
+
 	for _, task := range resp.Tasks {
 		info := task.Info
-		taskInfo = append(taskInfo, &types.ReplicationTaskInfo{
+		if info == nil {
+			return nil, nil, nil, fmt.Errorf("nil task info in DLQ response")
+		}
+		ti := &types.ReplicationTaskInfo{
 			DomainID:     info.DomainID,
 			WorkflowID:   info.WorkflowID,
 			RunID:        info.RunID,
@@ -251,22 +255,45 @@ func (r *dlqHandlerImpl) readMessagesWithAckLevel(
 			FirstEventID: info.FirstEventID,
 			NextEventID:  info.NextEventID,
 			ScheduledID:  info.ScheduledID,
-		})
+		}
+		taskInfo = append(taskInfo, ti)
+
+		if task.Task != nil {
+			replicationTask, err := r.serializer.DeserializeReplicationDLQTask(task.Task)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			hydrated[info.TaskID] = replicationTask
+		} else {
+			needHydration = append(needHydration, ti)
+		}
 	}
-	response := &types.GetDLQReplicationMessagesResponse{}
-	if len(taskInfo) > 0 {
-		response, err = remoteAdminClient.GetDLQReplicationMessages(
+
+	if len(needHydration) > 0 {
+		remoteAdminClient, err := r.shard.GetService().GetClientBean().GetRemoteAdminClient(sourceCluster)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		response, err := remoteAdminClient.GetDLQReplicationMessages(
 			ctx,
 			&types.GetDLQReplicationMessagesRequest{
-				TaskInfos: taskInfo,
+				TaskInfos: needHydration,
 			},
 		)
 		if err != nil {
 			return nil, nil, nil, err
 		}
+		for _, task := range response.ReplicationTasks {
+			hydrated[task.SourceTaskID] = task
+		}
 	}
 
-	return response.ReplicationTasks, taskInfo, resp.NextPageToken, nil
+	replicationTasks := make([]*types.ReplicationTask, 0, len(resp.Tasks))
+	for _, task := range resp.Tasks {
+		replicationTasks = append(replicationTasks, hydrated[task.Info.TaskID])
+	}
+
+	return replicationTasks, taskInfo, resp.NextPageToken, nil
 }
 
 func (r *dlqHandlerImpl) PurgeMessages(

--- a/service/history/replication/dlq_handler.go
+++ b/service/history/replication/dlq_handler.go
@@ -240,11 +240,18 @@ func (r *dlqHandlerImpl) readMessagesWithAckLevel(
 
 	taskInfo := make([]*types.ReplicationTaskInfo, 0, len(resp.Tasks))
 	for _, task := range resp.Tasks {
-		ti, err := task.ToInternalReplicationTaskInfo()
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		taskInfo = append(taskInfo, ti)
+		info := task.Info
+		taskInfo = append(taskInfo, &types.ReplicationTaskInfo{
+			DomainID:     info.DomainID,
+			WorkflowID:   info.WorkflowID,
+			RunID:        info.RunID,
+			TaskType:     int16(info.TaskType),
+			TaskID:       info.TaskID,
+			Version:      info.Version,
+			FirstEventID: info.FirstEventID,
+			NextEventID:  info.NextEventID,
+			ScheduledID:  info.ScheduledID,
+		})
 	}
 	response := &types.GetDLQReplicationMessagesResponse{}
 	if len(taskInfo) > 0 {

--- a/service/history/replication/dlq_handler.go
+++ b/service/history/replication/dlq_handler.go
@@ -80,7 +80,6 @@ type (
 	dlqHandlerImpl struct {
 		taskExecutors map[string]TaskExecutor
 		shard         shard.Context
-		serializer    persistence.PayloadSerializer
 		logger        log.Logger
 		metricsClient metrics.Client
 		done          chan struct{}
@@ -107,7 +106,6 @@ func NewDLQHandler(
 	return &dlqHandlerImpl{
 		shard:         shard,
 		taskExecutors: taskExecutors,
-		serializer:    persistence.NewPayloadSerializer(),
 		logger:        shard.GetLogger(),
 		metricsClient: shard.GetMetricsClient(),
 		done:          make(chan struct{}),
@@ -244,11 +242,11 @@ func (r *dlqHandlerImpl) readMessagesWithAckLevel(
 	return replicationTasks, taskInfo, resp.NextPageToken, nil
 }
 
-// hydrateDLQTasks resolves the full replication task payload for each raw DLQ entry.
-// It first attempts local deserialization from the stored blob; tasks without a blob
-// or with a corrupt blob are fetched from the source cluster via GetDLQReplicationMessages.
-// Both returned slices are always the same length and parallel — replicationTasks[i] is nil
-// when the task could not be resolved (e.g. source workflow deleted).
+// hydrateDLQTasks resolves the full replication task payload for each DLQ entry.
+// Entries whose payload was not delivered by the persistence layer are fetched
+// from the source cluster via GetDLQReplicationMessages. Both returned slices are
+// always the same length and parallel — replicationTasks[i] is nil when the task
+// could not be resolved (e.g. source workflow deleted).
 func (r *dlqHandlerImpl) hydrateDLQTasks(
 	ctx context.Context,
 	sourceCluster string,
@@ -278,14 +276,7 @@ func (r *dlqHandlerImpl) hydrateDLQTasks(
 		taskInfos = append(taskInfos, ti)
 
 		if task.Task != nil {
-			replicationTask, err := r.serializer.DeserializeReplicationDLQTask(task.Task)
-			if err != nil {
-				r.logger.Warn("failed to deserialize DLQ task blob, falling back to cross-cluster hydration",
-					tag.WorkflowDomainID(info.DomainID), tag.WorkflowID(info.WorkflowID), tag.WorkflowRunID(info.RunID), tag.TaskID(info.TaskID), tag.Error(err))
-				needHydration = append(needHydration, ti)
-			} else {
-				hydrated[info.TaskID] = replicationTask
-			}
+			hydrated[info.TaskID] = task.Task
 		} else {
 			needHydration = append(needHydration, ti)
 		}

--- a/service/history/replication/dlq_handler_test.go
+++ b/service/history/replication/dlq_handler_test.go
@@ -298,14 +298,18 @@ func (s *dlqHandlerSuite) TestReadMessages_OK() {
 	s.mockClientBean.EXPECT().GetRemoteAdminClient(s.sourceCluster).Return(s.adminClient, nil).AnyTimes()
 	s.adminClient.EXPECT().
 		GetDLQReplicationMessages(ctx, gomock.Any()).
-		Return(&types.GetDLQReplicationMessagesResponse{}, nil)
+		Return(&types.GetDLQReplicationMessagesResponse{
+			ReplicationTasks: []*types.ReplicationTask{{SourceTaskID: 1}},
+		}, nil)
 	tasks, info, token, err := s.messageHandler.ReadMessages(ctx, s.sourceCluster, lastMessageID, pageSize, pageToken)
 	s.NoError(err)
 	s.Nil(token)
+	s.Len(info, 1)
 	s.Equal(domainID, info[0].GetDomainID())
 	s.Equal(workflowID, info[0].GetWorkflowID())
 	s.Equal(runID, info[0].GetRunID())
-	s.Empty(tasks)
+	s.Len(tasks, 1)
+	s.Equal(int64(1), tasks[0].SourceTaskID)
 }
 
 func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_OK() {
@@ -545,7 +549,7 @@ func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_MixedLocalAndRemote() {
 }
 
 func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_MissingFromRemote() {
-	// Task has no blob and is not returned by the remote — should be skipped with a warning.
+	// Task has no blob and is not returned by the remote — replicationTasks[0] is nil, taskInfo[0] is still populated.
 	resp := &persistence.GetReplicationDLQTasksResponse{
 		Tasks: []*persistence.ReplicationDLQTask{
 			{
@@ -562,8 +566,10 @@ func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_MissingFromRemote() {
 	replicationTasks, taskInfo, _, err := s.messageHandler.readMessagesWithAckLevel(context.Background(), s.sourceCluster, 10, 12, nil)
 
 	s.NoError(err)
-	s.Empty(replicationTasks)
-	s.Empty(taskInfo) // task skipped from both slices when missing from remote
+	s.Len(replicationTasks, 1)
+	s.Nil(replicationTasks[0]) // task could not be hydrated
+	s.Len(taskInfo, 1)
+	s.Equal("domainID", taskInfo[0].GetDomainID())
 }
 
 func (s *dlqHandlerSuite) TestPurgeMessages() {

--- a/service/history/replication/dlq_handler_test.go
+++ b/service/history/replication/dlq_handler_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/uber/cadence/client/admin"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
@@ -300,7 +301,7 @@ func (s *dlqHandlerSuite) TestReadMessages_OK() {
 	s.Equal(domainID, info[0].GetDomainID())
 	s.Equal(workflowID, info[0].GetWorkflowID())
 	s.Equal(runID, info[0].GetRunID())
-	s.Nil(tasks)
+	s.Empty(tasks)
 }
 
 func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_OK() {
@@ -386,7 +387,17 @@ func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_GetReplicationTasksFromDL
 }
 
 func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_InvalidCluster() {
-	s.executionManager.On("GetReplicationTasksFromDLQ", mock.Anything, mock.Anything).Return(nil, nil).Times(1)
+	resp := &persistence.GetReplicationDLQTasksResponse{
+		Tasks: []*persistence.ReplicationDLQTask{
+			{
+				Info: &persistence.ReplicationTaskInfo{
+					DomainID: "domainID",
+					TaskID:   1,
+				},
+			},
+		},
+	}
+	s.executionManager.On("GetReplicationTasksFromDLQ", mock.Anything, mock.Anything).Return(resp, nil).Times(1)
 
 	s.mockShard.Resource.ClientBean = client.NewMockBean(s.controller)
 	s.mockShard.Resource.ClientBean.EXPECT().GetRemoteAdminClient("invalidCluster").Return(nil, errors.New("invalidCluster")).Times(1)
@@ -434,6 +445,95 @@ func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_GetDLQReplicationMessages
 
 	s.Error(err)
 	s.Equal(err, errors.New(errorMessage))
+}
+
+func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_LocalBlob() {
+	// When task.Task blob is available, it should be deserialized locally without a cross-cluster call.
+	replicationTask := &types.ReplicationTask{
+		TaskType:     types.ReplicationTaskTypeHistory.Ptr(),
+		SourceTaskID: 123,
+	}
+	blob, err := s.messageHandler.serializer.SerializeReplicationDLQTask(replicationTask, constants.EncodingTypeThriftRW)
+	s.NoError(err)
+
+	resp := &persistence.GetReplicationDLQTasksResponse{
+		Tasks: []*persistence.ReplicationDLQTask{
+			{
+				Info: &persistence.ReplicationTaskInfo{
+					DomainID: "domainID",
+					TaskID:   123,
+				},
+				Task: blob,
+			},
+		},
+	}
+	s.executionManager.On("GetReplicationTasksFromDLQ", mock.Anything, mock.Anything).Return(resp, nil).Times(1)
+
+	// No GetRemoteAdminClient or GetDLQReplicationMessages calls expected.
+	replicationTasks, taskInfo, _, err := s.messageHandler.readMessagesWithAckLevel(context.Background(), s.sourceCluster, 123, 12, nil)
+
+	s.NoError(err)
+	s.Len(replicationTasks, 1)
+	s.Equal(int64(123), replicationTasks[0].SourceTaskID)
+	s.Len(taskInfo, 1)
+}
+
+func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_MixedLocalAndRemote() {
+	// Task 1 has a local blob; task 2 requires cross-cluster hydration.
+	replicationTask := &types.ReplicationTask{
+		TaskType:     types.ReplicationTaskTypeHistory.Ptr(),
+		SourceTaskID: 1,
+	}
+	blob, err := s.messageHandler.serializer.SerializeReplicationDLQTask(replicationTask, constants.EncodingTypeThriftRW)
+	s.NoError(err)
+
+	resp := &persistence.GetReplicationDLQTasksResponse{
+		Tasks: []*persistence.ReplicationDLQTask{
+			{
+				Info: &persistence.ReplicationTaskInfo{DomainID: "domainID", TaskID: 1},
+				Task: blob,
+			},
+			{
+				Info: &persistence.ReplicationTaskInfo{DomainID: "domainID", TaskID: 2},
+			},
+		},
+	}
+	s.executionManager.On("GetReplicationTasksFromDLQ", mock.Anything, mock.Anything).Return(resp, nil).Times(1)
+
+	s.adminClient.EXPECT().
+		GetDLQReplicationMessages(context.Background(), gomock.Any()).
+		Return(&types.GetDLQReplicationMessagesResponse{
+			ReplicationTasks: []*types.ReplicationTask{{SourceTaskID: 2}},
+		}, nil).Times(1)
+
+	replicationTasks, taskInfo, _, err := s.messageHandler.readMessagesWithAckLevel(context.Background(), s.sourceCluster, 10, 12, nil)
+	s.NoError(err)
+	s.Len(replicationTasks, 2)
+	s.Equal(int64(1), replicationTasks[0].SourceTaskID)
+	s.Equal(int64(2), replicationTasks[1].SourceTaskID)
+	s.Len(taskInfo, 2)
+}
+
+func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_MissingFromRemote() {
+	// Task has no blob and is not returned by the remote — should be skipped with a warning.
+	resp := &persistence.GetReplicationDLQTasksResponse{
+		Tasks: []*persistence.ReplicationDLQTask{
+			{
+				Info: &persistence.ReplicationTaskInfo{DomainID: "domainID", TaskID: 1},
+			},
+		},
+	}
+	s.executionManager.On("GetReplicationTasksFromDLQ", mock.Anything, mock.Anything).Return(resp, nil).Times(1)
+
+	s.adminClient.EXPECT().
+		GetDLQReplicationMessages(context.Background(), gomock.Any()).
+		Return(&types.GetDLQReplicationMessagesResponse{ReplicationTasks: nil}, nil).Times(1)
+
+	replicationTasks, taskInfo, _, err := s.messageHandler.readMessagesWithAckLevel(context.Background(), s.sourceCluster, 10, 12, nil)
+
+	s.NoError(err)
+	s.Empty(replicationTasks)
+	s.Len(taskInfo, 1) // taskInfo is always populated regardless
 }
 
 func (s *dlqHandlerSuite) TestPurgeMessages() {

--- a/service/history/replication/dlq_handler_test.go
+++ b/service/history/replication/dlq_handler_test.go
@@ -563,7 +563,7 @@ func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_MissingFromRemote() {
 
 	s.NoError(err)
 	s.Empty(replicationTasks)
-	s.Len(taskInfo, 1) // taskInfo is always populated regardless
+	s.Empty(taskInfo) // task skipped from both slices when missing from remote
 }
 
 func (s *dlqHandlerSuite) TestPurgeMessages() {

--- a/service/history/replication/dlq_handler_test.go
+++ b/service/history/replication/dlq_handler_test.go
@@ -58,6 +58,7 @@ type (
 		adminClient      *admin.MockClient
 		executionManager *mocks.ExecutionManager
 		shardManager     *mocks.ShardManager
+		mockSerializer   *persistence.MockPayloadSerializer
 		taskExecutor     *fakeTaskExecutor
 		taskExecutors    map[string]TaskExecutor
 		sourceCluster    string
@@ -110,6 +111,9 @@ func (s *dlqHandlerSuite) SetupTest() {
 		s.mockShard,
 		s.taskExecutors,
 	).(*dlqHandlerImpl)
+
+	s.mockSerializer = persistence.NewMockPayloadSerializer(s.controller)
+	s.messageHandler.serializer = s.mockSerializer
 }
 
 func (s *dlqHandlerSuite) TearDownTest() {
@@ -449,25 +453,22 @@ func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_GetDLQReplicationMessages
 
 func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_LocalBlob() {
 	// When task.Task blob is available, it should be deserialized locally without a cross-cluster call.
+	blob := &persistence.DataBlob{Data: []byte("task"), Encoding: constants.EncodingTypeThriftRW}
 	replicationTask := &types.ReplicationTask{
 		TaskType:     types.ReplicationTaskTypeHistory.Ptr(),
 		SourceTaskID: 123,
 	}
-	blob, err := s.messageHandler.serializer.SerializeReplicationDLQTask(replicationTask, constants.EncodingTypeThriftRW)
-	s.NoError(err)
 
 	resp := &persistence.GetReplicationDLQTasksResponse{
 		Tasks: []*persistence.ReplicationDLQTask{
 			{
-				Info: &persistence.ReplicationTaskInfo{
-					DomainID: "domainID",
-					TaskID:   123,
-				},
+				Info: &persistence.ReplicationTaskInfo{DomainID: "domainID", TaskID: 123},
 				Task: blob,
 			},
 		},
 	}
 	s.executionManager.On("GetReplicationTasksFromDLQ", mock.Anything, mock.Anything).Return(resp, nil).Times(1)
+	s.mockSerializer.EXPECT().DeserializeReplicationDLQTask(blob).Return(replicationTask, nil).Times(1)
 
 	// No GetRemoteAdminClient or GetDLQReplicationMessages calls expected.
 	replicationTasks, taskInfo, _, err := s.messageHandler.readMessagesWithAckLevel(context.Background(), s.sourceCluster, 123, 12, nil)
@@ -478,14 +479,42 @@ func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_LocalBlob() {
 	s.Len(taskInfo, 1)
 }
 
+func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_CorruptBlob_FallsBackToCrossCluster() {
+	// If the blob cannot be deserialized, fall back to cross-cluster hydration rather than failing.
+	blob := &persistence.DataBlob{Data: []byte("corrupt"), Encoding: constants.EncodingTypeThriftRW}
+
+	resp := &persistence.GetReplicationDLQTasksResponse{
+		Tasks: []*persistence.ReplicationDLQTask{
+			{
+				Info: &persistence.ReplicationTaskInfo{DomainID: "domainID", TaskID: 123},
+				Task: blob,
+			},
+		},
+	}
+	s.executionManager.On("GetReplicationTasksFromDLQ", mock.Anything, mock.Anything).Return(resp, nil).Times(1)
+	s.mockSerializer.EXPECT().DeserializeReplicationDLQTask(blob).Return(nil, errors.New("corrupt blob")).Times(1)
+
+	s.adminClient.EXPECT().
+		GetDLQReplicationMessages(context.Background(), gomock.Any()).
+		Return(&types.GetDLQReplicationMessagesResponse{
+			ReplicationTasks: []*types.ReplicationTask{{SourceTaskID: 123}},
+		}, nil).Times(1)
+
+	replicationTasks, taskInfo, _, err := s.messageHandler.readMessagesWithAckLevel(context.Background(), s.sourceCluster, 123, 12, nil)
+
+	s.NoError(err)
+	s.Len(replicationTasks, 1)
+	s.Equal(int64(123), replicationTasks[0].SourceTaskID)
+	s.Len(taskInfo, 1)
+}
+
 func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_MixedLocalAndRemote() {
 	// Task 1 has a local blob; task 2 requires cross-cluster hydration.
-	replicationTask := &types.ReplicationTask{
+	blob := &persistence.DataBlob{Data: []byte("task1"), Encoding: constants.EncodingTypeThriftRW}
+	replicationTask1 := &types.ReplicationTask{
 		TaskType:     types.ReplicationTaskTypeHistory.Ptr(),
 		SourceTaskID: 1,
 	}
-	blob, err := s.messageHandler.serializer.SerializeReplicationDLQTask(replicationTask, constants.EncodingTypeThriftRW)
-	s.NoError(err)
 
 	resp := &persistence.GetReplicationDLQTasksResponse{
 		Tasks: []*persistence.ReplicationDLQTask{
@@ -499,6 +528,7 @@ func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_MixedLocalAndRemote() {
 		},
 	}
 	s.executionManager.On("GetReplicationTasksFromDLQ", mock.Anything, mock.Anything).Return(resp, nil).Times(1)
+	s.mockSerializer.EXPECT().DeserializeReplicationDLQTask(blob).Return(replicationTask1, nil).Times(1)
 
 	s.adminClient.EXPECT().
 		GetDLQReplicationMessages(context.Background(), gomock.Any()).

--- a/service/history/replication/dlq_handler_test.go
+++ b/service/history/replication/dlq_handler_test.go
@@ -266,16 +266,17 @@ func (s *dlqHandlerSuite) TestReadMessages_OK() {
 	pageSize := 1
 	var pageToken []byte
 
-	resp := &persistence.GetHistoryTasksResponse{
-		Tasks: []persistence.Task{
-			&persistence.HistoryReplicationTask{
-				WorkflowIdentifier: persistence.WorkflowIdentifier{
-					DomainID:   uuid.New(),
-					WorkflowID: uuid.New(),
-					RunID:      uuid.New(),
-				},
-				TaskData: persistence.TaskData{
-					TaskID: 1,
+	domainID := uuid.New()
+	workflowID := uuid.New()
+	runID := uuid.New()
+	resp := &persistence.GetReplicationDLQTasksResponse{
+		Tasks: []*persistence.ReplicationDLQTask{
+			{
+				Info: &persistence.ReplicationTaskInfo{
+					DomainID:   domainID,
+					WorkflowID: workflowID,
+					RunID:      runID,
+					TaskID:     1,
 				},
 			},
 		},
@@ -296,27 +297,26 @@ func (s *dlqHandlerSuite) TestReadMessages_OK() {
 	tasks, info, token, err := s.messageHandler.ReadMessages(ctx, s.sourceCluster, lastMessageID, pageSize, pageToken)
 	s.NoError(err)
 	s.Nil(token)
-	s.Equal(resp.Tasks[0].GetDomainID(), info[0].GetDomainID())
-	s.Equal(resp.Tasks[0].GetWorkflowID(), info[0].GetWorkflowID())
-	s.Equal(resp.Tasks[0].GetRunID(), info[0].GetRunID())
+	s.Equal(domainID, info[0].GetDomainID())
+	s.Equal(workflowID, info[0].GetWorkflowID())
+	s.Equal(runID, info[0].GetRunID())
 	s.Nil(tasks)
 }
 
 func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_OK() {
-	replicationTasksResponse := &persistence.GetHistoryTasksResponse{
-		Tasks: []persistence.Task{
-			&persistence.HistoryReplicationTask{
-				WorkflowIdentifier: persistence.WorkflowIdentifier{
-					DomainID:   "domainID",
-					WorkflowID: "workflowID",
-					RunID:      "runID",
+	replicationTasksResponse := &persistence.GetReplicationDLQTasksResponse{
+		Tasks: []*persistence.ReplicationDLQTask{
+			{
+				Info: &persistence.ReplicationTaskInfo{
+					DomainID:     "domainID",
+					WorkflowID:   "workflowID",
+					RunID:        "runID",
+					TaskID:       123,
+					TaskType:     persistence.ReplicationTaskTypeHistory,
+					Version:      1,
+					FirstEventID: 1,
+					NextEventID:  2,
 				},
-				TaskData: persistence.TaskData{
-					TaskID:  123,
-					Version: 1,
-				},
-				FirstEventID: 1,
-				NextEventID:  2,
 			},
 		},
 		NextPageToken: []byte("token"),
@@ -355,12 +355,9 @@ func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_OK() {
 	s.NoError(err)
 	s.Equal(replicationTasks, DLQReplicationMessagesResponse.ReplicationTasks)
 	s.Len(taskInfo, len(replicationTasksResponse.Tasks))
-	// testing content of taskInfo because it's assembled in the method using tasks from replicationTasksFromDLQ
-	for i, task := range taskInfo {
-		t, err := replicationTasksResponse.Tasks[i].ToInternalReplicationTaskInfo()
-		s.NoError(err)
-		s.Equal(task, t)
-	}
+	s.Equal("domainID", taskInfo[0].GetDomainID())
+	s.Equal("workflowID", taskInfo[0].GetWorkflowID())
+	s.Equal("runID", taskInfo[0].GetRunID())
 	s.Equal(nextPageToken, replicationTasksResponse.NextPageToken)
 }
 
@@ -416,10 +413,13 @@ func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_GetDLQReplicationMessages
 		ShardID:           common.Ptr(0),
 	}
 
-	replicationTasksResponse := &persistence.GetHistoryTasksResponse{
-		Tasks: []persistence.Task{
-			&persistence.FailoverMarkerTask{
-				DomainID: "domainID",
+	replicationTasksResponse := &persistence.GetReplicationDLQTasksResponse{
+		Tasks: []*persistence.ReplicationDLQTask{
+			{
+				Info: &persistence.ReplicationTaskInfo{
+					DomainID: "domainID",
+					TaskID:   1,
+				},
 			},
 		},
 	}
@@ -478,26 +478,22 @@ func (s *dlqHandlerSuite) TestMergeMessages_OK() {
 	pageSize := 1
 	var pageToken []byte
 
-	resp := &persistence.GetHistoryTasksResponse{
-		Tasks: []persistence.Task{
-			&persistence.HistoryReplicationTask{
-				WorkflowIdentifier: persistence.WorkflowIdentifier{
+	resp := &persistence.GetReplicationDLQTasksResponse{
+		Tasks: []*persistence.ReplicationDLQTask{
+			{
+				Info: &persistence.ReplicationTaskInfo{
 					DomainID:   uuid.New(),
 					WorkflowID: uuid.New(),
 					RunID:      uuid.New(),
-				},
-				TaskData: persistence.TaskData{
-					TaskID: 1,
+					TaskID:     1,
 				},
 			},
-			&persistence.HistoryReplicationTask{
-				WorkflowIdentifier: persistence.WorkflowIdentifier{
+			{
+				Info: &persistence.ReplicationTaskInfo{
 					DomainID:   uuid.New(),
 					WorkflowID: uuid.New(),
 					RunID:      uuid.New(),
-				},
-				TaskData: persistence.TaskData{
-					TaskID: 2,
+					TaskID:     2,
 				},
 			},
 		},
@@ -551,7 +547,7 @@ func (s *dlqHandlerSuite) TestMergeMessages_GetReplicationTasksFromDLQFailed() {
 
 func (s *dlqHandlerSuite) TestMergeMessages_RangeDeleteReplicationTaskFromDLQFailed() {
 	errorMessage := "RangeDeleteReplicationTaskFromDLQFailed"
-	s.executionManager.On("GetReplicationTasksFromDLQ", mock.Anything, mock.Anything).Return(&persistence.GetHistoryTasksResponse{}, nil).Times(1)
+	s.executionManager.On("GetReplicationTasksFromDLQ", mock.Anything, mock.Anything).Return(&persistence.GetReplicationDLQTasksResponse{}, nil).Times(1)
 	s.executionManager.On("RangeDeleteReplicationTaskFromDLQ", mock.Anything, mock.Anything).Return(nil, errors.New(errorMessage)).Times(1)
 	_, err := s.messageHandler.MergeMessages(context.Background(), s.sourceCluster, 1, 1, nil)
 	s.Error(err)
@@ -574,7 +570,7 @@ func (s *dlqHandlerSuite) TestMergeMessages_executeFailed() {
 		BatchSize:         pageSize,
 		NextPageToken:     pageToken,
 		ShardID:           common.Ptr(0),
-	}).Return(&persistence.GetHistoryTasksResponse{Tasks: []persistence.Task{&persistence.HistoryReplicationTask{TaskData: persistence.TaskData{TaskID: 1}}}}, nil).Times(1)
+	}).Return(&persistence.GetReplicationDLQTasksResponse{Tasks: []*persistence.ReplicationDLQTask{{Info: &persistence.ReplicationTaskInfo{TaskID: 1}}}}, nil).Times(1)
 
 	s.adminClient.EXPECT().GetDLQReplicationMessages(ctx, gomock.Any()).
 		Return(&types.GetDLQReplicationMessagesResponse{ReplicationTasks: []*types.ReplicationTask{{SourceTaskID: 1}}}, nil)

--- a/service/history/replication/dlq_handler_test.go
+++ b/service/history/replication/dlq_handler_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/uber/cadence/client/admin"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/clock"
-	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
@@ -58,7 +57,6 @@ type (
 		adminClient      *admin.MockClient
 		executionManager *mocks.ExecutionManager
 		shardManager     *mocks.ShardManager
-		mockSerializer   *persistence.MockPayloadSerializer
 		taskExecutor     *fakeTaskExecutor
 		taskExecutors    map[string]TaskExecutor
 		sourceCluster    string
@@ -111,9 +109,6 @@ func (s *dlqHandlerSuite) SetupTest() {
 		s.mockShard,
 		s.taskExecutors,
 	).(*dlqHandlerImpl)
-
-	s.mockSerializer = persistence.NewMockPayloadSerializer(s.controller)
-	s.messageHandler.serializer = s.mockSerializer
 }
 
 func (s *dlqHandlerSuite) TearDownTest() {
@@ -456,8 +451,7 @@ func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_GetDLQReplicationMessages
 }
 
 func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_LocalBlob() {
-	// When task.Task blob is available, it should be deserialized locally without a cross-cluster call.
-	blob := &persistence.DataBlob{Data: []byte("task"), Encoding: constants.EncodingTypeThriftRW}
+	// When the manager hydrates the task, no cross-cluster call is needed.
 	replicationTask := &types.ReplicationTask{
 		TaskType:     types.ReplicationTaskTypeHistory.Ptr(),
 		SourceTaskID: 123,
@@ -467,12 +461,11 @@ func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_LocalBlob() {
 		Tasks: []*persistence.ReplicationDLQTask{
 			{
 				Info: &persistence.ReplicationTaskInfo{DomainID: "domainID", TaskID: 123},
-				Task: blob,
+				Task: replicationTask,
 			},
 		},
 	}
 	s.executionManager.On("GetReplicationTasksFromDLQ", mock.Anything, mock.Anything).Return(resp, nil).Times(1)
-	s.mockSerializer.EXPECT().DeserializeReplicationDLQTask(blob).Return(replicationTask, nil).Times(1)
 
 	// No GetRemoteAdminClient or GetDLQReplicationMessages calls expected.
 	replicationTasks, taskInfo, _, err := s.messageHandler.readMessagesWithAckLevel(context.Background(), s.sourceCluster, 123, 12, nil)
@@ -484,19 +477,16 @@ func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_LocalBlob() {
 }
 
 func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_CorruptBlob_FallsBackToCrossCluster() {
-	// If the blob cannot be deserialized, fall back to cross-cluster hydration rather than failing.
-	blob := &persistence.DataBlob{Data: []byte("corrupt"), Encoding: constants.EncodingTypeThriftRW}
-
+	// If the manager could not hydrate the payload (corrupt blob), Task is nil
+	// and the handler falls back to cross-cluster hydration rather than failing.
 	resp := &persistence.GetReplicationDLQTasksResponse{
 		Tasks: []*persistence.ReplicationDLQTask{
 			{
 				Info: &persistence.ReplicationTaskInfo{DomainID: "domainID", TaskID: 123},
-				Task: blob,
 			},
 		},
 	}
 	s.executionManager.On("GetReplicationTasksFromDLQ", mock.Anything, mock.Anything).Return(resp, nil).Times(1)
-	s.mockSerializer.EXPECT().DeserializeReplicationDLQTask(blob).Return(nil, errors.New("corrupt blob")).Times(1)
 
 	s.adminClient.EXPECT().
 		GetDLQReplicationMessages(context.Background(), gomock.Any()).
@@ -513,8 +503,7 @@ func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_CorruptBlob_FallsBackToCr
 }
 
 func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_MixedLocalAndRemote() {
-	// Task 1 has a local blob; task 2 requires cross-cluster hydration.
-	blob := &persistence.DataBlob{Data: []byte("task1"), Encoding: constants.EncodingTypeThriftRW}
+	// Task 1 is hydrated by the manager; task 2 has no payload and needs cross-cluster hydration.
 	replicationTask1 := &types.ReplicationTask{
 		TaskType:     types.ReplicationTaskTypeHistory.Ptr(),
 		SourceTaskID: 1,
@@ -524,7 +513,7 @@ func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_MixedLocalAndRemote() {
 		Tasks: []*persistence.ReplicationDLQTask{
 			{
 				Info: &persistence.ReplicationTaskInfo{DomainID: "domainID", TaskID: 1},
-				Task: blob,
+				Task: replicationTask1,
 			},
 			{
 				Info: &persistence.ReplicationTaskInfo{DomainID: "domainID", TaskID: 2},
@@ -532,7 +521,6 @@ func (s *dlqHandlerSuite) TestReadMessagesWithAckLevel_MixedLocalAndRemote() {
 		},
 	}
 	s.executionManager.On("GetReplicationTasksFromDLQ", mock.Anything, mock.Anything).Return(resp, nil).Times(1)
-	s.mockSerializer.EXPECT().DeserializeReplicationDLQTask(blob).Return(replicationTask1, nil).Times(1)
 
 	s.adminClient.EXPECT().
 		GetDLQReplicationMessages(context.Background(), gomock.Any()).

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -577,7 +577,7 @@ func (p *taskProcessorImpl) generateDLQRequest(
 		if err != nil {
 			return nil, err
 		}
-		taskBlob, err := p.historySerializer.SerializeReplicationTask(replicationTask, constants.EncodingTypeThriftRW)
+		taskBlob, err := p.historySerializer.SerializeReplicationDLQTask(replicationTask, constants.EncodingTypeThriftRW)
 		if err != nil {
 			return nil, err
 		}
@@ -613,7 +613,7 @@ func (p *taskProcessorImpl) generateDLQRequest(
 			return nil, fmt.Errorf("corrupted history event batch, empty events")
 		}
 
-		taskBlob, err := p.historySerializer.SerializeReplicationTask(replicationTask, constants.EncodingTypeThriftRW)
+		taskBlob, err := p.historySerializer.SerializeReplicationDLQTask(replicationTask, constants.EncodingTypeThriftRW)
 		if err != nil {
 			return nil, err
 		}

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -577,6 +577,10 @@ func (p *taskProcessorImpl) generateDLQRequest(
 		if err != nil {
 			return nil, err
 		}
+		taskBlob, err := p.historySerializer.SerializeReplicationTask(replicationTask, constants.EncodingTypeThriftRW)
+		if err != nil {
+			return nil, err
+		}
 		return &persistence.PutReplicationTaskToDLQRequest{
 			SourceClusterName: p.sourceCluster,
 			TaskInfo: &persistence.ReplicationTaskInfo{
@@ -587,6 +591,7 @@ func (p *taskProcessorImpl) generateDLQRequest(
 				TaskType:    persistence.ReplicationTaskTypeSyncActivity,
 				ScheduledID: taskAttributes.GetScheduledID(),
 			},
+			Task:       taskBlob,
 			DomainName: domainName,
 			ShardID:    common.Ptr(p.shard.GetShardID()),
 		}, nil
@@ -608,6 +613,10 @@ func (p *taskProcessorImpl) generateDLQRequest(
 			return nil, fmt.Errorf("corrupted history event batch, empty events")
 		}
 
+		taskBlob, err := p.historySerializer.SerializeReplicationTask(replicationTask, constants.EncodingTypeThriftRW)
+		if err != nil {
+			return nil, err
+		}
 		return &persistence.PutReplicationTaskToDLQRequest{
 			SourceClusterName: p.sourceCluster,
 			TaskInfo: &persistence.ReplicationTaskInfo{
@@ -620,6 +629,7 @@ func (p *taskProcessorImpl) generateDLQRequest(
 				NextEventID:  events[len(events)-1].ID + 1,
 				Version:      events[0].Version,
 			},
+			Task:       taskBlob,
 			DomainName: domainName,
 			ShardID:    common.Ptr(p.shard.GetShardID()),
 		}, nil

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -577,10 +577,6 @@ func (p *taskProcessorImpl) generateDLQRequest(
 		if err != nil {
 			return nil, err
 		}
-		taskBlob, err := p.historySerializer.SerializeReplicationDLQTask(replicationTask, constants.EncodingTypeThriftRW)
-		if err != nil {
-			return nil, err
-		}
 		return &persistence.PutReplicationTaskToDLQRequest{
 			SourceClusterName: p.sourceCluster,
 			TaskInfo: &persistence.ReplicationTaskInfo{
@@ -591,7 +587,7 @@ func (p *taskProcessorImpl) generateDLQRequest(
 				TaskType:    persistence.ReplicationTaskTypeSyncActivity,
 				ScheduledID: taskAttributes.GetScheduledID(),
 			},
-			Task:       taskBlob,
+			Task:       replicationTask,
 			DomainName: domainName,
 			ShardID:    common.Ptr(p.shard.GetShardID()),
 		}, nil
@@ -613,10 +609,6 @@ func (p *taskProcessorImpl) generateDLQRequest(
 			return nil, fmt.Errorf("corrupted history event batch, empty events")
 		}
 
-		taskBlob, err := p.historySerializer.SerializeReplicationDLQTask(replicationTask, constants.EncodingTypeThriftRW)
-		if err != nil {
-			return nil, err
-		}
 		return &persistence.PutReplicationTaskToDLQRequest{
 			SourceClusterName: p.sourceCluster,
 			TaskInfo: &persistence.ReplicationTaskInfo{
@@ -629,7 +621,7 @@ func (p *taskProcessorImpl) generateDLQRequest(
 				NextEventID:  events[len(events)-1].ID + 1,
 				Version:      events[0].Version,
 			},
-			Task:       taskBlob,
+			Task:       replicationTask,
 			DomainName: domainName,
 			ShardID:    common.Ptr(p.shard.GetShardID()),
 		}, nil

--- a/service/history/replication/task_processor_test.go
+++ b/service/history/replication/task_processor_test.go
@@ -262,20 +262,7 @@ func (s *taskProcessorSuite) TestProcessorLoop_TaskExecuteFailed_PutDLQSuccess()
 	s.mockDomainCache.EXPECT().GetDomainName(testDomainID).Return(testDomainName, nil).AnyTimes()
 
 	// task will be put into dlq
-	dlqReq := &persistence.PutReplicationTaskToDLQRequest{
-		SourceClusterName: "standby", // TODO move to a constant
-		TaskInfo: &persistence.ReplicationTaskInfo{
-			DomainID:    testDomainID,
-			WorkflowID:  testWorkflowID,
-			RunID:       testRunID,
-			TaskID:      testTaskID,
-			TaskType:    persistence.ReplicationTaskTypeSyncActivity,
-			ScheduledID: testScheduleID,
-		},
-		DomainName: testDomainName,
-		ShardID:    common.Ptr(0),
-	}
-	s.mockShard.Resource.ExecutionMgr.On("PutReplicationTaskToDLQ", mock.Anything, dlqReq).Return(nil).Times(1)
+	s.mockShard.Resource.ExecutionMgr.On("PutReplicationTaskToDLQ", mock.Anything, mock.Anything).Return(nil).Times(1)
 
 	// start the process loop
 	s.taskProcessor.wg.Add(1)
@@ -316,21 +303,8 @@ func (s *taskProcessorSuite) TestProcessorLoop_TaskExecuteFailed_PutDLQFailed() 
 	dqlRetryPolicy := backoff.NewExponentialRetryPolicy(time.Millisecond)
 	dqlRetryPolicy.SetMaximumAttempts(2)
 	s.taskProcessor.dlqRetryPolicy = dqlRetryPolicy
-	dlqReq := &persistence.PutReplicationTaskToDLQRequest{
-		SourceClusterName: "standby", // TODO move to a constant
-		TaskInfo: &persistence.ReplicationTaskInfo{
-			DomainID:    testDomainID,
-			WorkflowID:  testWorkflowID,
-			RunID:       testRunID,
-			TaskID:      testTaskID,
-			TaskType:    persistence.ReplicationTaskTypeSyncActivity,
-			ScheduledID: testScheduleID,
-		},
-		DomainName: testDomainName,
-		ShardID:    common.Ptr(0),
-	}
 	s.mockShard.Resource.ExecutionMgr.
-		On("PutReplicationTaskToDLQ", mock.Anything, dlqReq).
+		On("PutReplicationTaskToDLQ", mock.Anything, mock.Anything).
 		Return(errors.New("failed to put to dlq")).
 		Times(3)
 
@@ -446,6 +420,7 @@ func (s *taskProcessorSuite) TestGenerateDLQRequest_ReplicationTaskTypeHistoryV2
 	s.Equal(workflowID, request.TaskInfo.GetWorkflowID())
 	s.Equal(runID, request.TaskInfo.GetRunID())
 	s.Equal(persistence.ReplicationTaskTypeHistory, request.TaskInfo.GetTaskType())
+	s.NotNil(request.Task, "task blob should be serialized")
 }
 
 func (s *taskProcessorSuite) TestGenerateDLQRequest_ReplicationTaskTypeSyncActivity() {
@@ -471,6 +446,7 @@ func (s *taskProcessorSuite) TestGenerateDLQRequest_ReplicationTaskTypeSyncActiv
 	s.Equal(workflowID, request.TaskInfo.GetWorkflowID())
 	s.Equal(runID, request.TaskInfo.GetRunID())
 	s.Equal(persistence.ReplicationTaskTypeSyncActivity, request.TaskInfo.GetTaskType())
+	s.NotNil(request.Task, "task blob should be serialized")
 }
 
 func (s *taskProcessorSuite) TestGenerateDLQRequest_InvalidTaskType() {

--- a/service/history/replication/task_processor_test.go
+++ b/service/history/replication/task_processor_test.go
@@ -262,7 +262,16 @@ func (s *taskProcessorSuite) TestProcessorLoop_TaskExecuteFailed_PutDLQSuccess()
 	s.mockDomainCache.EXPECT().GetDomainName(testDomainID).Return(testDomainName, nil).AnyTimes()
 
 	// task will be put into dlq
-	s.mockShard.Resource.ExecutionMgr.On("PutReplicationTaskToDLQ", mock.Anything, mock.Anything).Return(nil).Times(1)
+	s.mockShard.Resource.ExecutionMgr.On("PutReplicationTaskToDLQ", mock.Anything, mock.MatchedBy(func(req *persistence.PutReplicationTaskToDLQRequest) bool {
+		return req.SourceClusterName == "standby" &&
+			req.TaskInfo.DomainID == testDomainID &&
+			req.TaskInfo.WorkflowID == testWorkflowID &&
+			req.TaskInfo.RunID == testRunID &&
+			req.TaskInfo.TaskType == persistence.ReplicationTaskTypeSyncActivity &&
+			req.TaskInfo.ScheduledID == testScheduleID &&
+			req.DomainName == testDomainName &&
+			req.Task != nil
+	})).Return(nil).Times(1)
 
 	// start the process loop
 	s.taskProcessor.wg.Add(1)
@@ -304,7 +313,16 @@ func (s *taskProcessorSuite) TestProcessorLoop_TaskExecuteFailed_PutDLQFailed() 
 	dqlRetryPolicy.SetMaximumAttempts(2)
 	s.taskProcessor.dlqRetryPolicy = dqlRetryPolicy
 	s.mockShard.Resource.ExecutionMgr.
-		On("PutReplicationTaskToDLQ", mock.Anything, mock.Anything).
+		On("PutReplicationTaskToDLQ", mock.Anything, mock.MatchedBy(func(req *persistence.PutReplicationTaskToDLQRequest) bool {
+			return req.SourceClusterName == "standby" &&
+				req.TaskInfo.DomainID == testDomainID &&
+				req.TaskInfo.WorkflowID == testWorkflowID &&
+				req.TaskInfo.RunID == testRunID &&
+				req.TaskInfo.TaskType == persistence.ReplicationTaskTypeSyncActivity &&
+				req.TaskInfo.ScheduledID == testScheduleID &&
+				req.DomainName == testDomainName &&
+				req.Task != nil
+		})).
 		Return(errors.New("failed to put to dlq")).
 		Times(3)
 


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Persist replication task together with DLQ message in the standby cluster.

https://github.com/cadence-workflow/cadence/issues/8031

**Why?**
To get the replication task for a DLQ message required a cross cluster call and hydration. There were already plans and infrastructure to persist in the standby cluster but this was not implemented.

**How did you test it?**
go test -race ./common/persistence/...
go test -race ./common/persistence/wrappers/...
go test -race ./common/persistence/nosql/...
go test -race ./common/persistence/sql/...
go test -race ./service/history/replication/...
go test -race -run TestNDCReplicationSuite ./host/ndc/...

**Potential risks**
There is very little risk. The change is backwards compatible. It stores the blob in the standby cluster. The extra storage should be fairly small given that dlq messages are not very frequent.

**Release notes**
Persist replication task for DLQ messaged in the standby cluster to avoid cross-cluster call and hydration in the active cluster.

**Documentation Changes**
N/A
