### PR TITLE
fix(schedule): emit metric when scheduler workflow rejects a backfill

### DIFF
--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -43,7 +43,11 @@ const (
 	SchedulerMissedFiredCountPerDomain    = "scheduler_missed_fired_count_per_domain"
 	SchedulerMissedSkippedCountPerDomain  = "scheduler_missed_skipped_count_per_domain"
 	SchedulerBackfillFiredCountPerDomain  = "scheduler_backfill_fired_count_per_domain"
-	SchedulerContinueAsNewCountPerDomain  = "scheduler_continue_as_new_count_per_domain"
+	// SchedulerBackfillRejectedCountPerDomain counts backfill signals dropped by
+	// the workflow after the RPC has already returned success. Tagged with the
+	// rejection reason (invalid_range, queue_full).
+	SchedulerBackfillRejectedCountPerDomain = "scheduler_backfill_rejected_count_per_domain"
+	SchedulerContinueAsNewCountPerDomain    = "scheduler_continue_as_new_count_per_domain"
 	// SchedulerBufferOverflowCountPerDomain measures fires dropped because the
 	// BUFFER overlap policy queue is full. Tagged with the drop reason so
 	// operators can distinguish drops driven by the user's buffer_limit
@@ -68,6 +72,10 @@ const (
 	// the server-side cap that protects ContinueAsNew payload size.
 	BufferOverflowReasonUserLimit   = "user_limit"
 	BufferOverflowReasonSystemLimit = "system_limit"
+
+	// Reason tag values for scheduler_backfill_rejected_count_per_domain.
+	BackfillRejectedReasonInvalidRange = "invalid_range"
+	BackfillRejectedReasonQueueFull    = "queue_full"
 
 	// MaxBufferedFiresSystemLimit caps the BUFFER overlap policy queue regardless
 	// of buffer_limit (including buffer_limit=0 meaning unlimited). It bounds the

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -254,7 +254,7 @@ func applyAllInputs(
 		var sig BackfillSignal
 		c.Receive(ctx, &sig)
 		scope.Tagged(map[string]string{SignalTypeTag: signalTypeTagBackfill}).Counter(SchedulerSignalReceivedCountPerDomain).Inc(1)
-		if handleBackfill(logger, sig, state) {
+		if handleBackfill(logger, scope, sig, state) {
 			stateChanged = true
 		}
 	})
@@ -327,7 +327,7 @@ func drainBufferedSignals(
 			break
 		}
 		scope.Tagged(map[string]string{SignalTypeTag: signalTypeTagBackfill}).Counter(SchedulerSignalReceivedCountPerDomain).Inc(1)
-		if handleBackfill(logger, sig, state) {
+		if handleBackfill(logger, scope, sig, state) {
 			stateChanged = true
 		}
 	}
@@ -447,8 +447,10 @@ func handleUpdate(logger *zap.Logger, sig UpdateSignal, input *SchedulerWorkflow
 	return changed
 }
 
-func handleBackfill(logger *zap.Logger, sig BackfillSignal, state *SchedulerWorkflowState) bool {
+func handleBackfill(logger *zap.Logger, scope tally.Scope, sig BackfillSignal, state *SchedulerWorkflowState) bool {
 	if !sig.EndTime.After(sig.StartTime) {
+		scope.Tagged(map[string]string{ReasonTag: BackfillRejectedReasonInvalidRange}).
+			Counter(SchedulerBackfillRejectedCountPerDomain).Inc(1)
 		logger.Warn("ignoring backfill with invalid time range",
 			zap.Time("startTime", sig.StartTime),
 			zap.Time("endTime", sig.EndTime),
@@ -456,6 +458,8 @@ func handleBackfill(logger *zap.Logger, sig BackfillSignal, state *SchedulerWork
 		return false
 	}
 	if len(state.PendingBackfills) >= maxPendingBackfills {
+		scope.Tagged(map[string]string{ReasonTag: BackfillRejectedReasonQueueFull}).
+			Counter(SchedulerBackfillRejectedCountPerDomain).Inc(1)
 		logger.Warn("ignoring backfill: pending backfill queue is full",
 			zap.String("backfillId", sig.BackfillID),
 			zap.Int("queueSize", len(state.PendingBackfills)),

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -694,11 +694,12 @@ func TestHandleUpdate(t *testing.T) {
 
 func TestHandleBackfill(t *testing.T) {
 	tests := []struct {
-		name           string
-		sig            BackfillSignal
-		initialPending int
-		wantQueued     bool
-		wantPendingLen int
+		name             string
+		sig              BackfillSignal
+		initialPending   int
+		wantQueued       bool
+		wantPendingLen   int
+		wantRejectReason string
 	}{
 		{
 			name: "valid backfill is queued",
@@ -717,8 +718,9 @@ func TestHandleBackfill(t *testing.T) {
 				StartTime: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
 				EndTime:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 			},
-			wantQueued:     false,
-			wantPendingLen: 0,
+			wantQueued:       false,
+			wantPendingLen:   0,
+			wantRejectReason: BackfillRejectedReasonInvalidRange,
 		},
 		{
 			name: "equal start and end is rejected",
@@ -726,8 +728,9 @@ func TestHandleBackfill(t *testing.T) {
 				StartTime: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 				EndTime:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 			},
-			wantQueued:     false,
-			wantPendingLen: 0,
+			wantQueued:       false,
+			wantPendingLen:   0,
+			wantRejectReason: BackfillRejectedReasonInvalidRange,
 		},
 		{
 			name: "multiple backfills accumulate",
@@ -758,9 +761,10 @@ func TestHandleBackfill(t *testing.T) {
 				EndTime:    time.Date(2026, 2, 2, 0, 0, 0, 0, time.UTC),
 				BackfillID: "bf-over-cap",
 			},
-			initialPending: maxPendingBackfills,
-			wantQueued:     false,
-			wantPendingLen: maxPendingBackfills,
+			initialPending:   maxPendingBackfills,
+			wantQueued:       false,
+			wantPendingLen:   maxPendingBackfills,
+			wantRejectReason: BackfillRejectedReasonQueueFull,
 		},
 	}
 
@@ -773,9 +777,21 @@ func TestHandleBackfill(t *testing.T) {
 					EndTime:   time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
 				})
 			}
-			got := handleBackfill(testLogger, tt.sig, state)
+			scope := tally.NewTestScope("", nil)
+			got := handleBackfill(testLogger, scope, tt.sig, state)
 			assert.Equal(t, tt.wantQueued, got)
 			assert.Equal(t, tt.wantPendingLen, len(state.PendingBackfills))
+
+			counters := scope.Snapshot().Counters()
+			if tt.wantRejectReason == "" {
+				_, ok := findCounter(counters, SchedulerBackfillRejectedCountPerDomain, nil)
+				assert.False(t, ok)
+				return
+			}
+			c, ok := findCounter(counters, SchedulerBackfillRejectedCountPerDomain,
+				map[string]string{ReasonTag: tt.wantRejectReason})
+			require.True(t, ok)
+			assert.Equal(t, int64(1), c.Value())
 		})
 	}
 }


### PR DESCRIPTION
**What changed?**

Emit a new workflow metric `scheduler_backfill_rejected_count_per_domain` when the scheduler workflow drops a backfill signal after `BackfillSchedule` has already returned success: invalid time range (`reason=invalid_range`) or pending-backfill queue full (`reason=queue_full`). Extended `TestHandleBackfill` to assert the counter and tags.

**Why?**

Those rejections were only visible in workflow logs. Callers still saw a successful RPC while no runs were scheduled, with no time-series signal to distinguish "rejected in workflow" from "still pending" or dispatch problems elsewhere.

**How did you test it?**

```bash
make .idl-status
make pr
git status --porcelain   # expected empty
make build
make test
```

**Potential risks**

None — isolated change with no API/schema/IDL impact. Adds one counter name and reuses the existing `reason` tag key used by buffer-overflow metrics.

**Release notes**

N/A

**Documentation Changes**

N/A 