### PR TITLE
chore: Upgrade github codecov action to v5

### DIFF
--- a/.github/workflows/codecov-on-master.yml
+++ b/.github/workflows/codecov-on-master.yml
@@ -38,8 +38,7 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5.5.0 # https://github.com/codecov/codecov-action
         with:
-          files:
-            - .build/coverage/unit_cover.out
+          files: .build/coverage/unit_cover.out
           exclude: ./
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: cadence-workflow/cadence

--- a/.github/workflows/codecov-on-master.yml
+++ b/.github/workflows/codecov-on-master.yml
@@ -36,7 +36,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/create_failed_test_issues.sh failed-tests.txt
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.5.0 # https://github.com/codecov/codecov-action
+        uses: codecov/codecov-action@v5.5.0 # https://github.com/codecov/codecov-action
         with:
           file: .build/coverage/unit_cover.out
           exclude: ./

--- a/.github/workflows/codecov-on-master.yml
+++ b/.github/workflows/codecov-on-master.yml
@@ -38,7 +38,8 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5.5.0 # https://github.com/codecov/codecov-action
         with:
-          file: .build/coverage/unit_cover.out
+          files:
+            - .build/coverage/unit_cover.out
           exclude: ./
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: cadence-workflow/cadence

--- a/.github/workflows/codecov-on-pr.yml
+++ b/.github/workflows/codecov-on-pr.yml
@@ -23,7 +23,7 @@ jobs:
         run: make cover_profile
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.5.0 # https://github.com/codecov/codecov-action
+        uses: codecov/codecov-action@v5.5.0 # https://github.com/codecov/codecov-action
         with:
           file: .build/coverage/unit_cover.out
           exclude: ./

--- a/.github/workflows/codecov-on-pr.yml
+++ b/.github/workflows/codecov-on-pr.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5.5.0 # https://github.com/codecov/codecov-action
         with:
-          file: .build/coverage/unit_cover.out
+          files:
+            - .build/coverage/unit_cover.out
           exclude: ./
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: cadence-workflow/cadence

--- a/.github/workflows/codecov-on-pr.yml
+++ b/.github/workflows/codecov-on-pr.yml
@@ -25,8 +25,7 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5.5.0 # https://github.com/codecov/codecov-action
         with:
-          files:
-            - .build/coverage/unit_cover.out
+          files: .build/coverage/unit_cover.out
           exclude: ./
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: cadence-workflow/cadence


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

Upgrades our Codecov action to v5.5 to support:
* quicker execution
* tokenless upload (if we want)

