### PR TITLE
refactor(persistence): make SQL ExecutionStore request-aware for shard ID

### DIFF
--- a/common/persistence/sql/sql_execution_store.go
+++ b/common/persistence/sql/sql_execution_store.go
@@ -28,12 +28,14 @@ import (
 	"fmt"
 	"math"
 	"runtime/debug"
+	"sync"
 	"time"
 
 	"golang.org/x/sync/errgroup"
 
 	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
 	p "github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/serialization"
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
@@ -48,8 +50,9 @@ const (
 type sqlExecutionStore struct {
 	sqlStore
 	shardID                                int
+	inconsistentShardIDLogs                sync.Map
 	taskSerializer                         serialization.TaskSerializer
-	txExecuteShardLockedFn                 func(context.Context, int, string, int64, func(sqlplugin.Tx) error) error
+	txExecuteShardLockedFn                 func(context.Context, int, int, string, int64, func(sqlplugin.Tx) error) error
 	lockCurrentExecutionIfExistsFn         func(context.Context, sqlplugin.Tx, int, serialization.UUID, string) (*sqlplugin.CurrentExecutionsRow, error)
 	createOrUpdateCurrentExecutionFn       func(context.Context, sqlplugin.Tx, p.CreateWorkflowMode, int, serialization.UUID, string, serialization.UUID, int, int, string, int64, int64) error
 	assertNotCurrentExecutionFn            func(context.Context, sqlplugin.Tx, int, serialization.UUID, string, serialization.UUID) error
@@ -92,9 +95,40 @@ func NewSQLExecutionStore(
 	return store, nil
 }
 
+func resolveShardID(requestShardID *int, storeShardID int) (shardID int, reason string) {
+	if requestShardID == nil {
+		return storeShardID, "missing"
+	}
+	if *requestShardID != storeShardID {
+		return storeShardID, "mismatch"
+	}
+	return storeShardID, ""
+}
+
+func (m *sqlExecutionStore) effectiveShardID(requestShardID *int, operation string) int {
+	shardID, reason := resolveShardID(requestShardID, m.shardID)
+	if reason == "" || m.logger == nil {
+		return shardID
+	}
+	if _, loaded := m.inconsistentShardIDLogs.LoadOrStore(operation, struct{}{}); loaded {
+		return shardID
+	}
+	tags := []tag.Tag{
+		tag.ShardID(m.shardID),
+		tag.OperationName(operation),
+		tag.Dynamic("reason", reason),
+	}
+	if requestShardID != nil {
+		tags = append(tags, tag.Dynamic("request-shard-id", *requestShardID))
+	}
+	m.logger.Warn("execution store request inconsistent with store shard ID; using store shard ID", tags...)
+	return shardID
+}
+
 // txExecuteShardLocked executes f under transaction and with read lock on shard row
 func (m *sqlExecutionStore) txExecuteShardLocked(
 	ctx context.Context,
+	shardID int,
 	dbShardID int,
 	operation string,
 	rangeID int64,
@@ -102,7 +136,7 @@ func (m *sqlExecutionStore) txExecuteShardLocked(
 ) error {
 
 	return m.txExecute(ctx, dbShardID, operation, func(tx sqlplugin.Tx) error {
-		if err := readLockShard(ctx, tx, m.shardID, rangeID); err != nil {
+		if err := readLockShard(ctx, tx, shardID, rangeID); err != nil {
 			return err
 		}
 		err := fn(tx)
@@ -121,10 +155,11 @@ func (m *sqlExecutionStore) CreateWorkflowExecution(
 	ctx context.Context,
 	request *p.InternalCreateWorkflowExecutionRequest,
 ) (response *p.CreateWorkflowExecutionResponse, err error) {
-	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(m.shardID, m.db.GetTotalNumDBShards())
+	shardID := m.effectiveShardID(request.ShardID, "CreateWorkflowExecution")
+	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(shardID, m.db.GetTotalNumDBShards())
 
-	err = m.txExecuteShardLockedFn(ctx, dbShardID, "CreateWorkflowExecution", request.RangeID, func(tx sqlplugin.Tx) error {
-		response, err = m.createWorkflowExecutionTx(ctx, tx, request)
+	err = m.txExecuteShardLockedFn(ctx, shardID, dbShardID, "CreateWorkflowExecution", request.RangeID, func(tx sqlplugin.Tx) error {
+		response, err = m.createWorkflowExecutionTx(ctx, tx, request, shardID)
 		return err
 	})
 	return
@@ -134,13 +169,13 @@ func (m *sqlExecutionStore) createWorkflowExecutionTx(
 	ctx context.Context,
 	tx sqlplugin.Tx,
 	request *p.InternalCreateWorkflowExecutionRequest,
+	shardID int,
 ) (*p.CreateWorkflowExecutionResponse, error) {
 
 	newWorkflow := request.NewWorkflowSnapshot
 	executionInfo := newWorkflow.ExecutionInfo
 	startVersion := newWorkflow.StartVersion
 	lastWriteVersion := newWorkflow.LastWriteVersion
-	shardID := m.shardID
 	domainID := serialization.MustParseUUID(executionInfo.DomainID)
 	workflowID := executionInfo.WorkflowID
 	runID := serialization.MustParseUUID(executionInfo.RunID)
@@ -154,7 +189,7 @@ func (m *sqlExecutionStore) createWorkflowExecutionTx(
 
 	var err error
 	var row *sqlplugin.CurrentExecutionsRow
-	if row, err = m.lockCurrentExecutionIfExistsFn(ctx, tx, m.shardID, domainID, workflowID); err != nil {
+	if row, err = m.lockCurrentExecutionIfExistsFn(ctx, tx, shardID, domainID, workflowID); err != nil {
 		return nil, err
 	}
 
@@ -226,7 +261,7 @@ func (m *sqlExecutionStore) createWorkflowExecutionTx(
 		ctx,
 		tx,
 		request.Mode,
-		m.shardID,
+		shardID,
 		domainID,
 		workflowID,
 		runID,
@@ -248,12 +283,13 @@ func (m *sqlExecutionStore) createWorkflowExecutionTx(
 func (m *sqlExecutionStore) getExecutions(
 	ctx context.Context,
 	request *p.InternalGetWorkflowExecutionRequest,
+	shardID int,
 	domainID serialization.UUID,
 	wfID string,
 	runID serialization.UUID,
 ) ([]sqlplugin.ExecutionsRow, error) {
 	executions, err := m.db.SelectFromExecutions(ctx, &sqlplugin.ExecutionsFilter{
-		ShardID: m.shardID, DomainID: domainID, WorkflowID: wfID, RunID: runID})
+		ShardID: shardID, DomainID: domainID, WorkflowID: wfID, RunID: runID})
 
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -299,6 +335,7 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 	domainID := serialization.MustParseUUID(request.DomainID)
 	runID := serialization.MustParseUUID(request.Execution.RunID)
 	wfID := request.Execution.WorkflowID
+	shardID := m.effectiveShardID(request.ShardID, "GetWorkflowExecution")
 
 	var executions []sqlplugin.ExecutionsRow
 	var activityInfos map[int64]*p.InternalActivityInfo
@@ -314,49 +351,49 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 	g.Go(func() (e error) {
 		defer func() { recoverPanic(recover(), &e) }()
 		activityInfos, e = getActivityInfoMap(
-			childCtx, m.db, m.shardID, domainID, wfID, runID, m.parser)
+			childCtx, m.db, shardID, domainID, wfID, runID, m.parser)
 		return e
 	})
 
 	g.Go(func() (e error) {
 		defer func() { recoverPanic(recover(), &e) }()
 		timerInfos, e = getTimerInfoMap(
-			childCtx, m.db, m.shardID, domainID, wfID, runID, m.parser)
+			childCtx, m.db, shardID, domainID, wfID, runID, m.parser)
 		return e
 	})
 
 	g.Go(func() (e error) {
 		defer func() { recoverPanic(recover(), &e) }()
 		childExecutionInfos, e = getChildExecutionInfoMap(
-			childCtx, m.db, m.shardID, domainID, wfID, runID, m.parser)
+			childCtx, m.db, shardID, domainID, wfID, runID, m.parser)
 		return e
 	})
 
 	g.Go(func() (e error) {
 		defer func() { recoverPanic(recover(), &e) }()
 		requestCancelInfos, e = getRequestCancelInfoMap(
-			childCtx, m.db, m.shardID, domainID, wfID, runID, m.parser)
+			childCtx, m.db, shardID, domainID, wfID, runID, m.parser)
 		return e
 	})
 
 	g.Go(func() (e error) {
 		defer func() { recoverPanic(recover(), &e) }()
 		signalInfos, e = getSignalInfoMap(
-			childCtx, m.db, m.shardID, domainID, wfID, runID, m.parser)
+			childCtx, m.db, shardID, domainID, wfID, runID, m.parser)
 		return e
 	})
 
 	g.Go(func() (e error) {
 		defer func() { recoverPanic(recover(), &e) }()
 		bufferedEvents, e = getBufferedEvents(
-			childCtx, m.db, m.shardID, domainID, wfID, runID)
+			childCtx, m.db, shardID, domainID, wfID, runID)
 		return e
 	})
 
 	g.Go(func() (e error) {
 		defer func() { recoverPanic(recover(), &e) }()
 		signalsRequested, e = getSignalsRequested(
-			childCtx, m.db, m.shardID, domainID, wfID, runID)
+			childCtx, m.db, shardID, domainID, wfID, runID)
 		return e
 	})
 
@@ -370,7 +407,7 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 	// and in that case we can get checksum error because data is partially read.
 	// Since checksum is stored in the executions table, we make it the last step of reading,
 	// in this case, either we read full data with checksum or we don't get checksum and return error.
-	executions, err = m.getExecutions(ctx, request, domainID, wfID, runID)
+	executions, err = m.getExecutions(ctx, request, shardID, domainID, wfID, runID)
 	if err != nil {
 		return nil, err
 	}
@@ -387,7 +424,7 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 	// we read might not be from a consistent view, the checksum validation might fail
 	// in that case, we clear the checksum data so that we will not perform the validation
 	if state.ChecksumData != nil {
-		row, err := m.db.SelectFromShards(ctx, &sqlplugin.ShardsFilter{ShardID: int64(m.shardID)})
+		row, err := m.db.SelectFromShards(ctx, &sqlplugin.ShardsFilter{ShardID: int64(shardID)})
 		if err != nil {
 			return nil, convertCommonErrors(m.db, "GetWorkflowExecution", "", err)
 		}
@@ -413,9 +450,10 @@ func (m *sqlExecutionStore) UpdateWorkflowExecution(
 	ctx context.Context,
 	request *p.InternalUpdateWorkflowExecutionRequest,
 ) error {
-	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(m.shardID, m.db.GetTotalNumDBShards())
-	return m.txExecuteShardLockedFn(ctx, dbShardID, "UpdateWorkflowExecution", request.RangeID, func(tx sqlplugin.Tx) error {
-		return m.updateWorkflowExecutionTx(ctx, tx, request)
+	shardID := m.effectiveShardID(request.ShardID, "UpdateWorkflowExecution")
+	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(shardID, m.db.GetTotalNumDBShards())
+	return m.txExecuteShardLockedFn(ctx, shardID, dbShardID, "UpdateWorkflowExecution", request.RangeID, func(tx sqlplugin.Tx) error {
+		return m.updateWorkflowExecutionTx(ctx, tx, request, shardID)
 	})
 }
 
@@ -423,6 +461,7 @@ func (m *sqlExecutionStore) updateWorkflowExecutionTx(
 	ctx context.Context,
 	tx sqlplugin.Tx,
 	request *p.InternalUpdateWorkflowExecutionRequest,
+	shardID int,
 ) error {
 
 	updateWorkflow := request.UpdateWorkflowMutation
@@ -432,7 +471,6 @@ func (m *sqlExecutionStore) updateWorkflowExecutionTx(
 	domainID := serialization.MustParseUUID(executionInfo.DomainID)
 	workflowID := executionInfo.WorkflowID
 	runID := serialization.MustParseUUID(executionInfo.RunID)
-	shardID := m.shardID
 
 	if err := p.ValidateUpdateWorkflowModeState(
 		request.Mode,
@@ -527,9 +565,10 @@ func (m *sqlExecutionStore) ConflictResolveWorkflowExecution(
 	ctx context.Context,
 	request *p.InternalConflictResolveWorkflowExecutionRequest,
 ) error {
-	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(m.shardID, m.db.GetTotalNumDBShards())
-	return m.txExecuteShardLockedFn(ctx, dbShardID, "ConflictResolveWorkflowExecution", request.RangeID, func(tx sqlplugin.Tx) error {
-		return m.conflictResolveWorkflowExecutionTx(ctx, tx, request)
+	shardID := m.effectiveShardID(request.ShardID, "ConflictResolveWorkflowExecution")
+	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(shardID, m.db.GetTotalNumDBShards())
+	return m.txExecuteShardLockedFn(ctx, shardID, dbShardID, "ConflictResolveWorkflowExecution", request.RangeID, func(tx sqlplugin.Tx) error {
+		return m.conflictResolveWorkflowExecutionTx(ctx, tx, request, shardID)
 	})
 }
 
@@ -537,13 +576,12 @@ func (m *sqlExecutionStore) conflictResolveWorkflowExecutionTx(
 	ctx context.Context,
 	tx sqlplugin.Tx,
 	request *p.InternalConflictResolveWorkflowExecutionRequest,
+	shardID int,
 ) error {
 
 	currentWorkflow := request.CurrentWorkflowMutation
 	resetWorkflow := request.ResetWorkflowSnapshot
 	newWorkflow := request.NewWorkflowSnapshot
-
-	shardID := m.shardID
 
 	domainID := serialization.MustParseUUID(resetWorkflow.ExecutionInfo.DomainID)
 	workflowID := resetWorkflow.ExecutionInfo.WorkflowID
@@ -589,7 +627,7 @@ func (m *sqlExecutionStore) conflictResolveWorkflowExecutionTx(
 			if err := m.assertRunIDAndUpdateCurrentExecutionFn(
 				ctx,
 				tx,
-				m.shardID,
+				shardID,
 				domainID,
 				workflowID,
 				runID,
@@ -608,7 +646,7 @@ func (m *sqlExecutionStore) conflictResolveWorkflowExecutionTx(
 			if err := m.assertRunIDAndUpdateCurrentExecutionFn(
 				ctx,
 				tx,
-				m.shardID,
+				shardID,
 				domainID,
 				workflowID,
 				runID,
@@ -648,13 +686,14 @@ func (m *sqlExecutionStore) DeleteWorkflowExecution(
 	ctx context.Context,
 	request *p.DeleteWorkflowExecutionRequest,
 ) error {
-	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(m.shardID, m.db.GetTotalNumDBShards())
+	shardID := m.effectiveShardID(request.ShardID, "DeleteWorkflowExecution")
+	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(shardID, m.db.GetTotalNumDBShards())
 	domainID := serialization.MustParseUUID(request.DomainID)
 	runID := serialization.MustParseUUID(request.RunID)
 	wfID := request.WorkflowID
 	return m.txExecute(ctx, dbShardID, "DeleteWorkflowExecution", func(tx sqlplugin.Tx) error {
 		if _, err := tx.DeleteFromExecutions(ctx, &sqlplugin.ExecutionsFilter{
-			ShardID:    m.shardID,
+			ShardID:    shardID,
 			DomainID:   domainID,
 			WorkflowID: wfID,
 			RunID:      runID,
@@ -662,7 +701,7 @@ func (m *sqlExecutionStore) DeleteWorkflowExecution(
 			return convertCommonErrors(tx, "DeleteWorkflowExecution", "", err)
 		}
 		if _, err := tx.DeleteFromActivityInfoMaps(ctx, &sqlplugin.ActivityInfoMapsFilter{
-			ShardID:    int64(m.shardID),
+			ShardID:    int64(shardID),
 			DomainID:   domainID,
 			WorkflowID: wfID,
 			RunID:      runID,
@@ -670,7 +709,7 @@ func (m *sqlExecutionStore) DeleteWorkflowExecution(
 			return convertCommonErrors(tx, "DeleteFromActivityInfoMaps", "", err)
 		}
 		if _, err := tx.DeleteFromTimerInfoMaps(ctx, &sqlplugin.TimerInfoMapsFilter{
-			ShardID:    int64(m.shardID),
+			ShardID:    int64(shardID),
 			DomainID:   domainID,
 			WorkflowID: wfID,
 			RunID:      runID,
@@ -678,7 +717,7 @@ func (m *sqlExecutionStore) DeleteWorkflowExecution(
 			return convertCommonErrors(tx, "DeleteFromTimerInfoMaps", "", err)
 		}
 		if _, err := tx.DeleteFromChildExecutionInfoMaps(ctx, &sqlplugin.ChildExecutionInfoMapsFilter{
-			ShardID:    int64(m.shardID),
+			ShardID:    int64(shardID),
 			DomainID:   domainID,
 			WorkflowID: wfID,
 			RunID:      runID,
@@ -686,7 +725,7 @@ func (m *sqlExecutionStore) DeleteWorkflowExecution(
 			return convertCommonErrors(tx, "DeleteFromChildExecutionInfoMaps", "", err)
 		}
 		if _, err := tx.DeleteFromRequestCancelInfoMaps(ctx, &sqlplugin.RequestCancelInfoMapsFilter{
-			ShardID:    int64(m.shardID),
+			ShardID:    int64(shardID),
 			DomainID:   domainID,
 			WorkflowID: wfID,
 			RunID:      runID,
@@ -694,7 +733,7 @@ func (m *sqlExecutionStore) DeleteWorkflowExecution(
 			return convertCommonErrors(tx, "DeleteFromRequestCancelInfoMaps", "", err)
 		}
 		if _, err := tx.DeleteFromSignalInfoMaps(ctx, &sqlplugin.SignalInfoMapsFilter{
-			ShardID:    int64(m.shardID),
+			ShardID:    int64(shardID),
 			DomainID:   domainID,
 			WorkflowID: wfID,
 			RunID:      runID,
@@ -702,7 +741,7 @@ func (m *sqlExecutionStore) DeleteWorkflowExecution(
 			return convertCommonErrors(tx, "DeleteFromSignalInfoMaps", "", err)
 		}
 		if _, err := tx.DeleteFromBufferedEvents(ctx, &sqlplugin.BufferedEventsFilter{
-			ShardID:    m.shardID,
+			ShardID:    shardID,
 			DomainID:   domainID,
 			WorkflowID: wfID,
 			RunID:      runID,
@@ -710,7 +749,7 @@ func (m *sqlExecutionStore) DeleteWorkflowExecution(
 			return convertCommonErrors(tx, "DeleteFromBufferedEvents", "", err)
 		}
 		if _, err := tx.DeleteFromSignalsRequestedSets(ctx, &sqlplugin.SignalsRequestedSetsFilter{
-			ShardID:    int64(m.shardID),
+			ShardID:    int64(shardID),
 			DomainID:   domainID,
 			WorkflowID: wfID,
 			RunID:      runID,
@@ -730,10 +769,11 @@ func (m *sqlExecutionStore) DeleteCurrentWorkflowExecution(
 	request *p.DeleteCurrentWorkflowExecutionRequest,
 ) error {
 
+	shardID := m.effectiveShardID(request.ShardID, "DeleteCurrentWorkflowExecution")
 	domainID := serialization.MustParseUUID(request.DomainID)
 	runID := serialization.MustParseUUID(request.RunID)
 	_, err := m.db.DeleteFromCurrentExecutions(ctx, &sqlplugin.CurrentExecutionsFilter{
-		ShardID:    int64(m.shardID),
+		ShardID:    int64(shardID),
 		DomainID:   domainID,
 		WorkflowID: request.WorkflowID,
 		RunID:      runID,
@@ -749,8 +789,9 @@ func (m *sqlExecutionStore) GetCurrentExecution(
 	request *p.GetCurrentExecutionRequest,
 ) (*p.GetCurrentExecutionResponse, error) {
 
+	shardID := m.effectiveShardID(request.ShardID, "GetCurrentExecution")
 	row, err := m.db.SelectFromCurrentExecutions(ctx, &sqlplugin.CurrentExecutionsFilter{
-		ShardID:    int64(m.shardID),
+		ShardID:    int64(shardID),
 		DomainID:   serialization.MustParseUUID(request.DomainID),
 		WorkflowID: request.WorkflowID,
 	})
@@ -785,6 +826,7 @@ func (m *sqlExecutionStore) ListConcreteExecutions(
 	request *p.ListConcreteExecutionsRequest,
 ) (*p.InternalListConcreteExecutionsResponse, error) {
 
+	shardID := m.effectiveShardID(request.ShardID, "ListConcreteExecutions")
 	filter := &sqlplugin.ExecutionsFilter{}
 	if len(request.PageToken) > 0 {
 		err := gobDeserialize(request.PageToken, &filter)
@@ -795,7 +837,7 @@ func (m *sqlExecutionStore) ListConcreteExecutions(
 		}
 	} else {
 		filter = &sqlplugin.ExecutionsFilter{
-			ShardID:    m.shardID,
+			ShardID:    shardID,
 			WorkflowID: "",
 		}
 	}
@@ -814,7 +856,7 @@ func (m *sqlExecutionStore) ListConcreteExecutions(
 	}
 	lastExecution := executions[len(executions)-1]
 	nextFilter := &sqlplugin.ExecutionsFilter{
-		ShardID:    m.shardID,
+		ShardID:    shardID,
 		WorkflowID: lastExecution.WorkflowID,
 	}
 	token, err := gobSerialize(nextFilter)
@@ -854,13 +896,14 @@ func (m *sqlExecutionStore) GetReplicationTasksFromDLQ(
 	request *p.GetReplicationTasksFromDLQRequest,
 ) (*p.GetHistoryTasksResponse, error) {
 
+	shardID := m.effectiveShardID(request.ShardID, "GetReplicationTasksFromDLQ")
 	readLevel, maxReadLevel, err := getReadLevels(request)
 	if err != nil {
 		return nil, err
 	}
 
 	filter := sqlplugin.ReplicationTasksFilter{
-		ShardID:            m.shardID,
+		ShardID:            shardID,
 		InclusiveMinTaskID: readLevel,
 		ExclusiveMaxTaskID: maxReadLevel,
 		PageSize:           request.BatchSize,
@@ -898,9 +941,10 @@ func (m *sqlExecutionStore) GetReplicationDLQSize(
 	request *p.GetReplicationDLQSizeRequest,
 ) (*p.GetReplicationDLQSizeResponse, error) {
 
+	shardID := m.effectiveShardID(request.ShardID, "GetReplicationDLQSize")
 	size, err := m.db.SelectFromReplicationDLQ(ctx, &sqlplugin.ReplicationTaskDLQFilter{
 		SourceClusterName: request.SourceClusterName,
-		ShardID:           m.shardID,
+		ShardID:           shardID,
 	})
 
 	switch err {
@@ -922,8 +966,9 @@ func (m *sqlExecutionStore) DeleteReplicationTaskFromDLQ(
 	request *p.DeleteReplicationTaskFromDLQRequest,
 ) error {
 
+	shardID := m.effectiveShardID(request.ShardID, "DeleteReplicationTaskFromDLQ")
 	filter := sqlplugin.ReplicationTasksFilter{
-		ShardID: m.shardID,
+		ShardID: shardID,
 		TaskID:  request.TaskID,
 	}
 
@@ -940,8 +985,9 @@ func (m *sqlExecutionStore) RangeDeleteReplicationTaskFromDLQ(
 	ctx context.Context,
 	request *p.RangeDeleteReplicationTaskFromDLQRequest,
 ) (*p.RangeDeleteReplicationTaskFromDLQResponse, error) {
+	shardID := m.effectiveShardID(request.ShardID, "RangeDeleteReplicationTaskFromDLQ")
 	filter := sqlplugin.ReplicationTasksFilter{
-		ShardID:            m.shardID,
+		ShardID:            shardID,
 		InclusiveMinTaskID: request.InclusiveBeginTaskID,
 		ExclusiveMaxTaskID: request.ExclusiveEndTaskID,
 		PageSize:           request.PageSize,
@@ -964,8 +1010,9 @@ func (m *sqlExecutionStore) CreateFailoverMarkerTasks(
 	ctx context.Context,
 	request *p.CreateFailoverMarkersRequest,
 ) error {
-	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(m.shardID, m.db.GetTotalNumDBShards())
-	return m.txExecuteShardLockedFn(ctx, dbShardID, "CreateFailoverMarkerTasks", request.RangeID, func(tx sqlplugin.Tx) error {
+	shardID := m.effectiveShardID(request.ShardID, "CreateFailoverMarkerTasks")
+	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(shardID, m.db.GetTotalNumDBShards())
+	return m.txExecuteShardLockedFn(ctx, shardID, dbShardID, "CreateFailoverMarkerTasks", request.RangeID, func(tx sqlplugin.Tx) error {
 		replicationTasksRows := make([]sqlplugin.ReplicationTasksRow, len(request.Markers))
 		for i, task := range request.Markers {
 			blob, err := m.parser.ReplicationTaskInfoToBlob(&serialization.ReplicationTaskInfo{
@@ -986,7 +1033,7 @@ func (m *sqlExecutionStore) CreateFailoverMarkerTasks(
 			if err != nil {
 				return err
 			}
-			replicationTasksRows[i].ShardID = m.shardID
+			replicationTasksRows[i].ShardID = shardID
 			replicationTasksRows[i].TaskID = task.GetTaskID()
 			replicationTasksRows[i].Data = blob.Data
 			replicationTasksRows[i].DataEncoding = string(blob.Encoding)
@@ -1023,6 +1070,7 @@ func (m *sqlExecutionStore) PutReplicationTaskToDLQ(
 	ctx context.Context,
 	request *p.InternalPutReplicationTaskToDLQRequest,
 ) error {
+	shardID := m.effectiveShardID(request.ShardID, "PutReplicationTaskToDLQ")
 	replicationTask := request.TaskInfo
 	blob, err := m.parser.ReplicationTaskInfoToBlob(&serialization.ReplicationTaskInfo{
 		DomainID:                serialization.MustParseUUID(replicationTask.DomainID),
@@ -1045,7 +1093,7 @@ func (m *sqlExecutionStore) PutReplicationTaskToDLQ(
 
 	row := &sqlplugin.ReplicationTaskDLQRow{
 		SourceClusterName: request.SourceClusterName,
-		ShardID:           m.shardID,
+		ShardID:           shardID,
 		TaskID:            replicationTask.TaskID,
 		Data:              blob.Data,
 		DataEncoding:      string(blob.Encoding),
@@ -1126,11 +1174,12 @@ func (m *sqlExecutionStore) GetHistoryTasks(
 	ctx context.Context,
 	request *p.GetHistoryTasksRequest,
 ) (*p.GetHistoryTasksResponse, error) {
+	shardID := m.effectiveShardID(request.ShardID, "GetHistoryTasks")
 	switch request.TaskCategory.Type() {
 	case p.HistoryTaskCategoryTypeImmediate:
-		return m.getImmediateHistoryTasks(ctx, request)
+		return m.getImmediateHistoryTasks(ctx, request, shardID)
 	case p.HistoryTaskCategoryTypeScheduled:
-		return m.getScheduledHistoryTasks(ctx, request)
+		return m.getScheduledHistoryTasks(ctx, request, shardID)
 	default:
 		return nil, &types.BadRequestError{Message: fmt.Sprintf("Unknown task category type: %v", request.TaskCategory.Type())}
 	}
@@ -1139,6 +1188,7 @@ func (m *sqlExecutionStore) GetHistoryTasks(
 func (m *sqlExecutionStore) getImmediateHistoryTasks(
 	ctx context.Context,
 	request *p.GetHistoryTasksRequest,
+	shardID int,
 ) (*p.GetHistoryTasksResponse, error) {
 	switch request.TaskCategory.ID() {
 	case p.HistoryTaskCategoryIDTransfer:
@@ -1151,7 +1201,7 @@ func (m *sqlExecutionStore) getImmediateHistoryTasks(
 			}
 		}
 		rows, err := m.db.SelectFromTransferTasks(ctx, &sqlplugin.TransferTasksFilter{
-			ShardID:            m.shardID,
+			ShardID:            shardID,
 			InclusiveMinTaskID: inclusiveMinTaskID,
 			ExclusiveMaxTaskID: request.ExclusiveMaxTaskKey.GetTaskID(),
 			PageSize:           request.PageSize,
@@ -1191,7 +1241,7 @@ func (m *sqlExecutionStore) getImmediateHistoryTasks(
 			exclusiveMaxTaskID = max(inclusiveMinTaskID+int64(request.PageSize), exclusiveMaxTaskID)
 		}
 		rows, err := m.db.SelectFromReplicationTasks(ctx, &sqlplugin.ReplicationTasksFilter{
-			ShardID:            m.shardID,
+			ShardID:            shardID,
 			InclusiveMinTaskID: inclusiveMinTaskID,
 			ExclusiveMaxTaskID: exclusiveMaxTaskID,
 			PageSize:           request.PageSize,
@@ -1226,6 +1276,7 @@ func (m *sqlExecutionStore) getImmediateHistoryTasks(
 func (m *sqlExecutionStore) getScheduledHistoryTasks(
 	ctx context.Context,
 	request *p.GetHistoryTasksRequest,
+	shardID int,
 ) (*p.GetHistoryTasksResponse, error) {
 	switch request.TaskCategory.ID() {
 	case p.HistoryTaskCategoryIDTimer:
@@ -1238,7 +1289,7 @@ func (m *sqlExecutionStore) getScheduledHistoryTasks(
 			}
 		}
 		rows, err := m.db.SelectFromTimerTasks(ctx, &sqlplugin.TimerTasksFilter{
-			ShardID:                m.shardID,
+			ShardID:                shardID,
 			MinVisibilityTimestamp: pageToken.Timestamp,
 			TaskID:                 pageToken.TaskID,
 			MaxVisibilityTimestamp: request.ExclusiveMaxTaskKey.GetScheduledTime(),
@@ -1284,11 +1335,12 @@ func (m *sqlExecutionStore) CompleteHistoryTask(
 	ctx context.Context,
 	request *p.CompleteHistoryTaskRequest,
 ) error {
+	shardID := m.effectiveShardID(request.ShardID, "CompleteHistoryTask")
 	switch request.TaskCategory.Type() {
 	case p.HistoryTaskCategoryTypeScheduled:
-		return m.completeScheduledHistoryTask(ctx, request)
+		return m.completeScheduledHistoryTask(ctx, request, shardID)
 	case p.HistoryTaskCategoryTypeImmediate:
-		return m.completeImmediateHistoryTask(ctx, request)
+		return m.completeImmediateHistoryTask(ctx, request, shardID)
 	default:
 		return &types.BadRequestError{Message: fmt.Sprintf("Unknown task category type: %v", request.TaskCategory.Type())}
 	}
@@ -1297,11 +1349,12 @@ func (m *sqlExecutionStore) CompleteHistoryTask(
 func (m *sqlExecutionStore) completeScheduledHistoryTask(
 	ctx context.Context,
 	request *p.CompleteHistoryTaskRequest,
+	shardID int,
 ) error {
 	switch request.TaskCategory.ID() {
 	case p.HistoryTaskCategoryIDTimer:
 		if _, err := m.db.DeleteFromTimerTasks(ctx, &sqlplugin.TimerTasksFilter{
-			ShardID:             m.shardID,
+			ShardID:             shardID,
 			VisibilityTimestamp: request.TaskKey.GetScheduledTime(),
 			TaskID:              request.TaskKey.GetTaskID(),
 		}); err != nil {
@@ -1316,11 +1369,12 @@ func (m *sqlExecutionStore) completeScheduledHistoryTask(
 func (m *sqlExecutionStore) completeImmediateHistoryTask(
 	ctx context.Context,
 	request *p.CompleteHistoryTaskRequest,
+	shardID int,
 ) error {
 	switch request.TaskCategory.ID() {
 	case p.HistoryTaskCategoryIDTransfer:
 		if _, err := m.db.DeleteFromTransferTasks(ctx, &sqlplugin.TransferTasksFilter{
-			ShardID: m.shardID,
+			ShardID: shardID,
 			TaskID:  request.TaskKey.GetTaskID(),
 		}); err != nil {
 			return convertCommonErrors(m.db, "CompleteImmediateHistoryTask", "", err)
@@ -1328,7 +1382,7 @@ func (m *sqlExecutionStore) completeImmediateHistoryTask(
 		return nil
 	case p.HistoryTaskCategoryIDReplication:
 		if _, err := m.db.DeleteFromReplicationTasks(ctx, &sqlplugin.ReplicationTasksFilter{
-			ShardID: m.shardID,
+			ShardID: shardID,
 			TaskID:  request.TaskKey.GetTaskID(),
 		}); err != nil {
 			return convertCommonErrors(m.db, "CompleteImmediateHistoryTask", "", err)
@@ -1343,11 +1397,12 @@ func (m *sqlExecutionStore) RangeCompleteHistoryTask(
 	ctx context.Context,
 	request *p.RangeCompleteHistoryTaskRequest,
 ) (*p.RangeCompleteHistoryTaskResponse, error) {
+	shardID := m.effectiveShardID(request.ShardID, "RangeCompleteHistoryTask")
 	switch request.TaskCategory.Type() {
 	case p.HistoryTaskCategoryTypeScheduled:
-		return m.rangeCompleteScheduledHistoryTask(ctx, request)
+		return m.rangeCompleteScheduledHistoryTask(ctx, request, shardID)
 	case p.HistoryTaskCategoryTypeImmediate:
-		return m.rangeCompleteImmediateHistoryTask(ctx, request)
+		return m.rangeCompleteImmediateHistoryTask(ctx, request, shardID)
 	default:
 		return nil, &types.BadRequestError{Message: fmt.Sprintf("Unknown task category type: %v", request.TaskCategory.Type())}
 	}
@@ -1356,11 +1411,12 @@ func (m *sqlExecutionStore) RangeCompleteHistoryTask(
 func (m *sqlExecutionStore) rangeCompleteScheduledHistoryTask(
 	ctx context.Context,
 	request *p.RangeCompleteHistoryTaskRequest,
+	shardID int,
 ) (*p.RangeCompleteHistoryTaskResponse, error) {
 	switch request.TaskCategory.ID() {
 	case p.HistoryTaskCategoryIDTimer:
 		result, err := m.db.RangeDeleteFromTimerTasks(ctx, &sqlplugin.TimerTasksFilter{
-			ShardID:                m.shardID,
+			ShardID:                shardID,
 			MinVisibilityTimestamp: request.InclusiveMinTaskKey.GetScheduledTime(),
 			MaxVisibilityTimestamp: request.ExclusiveMaxTaskKey.GetScheduledTime(),
 			PageSize:               request.PageSize,
@@ -1381,11 +1437,12 @@ func (m *sqlExecutionStore) rangeCompleteScheduledHistoryTask(
 func (m *sqlExecutionStore) rangeCompleteImmediateHistoryTask(
 	ctx context.Context,
 	request *p.RangeCompleteHistoryTaskRequest,
+	shardID int,
 ) (*p.RangeCompleteHistoryTaskResponse, error) {
 	switch request.TaskCategory.ID() {
 	case p.HistoryTaskCategoryIDTransfer:
 		result, err := m.db.RangeDeleteFromTransferTasks(ctx, &sqlplugin.TransferTasksFilter{
-			ShardID:            m.shardID,
+			ShardID:            shardID,
 			InclusiveMinTaskID: request.InclusiveMinTaskKey.GetTaskID(),
 			ExclusiveMaxTaskID: request.ExclusiveMaxTaskKey.GetTaskID(),
 			PageSize:           request.PageSize,
@@ -1400,7 +1457,7 @@ func (m *sqlExecutionStore) rangeCompleteImmediateHistoryTask(
 		return &p.RangeCompleteHistoryTaskResponse{TasksCompleted: int(rowsDeleted)}, nil
 	case p.HistoryTaskCategoryIDReplication:
 		result, err := m.db.RangeDeleteFromReplicationTasks(ctx, &sqlplugin.ReplicationTasksFilter{
-			ShardID:            m.shardID,
+			ShardID:            shardID,
 			ExclusiveMaxTaskID: request.ExclusiveMaxTaskKey.GetTaskID(),
 			PageSize:           request.PageSize,
 		})

--- a/common/persistence/sql/sql_execution_store_test.go
+++ b/common/persistence/sql/sql_execution_store_test.go
@@ -33,12 +33,59 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/constants"
+	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/serialization"
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
 	"github.com/uber/cadence/common/types"
 )
+
+func TestResolveShardID(t *testing.T) {
+	tests := []struct {
+		name           string
+		reqID          *int
+		storeID        int
+		expectedShard  int
+		expectedReason string
+	}{
+		{name: "nil request shard id is reported as missing", reqID: nil, storeID: 5, expectedShard: 5, expectedReason: "missing"},
+		{name: "matching request shard id has no reason", reqID: common.IntPtr(5), storeID: 5, expectedShard: 5, expectedReason: ""},
+		{name: "differing request shard id falls back to store and is reported as mismatch", reqID: common.IntPtr(9), storeID: 5, expectedShard: 5, expectedReason: "mismatch"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			shard, reason := resolveShardID(tc.reqID, tc.storeID)
+			assert.Equal(t, tc.expectedShard, shard)
+			assert.Equal(t, tc.expectedReason, reason)
+		})
+	}
+}
+
+func TestEffectiveShardID_logsOncePerOperationWhenRequestShardIDInconsistent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := log.NewMockLogger(ctrl)
+	mockLogger.EXPECT().
+		Warn("execution store request inconsistent with store shard ID; using store shard ID", gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(1)
+	mockLogger.EXPECT().
+		Warn("execution store request inconsistent with store shard ID; using store shard ID", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(1)
+
+	store := &sqlExecutionStore{
+		shardID: 123,
+		sqlStore: sqlStore{
+			logger: mockLogger,
+		},
+	}
+
+	assert.Equal(t, 123, store.effectiveShardID(nil, "GetWorkflowExecution"))
+	assert.Equal(t, 123, store.effectiveShardID(nil, "GetWorkflowExecution"))
+	assert.Equal(t, 123, store.effectiveShardID(common.IntPtr(999), "UpdateWorkflowExecution"))
+	assert.Equal(t, 123, store.effectiveShardID(common.IntPtr(123), "DeleteWorkflowExecution"))
+}
 
 func TestDeleteCurrentWorkflowExecution(t *testing.T) {
 	shardID := int64(100)
@@ -874,7 +921,7 @@ func TestTxExecuteShardLocked(t *testing.T) {
 				},
 			}
 
-			gotError := s.txExecuteShardLocked(context.Background(), 0, tt.operation, tt.rangeID, tt.fn)
+			gotError := s.txExecuteShardLocked(context.Background(), 0, 0, tt.operation, tt.rangeID, tt.fn)
 			assert.Equal(t, tt.wantError, gotError)
 		})
 	}
@@ -1157,7 +1204,7 @@ func TestCreateWorkflowExecution(t *testing.T) {
 					db:     mockDB,
 					logger: testlogger.New(t),
 				},
-				txExecuteShardLockedFn: func(_ context.Context, _ int, _ string, _ int64, fn func(sqlplugin.Tx) error) error {
+				txExecuteShardLockedFn: func(_ context.Context, _ int, _ int, _ string, _ int64, fn func(sqlplugin.Tx) error) error {
 					return fn(nil)
 				},
 				lockCurrentExecutionIfExistsFn:   tc.lockCurrentExecutionIfExistsFn,
@@ -1396,7 +1443,7 @@ func TestUpdateWorkflowExecution(t *testing.T) {
 					db:     mockDB,
 					logger: testlogger.New(t),
 				},
-				txExecuteShardLockedFn: func(_ context.Context, _ int, _ string, _ int64, fn func(sqlplugin.Tx) error) error {
+				txExecuteShardLockedFn: func(_ context.Context, _ int, _ int, _ string, _ int64, fn func(sqlplugin.Tx) error) error {
 					return fn(nil)
 				},
 				assertNotCurrentExecutionFn:            tc.assertNotCurrentExecutionFn,
@@ -1665,7 +1712,7 @@ func TestConflictResolveWorkflowExecution(t *testing.T) {
 					db:     mockDB,
 					logger: testlogger.New(t),
 				},
-				txExecuteShardLockedFn: func(_ context.Context, _ int, _ string, _ int64, fn func(sqlplugin.Tx) error) error {
+				txExecuteShardLockedFn: func(_ context.Context, _ int, _ int, _ string, _ int64, fn func(sqlplugin.Tx) error) error {
 					return fn(nil)
 				},
 				assertNotCurrentExecutionFn:            tc.assertNotCurrentExecutionFn,
@@ -1863,7 +1910,7 @@ func TestCreateFailoverMarkerTasks(t *testing.T) {
 					logger: testlogger.New(t),
 					parser: parser,
 				},
-				txExecuteShardLockedFn: func(_ context.Context, _ int, _ string, _ int64, fn func(sqlplugin.Tx) error) error {
+				txExecuteShardLockedFn: func(_ context.Context, _ int, _ int, _ string, _ int64, fn func(sqlplugin.Tx) error) error {
 					return fn(tx)
 				},
 			}


### PR DESCRIPTION
## Description

Update sqlExecutionStore to read ShardID from request instead of relying solely on internal m.shardID. This enables safe conversion of ExecutionManager to a host-level singleton in a subsequent PR.

## Changes

- Add resolveShardID and effectiveShardID helpers for shard resolution
- Thread resolved shardID through all operation methods
- Update txExecuteShardLocked signature to accept resolved shard ID
- Add deduped warn logging for missing/mismatched request ShardIDs
- Update tests for new helper signatures and add coverage tests

This aligns sqlExecutionStore with nosqlExecutionStore migration (PR #7919).

## Related Issues

Relates to #7643

## Testing

- go test ./common/persistence/sql passes
- make build passes
- Added TestResolveShardID and TestEffectiveShardID_logsOncePerOperationWhenRequestShardIDInconsistent
- Updated test helper signatures for txExecuteShardLockedFn