### PR TITLE
fix(matching): Make RecordTaskStarted request timeout configurable

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -3421,6 +3421,17 @@ const (
 	// Default value: 2 seconds
 	OperationalConfigStoreUpdateTimeout
 
+	// MatchingRecordTaskStartedTimeout is the request timeout for RecordActivityTaskStarted and RecordDecisionTaskStarted
+	// Any time we spend attempting to start an individual task is blocking that poller from starting a different task.
+	// If a task is taking too long we'd rather try other tasks to maintain higher throughput.
+	// At the same time, workflows with incredibly high contention will take longer to update. To avoid noise from
+	// expected failures we can adjust the value per domain.
+	// KeyName: matching.recordTaskStartedTimeout
+	// Value type: Duration
+	// Default value: 1s
+	// Allowed filters: Domain
+	MatchingRecordTaskStartedTimeout
+
 	// LastDurationKey must be the last one in this const group
 	LastDurationKey
 )
@@ -6154,6 +6165,12 @@ var DurationKeys = map[DurationKey]DynamicDuration{
 		KeyName:      "system.operationalConfigStoreUpdateTimeout",
 		Description:  "Per-call timeout for writing an operational dynamic config snapshot to the primary database",
 		DefaultValue: time.Second * 2,
+	},
+	MatchingRecordTaskStartedTimeout: {
+		KeyName:      "matching.recordTaskStartedTimeout",
+		Filters:      []Filter{DomainName},
+		Description:  "MatchingRecordTaskStartedTimeout is the request timeout for RecordActivityTaskStarted and RecordDecisionTaskStarted",
+		DefaultValue: time.Second,
 	},
 }
 

--- a/common/util.go
+++ b/common/util.go
@@ -55,9 +55,9 @@ const (
 	historyServiceOperationMaxInterval        = 10 * time.Second
 	historyServiceOperationExpirationInterval = 30 * time.Second
 
-	recordTaskStartedInitialInterval    = 50 * time.Millisecond
-	recordTaskStartedMaxInterval        = 1 * time.Second
-	recordTaskStartedExpirationInterval = 3 * time.Second
+	recordTaskStartedInitialInterval = 250 * time.Millisecond
+	recordTaskStartedMaxInterval     = 1 * time.Second
+	recordTaskStartedMaxAttempts     = 5
 
 	matchingServiceOperationInitialInterval    = 1000 * time.Millisecond
 	matchingServiceOperationMaxInterval        = 10 * time.Second
@@ -170,7 +170,8 @@ func CreateHistoryServiceRetryPolicy() backoff.RetryPolicy {
 func CreateRecordTaskStartedRetryPolicy() backoff.RetryPolicy {
 	policy := backoff.NewExponentialRetryPolicy(recordTaskStartedInitialInterval)
 	policy.SetMaximumInterval(recordTaskStartedMaxInterval)
-	policy.SetExpirationInterval(recordTaskStartedExpirationInterval)
+	policy.SetMaximumAttempts(recordTaskStartedMaxAttempts)
+	policy.SetExpirationInterval(backoff.NoInterval)
 
 	return policy
 }

--- a/service/matching/config/config.go
+++ b/service/matching/config/config.go
@@ -113,6 +113,7 @@ type (
 		ExcludeShortLivedTaskListsFromShardManager dynamicproperties.BoolPropertyFn
 		EmergencyOffboardingFromShardManager       dynamicproperties.BoolPropertyFn
 		PercentageOnboardedToShardManager          dynamicproperties.IntPropertyFn
+		RecordTaskStartedTimeout                   dynamicproperties.DurationPropertyFnWithDomainFilter
 	}
 
 	ForwarderConfig struct {
@@ -248,6 +249,7 @@ func NewConfig(dc *dynamicconfig.Collection, hostName string, rpcConfig config.R
 		ExcludeShortLivedTaskListsFromShardManager: dc.GetBoolProperty(dynamicproperties.MatchingExcludeShortLivedTaskListsFromShardManager),
 		EmergencyOffboardingFromShardManager:       dc.GetBoolProperty(dynamicproperties.MatchingEmergencyOffboardingFromShardManager),
 		PercentageOnboardedToShardManager:          dc.GetIntProperty(dynamicproperties.MatchingPercentageOnboardedToShardManager),
+		RecordTaskStartedTimeout:                   dc.GetDurationPropertyFilteredByDomain(dynamicproperties.MatchingRecordTaskStartedTimeout),
 		MinTaskListWritePartitions:                 dc.GetIntPropertyFilteredByTaskListInfo(dynamicproperties.MatchingTaskListMinimumWritePartitions),
 	}
 }

--- a/service/matching/config/config_test.go
+++ b/service/matching/config/config_test.go
@@ -108,6 +108,7 @@ func TestNewConfig(t *testing.T) {
 		"ExcludeShortLivedTaskListsFromShardManager": {dynamicproperties.MatchingExcludeShortLivedTaskListsFromShardManager, false},
 		"EmergencyOffboardingFromShardManager":       {dynamicproperties.MatchingEmergencyOffboardingFromShardManager, false},
 		"PercentageOnboardedToShardManager":          {dynamicproperties.MatchingPercentageOnboardedToShardManager, 0},
+		"RecordTaskStartedTimeout":                   {dynamicproperties.MatchingRecordTaskStartedTimeout, time.Duration(43)},
 		"MinTaskListWritePartitions":                 {dynamicproperties.MatchingTaskListMinimumWritePartitions, 1},
 	}
 	client := dynamicconfig.NewInMemoryClient()

--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -67,10 +67,6 @@ const (
 	// _defaultSDReportTTL is the default TTL for shard status reports from matching executor to shard distributor.
 	// This controls how frequently the executor reports its shard load/status to the distributor.
 	_defaultSDReportTTL = 1 * time.Minute
-	// _recordTaskStartedTimeout is the maximum time allowed for RecordDecisionTaskStarted or RecordActivityTaskStarted
-	// Any time we spend attempting to start an individual task is blocking that poller from starting a different task.
-	// If a task is taking too long we'd rather try other tasks to maintain higher throughput.
-	_recordTaskStartedTimeout = time.Second
 )
 
 // Implements matching.Engine
@@ -1340,10 +1336,11 @@ func (e *matchingEngineImpl) recordDecisionTaskStarted(
 		resp, err = e.historyService.RecordDecisionTaskStarted(ctx, request)
 		return err
 	}
+	requestTimeout := e.config.RecordTaskStartedTimeout(pollReq.Domain)
 	throttleRetry := backoff.NewThrottleRetry(
 		backoff.WithRetryPolicy(recordTaskStartedRetryPolicy),
 		backoff.WithRetryableError(isMatchingRetryableError),
-		backoff.WithOperationTimeout(_recordTaskStartedTimeout),
+		backoff.WithOperationTimeout(requestTimeout),
 		backoff.WithContextExpiration(),
 	)
 	err := throttleRetry.Do(ctx, op)
@@ -1369,10 +1366,11 @@ func (e *matchingEngineImpl) recordActivityTaskStarted(
 		resp, err = e.historyService.RecordActivityTaskStarted(ctx, request)
 		return err
 	}
+	requestTimeout := e.config.RecordTaskStartedTimeout(pollReq.Domain)
 	throttleRetry := backoff.NewThrottleRetry(
 		backoff.WithRetryPolicy(recordTaskStartedRetryPolicy),
 		backoff.WithRetryableError(isMatchingRetryableError),
-		backoff.WithOperationTimeout(_recordTaskStartedTimeout),
+		backoff.WithOperationTimeout(requestTimeout),
 		backoff.WithContextExpiration(),
 	)
 	err := throttleRetry.Do(ctx, op)


### PR DESCRIPTION
Add a DynamicConfig property controlling the timeout for RecordActivityTaskStarted and RecordDecisionTaskStarted. This allows for tuning the request timeout, particularly to raise it for domains with high lock contention on Workflows.

Replace the RecordTaskStarted RetryPolicy with one that uses a fixed number of attempts, and increase the initial backoff from 50ms to 250ms. This allows the total expiration to scale with the configured timeout without introduced options for the entire retry policy.

Prior to #7792 the RetryPolicy had an initial backoff of 1s. Raising it from 50ms to 250ms allows for a bit more leniency any time there's a transient state of immediate failure, particularly since there's now a fixed number of attempts.

Any failure to record a task as started results in the task being written back to the end of the TaskList.

<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Added dynamic config option for Request timeout

**Why?**
- Allow for fine tuning

**How did you test it?**
- Unit/integration tests

**Potential risks**
- Changing the RetryPolicy is always risky and may reveal error patterns that we didn't previously see

**Release notes**
NA

**Documentation Changes**
NA
