### PR TITLE
chore(dynamicconfig): add domain filter to PendingActivitiesCountLimit

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -410,13 +410,13 @@ const (
 	// KeyName: limit.pendingActivityCount.error
 	// Value type: Int
 	// Default value: 1024
-	// Allowed filters: N/A
+	// Allowed filters: DomainName
 	PendingActivitiesCountLimitError
 	// PendingActivitiesCountLimitWarn is the limit of how many activities a workflow can have before a warning is logged
 	// KeyName: limit.pendingActivityCount.warn
 	// Value type: Int
 	// Default value: 512
-	// Allowed filters: N/A
+	// Allowed filters: DomainName
 	PendingActivitiesCountLimitWarn
 	// DomainNameMaxLength is the length limit for domain name
 	// KeyName: limit.domainNameLength
@@ -3476,11 +3476,13 @@ var IntKeys = map[IntKey]DynamicInt{
 	},
 	PendingActivitiesCountLimitError: {
 		KeyName:      "limit.pendingActivityCount.error",
+		Filters:      []Filter{DomainName},
 		Description:  "PendingActivitiesCountLimitError is the limit of how many pending activities a workflow can have at a point in time",
 		DefaultValue: 1024,
 	},
 	PendingActivitiesCountLimitWarn: {
 		KeyName:      "limit.pendingActivityCount.warn",
+		Filters:      []Filter{DomainName},
 		Description:  "PendingActivitiesCountLimitWarn is the limit of how many activities a workflow can have before a warning is logged",
 		DefaultValue: 512,
 	},

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -236,8 +236,8 @@ type Config struct {
 	HistorySizeLimitWarn             dynamicproperties.IntPropertyFnWithDomainFilter
 	HistoryCountLimitError           dynamicproperties.IntPropertyFnWithDomainFilter
 	HistoryCountLimitWarn            dynamicproperties.IntPropertyFnWithDomainFilter
-	PendingActivitiesCountLimitError dynamicproperties.IntPropertyFn
-	PendingActivitiesCountLimitWarn  dynamicproperties.IntPropertyFn
+	PendingActivitiesCountLimitError dynamicproperties.IntPropertyFnWithDomainFilter
+	PendingActivitiesCountLimitWarn  dynamicproperties.IntPropertyFnWithDomainFilter
 	PendingActivityValidationEnabled dynamicproperties.BoolPropertyFn
 
 	// ValidSearchAttributes is legal indexed keys that can be used in list APIs
@@ -524,8 +524,8 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		HistorySizeLimitWarn:             dc.GetIntPropertyFilteredByDomain(dynamicproperties.HistorySizeLimitWarn),
 		HistoryCountLimitError:           dc.GetIntPropertyFilteredByDomain(dynamicproperties.HistoryCountLimitError),
 		HistoryCountLimitWarn:            dc.GetIntPropertyFilteredByDomain(dynamicproperties.HistoryCountLimitWarn),
-		PendingActivitiesCountLimitError: dc.GetIntProperty(dynamicproperties.PendingActivitiesCountLimitError),
-		PendingActivitiesCountLimitWarn:  dc.GetIntProperty(dynamicproperties.PendingActivitiesCountLimitWarn),
+		PendingActivitiesCountLimitError: dc.GetIntPropertyFilteredByDomain(dynamicproperties.PendingActivitiesCountLimitError),
+		PendingActivitiesCountLimitWarn:  dc.GetIntPropertyFilteredByDomain(dynamicproperties.PendingActivitiesCountLimitWarn),
 		PendingActivityValidationEnabled: dc.GetBoolProperty(dynamicproperties.EnablePendingActivityValidation),
 
 		ThrottledLogRPS:   dc.GetIntProperty(dynamicproperties.HistoryThrottledLogRPS),

--- a/service/history/execution/mutable_state_builder_methods_activity.go
+++ b/service/history/execution/mutable_state_builder_methods_activity.go
@@ -223,7 +223,7 @@ func (e *mutableStateBuilder) AddActivityTaskScheduledEvent(
 
 	pendingActivitiesCount := len(e.pendingActivityInfoIDs)
 
-	if pendingActivitiesCount >= e.config.PendingActivitiesCountLimitError() {
+	if pendingActivitiesCount >= e.config.PendingActivitiesCountLimitError(e.GetDomainEntry().GetInfo().Name) {
 		e.logger.Error("Pending activity count exceeds error limit",
 			tag.WorkflowDomainName(e.GetDomainEntry().GetInfo().Name),
 			tag.WorkflowID(e.executionInfo.WorkflowID),
@@ -233,7 +233,7 @@ func (e *mutableStateBuilder) AddActivityTaskScheduledEvent(
 		if e.config.PendingActivityValidationEnabled() {
 			return nil, nil, nil, ErrTooManyPendingActivities
 		}
-	} else if pendingActivitiesCount >= e.config.PendingActivitiesCountLimitWarn() && !e.pendingActivityWarningSent {
+	} else if pendingActivitiesCount >= e.config.PendingActivitiesCountLimitWarn(e.GetDomainEntry().GetInfo().Name) && !e.pendingActivityWarningSent {
 		e.logger.Warn("Pending activity count exceeds warn limit",
 			tag.WorkflowDomainName(e.GetDomainEntry().GetInfo().Name),
 			tag.WorkflowID(e.executionInfo.WorkflowID),

--- a/service/history/execution/mutable_state_builder_test.go
+++ b/service/history/execution/mutable_state_builder_test.go
@@ -126,7 +126,7 @@ func (s *mutableStateSuite) TearDownTest() {
 }
 
 func (s *mutableStateSuite) TestErrorReturnedWhenSchedulingTooManyPendingActivities() {
-	for i := 0; i < s.msBuilder.config.PendingActivitiesCountLimitError(); i++ {
+	for i := 0; i < s.msBuilder.config.PendingActivitiesCountLimitError(constants.TestDomainName); i++ {
 		s.msBuilder.pendingActivityInfoIDs[int64(i)] = &persistence.ActivityInfo{}
 	}
 


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

add domain filter to both `PendingActivitiesCountLimitWarn` and `PendingActivitiesCountLimitError`

**Why?**

Easier operation to add exceptions

**How did you test it?**

Unit Test (no new unit test)

**Potential risks**

Low

**Release notes**


**Documentation Changes**

