### PR TITLE
feat: Failover active-active domains via operational workflow

### DIFF
--- a/service/worker/failovermanager/workflow.go
+++ b/service/worker/failovermanager/workflow.go
@@ -126,11 +126,11 @@ type (
 		GracefulFailoverTimeoutInSeconds *int32
 		// ClusterAttributeRebalanceMap defines a mapping of cluster attribute to its preferred cluster.
 		// Optional; carried as metadata for the active-active rebalance path.
-		ClusterAttributeRebalanceMap ClusterAttributeRebalanceMap
+		ClusterAttributeRebalanceMap ClusterAttributeRebalanceMap `json:",omitempty"`
 		// ClusterAttributes, when non-empty, triggers failover for active-active domains.
 		// each listed scope+name pair is moved to TargetCluster via UpdateDomain.ActiveClusters instead of ActiveClusterName.
 		// GetDomainsActivity also switches to active-active mode when this is set.
-		ClusterAttributes []types.ClusterAttribute
+		ClusterAttributes []types.ClusterAttribute `json:",omitempty"`
 	}
 
 	// FailoverResult is workflow result

--- a/service/worker/failovermanager/workflow.go
+++ b/service/worker/failovermanager/workflow.go
@@ -73,7 +73,6 @@ const (
 	failoverActivityName            = "cadence-sys-failover-activity"
 	getDomainsActivityName          = "cadence-sys-getDomains-activity"
 	getRebalanceDomainsActivityName = "cadence-sys-getRebalanceDomains-activity"
-	// rebalanceDomainsActivityName    = "cadence-sys-rebalanceDomains-activity"
 
 	defaultBatchFailoverSize              = 20
 	defaultBatchFailoverWaitTimeInSeconds = 30
@@ -147,8 +146,9 @@ type (
 		TargetCluster string
 		SourceCluster string
 		Domains       []string
-		// ClusterAttributes, when non-empty, switches GetDomainsActivity to active-active mode:
-		// returns AA domains where any listed attribute is currently active on SourceCluster.
+		// ClusterAttributes specifies which cluster attributes to match for active-active failover.
+		// All active-active domains that have matching attributes (e.g scope:name) will be returned.
+		// Optional.
 		ClusterAttributes []types.ClusterAttribute
 	}
 
@@ -157,8 +157,9 @@ type (
 		Domains                          []string
 		TargetCluster                    string
 		GracefulFailoverTimeoutInSeconds *int32
-		// ClusterAttributes, when non-empty, triggers failover for active-active domains: UpdateDomain is called with
-		// ActiveClusters (each attribute set to TargetCluster) instead of ActiveClusterName.
+		// ClusterAttributes specifies which attributes to fail over to the TargetCluster across the environment.
+		// All active-active domains that have matching attributes (e.g scope:name) will be failed over.
+		// Optional.
 		ClusterAttributes []types.ClusterAttribute
 	}
 

--- a/service/worker/failovermanager/workflow.go
+++ b/service/worker/failovermanager/workflow.go
@@ -556,6 +556,9 @@ func FailoverActivity(ctx context.Context, params *FailoverActivityParams) (*Fai
 		if isActiveActiveFailover {
 			updateRequest.ActiveClusters = buildActiveClusters(params.TargetCluster, params.ClusterAttributes)
 		}
+		// ActiveClusterName is set for all global and active-active domains.
+		// For Active-Active domains any workflows that do not use cluster attributes use this field,
+		// so it should maintain the same behaviour as a standard global domain.
 		updateRequest.ActiveClusterName = common.StringPtr(params.TargetCluster)
 		if params.GracefulFailoverTimeoutInSeconds != nil {
 			updateRequest.FailoverTimeoutInSeconds = params.GracefulFailoverTimeoutInSeconds

--- a/service/worker/failovermanager/workflow.go
+++ b/service/worker/failovermanager/workflow.go
@@ -41,6 +41,21 @@ import (
 
 type (
 	contextKey string
+
+	// clusterAttributeScope scopes the ClusterAttributeRebalance to a specific scope.
+	// Using a standard scope (e.g "region", "datacenter") across domains will allow for a concise ClusterAttributeRebalanceMap.
+	clusterAttributeScope string
+	// ClusterAttributeName is the name of the cluster attribute that should be rebalanced to a specified cluster.
+	// Using standard names (e.g "us-west1", "us-east1") across domains will allow for many domains to be rebalanced.
+	clusterAttributeName string
+
+	// ClusterAttributeRebalanceMap defines a mapping of cluster attribute to its preferred cluster.
+	// This allows Active-Active domains to be rebalanced to the preferred cluster for each attribute, without using the domain level preferred cluster.
+	// Example: {"region": {"us-west1": "prod-us-west1", "us-east1": "prod-us-east1"}}
+	ClusterAttributeRebalanceMap map[clusterAttributeScope]ClusterAttributeToClusterMap
+
+	// ClusterAttributeToClusterMap specifies which ClusterAttribute names map to which cadence cluster
+	ClusterAttributeToClusterMap map[clusterAttributeName]string
 )
 
 const (
@@ -58,6 +73,7 @@ const (
 	failoverActivityName            = "cadence-sys-failover-activity"
 	getDomainsActivityName          = "cadence-sys-getDomains-activity"
 	getRebalanceDomainsActivityName = "cadence-sys-getRebalanceDomains-activity"
+	// rebalanceDomainsActivityName    = "cadence-sys-rebalanceDomains-activity"
 
 	defaultBatchFailoverSize              = 20
 	defaultBatchFailoverWaitTimeInSeconds = 30
@@ -88,6 +104,8 @@ const (
 	WorkflowAborted = "aborted"
 
 	unknownOperator = "unknown"
+
+	versionActiveActiveClusterAttributeFailover = "active-active-cluster-attribute-failover"
 )
 
 type (
@@ -107,6 +125,13 @@ type (
 		DrillWaitTime time.Duration
 		// GracefulFailoverTimeoutInSeconds
 		GracefulFailoverTimeoutInSeconds *int32
+		// ClusterAttributeRebalanceMap defines a mapping of cluster attribute to its preferred cluster.
+		// Optional; carried as metadata for the active-active rebalance path.
+		ClusterAttributeRebalanceMap ClusterAttributeRebalanceMap
+		// ClusterAttributes, when non-empty, triggers failover for active-active domains.
+		// each listed scope+name pair is moved to TargetCluster via UpdateDomain.ActiveClusters instead of ActiveClusterName.
+		// GetDomainsActivity also switches to active-active mode when this is set.
+		ClusterAttributes []types.ClusterAttribute
 	}
 
 	// FailoverResult is workflow result
@@ -122,6 +147,9 @@ type (
 		TargetCluster string
 		SourceCluster string
 		Domains       []string
+		// ClusterAttributes, when non-empty, switches GetDomainsActivity to active-active mode:
+		// returns AA domains where any listed attribute is currently active on SourceCluster.
+		ClusterAttributes []types.ClusterAttribute
 	}
 
 	// FailoverActivityParams params for activity
@@ -129,6 +157,9 @@ type (
 		Domains                          []string
 		TargetCluster                    string
 		GracefulFailoverTimeoutInSeconds *int32
+		// ClusterAttributes, when non-empty, triggers failover for active-active domains: UpdateDomain is called with
+		// ActiveClusters (each attribute set to TargetCluster) instead of ActiveClusterName.
+		ClusterAttributes []types.ClusterAttribute
 	}
 
 	// FailoverActivityResult result for failover activity
@@ -193,6 +224,10 @@ func FailoverWorkflow(ctx workflow.Context, params *FailoverParams) (*FailoverRe
 		TargetCluster: params.TargetCluster,
 		SourceCluster: params.SourceCluster,
 		Domains:       params.Domains,
+	}
+	wfVersion := workflow.GetVersion(ctx, versionActiveActiveClusterAttributeFailover, workflow.DefaultVersion, 1)
+	if wfVersion >= 1 {
+		getDomainsParams.ClusterAttributes = params.ClusterAttributes
 	}
 	var domains []string
 	err = workflow.ExecuteActivity(ao, GetDomainsActivity, getDomainsParams).Get(ctx, &domains)
@@ -259,10 +294,14 @@ func failoverDomainsByBatch(
 	for i := 0; i < times; i++ {
 		pauseSignalHandler()
 
+		v := workflow.GetVersion(ctx, versionActiveActiveClusterAttributeFailover, workflow.DefaultVersion, 1)
 		failoverActivityParams := &FailoverActivityParams{
 			Domains:                          domains[i*batchSize : min((i+1)*batchSize, totalNumOfDomains)],
 			TargetCluster:                    targetCluster,
 			GracefulFailoverTimeoutInSeconds: params.GracefulFailoverTimeoutInSeconds,
+		}
+		if v >= 1 {
+			failoverActivityParams.ClusterAttributes = params.ClusterAttributes
 		}
 		var actResult FailoverActivityResult
 		err := workflow.ExecuteActivity(ao, FailoverActivity, failoverActivityParams).Get(ctx, &actResult)
@@ -349,9 +388,14 @@ func GetDomainsActivity(ctx context.Context, params *GetDomainsActivityParams) (
 	}
 	var res []string
 	for _, domain := range domains {
-		if shouldFailover(domain, params.SourceCluster) {
-			domainName := domain.GetDomainInfo().GetName()
-			res = append(res, domainName)
+		var include bool
+		if len(params.ClusterAttributes) > 0 {
+			include = shouldFailoverActiveActiveDomain(domain, params.SourceCluster, params.ClusterAttributes)
+		} else {
+			include = shouldFailover(domain, params.SourceCluster)
+		}
+		if include {
+			res = append(res, domain.GetDomainInfo().GetName())
 		}
 	}
 	return res, nil
@@ -407,6 +451,34 @@ func isDomainFailoverManagedByCadence(domain *types.DescribeDomainResponse) bool
 	return strings.ToLower(strings.TrimSpace(domainData[constants.DomainDataKeyForManagedFailover])) == "true"
 }
 
+// shouldFailoverActiveActiveDomain returns true if the domain is an AA domain managed by Cadence that
+// has at least one of the specified cluster attributes currently active on sourceCluster.
+func shouldFailoverActiveActiveDomain(domain *types.DescribeDomainResponse, sourceCluster string, attrs []types.ClusterAttribute) bool {
+	if !domain.GetIsGlobalDomain() || !isDomainFailoverManagedByCadence(domain) {
+		return false
+	}
+	if domain.DomainInfo != nil && domain.DomainInfo.Status != nil {
+		s := *domain.DomainInfo.Status
+		if s == types.DomainStatusDeprecated || s == types.DomainStatusDeleted {
+			return false
+		}
+	}
+	ac := domain.ReplicationConfiguration.GetActiveClusters()
+	if ac == nil || len(ac.AttributeScopes) == 0 {
+		return false
+	}
+	for _, attr := range attrs {
+		info, err := ac.GetActiveClusterByClusterAttribute(attr.GetScope(), attr.GetName())
+		if err != nil {
+			continue
+		}
+		if info.ActiveClusterName == sourceCluster {
+			return true
+		}
+	}
+	return false
+}
+
 func getClient(ctx context.Context) frontend.Client {
 	manager := ctx.Value(failoverManagerContextKey).(*FailoverManager)
 	feClient := manager.clientBean.GetFrontendClient()
@@ -460,23 +532,31 @@ func getAllDomains(ctx context.Context, targetDomains []string) ([]*types.Descri
 
 // FailoverActivity activity def
 func FailoverActivity(ctx context.Context, params *FailoverActivityParams) (*FailoverActivityResult, error) {
-
 	logger := activity.GetLogger(ctx)
 	frontendClient := getClient(ctx)
 	domains := params.Domains
+	isActiveActiveFailover := len(params.ClusterAttributes) > 0
 	var successDomains []string
 	var failedDomains []string
 	for _, domain := range domains {
-		// Check if poller exist
-		if err := validateTaskListPollerInfo(ctx, params.TargetCluster, domain); err != nil {
-			logger.Error("Failed to validate task list poller info", zap.Error(err))
-			failedDomains = append(failedDomains, domain)
-			continue
+		// Omitting the poller validation check for active-active failover as the domain will already be
+		// polling on both clusters - or will already be in a failed state. Failing over/not failing over
+		// will not change this.
+		if !isActiveActiveFailover {
+			// Check if poller exist for single-cluster failover
+			if err := validateTaskListPollerInfo(ctx, params.TargetCluster, domain); err != nil {
+				logger.Error("Failed to validate task list poller info", zap.Error(err))
+				failedDomains = append(failedDomains, domain)
+				continue
+			}
 		}
 		updateRequest := &types.UpdateDomainRequest{
-			Name:              domain,
-			ActiveClusterName: common.StringPtr(params.TargetCluster),
+			Name: domain,
 		}
+		if isActiveActiveFailover {
+			updateRequest.ActiveClusters = buildActiveClusters(params.TargetCluster, params.ClusterAttributes)
+		}
+		updateRequest.ActiveClusterName = common.StringPtr(params.TargetCluster)
 		if params.GracefulFailoverTimeoutInSeconds != nil {
 			updateRequest.FailoverTimeoutInSeconds = params.GracefulFailoverTimeoutInSeconds
 		}
@@ -492,6 +572,28 @@ func FailoverActivity(ctx context.Context, params *FailoverActivityParams) (*Fai
 		SuccessDomains: successDomains,
 		FailedDomains:  failedDomains,
 	}, nil
+}
+
+// buildActiveClusters constructs an ActiveClusters payload for UpdateDomainRequest,
+// setting each listed attribute's ActiveClusterName to targetCluster. The server merges
+// this into the domain's existing ActiveClusters config (see domain/handler.go mergeActiveActiveScopes).
+func buildActiveClusters(targetCluster string, attrs []types.ClusterAttribute) *types.ActiveClusters {
+	result := &types.ActiveClusters{
+		AttributeScopes: make(map[string]types.ClusterAttributeScope),
+	}
+	for _, attr := range attrs {
+		scope, ok := result.AttributeScopes[attr.GetScope()]
+		if !ok {
+			scope = types.ClusterAttributeScope{
+				ClusterAttributes: make(map[string]types.ActiveClusterInfo),
+			}
+		}
+		scope.ClusterAttributes[attr.GetName()] = types.ActiveClusterInfo{
+			ActiveClusterName: targetCluster,
+		}
+		result.AttributeScopes[attr.GetScope()] = scope
+	}
+	return result
 }
 
 func cleanupChannel(channel workflow.Channel) {

--- a/service/worker/failovermanager/workflow.go
+++ b/service/worker/failovermanager/workflow.go
@@ -389,13 +389,7 @@ func GetDomainsActivity(ctx context.Context, params *GetDomainsActivityParams) (
 	}
 	var res []string
 	for _, domain := range domains {
-		var include bool
-		if len(params.ClusterAttributes) > 0 {
-			include = shouldFailoverActiveActiveDomain(domain, params.SourceCluster, params.ClusterAttributes)
-		} else {
-			include = shouldFailover(domain, params.SourceCluster)
-		}
-		if include {
+		if shouldFailover(domain, params.SourceCluster, params.ClusterAttributes) {
 			res = append(res, domain.GetDomainInfo().GetName())
 		}
 	}
@@ -422,62 +416,44 @@ func validateTargetAndSourceCluster(targetCluster, sourceCluster string) error {
 	return nil
 }
 
-func shouldFailover(domain *types.DescribeDomainResponse, sourceCluster string) bool {
-	if !domain.GetIsGlobalDomain() {
+// shouldFailover returns true if the domain should be included in a failover run.
+//
+// A domain is included when either of the following is true:
+//  1. Its default active cluster (ActiveClusterName) matches sourceCluster.
+//  2. A clusterAttributeFilter is provided and at least one of the listed cluster
+//     attributes is currently active on sourceCluster in the domain's ActiveClusters config.
+//
+// Both conditions are checked regardless of whether the domain has active-active configuration,
+// so plain global domains and active-active domains are treated uniformly.
+func shouldFailover(domain *types.DescribeDomainResponse, sourceCluster string, clusterAttributeFilter []types.ClusterAttribute) bool {
+	if !domain.GetIsGlobalDomain() || !isDomainFailoverManagedByCadence(domain) {
 		return false
 	}
-	// Skip deprecated and deleted domains
 	if domain.DomainInfo != nil && domain.DomainInfo.Status != nil {
 		status := *domain.DomainInfo.Status
 		if status == types.DomainStatusDeprecated || status == types.DomainStatusDeleted {
 			return false
 		}
 	}
-
-	// TODO(active-active): Remove this check once failover drills are supported for
-	// active-active workflows
-
-	if domain.ReplicationConfiguration.ActiveClusters != nil &&
-		len(domain.ReplicationConfiguration.ActiveClusters.AttributeScopes) > 0 {
-		return false
+	if domain.ReplicationConfiguration.GetActiveClusterName() == sourceCluster {
+		return true
 	}
-
-	currentActiveCluster := domain.ReplicationConfiguration.GetActiveClusterName()
-	isDomainTarget := currentActiveCluster == sourceCluster
-	return isDomainTarget && isDomainFailoverManagedByCadence(domain)
+	ac := domain.ReplicationConfiguration.GetActiveClusters()
+	if ac != nil {
+		for _, attr := range clusterAttributeFilter {
+			if info, err := ac.GetActiveClusterByClusterAttribute(attr.GetScope(), attr.GetName()); err == nil {
+				if info.ActiveClusterName == sourceCluster {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func isDomainFailoverManagedByCadence(domain *types.DescribeDomainResponse) bool {
 	domainData := domain.DomainInfo.GetData()
 	return strings.ToLower(strings.TrimSpace(domainData[constants.DomainDataKeyForManagedFailover])) == "true"
-}
-
-// shouldFailoverActiveActiveDomain returns true if the domain is an AA domain managed by Cadence that
-// has at least one of the specified cluster attributes currently active on sourceCluster.
-func shouldFailoverActiveActiveDomain(domain *types.DescribeDomainResponse, sourceCluster string, attrs []types.ClusterAttribute) bool {
-	if !domain.GetIsGlobalDomain() || !isDomainFailoverManagedByCadence(domain) {
-		return false
-	}
-	if domain.DomainInfo != nil && domain.DomainInfo.Status != nil {
-		s := *domain.DomainInfo.Status
-		if s == types.DomainStatusDeprecated || s == types.DomainStatusDeleted {
-			return false
-		}
-	}
-	ac := domain.ReplicationConfiguration.GetActiveClusters()
-	if ac == nil || len(ac.AttributeScopes) == 0 {
-		return false
-	}
-	for _, attr := range attrs {
-		info, err := ac.GetActiveClusterByClusterAttribute(attr.GetScope(), attr.GetName())
-		if err != nil {
-			continue
-		}
-		if info.ActiveClusterName == sourceCluster {
-			return true
-		}
-	}
-	return false
 }
 
 func getClient(ctx context.Context) frontend.Client {
@@ -540,27 +516,21 @@ func FailoverActivity(ctx context.Context, params *FailoverActivityParams) (*Fai
 	var successDomains []string
 	var failedDomains []string
 	for _, domain := range domains {
-		// Omitting the poller validation check for active-active failover as the domain will already be
-		// polling on both clusters - or will already be in a failed state. Failing over/not failing over
-		// will not change this.
-		if !isActiveActiveFailover {
-			// Check if poller exist for single-cluster failover
-			if err := validateTaskListPollerInfo(ctx, params.TargetCluster, domain); err != nil {
-				logger.Error("Failed to validate task list poller info", zap.Error(err))
-				failedDomains = append(failedDomains, domain)
-				continue
-			}
-		}
-		updateRequest := &types.UpdateDomainRequest{
-			Name: domain,
-		}
-		if isActiveActiveFailover {
-			updateRequest.ActiveClusters = buildActiveClusters(params.TargetCluster, params.ClusterAttributes)
+		if err := validateTaskListPollerInfo(ctx, params.TargetCluster, domain); err != nil {
+			logger.Error("Failed to validate task list poller info", zap.Error(err))
+			failedDomains = append(failedDomains, domain)
+			continue
 		}
 		// ActiveClusterName is set for all global and active-active domains.
 		// For Active-Active domains any workflows that do not use cluster attributes use this field,
 		// so it should maintain the same behaviour as a standard global domain.
-		updateRequest.ActiveClusterName = common.StringPtr(params.TargetCluster)
+		updateRequest := &types.UpdateDomainRequest{
+			Name:              domain,
+			ActiveClusterName: common.StringPtr(params.TargetCluster),
+		}
+		if isActiveActiveFailover {
+			updateRequest.ActiveClusters = buildActiveClusters(params.TargetCluster, params.ClusterAttributes)
+		}
 		if params.GracefulFailoverTimeoutInSeconds != nil {
 			updateRequest.FailoverTimeoutInSeconds = params.GracefulFailoverTimeoutInSeconds
 		}

--- a/service/worker/failovermanager/workflow_test.go
+++ b/service/worker/failovermanager/workflow_test.go
@@ -854,3 +854,327 @@ func (s *failoverWorkflowTestSuite) prepareTestActivityEnv() (*testsuite.TestAct
 
 	return s.activityEnv, mockResource
 }
+
+func (s *failoverWorkflowTestSuite) TestShouldAAFailover() {
+	aaDomain := func(regionToCluster map[string]string, managedFailover bool) *types.DescribeDomainResponse {
+		attrScopes := map[string]types.ClusterAttributeScope{}
+		attrs := map[string]types.ActiveClusterInfo{}
+		for region, cluster := range regionToCluster {
+			attrs[region] = types.ActiveClusterInfo{ActiveClusterName: cluster}
+		}
+		attrScopes["region"] = types.ClusterAttributeScope{ClusterAttributes: attrs}
+		managed := "false"
+		if managedFailover {
+			managed = "true"
+		}
+		return &types.DescribeDomainResponse{
+			IsGlobalDomain: true,
+			DomainInfo: &types.DomainInfo{
+				Data: map[string]string{constants.DomainDataKeyForManagedFailover: managed},
+			},
+			ReplicationConfiguration: &types.DomainReplicationConfiguration{
+				ActiveClusters: &types.ActiveClusters{AttributeScopes: attrScopes},
+			},
+		}
+	}
+
+	regionAttrs := []types.ClusterAttribute{{Scope: "region", Name: "us-west"}}
+
+	tests := []struct {
+		name          string
+		domain        *types.DescribeDomainResponse
+		sourceCluster string
+		attrs         []types.ClusterAttribute
+		expected      bool
+	}{
+		{
+			name:          "attribute on source cluster -> include",
+			domain:        aaDomain(map[string]string{"us-west": "c1", "us-east": "c2"}, true),
+			sourceCluster: "c1",
+			attrs:         regionAttrs,
+			expected:      true,
+		},
+		{
+			name:          "attribute already on different cluster -> exclude",
+			domain:        aaDomain(map[string]string{"us-west": "c2"}, true),
+			sourceCluster: "c1",
+			attrs:         regionAttrs,
+			expected:      false,
+		},
+		{
+			name:          "attribute not present in domain -> exclude",
+			domain:        aaDomain(map[string]string{"us-east": "c1"}, true),
+			sourceCluster: "c1",
+			attrs:         regionAttrs,
+			expected:      false,
+		},
+		{
+			name:          "not managed by cadence -> exclude",
+			domain:        aaDomain(map[string]string{"us-west": "c1"}, false),
+			sourceCluster: "c1",
+			attrs:         regionAttrs,
+			expected:      false,
+		},
+		{
+			name: "not global domain -> exclude",
+			domain: &types.DescribeDomainResponse{
+				IsGlobalDomain: false,
+				DomainInfo:     &types.DomainInfo{Data: map[string]string{constants.DomainDataKeyForManagedFailover: "true"}},
+				ReplicationConfiguration: &types.DomainReplicationConfiguration{
+					ActiveClusters: &types.ActiveClusters{
+						AttributeScopes: map[string]types.ClusterAttributeScope{
+							"region": {ClusterAttributes: map[string]types.ActiveClusterInfo{
+								"us-west": {ActiveClusterName: "c1"},
+							}},
+						},
+					},
+				},
+			},
+			sourceCluster: "c1",
+			attrs:         regionAttrs,
+			expected:      false,
+		},
+		{
+			name: "deprecated domain -> exclude",
+			domain: &types.DescribeDomainResponse{
+				IsGlobalDomain: true,
+				DomainInfo: &types.DomainInfo{
+					Status: types.DomainStatusDeprecated.Ptr(),
+					Data:   map[string]string{constants.DomainDataKeyForManagedFailover: "true"},
+				},
+				ReplicationConfiguration: &types.DomainReplicationConfiguration{
+					ActiveClusters: &types.ActiveClusters{
+						AttributeScopes: map[string]types.ClusterAttributeScope{
+							"region": {ClusterAttributes: map[string]types.ActiveClusterInfo{
+								"us-west": {ActiveClusterName: "c1"},
+							}},
+						},
+					},
+				},
+			},
+			sourceCluster: "c1",
+			attrs:         regionAttrs,
+			expected:      false,
+		},
+		{
+			name: "non-AA domain (no ActiveClusters) -> exclude",
+			domain: &types.DescribeDomainResponse{
+				IsGlobalDomain: true,
+				DomainInfo:     &types.DomainInfo{Data: map[string]string{constants.DomainDataKeyForManagedFailover: "true"}},
+				ReplicationConfiguration: &types.DomainReplicationConfiguration{
+					ActiveClusterName: "c1",
+				},
+			},
+			sourceCluster: "c1",
+			attrs:         regionAttrs,
+			expected:      false,
+		},
+	}
+
+	for _, tc := range tests {
+		s.T().Run(tc.name, func(t *testing.T) {
+			s.Equal(tc.expected, shouldFailoverActiveActiveDomain(tc.domain, tc.sourceCluster, tc.attrs))
+		})
+	}
+}
+
+func (s *failoverWorkflowTestSuite) TestGetDomainsActivity_AAMode() {
+	env, mockResource := s.prepareTestActivityEnv()
+
+	domains := &types.ListDomainsResponse{
+		Domains: []*types.DescribeDomainResponse{
+			{
+				DomainInfo: &types.DomainInfo{
+					Name: "aa-needs-failover",
+					Data: map[string]string{constants.DomainDataKeyForManagedFailover: "true"},
+				},
+				ReplicationConfiguration: &types.DomainReplicationConfiguration{
+					ActiveClusters: &types.ActiveClusters{
+						AttributeScopes: map[string]types.ClusterAttributeScope{
+							"region": {ClusterAttributes: map[string]types.ActiveClusterInfo{
+								"us-west": {ActiveClusterName: "c1"},
+							}},
+						},
+					},
+				},
+				IsGlobalDomain: true,
+			},
+			{
+				DomainInfo: &types.DomainInfo{
+					Name: "aa-already-correct",
+					Data: map[string]string{constants.DomainDataKeyForManagedFailover: "true"},
+				},
+				ReplicationConfiguration: &types.DomainReplicationConfiguration{
+					ActiveClusters: &types.ActiveClusters{
+						AttributeScopes: map[string]types.ClusterAttributeScope{
+							"region": {ClusterAttributes: map[string]types.ActiveClusterInfo{
+								"us-west": {ActiveClusterName: "c2"},
+							}},
+						},
+					},
+				},
+				IsGlobalDomain: true,
+			},
+			{
+				DomainInfo: &types.DomainInfo{
+					Name: "regular-domain",
+					Data: map[string]string{constants.DomainDataKeyForManagedFailover: "true"},
+				},
+				ReplicationConfiguration: &types.DomainReplicationConfiguration{
+					ActiveClusterName: "c1",
+				},
+				IsGlobalDomain: true,
+			},
+		},
+	}
+	mockResource.FrontendClient.EXPECT().ListDomains(gomock.Any(), gomock.Any()).Return(domains, nil)
+
+	params := &GetDomainsActivityParams{
+		TargetCluster: "c2",
+		SourceCluster: "c1",
+		ClusterAttributes: []types.ClusterAttribute{
+			{Scope: "region", Name: "us-west"},
+		},
+	}
+	actResult, err := env.ExecuteActivity(getDomainsActivityName, params)
+	s.NoError(err)
+	var result []string
+	s.NoError(actResult.Get(&result))
+	s.Equal([]string{"aa-needs-failover"}, result)
+}
+
+func (s *failoverWorkflowTestSuite) TestFailoverActivity_AA_Success() {
+	env, mockResource := s.prepareTestActivityEnv()
+
+	domains := []string{"aa-domain"}
+	attrs := []types.ClusterAttribute{
+		{Scope: "region", Name: "us-west"},
+		{Scope: "region", Name: "us-east"},
+	}
+	expectedActiveClusters := &types.ActiveClusters{
+		AttributeScopes: map[string]types.ClusterAttributeScope{
+			"region": {
+				ClusterAttributes: map[string]types.ActiveClusterInfo{
+					"us-west": {ActiveClusterName: "c2"},
+					"us-east": {ActiveClusterName: "c2"},
+				},
+			},
+		},
+	}
+	updateRequest := &types.UpdateDomainRequest{
+		Name:              "aa-domain",
+		ActiveClusters:    expectedActiveClusters,
+		ActiveClusterName: common.StringPtr("c2"),
+	}
+	mockResource.FrontendClient.EXPECT().UpdateDomain(gomock.Any(), updateRequest).Return(nil, nil).Times(1)
+
+	params := &FailoverActivityParams{
+		Domains:           domains,
+		TargetCluster:     "c2",
+		ClusterAttributes: attrs,
+	}
+	actResult, err := env.ExecuteActivity(failoverActivityName, params)
+	s.NoError(err)
+	var result FailoverActivityResult
+	s.NoError(actResult.Get(&result))
+	s.Equal(domains, result.SuccessDomains)
+	s.Empty(result.FailedDomains)
+}
+
+func (s *failoverWorkflowTestSuite) TestFailoverActivity_AA_UpdateDomainError() {
+	env, mockResource := s.prepareTestActivityEnv()
+
+	attrs := []types.ClusterAttribute{{Scope: "region", Name: "us-west"}}
+	mockResource.FrontendClient.EXPECT().UpdateDomain(gomock.Any(), gomock.Any()).Return(nil, errors.New("update failed")).Times(1)
+
+	params := &FailoverActivityParams{
+		Domains:           []string{"aa-domain"},
+		TargetCluster:     "c2",
+		ClusterAttributes: attrs,
+	}
+	actResult, err := env.ExecuteActivity(failoverActivityName, params)
+	s.NoError(err)
+	var result FailoverActivityResult
+	s.NoError(actResult.Get(&result))
+	s.Empty(result.SuccessDomains)
+	s.Equal([]string{"aa-domain"}, result.FailedDomains)
+}
+func TestBuildActiveClusters(t *testing.T) {
+	tests := []struct {
+		name          string
+		targetCluster string
+		attrs         []types.ClusterAttribute
+		expected      *types.ActiveClusters
+	}{
+		{
+			name:          "single scope single attribute",
+			targetCluster: "cluster-west",
+			attrs:         []types.ClusterAttribute{{Scope: "region", Name: "us-west"}},
+			expected: &types.ActiveClusters{
+				AttributeScopes: map[string]types.ClusterAttributeScope{
+					"region": {ClusterAttributes: map[string]types.ActiveClusterInfo{
+						"us-west": {ActiveClusterName: "cluster-west"},
+					}},
+				},
+			},
+		},
+		{
+			name:          "single scope multiple attributes",
+			targetCluster: "cluster-west",
+			attrs: []types.ClusterAttribute{
+				{Scope: "region", Name: "us-west"},
+				{Scope: "region", Name: "us-east"},
+			},
+			expected: &types.ActiveClusters{
+				AttributeScopes: map[string]types.ClusterAttributeScope{
+					"region": {ClusterAttributes: map[string]types.ActiveClusterInfo{
+						"us-west": {ActiveClusterName: "cluster-west"},
+						"us-east": {ActiveClusterName: "cluster-west"},
+					}},
+				},
+			},
+		},
+		{
+			name:          "multiple scopes",
+			targetCluster: "cluster-a",
+			attrs: []types.ClusterAttribute{
+				{Scope: "region", Name: "us-west"},
+				{Scope: "datacenter", Name: "dc1"},
+			},
+			expected: &types.ActiveClusters{
+				AttributeScopes: map[string]types.ClusterAttributeScope{
+					"region": {ClusterAttributes: map[string]types.ActiveClusterInfo{
+						"us-west": {ActiveClusterName: "cluster-a"},
+					}},
+					"datacenter": {ClusterAttributes: map[string]types.ActiveClusterInfo{
+						"dc1": {ActiveClusterName: "cluster-a"},
+					}},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildActiveClusters(tc.targetCluster, tc.attrs)
+			if len(got.AttributeScopes) != len(tc.expected.AttributeScopes) {
+				t.Fatalf("scope count mismatch: got %d, want %d", len(got.AttributeScopes), len(tc.expected.AttributeScopes))
+			}
+			for scope, expectedScope := range tc.expected.AttributeScopes {
+				gotScope, ok := got.AttributeScopes[scope]
+				if !ok {
+					t.Fatalf("missing scope %q", scope)
+				}
+				for name, expectedInfo := range expectedScope.ClusterAttributes {
+					gotInfo, ok := gotScope.ClusterAttributes[name]
+					if !ok {
+						t.Fatalf("missing attribute %q in scope %q", name, scope)
+					}
+					if gotInfo.ActiveClusterName != expectedInfo.ActiveClusterName {
+						t.Errorf("scope %q attr %q: got cluster %q, want %q", scope, name, gotInfo.ActiveClusterName, expectedInfo.ActiveClusterName)
+					}
+				}
+			}
+		})
+	}
+}

--- a/service/worker/failovermanager/workflow_test.go
+++ b/service/worker/failovermanager/workflow_test.go
@@ -271,11 +271,13 @@ func (s *failoverWorkflowTestSuite) TestWorkflow_WithDrillWaitTime_Success() {
 func (s *failoverWorkflowTestSuite) TestShouldFailover() {
 
 	tests := []struct {
+		name          string
 		domain        *types.DescribeDomainResponse
 		sourceCluster string
 		expected      bool
 	}{
 		{
+			name: "when domain is not global, should be excluded",
 			domain: &types.DescribeDomainResponse{
 				IsGlobalDomain: false,
 			},
@@ -283,6 +285,7 @@ func (s *failoverWorkflowTestSuite) TestShouldFailover() {
 			expected:      false,
 		},
 		{
+			name: "when domain is not managed by Cadence, should be excluded",
 			domain: &types.DescribeDomainResponse{
 				IsGlobalDomain: true,
 				ReplicationConfiguration: &types.DomainReplicationConfiguration{
@@ -294,6 +297,7 @@ func (s *failoverWorkflowTestSuite) TestShouldFailover() {
 			expected:      false,
 		},
 		{
+			name: "when active cluster matches source cluster but domain is not managed by Cadence, should be excluded",
 			domain: &types.DescribeDomainResponse{
 				IsGlobalDomain: true,
 				ReplicationConfiguration: &types.DomainReplicationConfiguration{
@@ -305,6 +309,7 @@ func (s *failoverWorkflowTestSuite) TestShouldFailover() {
 			expected:      false,
 		},
 		{
+			name: "when domain is managed by Cadence and active cluster matches source cluster, should be included",
 			domain: &types.DescribeDomainResponse{
 				IsGlobalDomain: true,
 				ReplicationConfiguration: &types.DomainReplicationConfiguration{
@@ -321,6 +326,7 @@ func (s *failoverWorkflowTestSuite) TestShouldFailover() {
 			expected:      true,
 		},
 		{
+			name: "when domain with active-active configuration is managed by Cadence and active cluster name matches source cluster, should be included",
 			domain: &types.DescribeDomainResponse{
 				IsGlobalDomain: true,
 				ReplicationConfiguration: &types.DomainReplicationConfiguration{
@@ -345,9 +351,10 @@ func (s *failoverWorkflowTestSuite) TestShouldFailover() {
 				},
 			},
 			sourceCluster: "c2",
-			expected:      false,
+			expected:      true,
 		},
 		{
+			name: "when domain has active-active configuration with empty attribute scopes but active cluster name matches source cluster, should be included",
 			domain: &types.DescribeDomainResponse{
 				IsGlobalDomain: true,
 				ReplicationConfiguration: &types.DomainReplicationConfiguration{
@@ -368,11 +375,14 @@ func (s *failoverWorkflowTestSuite) TestShouldFailover() {
 				},
 			},
 			sourceCluster: "c2",
-			expected:      false,
+			expected:      true,
 		},
 	}
 	for _, t := range tests {
-		s.Equal(t.expected, shouldFailover(t.domain, t.sourceCluster))
+		t := t
+		s.Run(t.name, func() {
+			s.Equal(t.expected, shouldFailover(t.domain, t.sourceCluster, nil))
+		})
 	}
 }
 
@@ -460,7 +470,7 @@ func (s *failoverWorkflowTestSuite) TestGetDomainsActivity_WithTargetDomains() {
 	s.Equal([]string{"d1"}, result) // d3 filtered out because not managed
 }
 
-func (s *failoverWorkflowTestSuite) TestGetDomainsActivity_FiltersActiveActiveDomains() {
+func (s *failoverWorkflowTestSuite) TestGetDomainsActivity_IncludesActiveActiveDomains() {
 	env, mockResource := s.prepareTestActivityEnv()
 
 	domains := &types.ListDomainsResponse{
@@ -528,7 +538,7 @@ func (s *failoverWorkflowTestSuite) TestGetDomainsActivity_FiltersActiveActiveDo
 	s.NoError(err)
 	var result []string
 	s.NoError(actResult.Get(&result))
-	s.Equal([]string{"regular-domain"}, result)
+	s.ElementsMatch([]string{"regular-domain", "active-active-domain", "empty-active-clusters-domain"}, result)
 }
 
 func (s *failoverWorkflowTestSuite) TestGetDomainsActivity_WithActiveActiveTargetDomains() {
@@ -585,7 +595,7 @@ func (s *failoverWorkflowTestSuite) TestGetDomainsActivity_WithActiveActiveTarge
 	s.NoError(err)
 	var result []string
 	s.NoError(actResult.Get(&result))
-	s.Equal([]string{"regular-domain"}, result)
+	s.ElementsMatch([]string{"regular-domain", "active-active-domain"}, result)
 }
 
 func (s *failoverWorkflowTestSuite) TestFailoverActivity_ForceFailover_Success() {
@@ -800,7 +810,7 @@ func (s *failoverWorkflowTestSuite) TestShouldFailover_DeprecatedDomain() {
 		},
 	}
 
-	result := shouldFailover(deprecatedDomain, "cluster1")
+	result := shouldFailover(deprecatedDomain, "cluster1", nil)
 	s.False(result, "Deprecated domains should not be included in failover")
 }
 
@@ -823,7 +833,7 @@ func (s *failoverWorkflowTestSuite) TestShouldFailover_DeletedDomain() {
 		},
 	}
 
-	result := shouldFailover(deletedDomain, "cluster1")
+	result := shouldFailover(deletedDomain, "cluster1", nil)
 	s.False(result, "Deleted domains should not be included in failover")
 }
 
@@ -855,14 +865,12 @@ func (s *failoverWorkflowTestSuite) prepareTestActivityEnv() (*testsuite.TestAct
 	return s.activityEnv, mockResource
 }
 
-func (s *failoverWorkflowTestSuite) TestShouldAAFailover() {
-	aaDomain := func(regionToCluster map[string]string, managedFailover bool) *types.DescribeDomainResponse {
-		attrScopes := map[string]types.ClusterAttributeScope{}
+func (s *failoverWorkflowTestSuite) TestShouldFailover_WithClusterAttributeFilter() {
+	activeClustersWithAttr := func(regionToCluster map[string]string, managedFailover bool) *types.DescribeDomainResponse {
 		attrs := map[string]types.ActiveClusterInfo{}
 		for region, cluster := range regionToCluster {
 			attrs[region] = types.ActiveClusterInfo{ActiveClusterName: cluster}
 		}
-		attrScopes["region"] = types.ClusterAttributeScope{ClusterAttributes: attrs}
 		managed := "false"
 		if managedFailover {
 			managed = "true"
@@ -873,7 +881,11 @@ func (s *failoverWorkflowTestSuite) TestShouldAAFailover() {
 				Data: map[string]string{constants.DomainDataKeyForManagedFailover: managed},
 			},
 			ReplicationConfiguration: &types.DomainReplicationConfiguration{
-				ActiveClusters: &types.ActiveClusters{AttributeScopes: attrScopes},
+				ActiveClusters: &types.ActiveClusters{
+					AttributeScopes: map[string]types.ClusterAttributeScope{
+						"region": {ClusterAttributes: attrs},
+					},
+				},
 			},
 		}
 	}
@@ -888,35 +900,35 @@ func (s *failoverWorkflowTestSuite) TestShouldAAFailover() {
 		expected      bool
 	}{
 		{
-			name:          "attribute on source cluster -> include",
-			domain:        aaDomain(map[string]string{"us-west": "c1", "us-east": "c2"}, true),
+			name:          "when a filtered cluster attribute is active on source cluster, should be included",
+			domain:        activeClustersWithAttr(map[string]string{"us-west": "c1", "us-east": "c2"}, true),
 			sourceCluster: "c1",
 			attrs:         regionAttrs,
 			expected:      true,
 		},
 		{
-			name:          "attribute already on different cluster -> exclude",
-			domain:        aaDomain(map[string]string{"us-west": "c2"}, true),
+			name:          "when a filtered cluster attribute is active on a different cluster, should be excluded",
+			domain:        activeClustersWithAttr(map[string]string{"us-west": "c2"}, true),
 			sourceCluster: "c1",
 			attrs:         regionAttrs,
 			expected:      false,
 		},
 		{
-			name:          "attribute not present in domain -> exclude",
-			domain:        aaDomain(map[string]string{"us-east": "c1"}, true),
+			name:          "when the filtered attribute scope does not exist in the domain, should be excluded",
+			domain:        activeClustersWithAttr(map[string]string{"us-east": "c1"}, true),
 			sourceCluster: "c1",
 			attrs:         regionAttrs,
 			expected:      false,
 		},
 		{
-			name:          "not managed by cadence -> exclude",
-			domain:        aaDomain(map[string]string{"us-west": "c1"}, false),
+			name:          "when domain is not managed by Cadence, should be excluded",
+			domain:        activeClustersWithAttr(map[string]string{"us-west": "c1"}, false),
 			sourceCluster: "c1",
 			attrs:         regionAttrs,
 			expected:      false,
 		},
 		{
-			name: "not global domain -> exclude",
+			name: "when domain is not global, should be excluded",
 			domain: &types.DescribeDomainResponse{
 				IsGlobalDomain: false,
 				DomainInfo:     &types.DomainInfo{Data: map[string]string{constants.DomainDataKeyForManagedFailover: "true"}},
@@ -935,7 +947,7 @@ func (s *failoverWorkflowTestSuite) TestShouldAAFailover() {
 			expected:      false,
 		},
 		{
-			name: "deprecated domain -> exclude",
+			name: "when domain is deprecated, should be excluded",
 			domain: &types.DescribeDomainResponse{
 				IsGlobalDomain: true,
 				DomainInfo: &types.DomainInfo{
@@ -957,7 +969,7 @@ func (s *failoverWorkflowTestSuite) TestShouldAAFailover() {
 			expected:      false,
 		},
 		{
-			name: "non-AA domain (no ActiveClusters) -> exclude",
+			name: "when domain's active cluster name matches source cluster, should be included regardless of attribute configuration",
 			domain: &types.DescribeDomainResponse{
 				IsGlobalDomain: true,
 				DomainInfo:     &types.DomainInfo{Data: map[string]string{constants.DomainDataKeyForManagedFailover: "true"}},
@@ -967,18 +979,59 @@ func (s *failoverWorkflowTestSuite) TestShouldAAFailover() {
 			},
 			sourceCluster: "c1",
 			attrs:         regionAttrs,
+			expected:      true,
+		},
+		{
+			name: "when active cluster name does not match and no filtered attribute is on source cluster, should be excluded",
+			domain: &types.DescribeDomainResponse{
+				IsGlobalDomain: true,
+				DomainInfo:     &types.DomainInfo{Data: map[string]string{constants.DomainDataKeyForManagedFailover: "true"}},
+				ReplicationConfiguration: &types.DomainReplicationConfiguration{
+					ActiveClusterName: "c2",
+					ActiveClusters: &types.ActiveClusters{
+						AttributeScopes: map[string]types.ClusterAttributeScope{
+							"region": {ClusterAttributes: map[string]types.ActiveClusterInfo{
+								"us-west": {ActiveClusterName: "c2"},
+							}},
+						},
+					},
+				},
+			},
+			sourceCluster: "c1",
+			attrs:         regionAttrs,
 			expected:      false,
+		},
+		{
+			name: "when default active cluster name is on source cluster and a filtered attribute is not, should be included via active cluster name",
+			domain: &types.DescribeDomainResponse{
+				IsGlobalDomain: true,
+				DomainInfo:     &types.DomainInfo{Data: map[string]string{constants.DomainDataKeyForManagedFailover: "true"}},
+				ReplicationConfiguration: &types.DomainReplicationConfiguration{
+					ActiveClusterName: "c1",
+					ActiveClusters: &types.ActiveClusters{
+						AttributeScopes: map[string]types.ClusterAttributeScope{
+							"region": {ClusterAttributes: map[string]types.ActiveClusterInfo{
+								"us-west": {ActiveClusterName: "c2"},
+							}},
+						},
+					},
+				},
+			},
+			sourceCluster: "c1",
+			attrs:         regionAttrs,
+			expected:      true,
 		},
 	}
 
 	for _, tc := range tests {
-		s.T().Run(tc.name, func(t *testing.T) {
-			s.Equal(tc.expected, shouldFailoverActiveActiveDomain(tc.domain, tc.sourceCluster, tc.attrs))
+		tc := tc
+		s.Run(tc.name, func() {
+			s.Equal(tc.expected, shouldFailover(tc.domain, tc.sourceCluster, tc.attrs))
 		})
 	}
 }
 
-func (s *failoverWorkflowTestSuite) TestGetDomainsActivity_AAMode() {
+func (s *failoverWorkflowTestSuite) TestGetDomainsActivity_ActiveActiveMode() {
 	env, mockResource := s.prepareTestActivityEnv()
 
 	domains := &types.ListDomainsResponse{
@@ -1040,10 +1093,10 @@ func (s *failoverWorkflowTestSuite) TestGetDomainsActivity_AAMode() {
 	s.NoError(err)
 	var result []string
 	s.NoError(actResult.Get(&result))
-	s.Equal([]string{"aa-needs-failover"}, result)
+	s.ElementsMatch([]string{"aa-needs-failover", "regular-domain"}, result)
 }
 
-func (s *failoverWorkflowTestSuite) TestFailoverActivity_AA_Success() {
+func (s *failoverWorkflowTestSuite) TestFailoverActivity_ActiveActive_Success() {
 	env, mockResource := s.prepareTestActivityEnv()
 
 	domains := []string{"aa-domain"}
@@ -1051,6 +1104,16 @@ func (s *failoverWorkflowTestSuite) TestFailoverActivity_AA_Success() {
 		{Scope: "region", Name: "us-west"},
 		{Scope: "region", Name: "us-east"},
 	}
+	describeTaskListResp := &types.DescribeTaskListResponse{Pollers: []*types.PollerInfo{{Identity: "test"}}}
+	taskListMap := map[string]*types.DescribeTaskListResponse{"tl": describeTaskListResp}
+	mockResource.FrontendClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(&types.GetTaskListsByDomainResponse{
+		DecisionTaskListMap: taskListMap,
+		ActivityTaskListMap: taskListMap,
+	}, nil).Times(1)
+	mockResource.RemoteFrontendClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(&types.GetTaskListsByDomainResponse{
+		DecisionTaskListMap: taskListMap,
+		ActivityTaskListMap: taskListMap,
+	}, nil).Times(1)
 	expectedActiveClusters := &types.ActiveClusters{
 		AttributeScopes: map[string]types.ClusterAttributeScope{
 			"region": {
@@ -1081,10 +1144,20 @@ func (s *failoverWorkflowTestSuite) TestFailoverActivity_AA_Success() {
 	s.Empty(result.FailedDomains)
 }
 
-func (s *failoverWorkflowTestSuite) TestFailoverActivity_AA_UpdateDomainError() {
+func (s *failoverWorkflowTestSuite) TestFailoverActivity_ActiveActive_UpdateDomainError() {
 	env, mockResource := s.prepareTestActivityEnv()
 
 	attrs := []types.ClusterAttribute{{Scope: "region", Name: "us-west"}}
+	describeTaskListResp := &types.DescribeTaskListResponse{Pollers: []*types.PollerInfo{{Identity: "test"}}}
+	taskListMap := map[string]*types.DescribeTaskListResponse{"tl": describeTaskListResp}
+	mockResource.FrontendClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(&types.GetTaskListsByDomainResponse{
+		DecisionTaskListMap: taskListMap,
+		ActivityTaskListMap: taskListMap,
+	}, nil).Times(1)
+	mockResource.RemoteFrontendClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(&types.GetTaskListsByDomainResponse{
+		DecisionTaskListMap: taskListMap,
+		ActivityTaskListMap: taskListMap,
+	}, nil).Times(1)
 	mockResource.FrontendClient.EXPECT().UpdateDomain(gomock.Any(), gomock.Any()).Return(nil, errors.New("update failed")).Times(1)
 
 	params := &FailoverActivityParams{

--- a/tools/cli/admin_failover_commands_test.go
+++ b/tools/cli/admin_failover_commands_test.go
@@ -146,6 +146,43 @@ func TestAdminFailoverStart(t *testing.T) {
 			},
 		},
 		{
+			desc:          "cron without drill wait time",
+			wantErr:       true,
+			sourceCluster: "cluster1",
+			targetCluster: "cluster2",
+			failoverCron:  "0 0 * * *",
+			mockFn: func(t *testing.T, m *frontend.MockClient) {
+				// no frontend calls: error before any RPC
+			},
+		},
+		{
+			desc:          "drill pause EntityNotExistsError, failover continues",
+			sourceCluster: "cluster1",
+			targetCluster: "cluster2",
+			mockFn: func(t *testing.T, m *frontend.MockClient) {
+				m.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).Return(&types.EntityNotExistsError{}).Times(1)
+				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).Return(&types.StartWorkflowExecutionResponse{}, nil).Times(1)
+			},
+		},
+		{
+			desc:          "drill pause AlreadyCompleted, failover continues",
+			sourceCluster: "cluster1",
+			targetCluster: "cluster2",
+			mockFn: func(t *testing.T, m *frontend.MockClient) {
+				m.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).Return(&types.WorkflowExecutionAlreadyCompletedError{}).Times(1)
+				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).Return(&types.StartWorkflowExecutionResponse{}, nil).Times(1)
+			},
+		},
+		{
+			desc:          "drill pause fails with unexpected error",
+			wantErr:       true,
+			sourceCluster: "cluster1",
+			targetCluster: "cluster2",
+			mockFn: func(t *testing.T, m *frontend.MockClient) {
+				m.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).Return(fmt.Errorf("unexpected signal error")).Times(1)
+			},
+		},
+		{
 			desc:                    "success with cron",
 			sourceCluster:           "cluster1",
 			targetCluster:           "cluster2",
@@ -467,6 +504,13 @@ func TestAdminFailoverAbort(t *testing.T) {
 						}
 						return nil
 					}).Times(1)
+			},
+		},
+		{
+			desc:    "terminate fails",
+			wantErr: true,
+			mockFn: func(t *testing.T, m *frontend.MockClient) {
+				m.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).Return(fmt.Errorf("terminate failed")).Times(1)
 			},
 		},
 	}


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
This PR is part of a stack. 
| ◀️ | ▶️ |
| -- | -- |
| N/A | https://github.com/cadence-workflow/cadence/pull/8087 |

**What changed?**

Support failing over Active-Active domains via the existing failover managed workflow. 

**Why?**

#8088 

This reduces the functional difference between a global domain and an active-active domain. Operators can now fail over active active domains in the same way that a global domain would be by specifying the cluster attributes that should be failed over. For example, the following would fail over all global domains to cluster1, and all active-active domains would ALSO have the attributes `cluster:cluster0` and `cluster:cluster2` failed over to cluster1. 

```bash
./cadence admin cluster failover start --target_cluster cluster1 --source_cluster cluster0 --cluster_attributes_json '[{"scope": "cluster", "name": "cluster0"}, {"scope": "cluster", "name": "cluster2"}]'
```

(Note that the CLI updates are in a stacked PR). 

This does rely on domain operators having 'conventional' attribute scopes and names. Otherwise operators will have to specify a huge swathe of cluster attributes to fail over all domains. 

**How did you test it?**

Locally against a canary cluster:
```bash
# All of these commands should be run in a new window
docker compose  -f docker/dev/cassandra.yml up
make install-schema-xdc
make start-xdc-cluster0
make start-xdc-cluster1
make start-xdc-cluster2
make start-canary

# These commands can be run in a single window
./cadence --domain cadence-canary domain update --active_clusters cluster.cluster0:cluster0,cluster.cluster1:cluster1,cluster.cluster2:cluster2
# wait 60s
./cadence --do dlq-test domain update --domain_data 'IsManagedByCadence=true'
# wait 60s
./cadence admin cluster failover start --target_cluster cluster1 --source_cluster cluster0 --cluster_attributes_json '[{"scope": "cluster", "name": "cluster0"}, {"scope": "cluster", "name": "cluster2"}]'
```

**Potential risks**

N/A

**Release notes**

N/A

**Documentation Changes**

Yes - we should update our failover documentation. 