### PR TITLE
fix(scheduler): JSON-round-trip StartWorkflowAction payload in workflow input

### DIFF
--- a/common/types/schedule.go
+++ b/common/types/schedule.go
@@ -178,16 +178,19 @@ func (v *ScheduleSpec) GetJitter() (o time.Duration) {
 }
 
 // StartWorkflowAction defines a workflow to start when the schedule triggers.
+// Input, Memo, and SearchAttributes must JSON-round-trip: the scheduler workflow
+// encodes types.ScheduleAction with encoding/json (create input, update signals,
+// ContinueAsNew, local-activity payloads).
 type StartWorkflowAction struct {
 	WorkflowType                        *WorkflowType     `json:"workflowType,omitempty"`
 	TaskList                            *TaskList         `json:"taskList,omitempty"`
-	Input                               []byte            `json:"-"` // Potential PII
+	Input                               []byte            `json:"input,omitempty"`
 	WorkflowIDPrefix                    string            `json:"workflowIdPrefix,omitempty"`
 	ExecutionStartToCloseTimeoutSeconds *int32            `json:"executionStartToCloseTimeoutSeconds,omitempty"`
 	TaskStartToCloseTimeoutSeconds      *int32            `json:"taskStartToCloseTimeoutSeconds,omitempty"`
 	RetryPolicy                         *RetryPolicy      `json:"retryPolicy,omitempty"`
-	Memo                                *Memo             `json:"-"` // Filtering PII
-	SearchAttributes                    *SearchAttributes `json:"-"` // Filtering PII
+	Memo                                *Memo             `json:"memo,omitempty"`
+	SearchAttributes                    *SearchAttributes `json:"searchAttributes,omitempty"`
 }
 
 func (v *StartWorkflowAction) GetWorkflowType() *WorkflowType {

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -100,6 +100,7 @@ func TestCreateSchedule(t *testing.T) {
 			StartWorkflow: &types.StartWorkflowAction{
 				WorkflowType: &types.WorkflowType{Name: "my-workflow"},
 				TaskList:     &types.TaskList{Name: "my-tasklist"},
+				Input:        []byte(`{"k":1}`),
 			},
 		},
 	}
@@ -249,6 +250,8 @@ func TestCreateSchedule(t *testing.T) {
 						assert.Equal(t, testDomain, input.Domain)
 						assert.Equal(t, "my-schedule", input.ScheduleID)
 						assert.Equal(t, "*/5 * * * *", input.Spec.CronExpression)
+						require.NotNil(t, input.Action.StartWorkflow)
+						assert.Equal(t, []byte(`{"k":1}`), input.Action.StartWorkflow.Input)
 
 						return &types.StartWorkflowExecutionResponse{RunID: "test-run-id"}, nil
 					})


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
StartWorkflowAction used json:"-" on input, memo, and search attributes, which encoding/json omitted when marshaling SchedulerWorkflowInput for create, signals, and ContinueAsNew. Scheduled runs then started workflows with empty input. Use standard omitempty tags and assert in CreateSchedule test.


**Why?**
Anything that used `json.Marshal` on that graph silently dropped workflow input (and memo / search attributes on the *target* start). Scheduled fires still ran, yet `StartWorkflowExecution` saw empty input, which breaks workflows that expect JSON args (for example CLI `--input`). 

**How did you test it?**
```bash
go test ./service/frontend/api/... -count=1 
go test ./common/types/mapper/proto/... -count=1 

**Potential risks**
Describe / query paths that JSON-serialize the schedule action may now surface input, memo, or search attributes on the action where they were previously absent from that JSON. 

**Release notes**
Fixed schedules so workflow input (and memo / search attributes configured on the schedule action) is passed through to each scheduled workflow start instead of being dropped.

**Documentation Changes**
N/A
