### PR TITLE
fix(schedule): make pause idempotent when schedule is already paused

### DIFF
--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -363,6 +363,10 @@ func buildScheduleSearchAttributes(input *SchedulerWorkflowInput, state *Schedul
 }
 
 func handlePause(logger *zap.Logger, sig PauseSignal, state *SchedulerWorkflowState) bool {
+	if state.Paused {
+		logger.Info("ignoring pause signal, schedule is already paused")
+		return false
+	}
 	state.Paused = true
 	state.PauseReason = sig.Reason
 	state.PausedBy = sig.PausedBy

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -475,13 +475,13 @@ func TestHandlePause(t *testing.T) {
 			wantChanged:  true,
 		},
 		{
-			name:         "pause overwrites previous pause reason",
+			name:         "pause when already paused is a no-op",
 			initial:      SchedulerWorkflowState{Paused: true, PauseReason: "old", PausedBy: "old-user"},
 			sig:          PauseSignal{Reason: "new reason", PausedBy: "new-user"},
 			wantPaused:   true,
-			wantReason:   "new reason",
-			wantPausedBy: "new-user",
-			wantChanged:  true,
+			wantReason:   "old",
+			wantPausedBy: "old-user",
+			wantChanged:  false,
 		},
 		{
 			name:         "pause with empty reason",


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

1.  Added an idempotency guard to handlePause. When a pause signal arrives for a schedule that is already paused, the function now logs "ignoring pause signal, schedule is already paused" and returns false (no state change). Previously it unconditionally overwrote PauseReason/PausedBy and always returned true.    
2. Updated the test case in workflow_test.go that was explicitly asserting the old overwrite behavior ("pause overwrites previous pause reason") to instead assert the correct no-op semantics ("pause when already paused is a no-op").   

**Why?**

- handleUnpause already had this guard: if the schedule is not paused, it logs and returns false. 
- handlePause had no equivalent check, producing three problems:                                                     
  1. re-pausing with a different --reason silently overwrote who originally paused the schedule and why, with no indication to the caller.                                           
  2. Unnecessary ContinueAsNew: returning true on every re-pause caused the workflow to checkpoint even when no meaningful state changed, wasting history resources.
  3. because the frontend signals the workflow fire-and-forget, the CLI always printed "paused successfully" without any way to detect the no-op — fixing idempotency at the workflow layer is the correct place to address this. 

**How did you test it?**

- Unit test

**Potential risks**

-  Low. This is a purely additive guard inside a single workflow signal handler. No IDL, schema, or API surface changed.

**Release notes**
Fixed a bug where pausing an already-paused schedule would silently overwrite the original pause reason and requester identity, and would trigger an unnecessary workflow checkpoint. Pausing an already-paused schedule is now a true no-op (consistent with how unpausing an already-running schedule behaves).


**Documentation Changes**
N/A
