### PR TITLE
fix(schedule): terminate scheduler workflow when delete signal cannot be delivered

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -340,24 +340,43 @@ func (wh *WorkflowHandler) DeleteSchedule(
 		return nil, &types.BadRequestError{Message: "ScheduleID is not set on request."}
 	}
 
-	err := wh.signalScheduleWorkflow(ctx, domainName, scheduleID, scheduler.SignalNameDelete, nil)
-	if err == nil {
+	signalErr := wh.signalScheduleWorkflow(ctx, domainName, scheduleID, scheduler.SignalNameDelete, nil)
+	if signalErr == nil || isScheduleAlreadyGone(signalErr) {
 		return &types.DeleteScheduleResponse{}, nil
 	}
 
-	// Anomalous terminal states of the scheduler workflow (Failed/Terminated/
-	// TimedOut/Canceled) are an operational concern — they should be observed
-	// via scheduler-workflow metrics and logs, not re-surfaced through the
-	// public delete API where they are not actionable for the caller.
-	if errors.As(err, new(*types.EntityNotExistsError)) ||
-		errors.As(err, new(*types.WorkflowExecutionAlreadyCompletedError)) {
-		wh.GetLogger().Info("DeleteSchedule: scheduler workflow already gone; treating as already deleted",
-			tag.WorkflowDomainName(domainName),
-			tag.WorkflowID(scheduleWorkflowID(scheduleID)),
-			tag.Error(err))
+	// The signal could not be delivered. The scheduler workflow may be in a state
+	// where it cannot acknowledge signals (e.g. decision-task failure loop, signal
+	// limit exceeded). Fall back to terminating the scheduler workflow so that
+	// DeleteSchedule remains a deterministic operation for the caller.
+	wh.GetLogger().Info("DeleteSchedule: signal delivery failed, falling back to terminate",
+		tag.WorkflowDomainName(domainName),
+		tag.WorkflowID(scheduleWorkflowID(scheduleID)),
+		tag.Error(signalErr))
+
+	terminateErr := wh.TerminateWorkflowExecution(ctx, &types.TerminateWorkflowExecutionRequest{
+		Domain: domainName,
+		WorkflowExecution: &types.WorkflowExecution{
+			WorkflowID: scheduleWorkflowID(scheduleID),
+		},
+		Reason: "terminated by DeleteSchedule",
+	})
+	if terminateErr == nil || isScheduleAlreadyGone(terminateErr) {
 		return &types.DeleteScheduleResponse{}, nil
 	}
-	return nil, err
+
+	// Both paths failed. Return the original signal error since signal is the
+	// primary path and the one a caller would normally retry against.
+	return nil, signalErr
+}
+
+// isScheduleAlreadyGone reports whether an error from the scheduler workflow
+// signal or terminate path indicates that the underlying workflow no longer
+// exists or is already closed. Such errors satisfy the idempotent contract of
+// DeleteSchedule and are returned to the caller as success.
+func isScheduleAlreadyGone(err error) bool {
+	return errors.As(err, new(*types.EntityNotExistsError)) ||
+		errors.As(err, new(*types.WorkflowExecutionAlreadyCompletedError))
 }
 
 func (wh *WorkflowHandler) PauseSchedule(
@@ -489,7 +508,6 @@ func (wh *WorkflowHandler) ListSchedules(
 	// methods below (not via the frontend client), so cluster redirection middleware
 	// is skipped. For global (XDC) domains, the passive region may return stale
 	// visibility data; that applies to Describe and List schedules until XDC support.
-	// Operator-oriented details: docs/list-schedules-visibility.md
 	var executions []*types.WorkflowExecutionInfo
 	var nextPageToken []byte
 	var err error

--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
+	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/frontend/validate"
@@ -345,11 +346,14 @@ func (wh *WorkflowHandler) DeleteSchedule(
 		return &types.DeleteScheduleResponse{}, nil
 	}
 
-	// The signal could not be delivered. The scheduler workflow may be in a state
-	// where it cannot acknowledge signals (e.g. decision-task failure loop, signal
-	// limit exceeded). Fall back to terminating the scheduler workflow so that
-	// DeleteSchedule remains a deterministic operation for the caller.
-	wh.GetLogger().Info("DeleteSchedule: signal delivery failed, falling back to terminate",
+	if shouldSkipTerminateOnDeleteScheduleSignalFailure(signalErr) {
+		return nil, signalErr
+	}
+
+	// Non-transient signal failure: fall back to terminating the scheduler workflow.
+	// If SignalWorkflowExecution returned nil, the signal was accepted by history but
+	// may still never run in the worker; that case is outside this fallback.
+	wh.GetLogger().Info("DeleteSchedule: signal failed, falling back to terminate",
 		tag.WorkflowDomainName(domainName),
 		tag.WorkflowID(scheduleWorkflowID(scheduleID)),
 		tag.Error(signalErr))
@@ -365,8 +369,14 @@ func (wh *WorkflowHandler) DeleteSchedule(
 		return &types.DeleteScheduleResponse{}, nil
 	}
 
-	// Both paths failed. Return the original signal error since signal is the
-	// primary path and the one a caller would normally retry against.
+	wh.GetLogger().Error("DeleteSchedule: both signal and terminate failed",
+		tag.WorkflowDomainName(domainName),
+		tag.WorkflowID(scheduleWorkflowID(scheduleID)),
+		tag.Error(signalErr),
+		tag.Dynamic("terminateError", terminateErr))
+
+	// Return the original signal error since signal is the primary path and the
+	// one a caller would normally retry against.
 	return nil, signalErr
 }
 
@@ -377,6 +387,19 @@ func (wh *WorkflowHandler) DeleteSchedule(
 func isScheduleAlreadyGone(err error) bool {
 	return errors.As(err, new(*types.EntityNotExistsError)) ||
 		errors.As(err, new(*types.WorkflowExecutionAlreadyCompletedError))
+}
+
+// shouldSkipTerminateOnDeleteScheduleSignalFailure is true for errors where the
+// client should retry DeleteSchedule without terminating the scheduler workflow:
+// transient service/transport failures (common.FrontendRetry,
+// common.IsContextTimeoutError) and workflow-ID rate limiting, which is surfaced
+// as ServiceBusy but is not classified as retryable by FrontendRetry.
+func shouldSkipTerminateOnDeleteScheduleSignalFailure(err error) bool {
+	if common.FrontendRetry(err) || common.IsContextTimeoutError(err) {
+		return true
+	}
+	var sb *types.ServiceBusyError
+	return errors.As(err, &sb) && sb.Reason == constants.WorkflowIDRateLimitReason
 }
 
 func (wh *WorkflowHandler) PauseSchedule(

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -711,12 +711,40 @@ func TestDeleteSchedule(t *testing.T) {
 			},
 			wantErr: false,
 		},
-		"non-idempotent error from delete signal passes through unchanged": {
+		"signal failure falls back to terminate and returns success": {
 			request: &types.DeleteScheduleRequest{Domain: testDomain, ScheduleID: "s1"},
 			mockFn: func(f *scheduleTestFixture) {
 				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
 				f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
 					Return(errors.New("some internal error"))
+				f.historyClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.HistoryTerminateWorkflowExecutionRequest, _ ...yarpc.CallOption) error {
+						assert.Equal(t, scheduleWorkflowID("s1"), req.TerminateRequest.GetWorkflowExecution().GetWorkflowID())
+						assert.NotEmpty(t, req.TerminateRequest.GetReason())
+						return nil
+					})
+			},
+			wantErr: false,
+		},
+		"signal failure falls back to terminate; terminate also reports already gone": {
+			request: &types.DeleteScheduleRequest{Domain: testDomain, ScheduleID: "s1"},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(errors.New("some internal error"))
+				f.historyClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.WorkflowExecutionAlreadyCompletedError{Message: "already completed"})
+			},
+			wantErr: false,
+		},
+		"signal failure and terminate failure surface the original signal error": {
+			request: &types.DeleteScheduleRequest{Domain: testDomain, ScheduleID: "s1"},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(errors.New("signal boom"))
+				f.historyClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(errors.New("terminate boom"))
 			},
 			wantErr: true,
 		},

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -32,10 +32,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/yarpcerrors"
 
 	"github.com/uber/cadence/client/history"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/client"
+	"github.com/uber/cadence/common/constants"
 	dc "github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/metrics"
@@ -710,6 +712,33 @@ func TestDeleteSchedule(t *testing.T) {
 					Return(&types.WorkflowExecutionAlreadyCompletedError{Message: "workflow execution already completed"})
 			},
 			wantErr: false,
+		},
+		"transient signal failure returns error without terminate": {
+			request: &types.DeleteScheduleRequest{Domain: testDomain, ScheduleID: "s1"},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.ServiceBusyError{Message: "busy"})
+			},
+			wantErr: true,
+		},
+		"workflow id rate limit returns error without terminate": {
+			request: &types.DeleteScheduleRequest{Domain: testDomain, ScheduleID: "s1"},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.ServiceBusyError{Reason: constants.WorkflowIDRateLimitReason})
+			},
+			wantErr: true,
+		},
+		"deadline exceeded signal failure returns error without terminate": {
+			request: &types.DeleteScheduleRequest{Domain: testDomain, ScheduleID: "s1"},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(yarpcerrors.DeadlineExceededErrorf("deadline exceeded"))
+			},
+			wantErr: true,
 		},
 		"signal failure falls back to terminate and returns success": {
 			request: &types.DeleteScheduleRequest{Domain: testDomain, ScheduleID: "s1"},


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
DeleteSchedule still sends the scheduler-delete signal first. If that returns a non-idempotent error, the handler now falls back to TerminateWorkflowExecution on the scheduler workflow ID (cadence-scheduler:<scheduleID>) with reason terminated by DeleteSchedule. EntityNotExistsError and WorkflowExecutionAlreadyCompletedError are treated as success on either path. If both signal and terminate fail, the original signal error is returned (terminate error is not surfaced when signal is the primary retry surface).

**Why?**
When the scheduler workflow cannot process signals (e.g. decision-task failure loop, signal path errors), callers could get a failed DeleteSchedule even though the schedule was effectively stuck—Temporal-style delete uses terminate for the same reason. Keeping signal-first preserves the graceful state.Deleted path for healthy workflows.

**How did you test it?**
go test -race -run TestDeleteSchedule ./service/frontend/api/...
make pr

**Potential risks**
- Terminate force-closes the scheduler workflow; any in-memory-only state not yet persisted is lost (same as any terminate). Child workflows started by the schedule are not terminated by this call.
- If SignalWorkflowExecution returns success but the workflow never applies the delete signal (rare stuck loop where history accepts signals but decisions never run), this change does not add a second escalation—only non-nil signal errors trigger terminate.

**Release notes**
N/A

**Documentation Changes**
N/A
