### PR TITLE
fix(schedule): make DeleteSchedule idempotent when scheduler workflow is already gone

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -316,10 +316,24 @@ func (wh *WorkflowHandler) DeleteSchedule(
 		return nil, &types.BadRequestError{Message: "ScheduleID is not set on request."}
 	}
 
-	if err := wh.signalScheduleWorkflow(ctx, domainName, scheduleID, scheduler.SignalNameDelete, nil); err != nil {
-		return nil, err
+	err := wh.signalScheduleWorkflow(ctx, domainName, scheduleID, scheduler.SignalNameDelete, nil)
+	if err == nil {
+		return &types.DeleteScheduleResponse{}, nil
 	}
-	return &types.DeleteScheduleResponse{}, nil
+
+	// Anomalous terminal states of the scheduler workflow (Failed/Terminated/
+	// TimedOut/Canceled) are an operational concern — they should be observed
+	// via scheduler-workflow metrics and logs, not re-surfaced through the
+	// public delete API where they are not actionable for the caller.
+	if errors.As(err, new(*types.EntityNotExistsError)) ||
+		errors.As(err, new(*types.WorkflowExecutionAlreadyCompletedError)) {
+		wh.GetLogger().Info("DeleteSchedule: scheduler workflow already gone; treating as already deleted",
+			tag.WorkflowDomainName(domainName),
+			tag.WorkflowID(scheduleWorkflowID(scheduleID)),
+			tag.Error(err))
+		return &types.DeleteScheduleResponse{}, nil
+	}
+	return nil, err
 }
 
 func (wh *WorkflowHandler) PauseSchedule(

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -65,6 +65,7 @@ func newScheduleTestFixture(t *testing.T) *scheduleTestFixture {
 
 	versionChecker := client.NewMockVersionChecker(ctrl)
 	versionChecker.EXPECT().ClientSupported(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	versionChecker.EXPECT().SupportsWorkflowAlreadyCompletedError(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mockResource.MembershipResolver.EXPECT().MemberCount(service.Frontend).Return(5, nil).AnyTimes()
 
 	config := frontendcfg.NewConfig(
@@ -618,7 +619,17 @@ func TestDeleteSchedule(t *testing.T) {
 			mockFn:  func(f *scheduleTestFixture) {},
 			wantErr: true,
 		},
-		"success": {
+		"empty domain": {
+			request: &types.DeleteScheduleRequest{ScheduleID: "s1"},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"empty schedule ID": {
+			request: &types.DeleteScheduleRequest{Domain: testDomain},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"success: signal delivered": {
 			request: &types.DeleteScheduleRequest{Domain: testDomain, ScheduleID: "s1"},
 			mockFn: func(f *scheduleTestFixture) {
 				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
@@ -630,6 +641,33 @@ func TestDeleteSchedule(t *testing.T) {
 					})
 			},
 			wantErr: false,
+		},
+		"idempotent: scheduler workflow not found is treated as already deleted": {
+			request: &types.DeleteScheduleRequest{Domain: testDomain, ScheduleID: "s1"},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.EntityNotExistsError{Message: "workflow cadence-scheduler:s1 not found"})
+			},
+			wantErr: false,
+		},
+		"idempotent: scheduler workflow already closed is treated as already deleted": {
+			request: &types.DeleteScheduleRequest{Domain: testDomain, ScheduleID: "s1"},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.WorkflowExecutionAlreadyCompletedError{Message: "workflow execution already completed"})
+			},
+			wantErr: false,
+		},
+		"non-idempotent error from delete signal passes through unchanged": {
+			request: &types.DeleteScheduleRequest{Domain: testDomain, ScheduleID: "s1"},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(errors.New("some internal error"))
+			},
+			wantErr: true,
 		},
 	}
 
@@ -832,40 +870,6 @@ func TestNormalizeScheduleError(t *testing.T) {
 		assert.Contains(t, notFound.Message, `schedule "s1" not found in domain`)
 	})
 
-	t.Run("delete not found returns friendly message", func(t *testing.T) {
-		f := newScheduleTestFixture(t)
-		defer f.finish()
-
-		f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
-		f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
-			Return(&types.EntityNotExistsError{Message: "workflow cadence-scheduler:s1 not found"})
-
-		_, err := f.handler.DeleteSchedule(context.Background(), &types.DeleteScheduleRequest{
-			Domain:     testDomain,
-			ScheduleID: "s1",
-		})
-
-		var notFound *types.EntityNotExistsError
-		require.True(t, errors.As(err, &notFound))
-		assert.Contains(t, notFound.Message, `schedule "s1" not found in domain`)
-	})
-
-	t.Run("non-EntityNotExistsError passes through unchanged", func(t *testing.T) {
-		f := newScheduleTestFixture(t)
-		defer f.finish()
-
-		origErr := errors.New("some internal error")
-		f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
-		f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
-			Return(origErr)
-
-		_, err := f.handler.DeleteSchedule(context.Background(), &types.DeleteScheduleRequest{
-			Domain:     testDomain,
-			ScheduleID: "s1",
-		})
-
-		assert.Equal(t, origErr, err)
-	})
 }
 
 func TestScheduleWorkflowID(t *testing.T) {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
`DeleteSchedule` in the frontend handler now treats "the scheduler workflow is no longer running" as success rather than surfacing the underlying signal-RPC error to the caller. Concretely, when the underlying `SignalWorkflowExecution` returns either `EntityNotExistsError` (workflow record gone) or `WorkflowExecutionAlreadyCompletedError` (workflow already closed), the handler logs an INFO line and returns `&types.DeleteScheduleResponse{}` instead of an error. Any other error from the signal RPC continues to pass through unchanged.

**Why?**
deleted schedule as a closed scheduler workflow i.e. the scheduler workflow is the registry record for the schedule. 

**How did you test it?**
go test -race -run 'TestDeleteSchedule|TestNormalizeScheduleError' ./service/frontend/api/... go test -race ./service/frontend/api/... make lint

**Potential risks**
Behavioral change on a public API:

**Release notes**
N/A

**Documentation Changes**
N/A
