### PR TITLE
feat: Add minimum tasklist write partition dynamic config

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -910,6 +910,12 @@ const (
 	// Default value: 0
 	// Allowed filters: N/A
 	MatchingPercentageOnboardedToShardManager
+	// MatchingTaskListMinimumWritePartitions is the minimum number of write partitions that the AdaptiveScaler will specify for a TaskList.
+	// KeyName: matching.taskListMinimumWritePartitions
+	// Value type: Int
+	// Default value: 1
+	// Allowed filters: DomainName,TasklistName,TaskType
+	MatchingTaskListMinimumWritePartitions
 
 	// key for history
 
@@ -3866,6 +3872,12 @@ var IntKeys = map[IntKey]DynamicInt{
 		KeyName:      "matching.percentageOnboardedToShardManager",
 		Description:  "MatchingPercentageOnboardedToShardManager is the percentage of task lists that will be onboarded to the shard manager",
 		DefaultValue: 0,
+	},
+	MatchingTaskListMinimumWritePartitions: {
+		KeyName:      "matching.taskListMinimumWritePartitions",
+		Filters:      []Filter{DomainName, TaskListName, TaskType},
+		Description:  "MatchingTaskListMinimumWritePartitions is the minimum number of write partitions",
+		DefaultValue: 1,
 	},
 	HistoryRPS: {
 		KeyName:      "history.rps",

--- a/service/matching/config/config.go
+++ b/service/matching/config/config.go
@@ -61,6 +61,7 @@ type (
 		TaskIsolationDuration                     dynamicproperties.DurationPropertyFnWithTaskListInfoFilters
 		TaskIsolationPollerWindow                 dynamicproperties.DurationPropertyFnWithTaskListInfoFilters
 		EnableGetNumberOfPartitionsFromCache      dynamicproperties.BoolPropertyFnWithTaskListInfoFilters
+		MinTaskListWritePartitions                dynamicproperties.IntPropertyFnWithTaskListInfoFilters
 		PartitionUpscaleRPS                       dynamicproperties.IntPropertyFnWithTaskListInfoFilters
 		PartitionDownscaleFactor                  dynamicproperties.FloatPropertyFnWithTaskListInfoFilters
 		PartitionUpscaleSustainedDuration         dynamicproperties.DurationPropertyFnWithTaskListInfoFilters
@@ -139,6 +140,7 @@ type (
 		AsyncTaskDispatchTimeout                  func() time.Duration
 		LocalPollWaitTime                         func() time.Duration
 		LocalTaskWaitTime                         func() time.Duration
+		MinTaskListWritePartitions                func() int
 		PartitionUpscaleRPS                       func() int
 		PartitionDownscaleFactor                  func() float64
 		PartitionUpscaleSustainedDuration         func() time.Duration
@@ -246,5 +248,6 @@ func NewConfig(dc *dynamicconfig.Collection, hostName string, rpcConfig config.R
 		EnableReturnAllTaskListKinds:               dc.GetBoolProperty(dynamicproperties.MatchingEnableReturnAllTaskListKinds),
 		ExcludeShortLivedTaskListsFromShardManager: dc.GetBoolProperty(dynamicproperties.MatchingExcludeShortLivedTaskListsFromShardManager),
 		PercentageOnboardedToShardManager:          dc.GetIntProperty(dynamicproperties.MatchingPercentageOnboardedToShardManager),
+		MinTaskListWritePartitions:                 dc.GetIntPropertyFilteredByTaskListInfo(dynamicproperties.MatchingTaskListMinimumWritePartitions),
 	}
 }

--- a/service/matching/config/config_test.go
+++ b/service/matching/config/config_test.go
@@ -108,6 +108,7 @@ func TestNewConfig(t *testing.T) {
 		"AppendTaskTimeout":                          {dynamicproperties.AppendTaskTimeout, time.Duration(42)},
 		"ExcludeShortLivedTaskListsFromShardManager": {dynamicproperties.MatchingExcludeShortLivedTaskListsFromShardManager, false},
 		"PercentageOnboardedToShardManager":          {dynamicproperties.MatchingPercentageOnboardedToShardManager, 0},
+		"MinTaskListWritePartitions":                 {dynamicproperties.MatchingTaskListMinimumWritePartitions, 1},
 	}
 	client := dynamicconfig.NewInMemoryClient()
 	for fieldName, expected := range fields {

--- a/service/matching/tasklist/adaptive_scaler.go
+++ b/service/matching/tasklist/adaptive_scaler.go
@@ -239,14 +239,17 @@ func (a *adaptiveScalerImpl) calculateWritePartitionCount(qps float64, numWriteP
 	a.scope.UpdateGauge(metrics.TaskListPartitionUpscaleThresholdGauge, upscaleThreshold)
 	a.scope.UpdateGauge(metrics.TaskListPartitionDownscaleThresholdGauge, downscaleThreshold)
 
-	result := numWritePartitions
+	// Ensure number of write partitions is over than minimum value of write partitions
+	minWritePartitions := max(1, a.config.MinTaskListWritePartitions())
+	result := max(numWritePartitions, minWritePartitions)
+
 	if a.overLoad.CheckAndReset(qps > upscaleThreshold) {
-		result = getNumberOfPartitions(qps, upscaleRps)
+		result = getNumberOfPartitions(qps, upscaleRps, minWritePartitions)
 		a.scope.IncCounter(metrics.PartitionUpscale)
 		a.logger.Info("adjust write partitions", tag.CurrentQPS(qps), tag.PartitionUpscaleThreshold(upscaleThreshold), tag.PartitionDownscaleThreshold(downscaleThreshold), tag.PartitionDownscaleFactor(downscaleFactor), tag.CurrentNumWritePartitions(numWritePartitions), tag.NumWritePartitions(result))
 	}
 	if a.underLoad.CheckAndReset(qps < downscaleThreshold) {
-		result = getNumberOfPartitions(qps, upscaleRps)
+		result = getNumberOfPartitions(qps, upscaleRps, minWritePartitions)
 		a.scope.IncCounter(metrics.PartitionDownscale)
 		a.logger.Info("adjust write partitions", tag.CurrentQPS(qps), tag.PartitionUpscaleThreshold(upscaleThreshold), tag.PartitionDownscaleThreshold(downscaleThreshold), tag.PartitionDownscaleFactor(downscaleFactor), tag.CurrentNumWritePartitions(numWritePartitions), tag.NumWritePartitions(result))
 
@@ -421,10 +424,18 @@ func getTaskListType(taskListType int) *types.TaskListType {
 	return nil
 }
 
-func getNumberOfPartitions(qps float64, upscaleQPS float64) int {
-	p := int(math.Ceil(qps / upscaleQPS))
-	if p <= 0 {
-		p = 1
+// getNumberOfPartitions calculates the number of partitions using qps (float64) and upsacleQPS (float64).
+// If the calculated result is lower than the value of minimum write partitions (dynamicConfig),
+// it enforces to return the minimum value of write partitions. (default 1)
+func getNumberOfPartitions(qps float64, upscaleQPS float64, minWritePartitions int) int {
+	partitions := int(math.Ceil(qps / upscaleQPS))
+
+	// ensure minWritePartitions is greater than 0
+	minWritePartitions = max(1, minWritePartitions)
+
+	if partitions < minWritePartitions {
+		// Set minimum number of write partition using dynamic config (default 1)
+		partitions = minWritePartitions
 	}
-	return p
+	return partitions
 }

--- a/service/matching/tasklist/adaptive_scaler_test.go
+++ b/service/matching/tasklist/adaptive_scaler_test.go
@@ -594,6 +594,45 @@ func TestAdaptiveScalerRun(t *testing.T) {
 			},
 			cycles: 3,
 		},
+		{
+			name: "set minimum write partitions from dynamic config",
+			mockSetup: func(deps *mockAdaptiveScalerDeps) {
+				require.NoError(t, deps.dynamicClient.UpdateValue(dynamicproperties.MatchingTaskListMinimumWritePartitions, 4))
+
+				mockDescribeTaskList(deps, 0, withPartitionsAndQPS(1, 0))
+				deps.mockManager.EXPECT().TaskListPartitionConfig().Return(nil)
+				deps.mockManager.EXPECT().UpdateTaskListPartitionConfig(gomock.Any(), &types.TaskListPartitionConfig{
+					ReadPartitions:  partitions(4),
+					WritePartitions: partitions(4),
+				}).Return(nil)
+			},
+			cycles: 1,
+		},
+		{
+			name: "clamp malformed minimum write partitions to 1 on downscale",
+			mockSetup: func(deps *mockAdaptiveScalerDeps) {
+				require.NoError(t, deps.dynamicClient.UpdateValue(dynamicproperties.MatchingTaskListMinimumWritePartitions, -1))
+
+				mockDescribeTaskList(deps, 0, withPartitionsAndQPS(10, 0))
+				deps.mockManager.EXPECT().TaskListPartitionConfig().Return(&types.TaskListPartitionConfig{
+					WritePartitions: partitions(10),
+					ReadPartitions:  partitions(10),
+				})
+
+				mockDescribeTaskList(deps, 0, withPartitionsAndQPS(10, 0))
+				mockDescribeTaskList(deps, 9, withPartitionsAndQPS(10, 0))
+				deps.mockManager.EXPECT().TaskListPartitionConfig().Return(&types.TaskListPartitionConfig{
+					WritePartitions: partitions(10),
+					ReadPartitions:  partitions(10),
+				})
+				deps.mockManager.EXPECT().UpdateTaskListPartitionConfig(gomock.Any(),
+					&types.TaskListPartitionConfig{
+						WritePartitions: partitions(1),
+						ReadPartitions:  partitions(10),
+					}).Return(nil)
+			},
+			cycles: 2,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/service/matching/tasklist/isolation_balancer.go
+++ b/service/matching/tasklist/isolation_balancer.go
@@ -178,7 +178,7 @@ func (i *isolationBalancer) calculatePartitionGoal(aggregateMetrics *aggregatePa
 		sustainedOverLoad := state.overLoad.Check(groupQPS > upscaleThreshold)
 		sustainedUnderLoad := state.underLoad.Check(groupQPS < downscaleThreshold)
 
-		idealPartitions := getNumberOfPartitions(groupQPS, upscaleRps)
+		idealPartitions := getNumberOfPartitions(groupQPS, upscaleRps, 1)
 		// partitions must be >= minPartitions and <= writePartitionCount
 		targetPartitions := min(max(minPartitions, idealPartitions), writePartitionCount)
 

--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -1052,6 +1052,9 @@ func newTaskListConfig(id *Identifier, cfg *config.Config, domainName string) *c
 		MinTaskThrottlingBurstSize: func() int {
 			return cfg.MinTaskThrottlingBurstSize(domainName, taskListName, taskType)
 		},
+		MinTaskListWritePartitions: func() int {
+			return cfg.MinTaskListWritePartitions(domainName, taskListName, taskType)
+		},
 		EnableSyncMatch: func() bool {
 			return cfg.EnableSyncMatch(domainName, taskListName, taskType)
 		},


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Resolves #8021
- [ ] common/dynamicconfig/dynamicproperties/constants.go
- [ ] service/matching/config/config.go
- [ ] service/matching/config/config_test.go
- [ ] service/matching/tasklist/adaptive_scaler.go
- [ ] service/matching/tasklist/adaptive_scaler_test.go
- [ ] service/matching/tasklist/isolation_balancer.go
- [ ] service/matching/tasklist/task_list_manager.go

**Why?**

- common/dynamicconfig/dynamicproperties/constants.go: Add minimum tasklist write partition dynamic config with default value 1

- service/matching/config/config.go: Setup getter function to resolve the config value

- service/matching/config/config_test.go: To verify newly added config value

- service/matching/tasklist/adaptive_scaler.go: Add guard logic to enforce the writePartition value greater than 1, refactored `getNumberOfPartitions` to insert the min tasklist write partition config into it.

- service/matching/tasklist/adaptive_scaler_test.go: New test cases to check the modified logic

- service/matching/tasklist/isolation_balancer.go: isolation_balancer uses `getNumberOfPartitions` function which is defined in `adaptive_scaler.go`. Current issue is not targeted the changes in isolation_balancer, so i just make the behavior exactly same as before.

- service/matching/tasklist/task_list_manager.go: Setup getter function to resolve the config value

**How did you test it?**

Ran `go test ./service/matching/config/ ./service/matching/tasklist`

**Potential risks**


**Release notes**


**Documentation Changes**

