### PR TITLE
fix: close file to prevent leak in setuptask

### DIFF
--- a/tools/common/schema/setuptask.go
+++ b/tools/common/schema/setuptask.go
@@ -64,6 +64,7 @@ func (task *SetupTask) Run() error {
 		if err != nil {
 			return err
 		}
+		defer file.Close()
 		stmts, err := ParseFile(file)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Close file after parsing it.

Delivers https://github.com/cadence-workflow/cadence/pull/5942 that was never merged.

**Why?**
File was not being closed and we could be leaking resources.

**How did you test it?**
Not covered by unit tests. Not worth to add it at this point.

**Potential risks**
No risk.

**Release notes**
N/A

**Documentation Changes**
N/A
