### PR TITLE
fix(metrics): emit correct `is_retry` tag on retried persistence and client calls

### DIFF
--- a/client/wrappers/metered/base.go
+++ b/client/wrappers/metered/base.go
@@ -22,15 +22,12 @@
 
 package metered
 
-import "context"
+import (
+	"context"
 
-type retryCountKeyType string
-
-const retryCountKey = retryCountKeyType("retryCount")
+	"github.com/uber/cadence/common/backoff"
+)
 
 func getRetryCountFromContext(ctx context.Context) int {
-	if retryCount, ok := ctx.Value(retryCountKey).(int); ok {
-		return retryCount
-	}
-	return -1
+	return backoff.GetRetryCountFromContext(ctx)
 }

--- a/common/backoff/retry.go
+++ b/common/backoff/retry.go
@@ -36,6 +36,13 @@ const retryCountKey = retryCountKeyType("retryCount")
 
 var errCauseOperationTimeout = errors.New("operation timeout")
 
+func GetRetryCountFromContext(ctx context.Context) int {
+	if retryCount, ok := ctx.Value(retryCountKey).(int); ok {
+		return retryCount
+	}
+	return -1
+}
+
 type (
 	// Operation to retry
 	Operation func(ctx context.Context) error

--- a/common/persistence/wrappers/metered/base.go
+++ b/common/persistence/wrappers/metered/base.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -34,10 +35,6 @@ import (
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
 )
-
-type retryCountKeyType string
-
-const retryCountKey = retryCountKeyType("retryCount")
 
 type base struct {
 	metricClient                  metrics.Client
@@ -359,8 +356,5 @@ func getCustomMetricTags(req any) (res []metrics.Tag) {
 }
 
 func getRetryCountFromContext(ctx context.Context) int {
-	if retryCount, ok := ctx.Value(retryCountKey).(int); ok {
-		return retryCount
-	}
-	return 0
+	return backoff.GetRetryCountFromContext(ctx)
 }

--- a/common/persistence/wrappers/metered/metered_test.go
+++ b/common/persistence/wrappers/metered/metered_test.go
@@ -27,13 +27,16 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 
+	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log"
@@ -46,6 +49,42 @@ var _staticMethods = map[string]bool{
 	"Close":      true,
 	"GetName":    true,
 	"GetShardID": true,
+}
+
+func TestGetRetryCountFromContext(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	wrapped := persistence.NewMockExecutionManager(ctrl)
+	wrapped.EXPECT().GetShardID().Return(1).AnyTimes()
+	request := &persistence.GetHistoryTasksRequest{}
+
+	gomock.InOrder(
+		wrapped.EXPECT().GetHistoryTasks(gomock.Any(), request).Return(nil, &types.InternalServiceError{}),
+		wrapped.EXPECT().GetHistoryTasks(gomock.Any(), request).Return(&persistence.GetHistoryTasksResponse{}, nil),
+	)
+
+	metricScope := tally.NewTestScope("", nil)
+	meteredManager := NewExecutionManager(
+		wrapped,
+		metrics.NewClient(metricScope, metrics.ServiceIdx(0), metrics.MigrationConfig{}),
+		log.NewLogger(zap.NewNop()),
+		&config.Persistence{},
+		dynamicproperties.GetBoolPropertyFn(false),
+	)
+
+	policy := backoff.NewExponentialRetryPolicy(time.Nanosecond)
+	policy.SetMaximumAttempts(2)
+
+	retryer := persistence.NewPersistenceRetryer(meteredManager, persistence.NewMockHistoryManager(ctrl), policy)
+	_, err := retryer.GetHistoryTasks(context.Background(), request)
+	require.NoError(t, err)
+
+	countsByIsRetry := map[string]int64{}
+	for _, counter := range metricScope.Snapshot().Counters() {
+		if counter.Name() == "persistence_requests" {
+			countsByIsRetry[counter.Tags()["is_retry"]] += counter.Value()
+		}
+	}
+	require.Equal(t, map[string]int64{"false": 1, "true": 1}, countsByIsRetry)
 }
 
 func TestWrappersAgainstPreviousImplementation(t *testing.T) {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
  - Added a shared `backoff.GetRetryCountFromContext` helper.
  - Updated persistence and client metered wrappers to read retry count through `common/backoff`.
  - Added regression tests covering metered persistence and retryable client metrics.

**Why?**
The metered wrappers in `common/persistence/wrappers/metered` and `client/wrappers/metered` each declared their own private `retryCountKeyType` (a string-based named type). `common/backoff/retry.go` writes the retry counter into the context using its own such type. Because `context.Value` compares keys by dynamic type identity, the metered wrappers lookups always missed: 

- common/persistence/wrappers/metered fell back to 0, so every retried persistence call was emitted with is_retry="false". 
- client/wrappers/metered fell back to -1, which the generated wrappers interpret as "not in a retry context", so the is_retry tag was omitted entirely on every retried client call. 

Export `GetRetryCountFromContext` from common/backoff and have both metered wrappers delegate to it. Add a regression test that wires the production retry chain (mock ExecutionManager -> metered.NewExecutionManager -> persistence.NewPersistenceRetryer) and asserts is_retry="false" on the initial attempt and is_retry="true" on the retried attempt.

ref: https://github.com/cadence-workflow/cadence/issues/7844

**How did you test it?**
unit tests

**Potential risks**


**Release notes**


**Documentation Changes**

