### PR TITLE
chore(thrift): bump cadence-idl submodule 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/startreedata/pinot-client-go v0.2.0 // latest release supports pinot v0.12.0 which is also internal version
 	github.com/stretchr/testify v1.10.0
 	github.com/uber-go/tally v3.5.8+incompatible
-	github.com/uber/cadence-idl v0.0.0-20260424161124-35996664fb49
+	github.com/uber/cadence-idl v0.0.0-20260508160245-cf842606324d
 	github.com/uber/ringpop-go v0.10.0
 	github.com/uber/tchannel-go v1.34.4
 	github.com/urfave/cli/v2 v2.27.4

--- a/go.sum
+++ b/go.sum
@@ -511,8 +511,8 @@ github.com/uber-go/mapdecode v1.0.0/go.mod h1:b5nP15FwXTgpjTjeA9A2uTHXV5UJCl4arw
 github.com/uber-go/tally v3.3.12+incompatible/go.mod h1:YDTIBxdXyOU/sCWilKB4bgyufu1cEi0jdVnRdxvjnmU=
 github.com/uber-go/tally v3.5.8+incompatible h1:Z2vK6ib6G/r6bAGu7lAI/98cLPLUOtdHrY2bBikk4wg=
 github.com/uber-go/tally v3.5.8+incompatible/go.mod h1:YDTIBxdXyOU/sCWilKB4bgyufu1cEi0jdVnRdxvjnmU=
-github.com/uber/cadence-idl v0.0.0-20260424161124-35996664fb49 h1:QlBo+k6pZoWeGaczD1qCtK4E5JJbiE25GJsXgJJoLDU=
-github.com/uber/cadence-idl v0.0.0-20260424161124-35996664fb49/go.mod h1:ux5U12WfKGx6AFibwe52/OMp51fjUKSvosh0/eiSzps=
+github.com/uber/cadence-idl v0.0.0-20260508160245-cf842606324d h1:w3FjJYYnB5moDmQ/w4KqLJGGfgvWKy/S6YQTyLSi2yk=
+github.com/uber/cadence-idl v0.0.0-20260508160245-cf842606324d/go.mod h1:ux5U12WfKGx6AFibwe52/OMp51fjUKSvosh0/eiSzps=
 github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=


### PR DESCRIPTION
…Schedule APIs

<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

- Bumped cadence-idl submodule from 35996664fb49 to cf842606324d (https://github.com/cadence-workflow/cadence-idl/commit/cf842606324dd1ffae84ca483bae51f6ecad0dc7) 
- Updated go.mod/go.sum to match (v0.0.0-20260508160245-cf842606324d)                                                                                                                                           

**Why?**

- Prerequisite for wiring Schedule APIs through the Thrift transport layer. 
- Once this PR merged, we are able to wire thrift transport layer with schedule APIs
- Following that, we will be able to unblock create go-client SDK for schedule. This go-client SDK PR(https://github.com/cadence-workflow/cadence-go-client/pull/1501) is currently blocked by these above 

**How did you test it?**

- Verified submodule SHA and go.mod pseudo-version encode the same commit (cf842606324d)                                                                                                                                                                                                                                                                           

**Potential risks**
Low:
- This is a purely additive IDL change — no existing types or methods were modified. 

**Release notes**
N/A

**Documentation Changes**
N/A
