### PR TITLE
feat(CLI): Add concurrency_limit support in CLI.

### DIFF
--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -190,6 +190,7 @@ const (
 	FlagMaxMessageCount                = "max_message_count"
 	FlagLastMessageID                  = "last_message_id"
 	FlagConcurrency                    = "concurrency"
+	FlagConcurrencyLimit               = "concurrency_limit"
 	FlagReportRate                     = "report_rate"
 	FlagLowerShardBound                = "lower_shard_bound"
 	FlagUpperShardBound                = "upper_shard_bound"

--- a/tools/cli/schedule.go
+++ b/tools/cli/schedule.go
@@ -102,7 +102,7 @@ var (
 		},
 		&cli.IntFlag{
 			Name:  FlagConcurrencyLimit,
-			Usage: "New max number of concurrently running target workflows when overlap policy is Concurrent (0 = unlimited)",
+			Usage: "Max concurrent target workflows (only effective with --overlap_policy concurrent; 0 = unlimited)",
 		},
 		&cli.StringFlag{
 			Name:  FlagCatchUpPolicy,

--- a/tools/cli/schedule.go
+++ b/tools/cli/schedule.go
@@ -70,6 +70,10 @@ var (
 			Name:  FlagOverlapPolicy,
 			Usage: "Overlap policy: SkipNew, Buffer, Concurrent, CancelPrevious, TerminatePrevious",
 		},
+		&cli.IntFlag{
+			Name:  FlagConcurrencyLimit,
+			Usage: "Max concurrent target workflows (only effective with --overlap_policy concurrent; 0 = unlimited)",
+		},
 		&cli.StringFlag{
 			Name:  FlagCatchUpPolicy,
 			Usage: "Catch-up policy: Skip, One, All",
@@ -95,6 +99,10 @@ var (
 		&cli.StringFlag{
 			Name:  FlagOverlapPolicy,
 			Usage: "New overlap policy: SkipNew, Buffer, Concurrent, CancelPrevious, TerminatePrevious",
+		},
+		&cli.IntFlag{
+			Name:  FlagConcurrencyLimit,
+			Usage: "New max number of concurrently running target workflows when overlap policy is Concurrent (0 = unlimited)",
 		},
 		&cli.StringFlag{
 			Name:  FlagCatchUpPolicy,

--- a/tools/cli/schedule_commands.go
+++ b/tools/cli/schedule_commands.go
@@ -166,6 +166,12 @@ func (sc *scheduleCLIImpl) UpdateSchedule(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	// Only reject explicit conflicts; standalone --concurrency_limit updates are
+	// valid when the schedule's existing server-side policy is already concurrent.
+	if policies != nil && policies.ConcurrencyLimit > 0 &&
+		c.IsSet(FlagOverlapPolicy) && policies.OverlapPolicy != types.ScheduleOverlapPolicyConcurrent {
+		return commoncli.Problem("--concurrency_limit requires --overlap_policy concurrent", nil)
+	}
 	request.Policies = policies
 
 	if request.Spec == nil && request.Policies == nil {

--- a/tools/cli/schedule_commands.go
+++ b/tools/cli/schedule_commands.go
@@ -88,6 +88,10 @@ func (sc *scheduleCLIImpl) CreateSchedule(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	if policies != nil && policies.ConcurrencyLimit > 0 &&
+		policies.OverlapPolicy != types.ScheduleOverlapPolicyConcurrent {
+		return commoncli.Problem("--concurrency_limit requires --overlap_policy concurrent", nil)
+	}
 	if policies != nil {
 		request.Policies = policies
 	}
@@ -165,7 +169,7 @@ func (sc *scheduleCLIImpl) UpdateSchedule(c *cli.Context) error {
 	request.Policies = policies
 
 	if request.Spec == nil && request.Policies == nil {
-		return commoncli.Problem("At least one of --cron_expression, --overlap_policy, or --catch_up_policy must be set", nil)
+		return commoncli.Problem("At least one of --cron_expression, --overlap_policy, --catch_up_policy, or --concurrency_limit must be set", nil)
 	}
 
 	ctx, cancel, err := newContext(c)
@@ -368,7 +372,8 @@ func (sc *scheduleCLIImpl) ListSchedules(c *cli.Context) error {
 func buildPoliciesFromFlags(c *cli.Context) (*types.SchedulePolicies, error) {
 	hasOverlap := c.IsSet(FlagOverlapPolicy)
 	hasCatchUp := c.IsSet(FlagCatchUpPolicy)
-	if !hasOverlap && !hasCatchUp {
+	hasLimit := c.IsSet(FlagConcurrencyLimit)
+	if !hasOverlap && !hasCatchUp && !hasLimit {
 		return nil, nil
 	}
 
@@ -386,6 +391,13 @@ func buildPoliciesFromFlags(c *cli.Context) (*types.SchedulePolicies, error) {
 			return nil, err
 		}
 		policies.CatchUpPolicy = p
+	}
+	if hasLimit {
+		limit := int32(c.Int(FlagConcurrencyLimit))
+		if limit < 0 {
+			return nil, commoncli.Problem("--concurrency_limit must be >= 0", nil)
+		}
+		policies.ConcurrencyLimit = limit
 	}
 	return policies, nil
 }

--- a/tools/cli/schedule_commands_test.go
+++ b/tools/cli/schedule_commands_test.go
@@ -77,6 +77,85 @@ func TestScheduleCLI_CreateSchedule(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestScheduleCLI_CreateSchedule_ConcurrencyLimit(t *testing.T) {
+	makeCtx := func(app *cli.App, extraArgs []string) *cli.Context {
+		set := flag.NewFlagSet("test", 0)
+		set.String(FlagDomain, "", "")
+		set.String(FlagTransport, "", "")
+		set.String(FlagScheduleID, "", "")
+		set.String(FlagCronExpression, "", "")
+		set.String(FlagWorkflowType, "", "")
+		set.String(FlagOverlapPolicy, "", "")
+		set.Int(FlagConcurrencyLimit, 0, "")
+		set.Int(FlagExecutionTimeout, 0, "")
+		set.Int(FlagDecisionTimeout, 0, "")
+		baseArgs := []string{
+			"--" + FlagDomain, "test-domain",
+			"--" + FlagTransport, grpcTransport,
+			"--" + FlagScheduleID, "my-sched",
+			"--" + FlagCronExpression, "*/5 * * * *",
+			"--" + FlagWorkflowType, "my-wf",
+			"--" + FlagExecutionTimeout, "3600",
+			"--" + FlagDecisionTimeout, "10",
+		}
+		_ = set.Parse(append(baseArgs, extraArgs...))
+		return cli.NewContext(app, set, nil)
+	}
+
+	tests := []struct {
+		name        string
+		extraArgs   []string
+		setupMock   func(*frontend.MockClient)
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:      "concurrent policy with limit succeeds",
+			extraArgs: []string{"--" + FlagOverlapPolicy, "concurrent", "--" + FlagConcurrencyLimit, "3"},
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().CreateSchedule(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ interface{}, req *types.CreateScheduleRequest, _ ...interface{}) (*types.CreateScheduleResponse, error) {
+						assert.Equal(t, types.ScheduleOverlapPolicyConcurrent, req.Policies.OverlapPolicy)
+						assert.Equal(t, int32(3), req.Policies.ConcurrencyLimit)
+						return &types.CreateScheduleResponse{ScheduleID: "my-sched"}, nil
+					})
+			},
+		},
+		{
+			name:        "concurrency_limit without overlap_policy returns error",
+			extraArgs:   []string{"--" + FlagConcurrencyLimit, "3"},
+			wantErr:     true,
+			errContains: "--concurrency_limit requires --overlap_policy concurrent",
+		},
+		{
+			name:        "concurrency_limit with non-concurrent policy returns error",
+			extraArgs:   []string{"--" + FlagOverlapPolicy, "skipnew", "--" + FlagConcurrencyLimit, "3"},
+			wantErr:     true,
+			errContains: "--concurrency_limit requires --overlap_policy concurrent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			mockClient := frontend.NewMockClient(mockCtrl)
+			app := newScheduleTestApp(t, mockClient)
+			if tt.setupMock != nil {
+				tt.setupMock(mockClient)
+			}
+			c := makeCtx(app, tt.extraArgs)
+			sc := &scheduleCLIImpl{frontendClient: mockClient}
+			err := sc.CreateSchedule(c)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestScheduleCLI_DescribeSchedule(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mockClient := frontend.NewMockClient(mockCtrl)
@@ -143,6 +222,80 @@ func TestScheduleCLI_UnpauseSchedule(t *testing.T) {
 	sc := &scheduleCLIImpl{frontendClient: mockClient}
 	err := sc.UnpauseSchedule(c)
 	assert.NoError(t, err)
+}
+
+func TestScheduleCLI_UpdateSchedule_ConcurrencyLimit(t *testing.T) {
+	makeCtx := func(app *cli.App, extraArgs []string) *cli.Context {
+		set := flag.NewFlagSet("test", 0)
+		set.String(FlagDomain, "", "")
+		set.String(FlagTransport, "", "")
+		set.String(FlagScheduleID, "", "")
+		set.String(FlagOverlapPolicy, "", "")
+		set.Int(FlagConcurrencyLimit, 0, "")
+		baseArgs := []string{
+			"--" + FlagDomain, "test-domain",
+			"--" + FlagTransport, grpcTransport,
+			"--" + FlagScheduleID, "my-sched",
+		}
+		_ = set.Parse(append(baseArgs, extraArgs...))
+		return cli.NewContext(app, set, nil)
+	}
+
+	tests := []struct {
+		name      string
+		extraArgs []string
+		setupMock func(*frontend.MockClient)
+		wantErr   bool
+	}{
+		{
+			name:      "only concurrency_limit succeeds",
+			extraArgs: []string{"--" + FlagConcurrencyLimit, "3"},
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().UpdateSchedule(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ interface{}, req *types.UpdateScheduleRequest, _ ...interface{}) (*types.UpdateScheduleResponse, error) {
+						assert.Nil(t, req.Spec)
+						assert.NotNil(t, req.Policies)
+						assert.Equal(t, int32(3), req.Policies.ConcurrencyLimit)
+						return &types.UpdateScheduleResponse{}, nil
+					})
+			},
+		},
+		{
+			name:      "concurrent policy with limit succeeds",
+			extraArgs: []string{"--" + FlagOverlapPolicy, "concurrent", "--" + FlagConcurrencyLimit, "5"},
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().UpdateSchedule(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ interface{}, req *types.UpdateScheduleRequest, _ ...interface{}) (*types.UpdateScheduleResponse, error) {
+						assert.Equal(t, types.ScheduleOverlapPolicyConcurrent, req.Policies.OverlapPolicy)
+						assert.Equal(t, int32(5), req.Policies.ConcurrencyLimit)
+						return &types.UpdateScheduleResponse{}, nil
+					})
+			},
+		},
+		{
+			name:    "no flags returns error",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			mockClient := frontend.NewMockClient(mockCtrl)
+			app := newScheduleTestApp(t, mockClient)
+			if tt.setupMock != nil {
+				tt.setupMock(mockClient)
+			}
+			c := makeCtx(app, tt.extraArgs)
+			sc := &scheduleCLIImpl{frontendClient: mockClient}
+			err := sc.UpdateSchedule(c)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
 func TestScheduleCLI_DeleteSchedule(t *testing.T) {
@@ -380,4 +533,79 @@ func TestScheduleCLI_CreateMissingDomain(t *testing.T) {
 	err := sc.CreateSchedule(c)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "domain")
+}
+
+func TestScheduleCLI_BuildPoliciesFromFlags(t *testing.T) {
+	app := cli.NewApp()
+
+	makeCtx := func(args []string) *cli.Context {
+		set := flag.NewFlagSet("test", 0)
+		set.String(FlagOverlapPolicy, "", "")
+		set.String(FlagCatchUpPolicy, "", "")
+		set.Int(FlagConcurrencyLimit, 0, "")
+		_ = set.Parse(args)
+		return cli.NewContext(app, set, nil)
+	}
+
+	tests := []struct {
+		name       string
+		args       []string
+		wantResult *types.SchedulePolicies
+		wantErr    bool
+	}{
+		{
+			name:       "no flags returns nil",
+			args:       nil,
+			wantResult: nil,
+		},
+		{
+			name:       "only --overlap_policy sets OverlapPolicy in result",
+			args:       []string{"--" + FlagOverlapPolicy, "concurrent"},
+			wantResult: &types.SchedulePolicies{OverlapPolicy: types.ScheduleOverlapPolicyConcurrent},
+		},
+		{
+			name:       "only --catch_up_policy sets CatchUpPolicy in result",
+			args:       []string{"--" + FlagCatchUpPolicy, "skip"},
+			wantResult: &types.SchedulePolicies{CatchUpPolicy: types.ScheduleCatchUpPolicySkip},
+		},
+		{
+			name:       "only --concurrency_limit sets ConcurrencyLimit in result",
+			args:       []string{"--" + FlagConcurrencyLimit, "3"},
+			wantResult: &types.SchedulePolicies{ConcurrencyLimit: 3},
+		},
+		{
+			name: "--overlap_policy concurrent and --concurrency_limit both set in result",
+			args: []string{"--" + FlagOverlapPolicy, "concurrent", "--" + FlagConcurrencyLimit, "3"},
+			wantResult: &types.SchedulePolicies{
+				OverlapPolicy:    types.ScheduleOverlapPolicyConcurrent,
+				ConcurrencyLimit: 3,
+			},
+		},
+		{
+			name: "--concurrency_limit with non-concurrent overlap policy passes through without error",
+			args: []string{"--" + FlagOverlapPolicy, "skipnew", "--" + FlagConcurrencyLimit, "3"},
+			wantResult: &types.SchedulePolicies{
+				OverlapPolicy:    types.ScheduleOverlapPolicySkipNew,
+				ConcurrencyLimit: 3,
+			},
+		},
+		{
+			name:    "negative --concurrency_limit returns error",
+			args:    []string{"--" + FlagConcurrencyLimit, "-1"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := makeCtx(tt.args)
+			got, err := buildPoliciesFromFlags(c)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantResult, got)
+			}
+		})
+	}
 }

--- a/tools/cli/schedule_commands_test.go
+++ b/tools/cli/schedule_commands_test.go
@@ -242,10 +242,11 @@ func TestScheduleCLI_UpdateSchedule_ConcurrencyLimit(t *testing.T) {
 	}
 
 	tests := []struct {
-		name      string
-		extraArgs []string
-		setupMock func(*frontend.MockClient)
-		wantErr   bool
+		name        string
+		extraArgs   []string
+		setupMock   func(*frontend.MockClient)
+		wantErr     bool
+		errContains string
 	}{
 		{
 			name:      "only concurrency_limit succeeds",
@@ -261,6 +262,18 @@ func TestScheduleCLI_UpdateSchedule_ConcurrencyLimit(t *testing.T) {
 			},
 		},
 		{
+			name:      "concurrency_limit 0 removes the cap",
+			extraArgs: []string{"--" + FlagConcurrencyLimit, "0"},
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().UpdateSchedule(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ interface{}, req *types.UpdateScheduleRequest, _ ...interface{}) (*types.UpdateScheduleResponse, error) {
+						assert.NotNil(t, req.Policies)
+						assert.Equal(t, int32(0), req.Policies.ConcurrencyLimit)
+						return &types.UpdateScheduleResponse{}, nil
+					})
+			},
+		},
+		{
 			name:      "concurrent policy with limit succeeds",
 			extraArgs: []string{"--" + FlagOverlapPolicy, "concurrent", "--" + FlagConcurrencyLimit, "5"},
 			setupMock: func(m *frontend.MockClient) {
@@ -271,6 +284,12 @@ func TestScheduleCLI_UpdateSchedule_ConcurrencyLimit(t *testing.T) {
 						return &types.UpdateScheduleResponse{}, nil
 					})
 			},
+		},
+		{
+			name:        "concurrency_limit with non-concurrent overlap policy returns error",
+			extraArgs:   []string{"--" + FlagOverlapPolicy, "skipnew", "--" + FlagConcurrencyLimit, "3"},
+			wantErr:     true,
+			errContains: "--concurrency_limit requires --overlap_policy concurrent",
 		},
 		{
 			name:    "no flags returns error",
@@ -291,6 +310,9 @@ func TestScheduleCLI_UpdateSchedule_ConcurrencyLimit(t *testing.T) {
 			err := sc.UpdateSchedule(c)
 			if tt.wantErr {
 				assert.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
 			} else {
 				assert.NoError(t, err)
 			}


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
 Added --concurrency_limit flag to cadence schedule create and cadence schedule update commands. The flag sets SchedulePolicies.ConcurrencyLimit, which caps the number of concurrently running target workflows    
  when --overlap_policy concurrent is used.
                                                                                                                                                                                                                     
  - flags.go: added FlagConcurrencyLimit = "concurrency_limit" constant                                                                                                                                              
  - schedule.go: added --concurrency_limit IntFlag to createScheduleFlags and updateScheduleFlags
  - schedule_commands.go: extended buildPoliciesFromFlags to read and validate the flag; added create-side validation that rejects --concurrency_limit > 0 without --overlap_policy concurrent; updated the update   
  guard error message to mention --concurrency_limit                                                                                                                                                                 
                                                  

**Why?**

- Without this flag, the only way to set a concurrency cap was via raw API/gRPC calls. An operator who set --overlap_policy concurrent had no discoverable path to limit parallelism.

**How did you test it?**
 Added unit tests in schedule_commands_test.go:                                                                                                                                                                     
  - TestScheduleCLI_BuildPoliciesFromFlags: covers each flag in isolation, the concurrent+limit combination, non-concurrent+limit passthrough, and negative value rejection
  - TestScheduleCLI_CreateSchedule_ConcurrencyLimit: covers the create-side validation — concurrent+limit succeeds, limit without overlap policy errors, limit with non-concurrent policy errors                     
  - TestScheduleCLI_UpdateSchedule_ConcurrencyLimit: covers limit-only update (valid standalone operation) and concurrent+limit together  

**Potential risks**

- no existing behavior is modified. The new flag defaults to 0 (unlimited), matching the prior behavior for all existing schedules.                                                      


**Release notes**

- cadence schedule create and cadence schedule update now accept --concurrency_limit <N> to cap the number of concurrently running target workflows when using --overlap_policy concurrent. 
- Setting --concurrency_limit 0 (the default) means unlimited.  

**Documentation Changes**

