### PR TITLE
feat: Configure history task dlq processing dynamically

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -5146,7 +5146,6 @@ var BoolKeys = map[BoolKey]DynamicBool{
 		KeyName:      "history.historyTaskDLQProcessorEnabled",
 		Description:  "HistoryTaskDLQProcessorEnabled enables processing HistoryTaskDLQ messages",
 		DefaultValue: false,
-		Filters:      []Filter{DomainName},
 	},
 }
 

--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -2371,7 +2371,7 @@ const (
 	// Allowed filters: DomainName
 	EnableTaskListAwareTaskSchedulerByDomain
 
-	// HistoryTaskDLQEnabled enables processing HistoryTaskDLQ messages.
+	// HistoryTaskDLQProcessorEnabled enables processing HistoryTaskDLQ messages.
 	// When enabled the HistoryTaskDLQProcessor will be started alongside the lifecycle of the history engine.
 	// KeyName: history.historyTaskDLQProcessorEnabled
 	// Value type: Bool
@@ -2729,17 +2729,17 @@ const (
 	// Allowed filters: namespace
 	ShardDistributorLoadBalancingMode
 
-	// HistoryTaskDeadLetterQueueMode enables writing tasks to the History Task DLQ rather than discarding them.
+	// HistoryTaskDLQMode enables writing tasks to the History Task Dead Letter Queue rather than discarding them.
 	// To enable this key, HistoryTaskDLQProcessorEnabled must be enabled.
 	//
 	// * "enabled" - tasks are written to the DLQ and processed by the HistoryTaskDLQProcessor.
 	// * "shadow" - tasks are written to the DLQ but never processed.
 	//
-	// KeyName: history.historyTaskDeadLetterQueueMode
+	// KeyName: history.HistoryTaskDLQMode
 	// Value type: string ["disabled","shadow","enabled"]
 	// Default value: "disabled"
 	// Allowed filters: domainName
-	HistoryTaskDeadLetterQueueMode
+	HistoryTaskDLQMode
 
 	// LastStringKey must be the last one in this const group
 	LastStringKey
@@ -5425,9 +5425,9 @@ var StringKeys = map[StringKey]DynamicString{
 		Description:  "ShardDistributorLoadBalancingMode is the load balancing mode for the shard distributor. Depending on the mode, the shard distributor will use different ways to distribute the shards",
 		DefaultValue: "naive",
 	},
-	HistoryTaskDeadLetterQueueMode: {
-		KeyName:      "history.historyTaskDeadLetterQueueMode",
-		Description:  "HistoryTaskDeadLetterQueueMode is the key to enable history task dead letter queue. When enabled, the history task will be sent to a dead letter queue if it fails to be processed after a certain number of retries.",
+	HistoryTaskDLQMode: {
+		KeyName:      "history.historyTaskDLQMode",
+		Description:  "HistoryTaskDLQMode is the key to enable history task dead letter queue. When enabled, the history task will be sent to a dead letter queue if it fails to be processed after a certain number of retries.",
 		DefaultValue: "disabled", // available options: "disabled","shadow","enabled"
 		Filters:      []Filter{DomainName},
 	},

--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -2371,6 +2371,13 @@ const (
 	// Allowed filters: DomainName
 	EnableTaskListAwareTaskSchedulerByDomain
 
+	// HistoryTaskDLQEnabled enables processing HistoryTaskDLQ messages.
+	// When enabled the HistoryTaskDLQProcessor will be started alongside the lifecycle of the history engine.
+	// KeyName: history.historyTaskDLQProcessorEnabled
+	// Value type: Bool
+	// Default value: false
+	HistoryTaskDLQProcessorEnabled
+
 	// LastBoolKey must be the last one in this const group
 	LastBoolKey
 )
@@ -2722,7 +2729,12 @@ const (
 	// Allowed filters: namespace
 	ShardDistributorLoadBalancingMode
 
-	// HistoryTaskDeadLetterQueueMode is the key to enable history task dead letter queue
+	// HistoryTaskDeadLetterQueueMode enables writing tasks to the History Task DLQ rather than discarding them.
+	// To enable this key, HistoryTaskDLQProcessorEnabled must be enabled.
+	//
+	// * "enabled" - tasks are written to the DLQ and processed by the HistoryTaskDLQProcessor.
+	// * "shadow" - tasks are written to the DLQ but never processed.
+	//
 	// KeyName: history.historyTaskDeadLetterQueueMode
 	// Value type: string ["disabled","shadow","enabled"]
 	// Default value: "disabled"
@@ -5129,6 +5141,12 @@ var BoolKeys = map[BoolKey]DynamicBool{
 		Description:  "EnableTaskListAwareTaskSchedulerByDomain is to enable task list aware task scheduler by domain",
 		Filters:      []Filter{DomainName},
 		DefaultValue: false,
+	},
+	HistoryTaskDLQProcessorEnabled: {
+		KeyName:      "history.historyTaskDLQProcessorEnabled",
+		Description:  "HistoryTaskDLQProcessorEnabled enables processing HistoryTaskDLQ messages",
+		DefaultValue: false,
+		Filters:      []Filter{DomainName},
 	},
 }
 

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -346,9 +346,9 @@ type Config struct {
 	GlobalRatelimiterGCAfter        dynamicproperties.DurationPropertyFn
 
 	// History Task DLQ Configuration
-	HistoryTaskDLQMode            dynamicproperties.StringPropertyFnWithDomainFilter
-	HistoryTaskProcessingInterval dynamicproperties.DurationPropertyFnWithShardIDFilter
-	HistoryTaskDLQEnabled         dynamicproperties.BoolPropertyFn
+	HistoryTaskDLQMode              dynamicproperties.StringPropertyFnWithDomainFilter
+	HistoryTaskDLQProcessorInterval dynamicproperties.DurationPropertyFnWithShardIDFilter
+	HistoryTaskDLQProcessorEnabled  dynamicproperties.BoolPropertyFn
 
 	// HostName for machine running the service
 	HostName string
@@ -617,9 +617,9 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		GlobalRatelimiterDecayAfter:     dc.GetDurationProperty(dynamicproperties.HistoryGlobalRatelimiterDecayAfter),
 		GlobalRatelimiterGCAfter:        dc.GetDurationProperty(dynamicproperties.HistoryGlobalRatelimiterGCAfter),
 
-		HistoryTaskDLQMode:            dc.GetStringPropertyFilteredByDomain(dynamicproperties.HistoryTaskDeadLetterQueueMode),
-		HistoryTaskProcessingInterval: dc.GetDurationPropertyFilteredByShardID(dynamicproperties.HistoryTaskDLQProcessorInterval),
-		HistoryTaskDLQEnabled:         dc.GetBoolProperty(dynamicproperties.HistoryTaskDLQProcessorEnabled),
+		HistoryTaskDLQMode:              dc.GetStringPropertyFilteredByDomain(dynamicproperties.HistoryTaskDLQMode),
+		HistoryTaskDLQProcessorInterval: dc.GetDurationPropertyFilteredByShardID(dynamicproperties.HistoryTaskDLQProcessorInterval),
+		HistoryTaskDLQProcessorEnabled:  dc.GetBoolProperty(dynamicproperties.HistoryTaskDLQProcessorEnabled),
 
 		HostName: hostname,
 	}

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -348,6 +348,7 @@ type Config struct {
 	// History Task DLQ Configuration
 	HistoryTaskDLQMode            dynamicproperties.StringPropertyFnWithDomainFilter
 	HistoryTaskProcessingInterval dynamicproperties.DurationPropertyFnWithShardIDFilter
+	HistoryTaskDLQEnabled         dynamicproperties.BoolPropertyFn
 
 	// HostName for machine running the service
 	HostName string

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -619,6 +619,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 
 		HistoryTaskDLQMode:            dc.GetStringPropertyFilteredByDomain(dynamicproperties.HistoryTaskDeadLetterQueueMode),
 		HistoryTaskProcessingInterval: dc.GetDurationPropertyFilteredByShardID(dynamicproperties.HistoryTaskDLQProcessorInterval),
+		HistoryTaskDLQEnabled:         dc.GetBoolProperty(dynamicproperties.HistoryTaskDLQProcessorEnabled),
 
 		HostName: hostname,
 	}

--- a/service/history/config/config_test.go
+++ b/service/history/config/config_test.go
@@ -282,8 +282,9 @@ func TestNewConfig(t *testing.T) {
 		"EnableCorruptionAutoRepair":                           {dynamicproperties.EnableCorruptionAutoRepair, true},
 		"CorruptionRepairTimeout":                              {dynamicproperties.CorruptionRepairTimeout, time.Duration(1)},
 		"RequireChecksumMatchAfterRebuildRepair":               {dynamicproperties.RequireChecksumMatchAfterRebuildRepair, true},
-		"HistoryTaskDLQMode":                                   {dynamicproperties.HistoryTaskDeadLetterQueueMode, "enabled"},
-		"HistoryTaskProcessingInterval":                        {dynamicproperties.HistoryTaskDLQProcessorInterval, time.Second},
+		"HistoryTaskDLQMode":                                   {dynamicproperties.HistoryTaskDLQMode, "enabled"},
+		"HistoryTaskDLQProcessorInterval":                      {dynamicproperties.HistoryTaskDLQProcessorInterval, time.Second},
+		"HistoryTaskDLQProcessorEnabled":                       {dynamicproperties.HistoryTaskDLQProcessorEnabled, true},
 	}
 	client := dynamicconfig.NewInMemoryClient()
 	for fieldName, expected := range fields {

--- a/service/history/taskdlq/processor.go
+++ b/service/history/taskdlq/processor.go
@@ -116,10 +116,6 @@ func NewProcessor(
 
 // Start starts the processor and launches the background processing loop.
 func (p *ProcessorImpl) Start() {
-	if !p.enabled() {
-		p.logger.Debug("DLQ processor not enabled, skipping start", tag.ShardID(p.shardID))
-		return
-	}
 	if !atomic.CompareAndSwapInt32(&p.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
 		return
 	}
@@ -156,11 +152,13 @@ func (p *ProcessorImpl) processLoop() {
 		case <-p.ctx.Done():
 			return
 		case <-timer.Chan():
-			if err := p.ProcessShard(p.ctx); err != nil {
-				p.logger.Error("DLQ periodic shard sweep failed",
-					tag.ShardID(p.shardID),
-					tag.Error(err),
-				)
+			if p.enabled() {
+				if err := p.ProcessShard(p.ctx); err != nil {
+					p.logger.Error("DLQ periodic shard sweep failed",
+						tag.ShardID(p.shardID),
+						tag.Error(err),
+					)
+				}
 			}
 			timer.Reset(p.interval())
 		}
@@ -181,6 +179,7 @@ func (p *ProcessorImpl) ProcessShard(ctx context.Context) error {
 }
 
 func (p *ProcessorImpl) ProcessPartition(ctx context.Context, domainID, clusterAttributeScope, clusterAttributeName string) error {
+	// Fast-fail for direct callers; processAckLevel also guards each partition individually.
 	if p.domainEnabled(domainID) != constants.HistoryTaskDLQModeEnabled {
 		p.logger.Debug("DLQ not enabled for domain, skipping partition processing", tag.ShardID(p.shardID), tag.WorkflowDomainID(domainID))
 		return nil

--- a/service/history/taskdlq/processor.go
+++ b/service/history/taskdlq/processor.go
@@ -62,15 +62,15 @@ type (
 	}
 
 	ProcessorImpl struct {
-		shardID       int
-		store         HistoryTaskDLQStore
-		executors     map[int]TaskExecutor // persistence.HistoryTaskCategoryID* → executor
-		pageSize      int
-		interval      dynamicproperties.DurationPropertyFn
-		domainEnabled dynamicproperties.StringPropertyFnWithDomainFilter
-		enabled       dynamicproperties.BoolPropertyFn
-		timeSource    clock.TimeSource
-		logger        log.Logger
+		shardID    int
+		store      HistoryTaskDLQStore
+		executors  map[int]TaskExecutor // persistence.HistoryTaskCategoryID* → executor
+		pageSize   int
+		interval   dynamicproperties.DurationPropertyFn
+		domainMode dynamicproperties.StringPropertyFnWithDomainFilter
+		enabled    dynamicproperties.BoolPropertyFn
+		timeSource clock.TimeSource
+		logger     log.Logger
 
 		status    int32
 		ctx       context.Context
@@ -94,23 +94,23 @@ func NewProcessor(
 	executors map[int]TaskExecutor,
 	pageSize int,
 	interval dynamicproperties.DurationPropertyFn,
-	domainEnabled dynamicproperties.StringPropertyFnWithDomainFilter,
+	domainMode dynamicproperties.StringPropertyFnWithDomainFilter,
 	enabled dynamicproperties.BoolPropertyFn,
 	timeSource clock.TimeSource,
 	logger log.Logger,
 ) *ProcessorImpl {
 	return &ProcessorImpl{
-		shardID:       shardID,
-		store:         store,
-		executors:     executors,
-		pageSize:      pageSize,
-		interval:      interval,
-		domainEnabled: domainEnabled,
-		enabled:       enabled,
-		timeSource:    timeSource,
-		logger:        logger,
-		status:        common.DaemonStatusInitialized,
-		cancel:        func() {}, // no-op until Start() sets the real cancel
+		shardID:    shardID,
+		store:      store,
+		executors:  executors,
+		pageSize:   pageSize,
+		interval:   interval,
+		domainMode: domainMode,
+		enabled:    enabled,
+		timeSource: timeSource,
+		logger:     logger,
+		status:     common.DaemonStatusInitialized,
+		cancel:     func() {}, // no-op until Start() sets the real cancel
 	}
 }
 
@@ -180,7 +180,7 @@ func (p *ProcessorImpl) ProcessShard(ctx context.Context) error {
 
 func (p *ProcessorImpl) ProcessPartition(ctx context.Context, domainID, clusterAttributeScope, clusterAttributeName string) error {
 	// Fast-fail for direct callers; processAckLevel also guards each partition individually.
-	if p.domainEnabled(domainID) != constants.HistoryTaskDLQModeEnabled {
+	if p.domainMode(domainID) != constants.HistoryTaskDLQModeEnabled {
 		p.logger.Debug("DLQ not enabled for domain, skipping partition processing", tag.ShardID(p.shardID), tag.WorkflowDomainID(domainID))
 		return nil
 	}
@@ -221,7 +221,7 @@ func (p *ProcessorImpl) processAckLevels(ctx context.Context, ackLevels []AckLev
 // each one. It stops at the first execution failure, then advances the ack level to
 // the last successfully executed task key.
 func (p *ProcessorImpl) processAckLevel(ctx context.Context, al AckLevel) error {
-	if p.domainEnabled(al.DomainID) != constants.HistoryTaskDLQModeEnabled {
+	if p.domainMode(al.DomainID) != constants.HistoryTaskDLQModeEnabled {
 		p.logger.Debug("DLQ not enabled for domain, skipping ack level processing", tag.ShardID(p.shardID), tag.WorkflowDomainID(al.DomainID))
 		return nil
 	}

--- a/service/history/taskdlq/processor.go
+++ b/service/history/taskdlq/processor.go
@@ -28,7 +28,6 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"go.uber.org/multierr"
 
@@ -38,12 +37,7 @@ import (
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/persistence"
-)
-
-const (
-	// defaultProcessingInterval is how often the periodic shard sweep runs.
-	// TODO(c-warren) Make this dynamically configurable via dynamic config in a future change.
-	defaultProcessingInterval = 30 * time.Minute
+	"github.com/uber/cadence/service/history/constants"
 )
 
 type (
@@ -68,13 +62,15 @@ type (
 	}
 
 	ProcessorImpl struct {
-		shardID    int
-		store      HistoryTaskDLQStore
-		executors  map[int]TaskExecutor // persistence.HistoryTaskCategoryID* → executor
-		pageSize   int
-		interval   dynamicproperties.DurationPropertyFn
-		timeSource clock.TimeSource
-		logger     log.Logger
+		shardID       int
+		store         HistoryTaskDLQStore
+		executors     map[int]TaskExecutor // persistence.HistoryTaskCategoryID* → executor
+		pageSize      int
+		interval      dynamicproperties.DurationPropertyFn
+		domainEnabled dynamicproperties.StringPropertyFnWithDomainFilter
+		enabled       dynamicproperties.BoolPropertyFn
+		timeSource    clock.TimeSource
+		logger        log.Logger
 
 		status    int32
 		ctx       context.Context
@@ -84,14 +80,6 @@ type (
 	}
 )
 
-// DefaultProcessingInterval returns a default processing interval of 30 minutes.
-// TODO(c-warren): Remove this once the dynamic config is implemented.
-func DefaultProcessingInterval() dynamicproperties.DurationPropertyFn {
-	return func(opts ...dynamicproperties.FilterOption) time.Duration {
-		return defaultProcessingInterval
-	}
-}
-
 var _ Processor = (*ProcessorImpl)(nil)
 
 // NewProcessor creates a Processor that reads from the history task DLQ for shardID.
@@ -99,33 +87,39 @@ var _ Processor = (*ProcessorImpl)(nil)
 // executors maps persistence.HistoryTaskCategoryID* constants to the appropriate
 // historyqueuev2 executor for each task type.
 //
-// interval controls how often the background loop calls ProcessShard. Pass
-// dynamicproperties.GetDurationPropertyFn(defaultProcessingInterval) to use the
-// package default, or supply a dynamic-config-backed function for live tuning.
+// interval controls how often the background loop calls ProcessShard.
 func NewProcessor(
 	shardID int,
 	store HistoryTaskDLQStore,
 	executors map[int]TaskExecutor,
 	pageSize int,
 	interval dynamicproperties.DurationPropertyFn,
+	domainEnabled dynamicproperties.StringPropertyFnWithDomainFilter,
+	enabled dynamicproperties.BoolPropertyFn,
 	timeSource clock.TimeSource,
 	logger log.Logger,
 ) *ProcessorImpl {
 	return &ProcessorImpl{
-		shardID:    shardID,
-		store:      store,
-		executors:  executors,
-		pageSize:   pageSize,
-		interval:   interval,
-		timeSource: timeSource,
-		logger:     logger,
-		status:     common.DaemonStatusInitialized,
-		cancel:     func() {}, // no-op until Start() sets the real cancel
+		shardID:       shardID,
+		store:         store,
+		executors:     executors,
+		pageSize:      pageSize,
+		interval:      interval,
+		domainEnabled: domainEnabled,
+		enabled:       enabled,
+		timeSource:    timeSource,
+		logger:        logger,
+		status:        common.DaemonStatusInitialized,
+		cancel:        func() {}, // no-op until Start() sets the real cancel
 	}
 }
 
 // Start starts the processor and launches the background processing loop.
 func (p *ProcessorImpl) Start() {
+	if !p.enabled() {
+		p.logger.Debug("DLQ processor not enabled, skipping start", tag.ShardID(p.shardID))
+		return
+	}
 	if !atomic.CompareAndSwapInt32(&p.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
 		return
 	}
@@ -187,6 +181,11 @@ func (p *ProcessorImpl) ProcessShard(ctx context.Context) error {
 }
 
 func (p *ProcessorImpl) ProcessPartition(ctx context.Context, domainID, clusterAttributeScope, clusterAttributeName string) error {
+	if p.domainEnabled(domainID) != constants.HistoryTaskDLQModeEnabled {
+		p.logger.Debug("DLQ not enabled for domain, skipping partition processing", tag.ShardID(p.shardID), tag.WorkflowDomainID(domainID))
+		return nil
+	}
+
 	p.processMu.Lock()
 	defer p.processMu.Unlock()
 	if ctx.Err() != nil {
@@ -223,6 +222,11 @@ func (p *ProcessorImpl) processAckLevels(ctx context.Context, ackLevels []AckLev
 // each one. It stops at the first execution failure, then advances the ack level to
 // the last successfully executed task key.
 func (p *ProcessorImpl) processAckLevel(ctx context.Context, al AckLevel) error {
+	if p.domainEnabled(al.DomainID) != constants.HistoryTaskDLQModeEnabled {
+		p.logger.Debug("DLQ not enabled for domain, skipping ack level processing", tag.ShardID(p.shardID), tag.WorkflowDomainID(al.DomainID))
+		return nil
+	}
+
 	executor, ok := p.executors[al.TaskType]
 	if !ok {
 		return fmt.Errorf("no executor registered for task type %d", al.TaskType)

--- a/service/history/taskdlq/processor_test.go
+++ b/service/history/taskdlq/processor_test.go
@@ -633,7 +633,7 @@ func TestStart_ShouldCallProcessShardOnInterval(t *testing.T) {
 	}
 }
 
-func TestStart_WhenNotEnabled_DoesNotStartBackgroundLoop(t *testing.T) {
+func TestStart_WhenNotEnabled_SkipsProcessingButContinuesLoop(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -655,19 +655,13 @@ func TestStart_WhenNotEnabled_DoesNotStartBackgroundLoop(t *testing.T) {
 	proc.Start()
 	defer proc.Stop()
 
-	// If the background loop had started it would immediately register a timer.
-	// BlockUntil(1) unblocks as soon as one goroutine is waiting on the time source,
-	// so if it does not return within the deadline the loop was never started.
-	timerRegistered := make(chan struct{})
-	go func() {
-		ts.BlockUntil(1)
-		close(timerRegistered)
-	}()
-	select {
-	case <-timerRegistered:
-		t.Fatal("background loop started despite processor being disabled")
-	case <-time.After(50 * time.Millisecond):
-	}
+	// The loop always starts; wait for the first timer to be registered.
+	ts.BlockUntil(1)
+	// Advance past the interval — enabled() returns false, so GetAckLevels must not be called.
+	ts.Advance(defaultTestProcessingInterval)
+	// Wait for the timer to be reset, confirming the loop ran and continued.
+	ts.BlockUntil(1)
+	// ctrl.Finish() verifies GetAckLevels was called 0 times.
 }
 
 func TestProcessShard_WhenDomainNotEnabled_SkipsProcessing(t *testing.T) {

--- a/service/history/taskdlq/processor_test.go
+++ b/service/history/taskdlq/processor_test.go
@@ -36,6 +36,11 @@ import (
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/service/history/constants"
+)
+
+const (
+	defaultTestProcessingInterval = 15 * time.Second
 )
 
 // newMockTask creates a mock persistence.Task whose GetTaskKey returns an immediate key for taskID.
@@ -57,7 +62,9 @@ func setupProcessor(t *testing.T, ctrl *gomock.Controller) (*ProcessorImpl, *Moc
 			persistence.HistoryTaskCategoryIDTransfer: executor,
 		},
 		10,
-		dynamicproperties.GetDurationPropertyFn(defaultProcessingInterval),
+		dynamicproperties.GetDurationPropertyFn(defaultTestProcessingInterval),
+		dynamicproperties.GetStringPropertyFnFilteredByDomain(constants.HistoryTaskDLQModeEnabled),
+		dynamicproperties.GetBoolPropertyFn(true),
 		clock.NewMockedTimeSource(),
 		testlogger.New(t),
 	)
@@ -280,7 +287,9 @@ func TestProcessPartition_WhenMultipleTaskTypes_ProcessesAll(t *testing.T) {
 			persistence.HistoryTaskCategoryIDTimer:    timerExecutor,
 		},
 		10,
-		dynamicproperties.GetDurationPropertyFn(defaultProcessingInterval),
+		dynamicproperties.GetDurationPropertyFn(defaultTestProcessingInterval),
+		dynamicproperties.GetStringPropertyFnFilteredByDomain(constants.HistoryTaskDLQModeEnabled),
+		dynamicproperties.GetBoolPropertyFn(true),
 		clock.NewMockedTimeSource(),
 		testlogger.New(t),
 	)
@@ -419,7 +428,9 @@ func TestProcessShard_AndProcessPartition_AreSerializedByMutex(t *testing.T) {
 		store,
 		map[int]TaskExecutor{},
 		10,
-		dynamicproperties.GetDurationPropertyFn(defaultProcessingInterval),
+		dynamicproperties.GetDurationPropertyFn(defaultTestProcessingInterval),
+		dynamicproperties.GetStringPropertyFnFilteredByDomain(constants.HistoryTaskDLQModeEnabled),
+		dynamicproperties.GetBoolPropertyFn(true),
 		clock.NewMockedTimeSource(),
 		testlogger.New(t),
 	)
@@ -488,7 +499,9 @@ func TestStop_WhenStoreRespectsContextCancellation_ReturnsPromptly(t *testing.T)
 		store,
 		map[int]TaskExecutor{},
 		10,
-		dynamicproperties.GetDurationPropertyFn(defaultProcessingInterval),
+		dynamicproperties.GetDurationPropertyFn(defaultTestProcessingInterval),
+		dynamicproperties.GetStringPropertyFnFilteredByDomain(constants.HistoryTaskDLQModeEnabled),
+		dynamicproperties.GetBoolPropertyFn(true),
 		ts,
 		testlogger.New(t),
 	)
@@ -496,7 +509,7 @@ func TestStop_WhenStoreRespectsContextCancellation_ReturnsPromptly(t *testing.T)
 	proc.Start()
 
 	ts.BlockUntil(1)
-	ts.Advance(defaultProcessingInterval)
+	ts.Advance(defaultTestProcessingInterval)
 
 	select {
 	case <-inGetAckLevels:
@@ -567,7 +580,9 @@ func TestStartStop_ShouldBeIdempotent(t *testing.T) {
 		store,
 		map[int]TaskExecutor{},
 		10,
-		dynamicproperties.GetDurationPropertyFn(defaultProcessingInterval),
+		dynamicproperties.GetDurationPropertyFn(defaultTestProcessingInterval),
+		dynamicproperties.GetStringPropertyFnFilteredByDomain(constants.HistoryTaskDLQModeEnabled),
+		dynamicproperties.GetBoolPropertyFn(true),
 		clock.NewMockedTimeSource(),
 		testlogger.New(t),
 	)
@@ -598,7 +613,9 @@ func TestStart_ShouldCallProcessShardOnInterval(t *testing.T) {
 		store,
 		map[int]TaskExecutor{},
 		10,
-		dynamicproperties.GetDurationPropertyFn(defaultProcessingInterval),
+		dynamicproperties.GetDurationPropertyFn(defaultTestProcessingInterval),
+		dynamicproperties.GetStringPropertyFnFilteredByDomain(constants.HistoryTaskDLQModeEnabled),
+		dynamicproperties.GetBoolPropertyFn(true),
 		ts,
 		testlogger.New(t),
 	)
@@ -607,11 +624,76 @@ func TestStart_ShouldCallProcessShardOnInterval(t *testing.T) {
 	defer proc.Stop()
 
 	ts.BlockUntil(1)
-	ts.Advance(defaultProcessingInterval)
+	ts.Advance(defaultTestProcessingInterval)
 
 	select {
 	case <-processed:
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for ProcessShard to be called by the background loop")
 	}
+}
+
+func TestStart_WhenNotEnabled_DoesNotStartBackgroundLoop(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ts := clock.NewMockedTimeSource()
+	store := NewMockHistoryTaskDLQStore(ctrl)
+	store.EXPECT().GetAckLevels(gomock.Any(), gomock.Any()).Times(0)
+	proc := NewProcessor(
+		1,
+		store,
+		map[int]TaskExecutor{},
+		10,
+		dynamicproperties.GetDurationPropertyFn(defaultTestProcessingInterval),
+		dynamicproperties.GetStringPropertyFnFilteredByDomain(constants.HistoryTaskDLQModeEnabled),
+		dynamicproperties.GetBoolPropertyFn(false),
+		ts,
+		testlogger.New(t),
+	)
+
+	proc.Start()
+	defer proc.Stop()
+
+	// If the background loop had started it would immediately register a timer.
+	// BlockUntil(1) unblocks as soon as one goroutine is waiting on the time source,
+	// so if it does not return within the deadline the loop was never started.
+	timerRegistered := make(chan struct{})
+	go func() {
+		ts.BlockUntil(1)
+		close(timerRegistered)
+	}()
+	select {
+	case <-timerRegistered:
+		t.Fatal("background loop started despite processor being disabled")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestProcessShard_WhenDomainNotEnabled_SkipsProcessing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	store := NewMockHistoryTaskDLQStore(ctrl)
+	executor := NewMockTaskExecutor(ctrl)
+	proc := NewProcessor(
+		1,
+		store,
+		map[int]TaskExecutor{
+			persistence.HistoryTaskCategoryIDTransfer: executor,
+		},
+		10,
+		dynamicproperties.GetDurationPropertyFn(defaultTestProcessingInterval),
+		dynamicproperties.GetStringPropertyFnFilteredByDomain(constants.HistoryTaskDLQModeDisabled),
+		dynamicproperties.GetBoolPropertyFn(true),
+		clock.NewMockedTimeSource(),
+		testlogger.New(t),
+	)
+
+	al := baseAckLevel(1)
+	store.EXPECT().GetAckLevels(gomock.Any(), 1).Return([]AckLevel{al}, nil)
+	store.EXPECT().GetTasks(gomock.Any(), gomock.Any()).Times(0)
+	executor.EXPECT().Execute(gomock.Any(), gomock.Any()).Times(0)
+
+	assert.NoError(t, proc.ProcessShard(context.Background()))
 }


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

Added feature flags to configure the History Task DLQ processor on two planes:
1. Enable/Disable the processor globally
2. Respect the existing DLQ mode when processing a given domain

**Why?**

The global DLQ mode flag will allow us to disable all processing of the DLQ, decoupling releasing this feature from the code deployment (and reducing potentially spammy logs when the feature is not yet enabled). 

The domain level flag was preexisting - previously we were only writing if this flag was enabled/shadow, and now this ensures we only process a particular domain if the flag is enabled. Shadow mode will write but will not read from the queue. 

**How did you test it?**

```
go test ./service/history/taskdlq/... -race
```

Also tested locally w/ a full POC stack. 

**Potential risks**

This set of flags does introduce a risk that someone might enable the per-domain flag without the per-environment flag. This would result in writes, but no reads - despite thinking that reads would occur. This is the best case scenario - there is no data loss, but the DLQ would build up. 

**Release notes**

This doesn't need release notes but the caveats stated here should be written in them when the feature is released. 

**Documentation Changes**

N/A
