### PR TITLE
fix(ack-cache): remove preallocation for slice and map

### DIFF
--- a/common/cache/ack_cache.go
+++ b/common/cache/ack_cache.go
@@ -119,12 +119,11 @@ func NewBoundedAckCache[T AckCacheItem](
 	budgetManager Manager,
 	cacheID string,
 ) AckCache[T] {
-	initialCount := maxCount()
 	return &BoundedAckCache[T]{
 		maxCount:      maxCount,
 		maxSize:       maxSize,
-		order:         make(sequenceHeap[T], 0, initialCount),
-		cache:         make(map[int64]T, initialCount),
+		order:         make(sequenceHeap[T], 0),
+		cache:         make(map[int64]T),
 		logger:        logger,
 		budgetManager: budgetManager,
 		cacheID:       cacheID,


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Removed preallocation for slice and map that used the maxCount set.

**Why?**
Preallocating the slice and map caused a very high memory utilization floor, even when the cache was not being used or had very low utilization.

**How did you test it?**
go test -race -run TestBoundedAckCache ./common/cache/...

**Potential risks**
Addressing risk of OOM caused by high memory utilization even under low usage.

**Release notes**
Remove pre-allocation of BoundedAckCache backing slice and map to eliminate per-cache startup overhead that may cause high memory usage even on low cache utilization.

**Documentation Changes**

