### PR TITLE
fix(schedule): DescribeSchedule returns error when scheduler workflow is not running cleanly   

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -206,6 +206,11 @@ func (wh *WorkflowHandler) DescribeSchedule(
 	}
 
 	wfID := scheduleWorkflowID(scheduleID)
+	// Reject the query if the scheduler workflow did not complete cleanly (e.g. FAILED,
+	// TERMINATED, TIMED_OUT). Without this, Cadence replays the closed workflow history
+	// and returns whatever state the query handler last saw — which is ACTIVE even for a
+	// scheduler that failed immediately (e.g. due to an invalid cron expression).
+	rejectCondition := types.QueryRejectConditionNotCompletedCleanly
 	queryResp, err := wh.QueryWorkflow(ctx, &types.QueryWorkflowRequest{
 		Domain: domainName,
 		Execution: &types.WorkflowExecution{
@@ -214,12 +219,31 @@ func (wh *WorkflowHandler) DescribeSchedule(
 		Query: &types.WorkflowQuery{
 			QueryType: scheduler.QueryTypeDescribe,
 		},
+		QueryRejectCondition: &rejectCondition,
 	})
 	if err != nil {
 		return nil, normalizeScheduleError(err, scheduleID, domainName)
 	}
 
-	if queryResp == nil || queryResp.GetQueryResult() == nil {
+	if queryResp == nil {
+		return nil, &types.InternalServiceError{Message: "nil query response from scheduler workflow"}
+	}
+
+	if queryResp.QueryRejected != nil {
+		closeStatus := "unknown"
+		if queryResp.QueryRejected.CloseStatus != nil {
+			closeStatus = queryResp.QueryRejected.CloseStatus.String()
+		}
+		return nil, &types.QueryFailedError{
+			Message: fmt.Sprintf(
+				"scheduler workflow for schedule %q is not running (close status: %s); "+
+					"the schedule may have an invalid configuration or was terminated unexpectedly",
+				scheduleID, closeStatus,
+			),
+		}
+	}
+
+	if queryResp.GetQueryResult() == nil {
 		return nil, &types.InternalServiceError{Message: "empty query result from scheduler workflow"}
 	}
 

--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -234,11 +234,10 @@ func (wh *WorkflowHandler) DescribeSchedule(
 		if queryResp.QueryRejected.CloseStatus != nil {
 			closeStatus = queryResp.QueryRejected.CloseStatus.String()
 		}
-		return nil, &types.QueryFailedError{
+		return nil, &types.InternalServiceError{
 			Message: fmt.Sprintf(
-				"scheduler workflow for schedule %q is not running (close status: %s); "+
-					"the schedule may have an invalid configuration or was terminated unexpectedly",
-				scheduleID, closeStatus,
+				"schedule %q in domain %q is not operational: scheduler workflow ended with status %s",
+				scheduleID, domainName, closeStatus,
 			),
 		}
 	}

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -313,10 +313,11 @@ func TestDescribeSchedule(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		request *types.DescribeScheduleRequest
-		mockFn  func(*scheduleTestFixture)
-		wantErr bool
-		check   func(*testing.T, *types.DescribeScheduleResponse)
+		request  *types.DescribeScheduleRequest
+		mockFn   func(*scheduleTestFixture)
+		wantErr  bool
+		checkErr func(*testing.T, error)
+		check    func(*testing.T, *types.DescribeScheduleResponse)
 	}{
 		"nil request": {
 			request: nil,
@@ -374,6 +375,11 @@ func TestDescribeSchedule(t *testing.T) {
 					}, nil)
 			},
 			wantErr: true,
+			checkErr: func(t *testing.T, err error) {
+				var internalErr *types.InternalServiceError
+				assert.ErrorAs(t, err, &internalErr)
+				assert.Contains(t, internalErr.Message, "FAILED")
+			},
 		},
 		"scheduler workflow terminated - query rejected": {
 			request: validRequest,
@@ -388,6 +394,11 @@ func TestDescribeSchedule(t *testing.T) {
 					}, nil)
 			},
 			wantErr: true,
+			checkErr: func(t *testing.T, err error) {
+				var internalErr *types.InternalServiceError
+				assert.ErrorAs(t, err, &internalErr)
+				assert.Contains(t, internalErr.Message, "TERMINATED")
+			},
 		},
 		"success": {
 			request: validRequest,
@@ -429,6 +440,9 @@ func TestDescribeSchedule(t *testing.T) {
 			resp, err := f.handler.DescribeSchedule(context.Background(), tt.request)
 			if tt.wantErr {
 				assert.Error(t, err)
+				if tt.checkErr != nil {
+					tt.checkErr(t, err)
+				}
 			} else {
 				assert.NoError(t, err)
 				if tt.check != nil {

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -358,6 +358,37 @@ func TestDescribeSchedule(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		// Regression: a scheduler workflow that ended FAILED (e.g. invalid cron) must not
+		// surface as ACTIVE. The handler sets QueryRejectConditionNotCompletedCleanly so
+		// Cadence rejects the query for any non-clean close status.
+		"scheduler workflow failed - query rejected": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				closeStatus := types.WorkflowExecutionCloseStatusFailed
+				f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+					Return(&types.HistoryQueryWorkflowResponse{
+						Response: &types.QueryWorkflowResponse{
+							QueryRejected: &types.QueryRejected{CloseStatus: &closeStatus},
+						},
+					}, nil)
+			},
+			wantErr: true,
+		},
+		"scheduler workflow terminated - query rejected": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				closeStatus := types.WorkflowExecutionCloseStatusTerminated
+				f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+					Return(&types.HistoryQueryWorkflowResponse{
+						Response: &types.QueryWorkflowResponse{
+							QueryRejected: &types.QueryRejected{CloseStatus: &closeStatus},
+						},
+					}, nil)
+			},
+			wantErr: true,
+		},
 		"success": {
 			request: validRequest,
 			mockFn: func(f *scheduleTestFixture) {
@@ -367,6 +398,9 @@ func TestDescribeSchedule(t *testing.T) {
 						assert.Equal(t, testDomainID, req.DomainUUID)
 						assert.Equal(t, "cadence-scheduler:my-schedule", req.Request.Execution.WorkflowID)
 						assert.Equal(t, scheduler.QueryTypeDescribe, req.Request.Query.QueryType)
+						// Verify the reject condition is set so closed/failed workflows are detected.
+						require.NotNil(t, req.Request.QueryRejectCondition)
+						assert.Equal(t, types.QueryRejectConditionNotCompletedCleanly, *req.Request.QueryRejectCondition)
 
 						return &types.HistoryQueryWorkflowResponse{
 							Response: &types.QueryWorkflowResponse{


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

- DescribeSchedule now sets QueryRejectConditionNotCompletedCleanly on the internal QueryWorkflow call. 
- When Cadence's History engine sees this condition and the scheduler workflow is closed with a non-clean status (**FAILED**, **TERMINATED**, **TIMED_OUT**), it returns a QueryRejected response instead of replaying the closed workflow's history to answer the query. 
- The handler converts that rejection into an InternalServiceError with a schedule-level message including the workflow's close status (e.g., schedule "X" in domain "Y" is not operational: scheduler workflow ended with status FAILED).


**Why?**

- DescribeSchedule was reporting Status: ACTIVE for scheduler workflows that had already ended in FAILED or TERMINATED state.
- The root cause: QueryWorkflow with no QueryRejectCondition (nil) allows Cadence to replay a closed workflow's history and answer the query from whatever state the query handler last saw.
- Because the scheduler registers its query handler before any other logic runs, the replayed state always shows Paused=false (ACTIVE), regardless of whether the workflow subsequently failed.
- The caller had no way to distinguish a healthy running scheduler from a permanently dead one.


**How did you test it?**
- Unit test

**Potential risks**
The change only affects DescribeSchedule.

- Running schedulers: unaffected. IsWorkflowRunning=true means the rejection gate is skipped entirely.
- Normally deleted/expired schedulers (close status COMPLETED): unaffected. QueryRejectConditionNotCompletedCleanly does not reject cleanly-completed workflows, so those still fall through to the existing EntityNotExistsError path.
- Schedulers mid-ContinueAsNew: unaffected. Cadence resolves a workflow ID with no run ID to the currently open execution; the old CONTINUED_AS_NEW execution is never queried.
- Behavior change for FAILED/TERMINATED schedulers: now return an InternalServiceError instead of a stale ACTIVE response. The error message speaks in schedule-level terms so callers can surface it directly to users.

**Release notes**

- DescribeSchedule now returns an error when the underlying scheduler workflow has ended abnormally (FAILED, TERMINATED, TIMED_OUT) instead of incorrectly reporting Status: ACTIVE. The error (InternalServiceError) includes the close status in a human-readable message to aid diagnosis. Callers that previously treated a stale ACTIVE response as healthy will now see an explicit error.

**Documentation Changes**

- N/A