### PR TITLE
feat: Support specifying active clusters via JSON for domain updates

### DIFF
--- a/tools/cli/domain_commands.go
+++ b/tools/cli/domain_commands.go
@@ -218,6 +218,8 @@ func (d *domainCLIImpl) UpdateDomain(c *cli.Context) error {
 			ActiveClusterName:        common.StringPtr(activeCluster),
 			FailoverTimeoutInSeconds: failoverTimeout,
 		}
+	} else if c.IsSet(FlagActiveClusters) && c.IsSet(FlagActiveClustersJSON) {
+		return commoncli.Problem("Cannot use both --active_clusters and --active_clusters_json flags.", nil)
 	} else if c.IsSet(FlagActiveClusters) { // active-active domain failover
 		activeClusters, err := parseActiveClustersByClusterAttribute(c.String(FlagActiveClusters))
 		if err != nil {
@@ -229,6 +231,16 @@ func (d *domainCLIImpl) UpdateDomain(c *cli.Context) error {
 			ActiveClusters: &types.ActiveClusters{
 				AttributeScopes: activeClusters.AttributeScopes,
 			},
+		}
+	} else if c.IsSet(FlagActiveClustersJSON) { // active-active domain failover via JSON
+		activeClusters, err := parseActiveClustersByClusterAttributeFromJSON(c.String(FlagActiveClustersJSON))
+		if err != nil {
+			return err
+		}
+
+		updateRequest = &types.UpdateDomainRequest{
+			Name:           domainName,
+			ActiveClusters: &activeClusters,
 		}
 	} else {
 		resp, err := d.describeDomain(ctx, &types.DescribeDomainRequest{

--- a/tools/cli/domain_commands_test.go
+++ b/tools/cli/domain_commands_test.go
@@ -316,7 +316,7 @@ func (s *cliAppSuite) TestDomainUpdate() {
 		},
 		{
 			"active-active domain failover via JSON",
-			`cadence --do test-domain domain update --active_clusters_json {"attributeScopes":{"region":{"clusterAttributes":{"region1":{"activeClusterName":"c1"},"region2":{"activeClusterName":"c2"}}}}}`,
+			`cadence --do test-domain domain update --active_clusters_json '{"attributeScopes":{"region":{"clusterAttributes":{"region1":{"activeClusterName":"c1"},"region2":{"activeClusterName":"c2"}}}}}'`,
 			"",
 			func() {
 				s.serverFrontendClient.EXPECT().UpdateDomain(gomock.Any(), &types.UpdateDomainRequest{
@@ -336,7 +336,7 @@ func (s *cliAppSuite) TestDomainUpdate() {
 		},
 		{
 			"active-active domain failover with both --active_clusters and --active_clusters_json errors",
-			`cadence --do test-domain domain update --active_clusters region.region1:c1 --active_clusters_json {"attributeScopes":{}}`,
+			`cadence --do test-domain domain update --active_clusters region.region1:c1 --active_clusters_json '{"attributeScopes":{}}'`,
 			"Cannot use both",
 			func() {},
 		},

--- a/tools/cli/domain_commands_test.go
+++ b/tools/cli/domain_commands_test.go
@@ -315,6 +315,32 @@ func (s *cliAppSuite) TestDomainUpdate() {
 			},
 		},
 		{
+			"active-active domain failover via JSON",
+			`cadence --do test-domain domain update --active_clusters_json {"attributeScopes":{"region":{"clusterAttributes":{"region1":{"activeClusterName":"c1"},"region2":{"activeClusterName":"c2"}}}}}`,
+			"",
+			func() {
+				s.serverFrontendClient.EXPECT().UpdateDomain(gomock.Any(), &types.UpdateDomainRequest{
+					Name: "test-domain",
+					ActiveClusters: &types.ActiveClusters{
+						AttributeScopes: map[string]types.ClusterAttributeScope{
+							"region": {
+								ClusterAttributes: map[string]types.ActiveClusterInfo{
+									"region1": {ActiveClusterName: "c1"},
+									"region2": {ActiveClusterName: "c2"},
+								},
+							},
+						},
+					},
+				}).Return(&types.UpdateDomainResponse{}, nil)
+			},
+		},
+		{
+			"active-active domain failover with both --active_clusters and --active_clusters_json errors",
+			`cadence --do test-domain domain update --active_clusters region.region1:c1 --active_clusters_json {"attributeScopes":{}}`,
+			"Cannot use both",
+			func() {},
+		},
+		{
 			"domain not exist",
 			"cadence --do test-domain domain update --desc new-description",
 			"does not exist",

--- a/tools/cli/domain_utils.go
+++ b/tools/cli/domain_utils.go
@@ -147,6 +147,11 @@ var (
 			Aliases: []string{"acs"},
 			Usage:   "Active clusters by cluster attribute in the format '<cluster-attr>.<scope>:<name> ie: region.manilla:cluster0,region.newyork:cluster1'",
 		},
+		&cli.StringFlag{
+			Name:    FlagActiveClustersJSON,
+			Aliases: []string{"acs-json"},
+			Usage:   `Active clusters by cluster attribute in JSON format. Eg {"attributeScopes":{"region":{"clusterAttributes":{"us-east":{"activeClusterName":"cluster1"}}}}}`,
+		},
 		&cli.StringSliceFlag{
 			Name:    FlagClusters,
 			Aliases: []string{"cl"},

--- a/tools/cli/domain_utils.go
+++ b/tools/cli/domain_utils.go
@@ -145,12 +145,12 @@ var (
 		&cli.StringSliceFlag{
 			Name:    FlagActiveClusters,
 			Aliases: []string{"acs"},
-			Usage:   "Active clusters by cluster attribute in the format '<cluster-attr>.<scope>:<name> ie: region.manilla:cluster0,region.newyork:cluster1'",
+			Usage:   "Active clusters by cluster attribute in the format '<attr-scope>.<attr-name>:<cluster_name> ie: region.manilla:cluster0,region.newyork:cluster1'",
 		},
 		&cli.StringFlag{
 			Name:    FlagActiveClustersJSON,
 			Aliases: []string{"acs-json"},
-			Usage:   `Active clusters by cluster attribute in JSON format. Eg {"attributeScopes":{"region":{"clusterAttributes":{"us-east":{"activeClusterName":"cluster1"}}}}}`,
+			Usage:   `Active clusters by cluster attribute in JSON format. Eg {"attributeScopes":{"<attr-scope>":{"clusterAttributes":{"<attr-name>":{"activeClusterName":"<cluster_name>"}}}}}`,
 		},
 		&cli.StringSliceFlag{
 			Name:    FlagClusters,
@@ -278,12 +278,12 @@ var (
 		&cli.StringSliceFlag{
 			Name:    FlagActiveClusters,
 			Aliases: []string{"acs"},
-			Usage:   "Active clusters by cluster attribute in the format '<cluster-attr>.<scope>:<name> ie: region.manilla:cluster0,region.newyork:cluster1'",
+			Usage:   "Active clusters by cluster attribute in the format '<attr-scope>.<attr-name>:<cluster_name> ie: region.manilla:cluster0,region.newyork:cluster1'",
 		},
 		&cli.StringFlag{
 			Name:    FlagActiveClustersJSON,
 			Aliases: []string{"acs-json"},
-			Usage:   `Active clusters by cluster attribute in JSON format. Eg {"attributeScopes":{"region-us-east1":{"clusterAttributes":{"new-york":{"activeClusterName":"cluster1"}}}}}`,
+			Usage:   `Active clusters by cluster attribute in JSON format. Eg {"attributeScopes":{"<attr-scope>":{"clusterAttributes":{"<attr-name>":{"activeClusterName":"<cluster_name>"}}}}}`,
 		},
 		&cli.StringFlag{
 			Name:    FlagFailoverReason,


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

Adds the `--active_clusters_json` parameter from `cadence domain failover` to `cadence domain update`. 

**Why?**

JSON is a more ergonomic and well understood format than our custom string parser, which should reduce the likelihood of errors when specifying cluster attributes for a given domain, and increase the ability to script changes like these. 

**How did you test it?**

Locally against a canary cluster:
```bash
# All of these commands should be run in a new window
docker compose  -f docker/dev/cassandra.yml up
make install-schema-xdc
make start-xdc-cluster0
make start-xdc-cluster1
make start-xdc-cluster2
make start-canary
```

Create a new file, attributes.json:
```
{
  "attributeScopes": {
    "cluster": {
      "clusterAttributes": {
        "cluster0": {"activeClusterName": "cluster0"}, 
        "cluster1": {"activeClusterName": "cluster1"}, 
        "cluster2": {"activeClusterName": "cluster2"}
      }
    }
  }
}
```

This will update the existing `cadence-canary` domain to an active-active domain with the attribute `cluster:cluster0` pointing to `cluster0`, etc. 

```bash
./cadence --transport grpc --ad localhost:7833 --domain cadence-canary domain update --acs-json "$(cat attributes.json)"
Domain cadence-canary successfully updated.
```

**Potential risks**

N/A

**Release notes**

N/A

**Documentation Changes**

N/A
