### PR TITLE
feat(dynamicconfig): add operational dynamic config store backed by primary database

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -1641,6 +1641,13 @@ const (
 	// Allowed filters: DomainName, TaskListName
 	HistoryTaskListNiceValue
 
+	// OperationalConfigStoreUpdateRetryAttempts is the number of attempts
+	// to push a value to the operational dynamic config store on conflict.
+	// KeyName: system.operationalConfigStoreUpdateRetryAttempts
+	// Value type: Int
+	// Default value: 1
+	OperationalConfigStoreUpdateRetryAttempts
+
 	// LastIntKey must be the last one in this const group
 	LastIntKey
 )
@@ -3383,6 +3390,27 @@ const (
 	// Allowed filters: namespace
 	ShardDistributorLoadBalancingGreedyLoadSmoothingTimeConstant
 
+	// OperationalConfigStorePollInterval controls how often the operational
+	// dynamic config store re-reads its snapshot from the primary database.
+	// KeyName: system.operationalConfigStorePollInterval
+	// Value type: Duration
+	// Default value: 2 seconds
+	OperationalConfigStorePollInterval
+
+	// OperationalConfigStoreFetchTimeout is the per-call timeout used when
+	// fetching the operational dynamic config snapshot from the primary database.
+	// KeyName: system.operationalConfigStoreFetchTimeout
+	// Value type: Duration
+	// Default value: 2 seconds
+	OperationalConfigStoreFetchTimeout
+
+	// OperationalConfigStoreUpdateTimeout is the per-call timeout used when
+	// writing an operational dynamic config snapshot to the primary database.
+	// KeyName: system.operationalConfigStoreUpdateTimeout
+	// Value type: Duration
+	// Default value: 2 seconds
+	OperationalConfigStoreUpdateTimeout
+
 	// LastDurationKey must be the last one in this const group
 	LastDurationKey
 )
@@ -4585,6 +4613,11 @@ var IntKeys = map[IntKey]DynamicInt{
 		Description:  "HistoryTaskListNiceValue is the nice value for task processing priority per domain and task list",
 		DefaultValue: 0,
 		Filters:      []Filter{DomainName, TaskListName},
+	},
+	OperationalConfigStoreUpdateRetryAttempts: {
+		KeyName:      "system.operationalConfigStoreUpdateRetryAttempts",
+		Description:  "Number of attempts to push a value to the operational dynamic config store on conflict",
+		DefaultValue: 1,
 	},
 }
 
@@ -6091,6 +6124,21 @@ var DurationKeys = map[DurationKey]DynamicDuration{
 		Filters:      []Filter{Namespace},
 		Description:  "ShardDistributorLoadBalancingGreedyLoadSmoothingTimeConstant is the time constant for exponential smoothing of shard load in greedy load balancing mode",
 		DefaultValue: time.Minute,
+	},
+	OperationalConfigStorePollInterval: {
+		KeyName:      "system.operationalConfigStorePollInterval",
+		Description:  "How often the operational dynamic config store re-reads its snapshot from the primary database",
+		DefaultValue: time.Second * 2,
+	},
+	OperationalConfigStoreFetchTimeout: {
+		KeyName:      "system.operationalConfigStoreFetchTimeout",
+		Description:  "Per-call timeout for fetching the operational dynamic config snapshot from the primary database",
+		DefaultValue: time.Second * 2,
+	},
+	OperationalConfigStoreUpdateTimeout: {
+		KeyName:      "system.operationalConfigStoreUpdateTimeout",
+		Description:  "Per-call timeout for writing an operational dynamic config snapshot to the primary database",
+		DefaultValue: time.Second * 2,
 	},
 }
 

--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -362,6 +362,7 @@ type ConfigType int
 const (
 	DynamicConfig ConfigType = iota
 	GlobalIsolationGroupConfig
+	OperationalDynamicConfig
 )
 
 type (

--- a/common/resource/params.go
+++ b/common/resource/params.go
@@ -86,6 +86,7 @@ type (
 		AuthorizationConfig        config.Authorization     // NOTE: empty(default) struct will get a authorization.NoopAuthorizer
 		IsolationGroupStore        configstore.Client       // This can be nil, the default config store will be created if so
 		IsolationGroupState        isolationgroup.State     // This can be nil, the default state store will be chosen if so
+		OperationalConfigStore     configstore.Client       // This can be nil, the default operational config store will be created if so
 		PinotConfig                *config.PinotVisibilityConfig
 		KafkaConfig                config.KafkaConfig
 		PinotClient                pinot.GenericClient

--- a/common/resource/resource_impl.go
+++ b/common/resource/resource_impl.go
@@ -144,6 +144,7 @@ type Impl struct {
 
 	isolationGroups           isolationgroup.State
 	isolationGroupConfigStore configstore.Client
+	operationalConfigStore    configstore.Client
 
 	asyncWorkflowQueueProvider queue.Provider
 
@@ -336,6 +337,7 @@ func New(
 	}
 
 	isolationGroupStore := createConfigStoreOrDefault(params, dynamicCollection)
+	operationalConfigStore := createOperationalConfigStoreOrDefault(params, dynamicCollection)
 
 	isolationGroupState, err := ensureIsolationGroupStateHandlerOrDefault(
 		params,
@@ -417,7 +419,8 @@ func New(
 		),
 		rpcFactory:                params.RPCFactory,
 		isolationGroups:           isolationGroupState,
-		isolationGroupConfigStore: isolationGroupStore, // can be nil where persistence is not available
+		isolationGroupConfigStore: isolationGroupStore,    // can be nil where persistence is not available
+		operationalConfigStore:    operationalConfigStore, // can be nil where persistence is not available
 
 		asyncWorkflowQueueProvider: params.AsyncWorkflowQueueProvider,
 
@@ -463,6 +466,9 @@ func (h *Impl) Start() {
 	if h.isolationGroupConfigStore != nil {
 		h.isolationGroupConfigStore.Start()
 	}
+	if h.operationalConfigStore != nil {
+		h.operationalConfigStore.Start()
+	}
 	// The service is now started up
 	h.logger.Info("service started")
 	// seed the random generator once for this service
@@ -492,6 +498,9 @@ func (h *Impl) Stop() {
 	h.persistenceBean.Close()
 	if h.isolationGroupConfigStore != nil {
 		h.isolationGroupConfigStore.Stop()
+	}
+	if h.operationalConfigStore != nil {
+		h.operationalConfigStore.Stop()
 	}
 	h.isolationGroups.Stop()
 }
@@ -724,6 +733,12 @@ func (h *Impl) GetIsolationGroupStore() configstore.Client {
 	return h.isolationGroupConfigStore
 }
 
+// GetOperationalConfigStore returns the operational dynamic config store or nil
+// when the persistence layer does not support a config store.
+func (h *Impl) GetOperationalConfigStore() configstore.Client {
+	return h.operationalConfigStore
+}
+
 // GetAsyncWorkflowQueueProvider returns the async workflow queue provider
 func (h *Impl) GetAsyncWorkflowQueueProvider() queue.Provider {
 	return h.asyncWorkflowQueueProvider
@@ -755,6 +770,33 @@ func createConfigStoreOrDefault(
 	if err != nil {
 		// not possible to create the client under some persistence configurations, so this is expected
 		params.Logger.Warn("not instantiating Isolation group config store, this feature will not be enabled", tag.Error(err))
+		return nil
+	}
+	return cfgStoreClient
+}
+
+// createOperationalConfigStoreOrDefault returns the operational dynamic config store.
+// Like the isolation group config store, it is only available where the persistence
+// layer supports a config store; otherwise nil is returned.
+func createOperationalConfigStoreOrDefault(
+	params *Params,
+	dc *dynamicconfig.Collection,
+) configstore.Client {
+	if params.OperationalConfigStore != nil {
+		return params.OperationalConfigStore
+	}
+	cscConfig := &csc.ClientConfig{
+		PollInterval:        dc.GetDurationProperty(dynamicproperties.OperationalConfigStorePollInterval)(),
+		UpdateRetryAttempts: dc.GetIntProperty(dynamicproperties.OperationalConfigStoreUpdateRetryAttempts)(),
+		FetchTimeout:        dc.GetDurationProperty(dynamicproperties.OperationalConfigStoreFetchTimeout)(),
+		UpdateTimeout:       dc.GetDurationProperty(dynamicproperties.OperationalConfigStoreUpdateTimeout)(),
+	}
+	cfgStoreClient, err := configstore.NewConfigStoreClient(
+		cscConfig, &params.PersistenceConfig, params.Logger, params.MetricsClient,
+		persistence.OperationalDynamicConfig,
+	)
+	if err != nil {
+		params.Logger.Warn("not instantiating operational dynamic config store, this feature will not be enabled", tag.Error(err))
 		return nil
 	}
 	return cfgStoreClient

--- a/common/resource/resource_impl_test.go
+++ b/common/resource/resource_impl_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/dynamicconfig/configstore"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/membership"
@@ -254,5 +255,25 @@ func TestStartStop(t *testing.T) {
 	assert.NotNil(t, i.GetDispatcher())
 	assert.NotNil(t, i.GetIsolationGroupState())
 	assert.Nil(t, i.GetIsolationGroupStore())
+	assert.Nil(t, i.GetOperationalConfigStore())
 	assert.Equal(t, params.AsyncWorkflowQueueProvider, i.GetAsyncWorkflowQueueProvider())
+}
+
+func TestCreateOperationalConfigStoreOrDefault_OverrideIsReturned(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	override := configstore.NewMockClient(ctrl)
+	got := createOperationalConfigStoreOrDefault(&Params{OperationalConfigStore: override}, nil)
+	assert.Same(t, override, got)
+}
+
+func TestCreateOperationalConfigStoreOrDefault_NilWhenPersistenceUnsupported(t *testing.T) {
+	logger := testlogger.New(t)
+	dc := dynamicconfig.NewCollection(dynamicconfig.NewInMemoryClient(), logger)
+	// PersistenceConfig with no DefaultStore configured cannot back a configstore.
+	got := createOperationalConfigStoreOrDefault(&Params{
+		Logger:            logger,
+		MetricsClient:     metrics.NewNoopMetricsClient(),
+		PersistenceConfig: config.Persistence{},
+	}, dc)
+	assert.Nil(t, got)
 }

--- a/common/resource/resource_mock.go
+++ b/common/resource/resource_mock.go
@@ -542,6 +542,20 @@ func (mr *MockResourceMockRecorder) GetMetricsScope() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetricsScope", reflect.TypeOf((*MockResource)(nil).GetMetricsScope))
 }
 
+// GetOperationalConfigStore mocks base method.
+func (m *MockResource) GetOperationalConfigStore() configstore.Client {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOperationalConfigStore")
+	ret0, _ := ret[0].(configstore.Client)
+	return ret0
+}
+
+// GetOperationalConfigStore indicates an expected call of GetOperationalConfigStore.
+func (mr *MockResourceMockRecorder) GetOperationalConfigStore() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperationalConfigStore", reflect.TypeOf((*MockResource)(nil).GetOperationalConfigStore))
+}
+
 // GetPayloadSerializer mocks base method.
 func (m *MockResource) GetPayloadSerializer() persistence.PayloadSerializer {
 	m.ctrl.T.Helper()

--- a/common/resource/resource_test_utils.go
+++ b/common/resource/resource_test_utils.go
@@ -106,11 +106,12 @@ type (
 		ExecutionMgr    *mocks.ExecutionManager
 		PersistenceBean *persistenceClient.MockBean
 
-		IsolationGroups     *isolationgroup.MockState
-		IsolationGroupStore *configstore.MockClient
-		HostName            string
-		Logger              log.Logger
-		taskvalidator       taskvalidator.Checker
+		IsolationGroups        *isolationgroup.MockState
+		IsolationGroupStore    *configstore.MockClient
+		OperationalConfigStore *configstore.MockClient
+		HostName               string
+		Logger                 log.Logger
+		taskvalidator          taskvalidator.Checker
 
 		AsyncWorkflowQueueProvider *queue.MockProvider
 
@@ -476,6 +477,11 @@ func (s *Test) GetIsolationGroupState() isolationgroup.State {
 // isolation-group stores
 func (s *Test) GetIsolationGroupStore() configstore.Client {
 	return s.IsolationGroupStore
+}
+
+// GetOperationalConfigStore returns the operational dynamic config store
+func (s *Test) GetOperationalConfigStore() configstore.Client {
+	return s.OperationalConfigStore
 }
 
 func (s *Test) GetAsyncWorkflowQueueProvider() queue.Provider {

--- a/common/resource/types.go
+++ b/common/resource/types.go
@@ -128,6 +128,7 @@ type Resource interface {
 	// GetIsolationGroupState returns the isolationGroupState
 	GetIsolationGroupState() isolationgroup.State
 	GetIsolationGroupStore() configstore.Client
+	GetOperationalConfigStore() configstore.Client
 
 	GetAsyncWorkflowQueueProvider() queue.Provider
 

--- a/service/history/resource/resource_mock.go
+++ b/service/history/resource/resource_mock.go
@@ -533,6 +533,20 @@ func (mr *MockResourceMockRecorder) GetMetricsScope() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetricsScope", reflect.TypeOf((*MockResource)(nil).GetMetricsScope))
 }
 
+// GetOperationalConfigStore mocks base method.
+func (m *MockResource) GetOperationalConfigStore() configstore.Client {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOperationalConfigStore")
+	ret0, _ := ret[0].(configstore.Client)
+	return ret0
+}
+
+// GetOperationalConfigStore indicates an expected call of GetOperationalConfigStore.
+func (mr *MockResourceMockRecorder) GetOperationalConfigStore() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperationalConfigStore", reflect.TypeOf((*MockResource)(nil).GetOperationalConfigStore))
+}
+
 // GetPayloadSerializer mocks base method.
 func (m *MockResource) GetPayloadSerializer() persistence.PayloadSerializer {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
> **Stacked on top of #8091** — that PR adds the `system.operationalConfigStore*` dynamic config keys this PR consumes. Please review #8091 first; until it merges, the diff here will include those changes too.

**What changed?**

Adds an always-instantiated `configstore.Client` to `Resource` (parallel to the existing optional `isolationGroupConfigStore`), exposed as `GetOperationalConfigStore()`. Distinguished from existing config stores by a new `persistence.OperationalDynamicConfig` `ConfigType` (append-only enum addition; existing values keep their iota positions). Polling cadence and timeouts are driven by the `system.operationalConfigStore*` keys defined in #8091. Same nil-fallback semantics as `isolationGroupConfigStore` — logs a warning if the persistence layer doesn't support a config store.

Nothing reads from this store yet; a follow-up PR will inject it into services and add `UpdateOperationalDynamicConfig` admin endpoint + CLI.

**Why?**

To enable sub-2s regional convergence for safety-critical operational config (e.g. sharding-related rollout flags) where stale per-host values can produce a split-brain in shard ownership. Backing such config with the primary database — via the already-existing configstore client, but as a separate, always-on instance — gives a reliable source of truth regardless of which dynamic config client the operator has configured as their primary.

**How did you test it?**

- `go test -count=1 ./common/resource/... ./common/persistence/ ./common/dynamicconfig/configstore/... ./service/history/resource/... ./service/history/handler/...` — all pass.
- New coverage on changed lines: `GetOperationalConfigStore` 100%, `createOperationalConfigStoreOrDefault` 87.5%.
- `make build` and `make lint` clean.
- Existing `TestStartStop` extended to assert the getter returns nil under the test's stub persistence; two focused new tests for `createOperationalConfigStoreOrDefault` (override path + nil-when-persistence-unsupported).

**Potential risks**

- New polling client per host — at the 2s default poll interval, ~0.5 RPS per host against the configstore partition.

**Release notes**

N/A

**Documentation Changes**

N/A.