### PR TITLE
test(scheduler): include scheduler in onebox enableWorker check

### DIFF
--- a/host/dynamicconfig.go
+++ b/host/dynamicconfig.go
@@ -58,6 +58,10 @@ var (
 // validSearchAttributesWithSchedules returns the default indexed-keys map
 // extended with the scheduler-managed search attributes that the schedule
 // pipeline upserts.
+//
+// TODO: drop this once the scheduler search attributes are part of the
+// default indexed-keys set in common/definition. At that point the
+// staticOverrides entry for ValidSearchAttributes can go away entirely.
 func validSearchAttributesWithSchedules() map[string]interface{} {
 	out := make(map[string]interface{}, len(definition.GetDefaultIndexedKeys())+6)
 	for k, v := range definition.GetDefaultIndexedKeys() {

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -374,7 +374,11 @@ func NewCadence(params *CadenceParams) Cadence {
 }
 
 func (c *cadenceImpl) enableWorker() bool {
-	return c.workerConfig.EnableArchiver || c.workerConfig.EnableIndexer || c.workerConfig.EnableReplicator || c.workerConfig.EnableAsyncWFConsumer
+	return c.workerConfig.EnableArchiver ||
+		c.workerConfig.EnableIndexer ||
+		c.workerConfig.EnableReplicator ||
+		c.workerConfig.EnableAsyncWFConsumer ||
+		c.workerConfig.EnableScheduler
 }
 
 func (c *cadenceImpl) Start() error {
@@ -1075,6 +1079,13 @@ func (c *cadenceImpl) startWorkerIndexer(params *resource.Params, service Servic
 // startSchedulerWorkerManager mirrors the production wiring in
 // service/worker/service.go so host/ tests can exercise the schedule pipeline.
 // Returns a domain cache the caller must stop on shutdown.
+//
+// TODO: this duplicates startup logic from service/worker/service.go. The
+// rest of the worker subsystems in this onebox (replicator/archiver/indexer/
+// async-wf) are wired the same hand-rolled way, so the right long-term fix
+// is to have host/ tests boot the worker service via worker.NewService(...)
+// and let it manage the WorkerManager (and friends) end-to-end, rather than
+// reaching into the bootstrap params here.
 func (c *cadenceImpl) startSchedulerWorkerManager(params *resource.Params, svc Service) cache.DomainCache {
 	metadataManager := metered.NewDomainManager(c.domainManager, svc.GetMetricsClient(), c.logger, &c.persistenceConfig)
 	domainCache := cache.NewDomainCache(metadataManager, c.clusterMetadata, svc.GetMetricsClient(), svc.GetLogger())


### PR DESCRIPTION
## Summary

Two follow-ups from review feedback on #8037 (already merged):

1. **`host/onebox.go`** — extend `enableWorker()` to include `EnableScheduler`. Without this, a cluster config with only the scheduler enabled (no archiver / indexer / replicator / async-wf) wouldn't actually start the worker process, leaving the scheduler wiring inside \`startWorker\` as dead code. The current integration suite happens to enable archiver and replicator alongside scheduler, so this isn't visible today, but it's a footgun for any future config that wants to exercise just the scheduler.

2. **`host/dynamicconfig.go`** — add a TODO calling out that \`validSearchAttributesWithSchedules\` is a temporary shim, to be removed once the scheduler-managed search attributes are part of the default indexed-keys set in \`common/definition\`.

3. **`host/onebox.go` (TODO on \`startSchedulerWorkerManager\`)** — record the broader observation: the rest of the worker subsystems in this onebox (replicator/archiver/indexer/async-wf) are wired the same hand-rolled way, and the right long-term fix is to have host/ tests boot the worker service via \`worker.NewService(...)\` rather than re-implementing the production wiring inline. Out of scope here, but flagged.

## Test plan

- [x] \`go build ./host/... ./service/worker/scheduler/...\` clean
- [x] Lint clean
- [x] CI runs the integration suite end-to-end