### PR TITLE
feat(schedules): add schedules SA to default Keys

### DIFF
--- a/common/definition/indexedKeys.go
+++ b/common/definition/indexedKeys.go
@@ -48,6 +48,16 @@ const (
 	CustomDomain           = "CustomDomain" // to support batch workflow
 	Operator               = "Operator"     // to support batch workflow
 
+	// Schedule search attributes set on target workflows started by the scheduler.
+	CadenceScheduleID       = "CadenceScheduleID"
+	CadenceScheduleTime     = "CadenceScheduleTime"
+	CadenceScheduleIsBackfill = "CadenceScheduleIsBackfill"
+
+	// Schedule search attributes set on the scheduler workflow itself (used by ListSchedules).
+	CadenceScheduleState        = "CadenceScheduleState"
+	CadenceScheduleCron         = "CadenceScheduleCron"
+	CadenceScheduleWorkflowType = "CadenceScheduleWorkflowType"
+
 	CustomStringField    = "CustomStringField"
 	CustomKeywordField   = "CustomKeywordField"
 	CustomIntField       = "CustomIntField"
@@ -113,6 +123,13 @@ var systemIndexedKeys = map[string]interface{}{
 	ScheduledExecutionTime: types.IndexedValueTypeInt,
 	ClusterAttributeScope:  types.IndexedValueTypeKeyword,
 	ClusterAttributeName:   types.IndexedValueTypeKeyword,
+	// Schedule search attributes — set on target workflows and on scheduler workflows.
+	CadenceScheduleID:         types.IndexedValueTypeKeyword,
+	CadenceScheduleTime:       types.IndexedValueTypeDatetime,
+	CadenceScheduleIsBackfill: types.IndexedValueTypeBool,
+	CadenceScheduleState:      types.IndexedValueTypeKeyword,
+	CadenceScheduleCron:       types.IndexedValueTypeKeyword,
+	CadenceScheduleWorkflowType: types.IndexedValueTypeKeyword,
 }
 
 // IsSystemIndexedKey return true is key is system added

--- a/common/definition/indexedKeys.go
+++ b/common/definition/indexedKeys.go
@@ -91,6 +91,14 @@ func createDefaultIndexedKeys() map[string]interface{} {
 		BinaryChecksums:      types.IndexedValueTypeKeyword,
 		CustomDomain:         types.IndexedValueTypeString,
 		Operator:             types.IndexedValueTypeString,
+		// Schedule search attributes are set by the scheduler workflow/activity via
+		// UpsertSearchAttributes and StartWorkflow
+		CadenceScheduleID:           types.IndexedValueTypeKeyword,
+		CadenceScheduleTime:         types.IndexedValueTypeDatetime,
+		CadenceScheduleIsBackfill:   types.IndexedValueTypeBool,
+		CadenceScheduleState:        types.IndexedValueTypeKeyword,
+		CadenceScheduleCron:         types.IndexedValueTypeKeyword,
+		CadenceScheduleWorkflowType: types.IndexedValueTypeKeyword,
 	}
 	for k, v := range systemIndexedKeys {
 		defaultIndexedKeys[k] = v
@@ -123,13 +131,6 @@ var systemIndexedKeys = map[string]interface{}{
 	ScheduledExecutionTime: types.IndexedValueTypeInt,
 	ClusterAttributeScope:  types.IndexedValueTypeKeyword,
 	ClusterAttributeName:   types.IndexedValueTypeKeyword,
-	// Schedule search attributes — set on target workflows and on scheduler workflows.
-	CadenceScheduleID:           types.IndexedValueTypeKeyword,
-	CadenceScheduleTime:         types.IndexedValueTypeDatetime,
-	CadenceScheduleIsBackfill:   types.IndexedValueTypeBool,
-	CadenceScheduleState:        types.IndexedValueTypeKeyword,
-	CadenceScheduleCron:         types.IndexedValueTypeKeyword,
-	CadenceScheduleWorkflowType: types.IndexedValueTypeKeyword,
 }
 
 // IsSystemIndexedKey return true is key is system added

--- a/common/definition/indexedKeys.go
+++ b/common/definition/indexedKeys.go
@@ -49,8 +49,8 @@ const (
 	Operator               = "Operator"     // to support batch workflow
 
 	// Schedule search attributes set on target workflows started by the scheduler.
-	CadenceScheduleID       = "CadenceScheduleID"
-	CadenceScheduleTime     = "CadenceScheduleTime"
+	CadenceScheduleID         = "CadenceScheduleID"
+	CadenceScheduleTime       = "CadenceScheduleTime"
 	CadenceScheduleIsBackfill = "CadenceScheduleIsBackfill"
 
 	// Schedule search attributes set on the scheduler workflow itself (used by ListSchedules).
@@ -124,11 +124,11 @@ var systemIndexedKeys = map[string]interface{}{
 	ClusterAttributeScope:  types.IndexedValueTypeKeyword,
 	ClusterAttributeName:   types.IndexedValueTypeKeyword,
 	// Schedule search attributes — set on target workflows and on scheduler workflows.
-	CadenceScheduleID:         types.IndexedValueTypeKeyword,
-	CadenceScheduleTime:       types.IndexedValueTypeDatetime,
-	CadenceScheduleIsBackfill: types.IndexedValueTypeBool,
-	CadenceScheduleState:      types.IndexedValueTypeKeyword,
-	CadenceScheduleCron:       types.IndexedValueTypeKeyword,
+	CadenceScheduleID:           types.IndexedValueTypeKeyword,
+	CadenceScheduleTime:         types.IndexedValueTypeDatetime,
+	CadenceScheduleIsBackfill:   types.IndexedValueTypeBool,
+	CadenceScheduleState:        types.IndexedValueTypeKeyword,
+	CadenceScheduleCron:         types.IndexedValueTypeKeyword,
 	CadenceScheduleWorkflowType: types.IndexedValueTypeKeyword,
 }
 

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -23,6 +23,7 @@ package scheduler
 import (
 	"time"
 
+	"github.com/uber/cadence/common/definition"
 	"github.com/uber/cadence/common/types"
 )
 
@@ -99,9 +100,11 @@ const (
 	signalTypeTagDelete   = "delete"
 
 	// Search attribute keys set on target workflows started by the scheduler.
-	SearchAttrScheduleID   = "CadenceScheduleID"
-	SearchAttrScheduleTime = "CadenceScheduleTime"
-	SearchAttrIsBackfill   = "CadenceScheduleIsBackfill"
+	// The string values are defined in common/definition to make them part of
+	// the default indexed keys for all visibility backends.
+	SearchAttrScheduleID   = definition.CadenceScheduleID
+	SearchAttrScheduleTime = definition.CadenceScheduleTime
+	SearchAttrIsBackfill   = definition.CadenceScheduleIsBackfill
 
 	// Search attribute keys set on the scheduler workflow itself for ListSchedules.
 	// CadenceScheduleState is a Keyword SA holding the current lifecycle state
@@ -109,14 +112,14 @@ const (
 	// be extended to additional states (e.g. "expired") without introducing new
 	// search attributes. "Deleted" is not a value because a deleted schedule's
 	// workflow is closed and filtered by workflow status instead.
-	SearchAttrScheduleState = "CadenceScheduleState"
+	SearchAttrScheduleState = definition.CadenceScheduleState
 	// CadenceScheduleCron holds the current cron expression so ListSchedules
 	// can display it without querying each scheduler workflow. Refreshed on
 	// workflow start (including after ContinueAsNew triggered by UpdateSchedule).
-	SearchAttrScheduleCron = "CadenceScheduleCron"
+	SearchAttrScheduleCron = definition.CadenceScheduleCron
 	// CadenceScheduleWorkflowType holds the target workflow type name that the
 	// schedule starts on each fire. Same refresh semantics as the cron SA.
-	SearchAttrScheduleWorkflowType = "CadenceScheduleWorkflowType"
+	SearchAttrScheduleWorkflowType = definition.CadenceScheduleWorkflowType
 
 	ScheduleStateActive = "active"
 	ScheduleStatePaused = "paused"


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Added 6 schedule SA string constants (CadenceScheduleID, CadenceScheduleTime, CadenceScheduleIsBackfill, CadenceScheduleState, CadenceScheduleCron, CadenceScheduleWorkflowType)

SearchAttr constants now reference definition.Cadence* instead of inline string literals

**Why?**
Any environment that does not have an explicit frontend.validSearchAttributes override in YAML or flipr now gets the schedule SAs for free. 

**How did you test it?**
N/A

**Potential risks**
N/A

**Release notes**
N/A

**Documentation Changes**
N/A
