### PR TITLE
fix(schedule): Add validation for cron expression at create and update.

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/frontend/validate"
@@ -122,6 +123,9 @@ func (wh *WorkflowHandler) CreateSchedule(
 	}
 	if request.GetSpec().GetCronExpression() == "" {
 		return nil, &types.BadRequestError{Message: "CronExpression is not set on request."}
+	}
+	if _, err := backoff.ValidateSchedule(request.GetSpec().GetCronExpression()); err != nil {
+		return nil, err
 	}
 	if request.GetAction() == nil || request.GetAction().GetStartWorkflow() == nil {
 		return nil, &types.BadRequestError{Message: "Action.StartWorkflow is not set on request."}
@@ -274,6 +278,11 @@ func (wh *WorkflowHandler) UpdateSchedule(
 		return nil, err
 	}
 	wh.warnIfBufferLimitExceedsSystemLimit(scheduleID, domainName, request.GetPolicies())
+	if spec := request.GetSpec(); spec != nil && spec.GetCronExpression() != "" {
+		if _, err := backoff.ValidateSchedule(spec.GetCronExpression()); err != nil {
+			return nil, err
+		}
+	}
 
 	signal := scheduler.UpdateSignal{
 		Spec:     request.GetSpec(),

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -139,6 +139,24 @@ func TestCreateSchedule(t *testing.T) {
 			mockFn:  func(f *scheduleTestFixture) {},
 			wantErr: true,
 		},
+		"invalid cron expression": {
+			request: &types.CreateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Spec:       &types.ScheduleSpec{CronExpression: "not-a-cron"},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"impossible cron date (Feb 30) parses but never fires": {
+			request: &types.CreateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Spec:       &types.ScheduleSpec{CronExpression: "0 0 30 2 *"},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
 		"nil action": {
 			request: &types.CreateScheduleRequest{
 				Domain:     testDomain,
@@ -551,6 +569,24 @@ func TestUpdateSchedule(t *testing.T) {
 					})
 			},
 			wantErr: false,
+		},
+		"invalid cron expression in spec update": {
+			request: &types.UpdateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Spec:       &types.ScheduleSpec{CronExpression: "not-a-cron"},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"impossible cron date in spec update (Feb 30) parses but never fires": {
+			request: &types.UpdateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Spec:       &types.ScheduleSpec{CronExpression: "0 0 30 2 *"},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
 		},
 	}
 


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

- Added cron expression validation to the CreateSchedule and UpdateSchedule frontend handlers (service/frontend/api/handler_schedule.go). Both now call backoff.ValidateSchedule before dispatching to the scheduler workflow, rejecting syntactically invalid expressions (e.g. "not-a-cron") and impossible dates that parse successfully but can never fire (e.g. "0 0 30 2 *" — Feb 30).   

**Why?**

- **CreateSchedule** only checked that CronExpression was non-empty. 
- The first actual parse happened inside the scheduler workflow (service/worker/scheduler/workflow.go:90), which ran after CreateSchedule had already returned success to the caller. 
- An invalid cron caused the workflow to immediately terminate with an error, leaving behind a registered schedule that would never fire — visible in ListSchedules but silently broken. The client received no indication that anything was wrong.

- For **UpdateSchedule**, an invalid cron in a spec update was silently ignored at the workflow level (logged as an error, spec left unchanged), again with no error returned to the caller                                                                                                                                                                                                                                              
  

- backoff.ValidateSchedule already existed and uses the same github.com/robfig/cron/v3 library as the workflow. It additionally catches impossible dates via a sched.Next().IsZero() check that a plain  cron.ParseStandard call would miss. Calling it at the frontend boundary ensures the client gets a BadRequestError before any workflow is started or signaled.

**How did you test it?**

- "not-a-cron" — exercises the ParseStandard error path (structurally invalid)                                                                                                                                     
- "0 0 30 2 *" — exercises the Next().IsZero() path (parses OK, but Feb 30 never exists)       

**Potential risks**

- None. No clients onboarded with schedule yet.

**Release notes**

-  CreateSchedule and UpdateSchedule now validate the cron expression at the API layer and return a BadRequestError immediately for invalid or impossible expressions (e.g. "0 0 30 2 *"), instead of accepting the request and silently crashing the underlying scheduler workflow.     

**Documentation Changes**

N/A