### PR TITLE
feat(dynamicconfig): add operational dynamic config store properties

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -1641,6 +1641,13 @@ const (
 	// Allowed filters: DomainName, TaskListName
 	HistoryTaskListNiceValue
 
+	// OperationalConfigStoreUpdateRetryAttempts is the number of attempts
+	// to push a value to the operational dynamic config store on conflict.
+	// KeyName: system.operationalConfigStoreUpdateRetryAttempts
+	// Value type: Int
+	// Default value: 1
+	OperationalConfigStoreUpdateRetryAttempts
+
 	// LastIntKey must be the last one in this const group
 	LastIntKey
 )
@@ -3383,6 +3390,27 @@ const (
 	// Allowed filters: namespace
 	ShardDistributorLoadBalancingGreedyLoadSmoothingTimeConstant
 
+	// OperationalConfigStorePollInterval controls how often the operational
+	// dynamic config store re-reads its snapshot from the primary database.
+	// KeyName: system.operationalConfigStorePollInterval
+	// Value type: Duration
+	// Default value: 2 seconds
+	OperationalConfigStorePollInterval
+
+	// OperationalConfigStoreFetchTimeout is the per-call timeout used when
+	// fetching the operational dynamic config snapshot from the primary database.
+	// KeyName: system.operationalConfigStoreFetchTimeout
+	// Value type: Duration
+	// Default value: 2 seconds
+	OperationalConfigStoreFetchTimeout
+
+	// OperationalConfigStoreUpdateTimeout is the per-call timeout used when
+	// writing an operational dynamic config snapshot to the primary database.
+	// KeyName: system.operationalConfigStoreUpdateTimeout
+	// Value type: Duration
+	// Default value: 2 seconds
+	OperationalConfigStoreUpdateTimeout
+
 	// LastDurationKey must be the last one in this const group
 	LastDurationKey
 )
@@ -4585,6 +4613,11 @@ var IntKeys = map[IntKey]DynamicInt{
 		Description:  "HistoryTaskListNiceValue is the nice value for task processing priority per domain and task list",
 		DefaultValue: 0,
 		Filters:      []Filter{DomainName, TaskListName},
+	},
+	OperationalConfigStoreUpdateRetryAttempts: {
+		KeyName:      "system.operationalConfigStoreUpdateRetryAttempts",
+		Description:  "Number of attempts to push a value to the operational dynamic config store on conflict",
+		DefaultValue: 1,
 	},
 }
 
@@ -6091,6 +6124,21 @@ var DurationKeys = map[DurationKey]DynamicDuration{
 		Filters:      []Filter{Namespace},
 		Description:  "ShardDistributorLoadBalancingGreedyLoadSmoothingTimeConstant is the time constant for exponential smoothing of shard load in greedy load balancing mode",
 		DefaultValue: time.Minute,
+	},
+	OperationalConfigStorePollInterval: {
+		KeyName:      "system.operationalConfigStorePollInterval",
+		Description:  "How often the operational dynamic config store re-reads its snapshot from the primary database",
+		DefaultValue: time.Second * 2,
+	},
+	OperationalConfigStoreFetchTimeout: {
+		KeyName:      "system.operationalConfigStoreFetchTimeout",
+		Description:  "Per-call timeout for fetching the operational dynamic config snapshot from the primary database",
+		DefaultValue: time.Second * 2,
+	},
+	OperationalConfigStoreUpdateTimeout: {
+		KeyName:      "system.operationalConfigStoreUpdateTimeout",
+		Description:  "Per-call timeout for writing an operational dynamic config snapshot to the primary database",
+		DefaultValue: time.Second * 2,
 	},
 }
 


### PR DESCRIPTION
**What changed?**

Adds four new dynamic config keys to control the polling cadence and timeouts of an upcoming operational dynamic config store:

| Key | Type | Default |
| --- | --- | --- |
| `system.operationalConfigStorePollInterval` | Duration | 2s |
| `system.operationalConfigStoreFetchTimeout` | Duration | 2s |
| `system.operationalConfigStoreUpdateTimeout` | Duration | 2s |
| `system.operationalConfigStoreUpdateRetryAttempts` | Int | 1 |

This is analogous to the existing isolation-group config store properties ([`system.isolationGroupState*`](https://github.com/cadence-workflow/cadence/blob/e5ae9bd25148eac140f717820be4d79f38ea3c87/common/dynamicconfig/dynamicproperties/constants.go#L5923-L5937)), which serve the same role for the existing isolation-group configstore. The new keys exist for an additional, separate operational configstore added in the follow-up.

This is a key-definitions-only PR — nothing reads these values yet.

**Why?**

The 2s default puts the operational store at the configstore client's [minimum poll interval](https://github.com/cadence-workflow/cadence/blob/e5ae9bd25148eac140f717820be4d79f38ea3c87/common/dynamicconfig/configstore/config_store_client.go#L58-L60). The motivation is to enable sub-2s regional convergence for safety-critical operational config (e.g. sharding-related rollout flags).

**How did you test it?**

- `go test -count=1 -race ./common/dynamicconfig/...` — passes.

**Potential risks**

- None expected.

**Release notes**

N/A

**Documentation Changes**

N/A.