### PR TITLE
fix: convert replicator panics into errors, rather than crashing the process

### DIFF
--- a/service/history/ndc/history_replicator.go
+++ b/service/history/ndc/history_replicator.go
@@ -22,6 +22,8 @@ package ndc
 
 import (
 	ctx "context"
+	"fmt"
+	"runtime"
 	"time"
 
 	"github.com/pborman/uuid"
@@ -343,7 +345,14 @@ func (r *historyReplicatorImpl) applyEvents(
 	defer func() {
 		if rec := recover(); rec != nil {
 			releaseFn(errPanic)
-			panic(rec)
+			stack := make([]byte, 1<<14) // 16kb
+			n := runtime.Stack(stack, false)
+			stack = stack[:n]
+			if retError == nil {
+				retError = fmt.Errorf("panic: %v, stack: %s", rec, stack)
+			} else {
+				retError = fmt.Errorf("panic: %v, stack: %s, previous err: %w", rec, stack, retError)
+			}
 		} else {
 			releaseFn(retError)
 		}

--- a/service/history/ndc/history_replicator.go
+++ b/service/history/ndc/history_replicator.go
@@ -345,9 +345,13 @@ func (r *historyReplicatorImpl) applyEvents(
 	defer func() {
 		if rec := recover(); rec != nil {
 			releaseFn(errPanic)
-			stack := make([]byte, 1<<14) // 16kb
+			stack := make([]byte, 1<<14)
 			n := runtime.Stack(stack, false)
 			stack = stack[:n]
+			r.logger.Error("panic in applyEvents",
+				tag.Error(fmt.Errorf("%v", rec)),
+				tag.Value(string(stack)),
+			)
 			if retError == nil {
 				retError = fmt.Errorf("panic: %v, stack: %s", rec, stack)
 			} else {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Convert replicator panics into errors, rather than crashing the process. https://github.com/cadence-workflow/cadence/pull/7097

**Why?**
Instead of making the replicator panic, log the error.

**How did you test it?**
go test -count=1 -race ./service/history/ndc/

Information in https://github.com/cadence-workflow/cadence/pull/7097

**Potential risks**
N/A

**Release notes**
N/A

**Documentation Changes**
N/A
