### PR TITLE
chore(reduce-logging): remove workflow completion logs

### DIFF
--- a/service/history/execution/context_util.go
+++ b/service/history/execution/context_util.go
@@ -210,25 +210,10 @@ func emitWorkflowCompletionStats(
 		scope.IncCounter(metrics.WorkflowFailedCount)
 	case types.EventTypeWorkflowExecutionTimedOut:
 		scope.IncCounter(metrics.WorkflowTimeoutCount)
-		logger.Info("workflow execution timed out",
-			tag.WorkflowID(workflowID),
-			tag.WorkflowRunID(runID),
-			tag.WorkflowDomainName(domainName),
-		)
 	case types.EventTypeWorkflowExecutionTerminated:
 		scope.IncCounter(metrics.WorkflowTerminateCount)
-		logger.Info("workflow terminated",
-			tag.WorkflowID(workflowID),
-			tag.WorkflowRunID(runID),
-			tag.WorkflowDomainName(domainName),
-		)
 	case types.EventTypeWorkflowExecutionContinuedAsNew:
 		scope.IncCounter(metrics.WorkflowContinuedAsNew)
-		logger.Debug("workflow continued as new",
-			tag.WorkflowID(workflowID),
-			tag.WorkflowRunID(runID),
-			tag.WorkflowDomainName(domainName),
-		)
 	default:
 		scope.IncCounter(metrics.WorkflowCompletedUnknownType)
 		logger.Warn("Workflow completed with an unknown event type",


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Removed workflow completion logs from service/history/execution/context_util.go
https://github.com/cadence-workflow/cadence/issues/7911

**Why?**
These logs are noisy and we can track workflow completion using Cadence APIs/UIs

**How did you test it?**
go test -count=1 -race -timeout 60s ./service/history/execution/

**Potential risks**
Users that rely on these logs may be affected. They should find another way to track this or use metrics. Setting to debug is not a good option due to the amount of existing debug logs.

**Release notes**
Removal of workflow completion logs

**Documentation Changes**

