### PR TITLE
fix(persistence): route PutReplicationTaskToDLQ metrics by domain

### DIFF
--- a/common/persistence/metered.go
+++ b/common/persistence/metered.go
@@ -320,8 +320,8 @@ func (r *IsWorkflowExecutionExistsRequest) GetDomainName() string {
 	return r.DomainName
 }
 
-func (r *PutReplicationTaskToDLQRequest) MetricTags() []metrics.Tag {
-	return []metrics.Tag{metrics.DomainTag(r.DomainName)}
+func (r *PutReplicationTaskToDLQRequest) GetDomainName() string {
+	return r.DomainName
 }
 
 func (r *CreateWorkflowExecutionRequest) GetExtraLogTags() []tag.Tag {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Updated `PutReplicationTaskToDLQRequest` to expose its domain via `GetDomainName()` instead of `MetricTags()`.

**Why?**
`MetricTags()` is for custom labels. For `ExecutionManager`, the domain label should come from `GetDomainName()` so the wrapper can use the domain-aware metrics path.

`PutReplicationTaskToDLQRequest` is the odd one out: it puts the domain in `MetricTags()` but does not expose `GetDomainName()`. Because of that, the generated wrapper treats it as a no-domain call and routes it through `callWithoutDomainTag`. That creates the bug:
other no-domain calls emit `persistence_requests{operation=..., is_retry=...}`
PutReplicationTaskToDLQ emits `persistence_requests{operation=..., domain=..., is_retry=...}`
Same metric name, different label keys, so Prometheus rejects the conflicting series.
Ref:#7844

**How did you test it?**


**Potential risks**


**Release notes**


**Documentation Changes**

