### PR TITLE
fix(scheduler): honor per-backfill overlap policy in workflow fires

### DIFF
--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -157,9 +157,13 @@ type SchedulerWorkflowState struct {
 // BufferedFire is a schedule fire queued for sequential execution by the BUFFER
 // overlap policy. ScheduledTime and TriggerSource are preserved so the deferred
 // start uses the same WorkflowID and RequestID it would have used at fire time.
+// OverlapPolicy is the overlap policy in effect for this fire (schedule default or
+// a backfill override). Zero (INVALID) means inherit input.Policies.OverlapPolicy
+// for compatibility with older persisted workflow state.
 type BufferedFire struct {
-	ScheduledTime time.Time     `json:"scheduledTime"`
-	TriggerSource TriggerSource `json:"triggerSource"`
+	ScheduledTime time.Time                   `json:"scheduledTime"`
+	TriggerSource TriggerSource               `json:"triggerSource"`
+	OverlapPolicy types.ScheduleOverlapPolicy `json:"overlapPolicy,omitempty"`
 }
 
 // RunningWorkflowInfo identifies a target workflow started by the scheduler,

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -181,7 +181,7 @@ func SchedulerWorkflow(ctx workflow.Context, input SchedulerWorkflowInput) error
 		}
 
 		if timerFired && !state.Paused {
-			processScheduleFire(ctx, logger, scope, &input, state, state.NextRunTime, TriggerSourceSchedule)
+			processScheduleFire(ctx, logger, scope, &input, state, state.NextRunTime, TriggerSourceSchedule, input.Policies.OverlapPolicy)
 		}
 
 		if changed || state.Iterations >= maxIterationsBeforeContinueAsNew {
@@ -488,17 +488,27 @@ func handleBackfill(logger *zap.Logger, sig BackfillSignal, state *SchedulerWork
 // the live-fire activity call, the previous workflow could complete.
 // tryStartFire would then start the live fire ahead of older queued fires,
 // breaking FIFO.
-func processScheduleFire(ctx workflow.Context, logger *zap.Logger, scope tally.Scope, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource) {
-	if input.Policies.OverlapPolicy == types.ScheduleOverlapPolicyBuffer && len(state.BufferedFires) > 0 {
+// effectiveFireOverlap returns the overlap policy applied to a single fire.
+// For backfill, BackfillSignal.overlap_policy may be INVALID (0) to inherit the
+// schedule's configured policy; any other value overrides for that backfill only.
+func effectiveFireOverlap(trigger TriggerSource, backfillOverlap, scheduleOverlap types.ScheduleOverlapPolicy) types.ScheduleOverlapPolicy {
+	if trigger == TriggerSourceBackfill && backfillOverlap != types.ScheduleOverlapPolicyInvalid {
+		return backfillOverlap
+	}
+	return scheduleOverlap
+}
+
+func processScheduleFire(ctx workflow.Context, logger *zap.Logger, scope tally.Scope, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource, overlapPolicy types.ScheduleOverlapPolicy) {
+	if overlapPolicy == types.ScheduleOverlapPolicyBuffer && len(state.BufferedFires) > 0 {
 		// Skipping tryStartFire, so advance LastRunTime here.
 		if scheduledTime.After(state.LastRunTime) {
 			state.LastRunTime = scheduledTime
 		}
-		enqueueBufferedFire(logger, scope, input, state, scheduledTime, trigger)
+		enqueueBufferedFire(logger, scope, input, state, scheduledTime, trigger, overlapPolicy)
 		return
 	}
-	if tryStartFire(ctx, logger, input, state, scheduledTime, trigger) == fireOutcomeBuffered {
-		enqueueBufferedFire(logger, scope, input, state, scheduledTime, trigger)
+	if tryStartFire(ctx, logger, input, state, scheduledTime, trigger, overlapPolicy) == fireOutcomeBuffered {
+		enqueueBufferedFire(logger, scope, input, state, scheduledTime, trigger, overlapPolicy)
 	}
 }
 
@@ -506,7 +516,7 @@ func processScheduleFire(ctx workflow.Context, logger *zap.Logger, scope tally.S
 // result to state, returning whether the fire was buffered. Shared by the
 // live-fire and drain-buffered-fire paths; the caller decides how to handle
 // a buffered outcome.
-func tryStartFire(ctx workflow.Context, logger *zap.Logger, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource) fireOutcome {
+func tryStartFire(ctx workflow.Context, logger *zap.Logger, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource, overlapPolicy types.ScheduleOverlapPolicy) fireOutcome {
 	// LastRunTime moves forward only. Under BUFFER, an older queued fire can
 	// drain after a newer fire has already been processed.
 	if scheduledTime.After(state.LastRunTime) {
@@ -531,7 +541,7 @@ func tryStartFire(ctx workflow.Context, logger *zap.Logger, input *SchedulerWork
 		Action:              *input.Action.StartWorkflow,
 		ScheduledTime:       scheduledTime,
 		TriggerSource:       trigger,
-		OverlapPolicy:       input.Policies.OverlapPolicy,
+		OverlapPolicy:       overlapPolicy,
 		LastStartedWorkflow: state.LastStartedWorkflow,
 	}
 
@@ -572,7 +582,7 @@ func tryStartFire(ctx workflow.Context, logger *zap.Logger, input *SchedulerWork
 // user-configured buffer_limit and the MaxBufferedFiresSystemLimit ceiling.
 // Drops increment SkippedRuns and emit scheduler_buffer_overflow_count_per_domain
 // tagged with the binding limit (user_limit vs. system_limit).
-func enqueueBufferedFire(logger *zap.Logger, scope tally.Scope, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource) {
+func enqueueBufferedFire(logger *zap.Logger, scope tally.Scope, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource, overlapPolicy types.ScheduleOverlapPolicy) {
 	effective, reason := effectiveBufferLimit(input.Policies.BufferLimit)
 	if len(state.BufferedFires) >= effective {
 		state.SkippedRuns++
@@ -591,6 +601,7 @@ func enqueueBufferedFire(logger *zap.Logger, scope tally.Scope, input *Scheduler
 	state.BufferedFires = append(state.BufferedFires, BufferedFire{
 		ScheduledTime: scheduledTime,
 		TriggerSource: trigger,
+		OverlapPolicy: overlapPolicy,
 	})
 	logger.Info("schedule fire buffered",
 		zap.Time("scheduledTime", scheduledTime),
@@ -631,7 +642,11 @@ func drainBufferedFires(ctx workflow.Context, logger *zap.Logger, input *Schedul
 			return true
 		}
 		head := state.BufferedFires[0]
-		if tryStartFire(ctx, logger, input, state, head.ScheduledTime, head.TriggerSource) == fireOutcomeBuffered {
+		headOverlap := head.OverlapPolicy
+		if headOverlap == types.ScheduleOverlapPolicyInvalid {
+			headOverlap = input.Policies.OverlapPolicy
+		}
+		if tryStartFire(ctx, logger, input, state, head.ScheduledTime, head.TriggerSource, headOverlap) == fireOutcomeBuffered {
 			return false
 		}
 		state.BufferedFires = state.BufferedFires[1:]
@@ -791,7 +806,7 @@ func processMissedRunsAt(ctx workflow.Context, logger *zap.Logger, scope tally.S
 		if fired >= maxCatchUpFiresPerExecution {
 			break
 		}
-		processScheduleFire(ctx, logger, scope, input, state, t, TriggerSourceSchedule)
+		processScheduleFire(ctx, logger, scope, input, state, t, TriggerSourceSchedule, input.Policies.OverlapPolicy)
 		fired++
 	}
 	unfired := int64(len(result.toFire) - fired)
@@ -854,7 +869,8 @@ func processBackfills(ctx workflow.Context, logger *zap.Logger, scope tally.Scop
 				scope.Counter(SchedulerBackfillFiredCountPerDomain).Inc(int64(fired))
 				return true
 			}
-			processScheduleFire(ctx, logger, scope, input, state, t, TriggerSourceBackfill)
+			overlap := effectiveFireOverlap(TriggerSourceBackfill, bf.OverlapPolicy, input.Policies.OverlapPolicy)
+			processScheduleFire(ctx, logger, scope, input, state, t, TriggerSourceBackfill, overlap)
 			fired++
 		}
 

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -471,6 +471,16 @@ func handleBackfill(logger *zap.Logger, sig BackfillSignal, state *SchedulerWork
 	return true
 }
 
+// effectiveFireOverlap returns the overlap policy applied to a single fire.
+// For backfill, BackfillSignal.overlap_policy may be INVALID (0) to inherit the
+// schedule's configured policy; any other value overrides for that backfill only.
+func effectiveFireOverlap(trigger TriggerSource, backfillOverlap, scheduleOverlap types.ScheduleOverlapPolicy) types.ScheduleOverlapPolicy {
+	if trigger == TriggerSourceBackfill && backfillOverlap != types.ScheduleOverlapPolicyInvalid {
+		return backfillOverlap
+	}
+	return scheduleOverlap
+}
+
 // processScheduleFire executes the configured action for a single schedule fire.
 // All side effects (overlap check, cancel/terminate, start) are encapsulated in
 // a single activity so that the overlap logic can evolve without introducing
@@ -488,16 +498,6 @@ func handleBackfill(logger *zap.Logger, sig BackfillSignal, state *SchedulerWork
 // the live-fire activity call, the previous workflow could complete.
 // tryStartFire would then start the live fire ahead of older queued fires,
 // breaking FIFO.
-// effectiveFireOverlap returns the overlap policy applied to a single fire.
-// For backfill, BackfillSignal.overlap_policy may be INVALID (0) to inherit the
-// schedule's configured policy; any other value overrides for that backfill only.
-func effectiveFireOverlap(trigger TriggerSource, backfillOverlap, scheduleOverlap types.ScheduleOverlapPolicy) types.ScheduleOverlapPolicy {
-	if trigger == TriggerSourceBackfill && backfillOverlap != types.ScheduleOverlapPolicyInvalid {
-		return backfillOverlap
-	}
-	return scheduleOverlap
-}
-
 func processScheduleFire(ctx workflow.Context, logger *zap.Logger, scope tally.Scope, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource, overlapPolicy types.ScheduleOverlapPolicy) {
 	if overlapPolicy == types.ScheduleOverlapPolicyBuffer && len(state.BufferedFires) > 0 {
 		// Skipping tryStartFire, so advance LastRunTime here.

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -780,6 +780,44 @@ func TestHandleBackfill(t *testing.T) {
 	}
 }
 
+func TestEffectiveFireOverlap(t *testing.T) {
+	tests := []struct {
+		name            string
+		trigger         TriggerSource
+		backfillOverlap types.ScheduleOverlapPolicy
+		scheduleOverlap types.ScheduleOverlapPolicy
+		want            types.ScheduleOverlapPolicy
+	}{
+		{
+			name:            "schedule fire always uses schedule overlap",
+			trigger:         TriggerSourceSchedule,
+			backfillOverlap: types.ScheduleOverlapPolicyConcurrent,
+			scheduleOverlap: types.ScheduleOverlapPolicySkipNew,
+			want:            types.ScheduleOverlapPolicySkipNew,
+		},
+		{
+			name:            "backfill INVALID inherits schedule overlap",
+			trigger:         TriggerSourceBackfill,
+			backfillOverlap: types.ScheduleOverlapPolicyInvalid,
+			scheduleOverlap: types.ScheduleOverlapPolicyBuffer,
+			want:            types.ScheduleOverlapPolicyBuffer,
+		},
+		{
+			name:            "backfill non-invalid overrides schedule overlap",
+			trigger:         TriggerSourceBackfill,
+			backfillOverlap: types.ScheduleOverlapPolicyConcurrent,
+			scheduleOverlap: types.ScheduleOverlapPolicyBuffer,
+			want:            types.ScheduleOverlapPolicyConcurrent,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := effectiveFireOverlap(tt.trigger, tt.backfillOverlap, tt.scheduleOverlap)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestProcessBackfillsRespectsPause(t *testing.T) {
 	sched := mustParseCron(t, "0 * * * *")
 	input := &SchedulerWorkflowInput{
@@ -1120,42 +1158,42 @@ func TestEnqueueBufferedFire(t *testing.T) {
 		{
 			name:         "unlimited buffer accepts fire when bufferLimit=0",
 			bufferLimit:  0,
-			initialFires: []BufferedFire{{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule}},
+			initialFires: []BufferedFire{{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule, OverlapPolicy: types.ScheduleOverlapPolicyBuffer}},
 			enqueueTime:  t0.Add(time.Minute),
 			trigger:      TriggerSourceSchedule,
 			wantFires: []BufferedFire{
-				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
-				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule},
+				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule, OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
+				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule, OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
 			},
 		},
 		{
 			name:        "enqueue below limit appends to tail",
 			bufferLimit: 3,
 			initialFires: []BufferedFire{
-				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
-				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule},
+				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule, OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
+				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule, OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
 			},
 			enqueueTime: t0.Add(2 * time.Minute),
 			trigger:     TriggerSourceSchedule,
 			wantFires: []BufferedFire{
-				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
-				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule},
-				{ScheduledTime: t0.Add(2 * time.Minute), TriggerSource: TriggerSourceSchedule},
+				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule, OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
+				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule, OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
+				{ScheduledTime: t0.Add(2 * time.Minute), TriggerSource: TriggerSourceSchedule, OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
 			},
 		},
 		{
 			name:        "enqueue at user limit drops fire and emits user_limit metric",
 			bufferLimit: 2,
 			initialFires: []BufferedFire{
-				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
-				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule},
+				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule, OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
+				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule, OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
 			},
 			initialSkipped: 5,
 			enqueueTime:    t0.Add(2 * time.Minute),
 			trigger:        TriggerSourceSchedule,
 			wantFires: []BufferedFire{
-				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
-				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule},
+				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule, OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
+				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule, OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
 			},
 			wantSkippedRuns:    6,
 			wantOverflowReason: BufferOverflowReasonUserLimit,
@@ -1188,7 +1226,7 @@ func TestEnqueueBufferedFire(t *testing.T) {
 			enqueueTime:  t0,
 			trigger:      TriggerSourceBackfill,
 			wantFires: []BufferedFire{
-				{ScheduledTime: t0, TriggerSource: TriggerSourceBackfill},
+				{ScheduledTime: t0, TriggerSource: TriggerSourceBackfill, OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
 			},
 		},
 	}
@@ -1203,7 +1241,7 @@ func TestEnqueueBufferedFire(t *testing.T) {
 				SkippedRuns:   tt.initialSkipped,
 			}
 			scope := tally.NewTestScope("", nil)
-			enqueueBufferedFire(testLogger, scope, input, state, tt.enqueueTime, tt.trigger)
+			enqueueBufferedFire(testLogger, scope, input, state, tt.enqueueTime, tt.trigger, types.ScheduleOverlapPolicyBuffer)
 			assert.Equal(t, tt.wantFires, state.BufferedFires)
 			assert.Equal(t, tt.wantSkippedRuns, state.SkippedRuns)
 
@@ -1228,6 +1266,7 @@ func largeBufferedFires(n int, base time.Time) []BufferedFire {
 		out[i] = BufferedFire{
 			ScheduledTime: base.Add(time.Duration(i) * time.Second),
 			TriggerSource: TriggerSourceSchedule,
+			OverlapPolicy: types.ScheduleOverlapPolicyBuffer,
 		}
 	}
 	return out
@@ -1280,7 +1319,7 @@ func TestProcessScheduleFireBufferEnqueuesWhenQueueNonEmpty(t *testing.T) {
 	}
 	state := &SchedulerWorkflowState{
 		BufferedFires: []BufferedFire{
-			{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
+			{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule, OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
 		},
 	}
 	scope := tally.NewTestScope("", nil)
@@ -1289,7 +1328,7 @@ func TestProcessScheduleFireBufferEnqueuesWhenQueueNonEmpty(t *testing.T) {
 	// nil ctx is safe because the BUFFER+non-empty-queue branch returns before
 	// touching workflow.ExecuteLocalActivity. If the fast path were ever
 	// removed, this call would panic — which is the property we want to lock in.
-	processScheduleFire(nil, testLogger, scope, input, state, liveFire, TriggerSourceSchedule)
+	processScheduleFire(nil, testLogger, scope, input, state, liveFire, TriggerSourceSchedule, types.ScheduleOverlapPolicyBuffer)
 
 	require.Len(t, state.BufferedFires, 2, "live fire should be enqueued at the tail")
 	assert.Equal(t, t0, state.BufferedFires[0].ScheduledTime, "older queued fire stays at head")
@@ -1419,8 +1458,8 @@ func TestEffectiveBufferLimit(t *testing.T) {
 func TestHandleUpdate_BufferedFiresClearedOnOverlapPolicyChange(t *testing.T) {
 	t0 := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 	initialFires := []BufferedFire{
-		{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule},
-		{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule},
+		{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule, OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
+		{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule, OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
 	}
 
 	tests := []struct {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Scheduler workflow now resolves overlap per fire for backfills: BackfillRequest / signal overlap_policy INVALID (0) or omitted uses the schedule’s stored SchedulePolicies.overlap_policy; any other value overrides only for that backfill (stored schedule policy unchanged).

BufferedFire gains overlap_policy (JSON overlapPolicy, omitempty). Enqueue/drain and the BUFFER “queue non-empty” fast path use the resolved overlap instead of always using input.Policies.OverlapPolicy.

drainBufferedFires treats persisted overlapPolicy == INVALID as “use current schedule overlap” for older Continue-as-new payloads without the field.

**Why?**
Previously, backfill overlap on PendingBackfills was ignored: processScheduleFire / tryStartFire always sent input.Policies.OverlapPolicy, so per-backfill overrides never reached processScheduleFireActivity. Buffered fires also had no per-fire overlap, so behavior could not match the API contract.

**How did you test it?**
go test -count=1 ./service/worker/scheduler/...

**Potential risks**
If the schedule overlap is BUFFER and the buffer is non-empty, a backfill with overlap CONCURRENT (or other non-BUFFER) does not use the BUFFER fast path and can go to the activity immediately while older fires remain queued. That matches “override for this fire” but can surprise anyone who expects strict global FIFO across all fire kinds. Document or accept explicitly.


**Release notes**
Backfill requests that set overlap_policy now take effect for backfill-generated fires. Omitted or INVALID backfill overlap continues to use the schedule’s configured overlap policy.

**Documentation Changes**
N/A
