### PR TITLE
refactor(active-active): Remove `ActiveClusterSelectionStrategy` and associated deprecated fields

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -307,14 +307,6 @@ func WorkflowResetNextEventID(resetNextEventID int64) Tag {
 	return newInt64("wf-reset-next-event-id", resetNextEventID)
 }
 
-func WorkflowExternalEntityType(externalEntityType string) Tag {
-	return newStringTag("wf-external-entity-type", externalEntityType)
-}
-
-func WorkflowExternalEntityKey(externalEntityKey string) Tag {
-	return newStringTag("wf-external-entity-key", externalEntityKey)
-}
-
 // history tree
 
 // WorkflowTreeID returns tag for WorkflowTreeID

--- a/common/types/mapper/proto/api_test.go
+++ b/common/types/mapper/proto/api_test.go
@@ -1671,20 +1671,6 @@ func CompletedTypeFuzzer(e *types.QueryTaskCompletedType, c fuzz.Continue) {
 	*e = types.QueryTaskCompletedType(c.Intn(2)) // 0-1: Completed, Failed
 }
 
-func ActiveClusterSelectionPolicyFuzzerClearAttribute(p *types.ActiveClusterSelectionPolicy, c fuzz.Continue) {
-	// Mapper round-trips only ClusterAttribute; clearing it gives a degenerate
-	// nil-equivalent policy that round-trips losslessly.
-	p.ClusterAttribute = nil
-}
-
-func ActiveClusterSelectionPolicyFuzzerWithAttribute(p *types.ActiveClusterSelectionPolicy, c fuzz.Continue) {
-	c.Fuzz(&p.ClusterAttribute)
-}
-
-func ActiveClusterSelectionPolicyFuzzerNoCustom(p *types.ActiveClusterSelectionPolicy, c fuzz.Continue) {
-	c.FuzzNoCustom(p)
-}
-
 func TestDataBlobArrayFuzz(t *testing.T) {
 	testutils.RunMapperFuzzTest(t, FromDataBlobArray, ToDataBlobArray,
 		testutils.WithCustomFuncs(testutils.EncodingTypeFuzzer),
@@ -1784,12 +1770,10 @@ func TestDescribeTaskListResponseFuzz(t *testing.T) {
 }
 
 func TestStartWorkflowExecutionAsyncRequestFuzz(t *testing.T) {
-	// ActiveClusterSelectionPolicy: string fields must match strategy
 	testutils.RunMapperFuzzTest(t, FromStartWorkflowExecutionAsyncRequest, ToStartWorkflowExecutionAsyncRequest,
 		testutils.WithCustomFuncs(
 			WorkflowIDReusePolicyFuzzer,
 			CronOverlapPolicyFuzzer,
-			ActiveClusterSelectionPolicyFuzzerClearAttribute,
 		),
 	)
 }
@@ -1943,7 +1927,6 @@ func TestStartChildWorkflowExecutionInitiatedEventAttributesFuzz(t *testing.T) {
 		testutils.WithCustomFuncs(
 			WorkflowIDReusePolicyFuzzer,
 			CronOverlapPolicyFuzzer,
-			ActiveClusterSelectionPolicyFuzzerWithAttribute,
 		),
 	)
 }
@@ -2014,7 +1997,6 @@ func TestHistoryEventFuzz(t *testing.T) {
 			ContinueAsNewInitiatorFuzzer,
 			WorkflowIDReusePolicyFuzzer,
 			CronOverlapPolicyFuzzer,
-			ActiveClusterSelectionPolicyFuzzerWithAttribute,
 			func(h *types.HistoryEvent, c fuzz.Continue) {
 				// Fuzz all fields first
 				c.Fuzz(h)
@@ -2082,7 +2064,6 @@ func TestDecisionFuzz(t *testing.T) {
 			DecisionTypeFuzzer,
 			WorkflowIDReusePolicyFuzzer,
 			CronOverlapPolicyFuzzer,
-			ActiveClusterSelectionPolicyFuzzerWithAttribute,
 		),
 	)
 }
@@ -2134,7 +2115,6 @@ func TestPollForDecisionTaskResponseFuzz(t *testing.T) {
 			ContinueAsNewInitiatorFuzzer,
 			WorkflowIDReusePolicyFuzzer,
 			CronOverlapPolicyFuzzer,
-			ActiveClusterSelectionPolicyFuzzerClearAttribute,
 			SignalExternalWorkflowExecutionFailedCauseFuzzer,
 			CancelExternalWorkflowExecutionFailedCauseFuzzer,
 			ChildWorkflowExecutionFailedCauseFuzzer,
@@ -2159,7 +2139,6 @@ func TestDecisionArrayFuzz(t *testing.T) {
 			DecisionTypeFuzzer,
 			WorkflowIDReusePolicyFuzzer,
 			CronOverlapPolicyFuzzer,
-			ActiveClusterSelectionPolicyFuzzerWithAttribute,
 		),
 	)
 }
@@ -2312,7 +2291,6 @@ func TestSignalWithStartWorkflowExecutionRequestFuzz(t *testing.T) {
 		testutils.WithCustomFuncs(
 			WorkflowIDReusePolicyFuzzer,
 			CronOverlapPolicyFuzzer,
-			ActiveClusterSelectionPolicyFuzzerWithAttribute,
 		),
 	)
 }
@@ -2519,10 +2497,8 @@ func TestActivityLocalDispatchInfoFuzz(t *testing.T) {
 }
 
 func TestStartWorkflowExecutionRequestFuzz(t *testing.T) {
-	// ActiveClusterSelectionPolicy has mutually exclusive fields
 	testutils.RunMapperFuzzTest(t, FromStartWorkflowExecutionRequest, ToStartWorkflowExecutionRequest,
 		testutils.WithCustomFuncs(
-			ActiveClusterSelectionPolicyFuzzerNoCustom,
 			WorkflowIDReusePolicyFuzzer,
 		),
 	)
@@ -2606,12 +2582,7 @@ func TestActiveClusterInfoFuzz(t *testing.T) {
 }
 
 func TestActiveClusterSelectionPolicyFuzz(t *testing.T) {
-	// ActiveClusterSelectionPolicy has mutually exclusive fields based on Strategy
-	testutils.RunMapperFuzzTest(t, FromActiveClusterSelectionPolicy, ToActiveClusterSelectionPolicy,
-		testutils.WithCustomFuncs(
-			ActiveClusterSelectionPolicyFuzzerNoCustom,
-		),
-	)
+	testutils.RunMapperFuzzTest(t, FromActiveClusterSelectionPolicy, ToActiveClusterSelectionPolicy)
 }
 
 func TestRespondActivityTaskCanceledRequestFuzz(t *testing.T) {
@@ -2667,9 +2638,6 @@ func TestWorkflowExecutionInfoFuzz(t *testing.T) {
 	// [Intended] ParentInitiatedID: converted to 0 instead of nil when ParentExecutionInfo exists but field is 0
 	// [BUG] CronSchedule is not round trip safe with an empty string
 	testutils.RunMapperFuzzTest(t, FromWorkflowExecutionInfo, ToWorkflowExecutionInfo,
-		testutils.WithCustomFuncs(
-			ActiveClusterSelectionPolicyFuzzerNoCustom, // ActiveClusterSelectionPolicy has mutually exclusive fields based on Strategy
-		),
 		testutils.WithExcludedFields("UpdateTime", "ParentDomainID", "ParentDomain", "ParentInitiatedID", "CronSchedule"),
 	)
 }
@@ -2683,10 +2651,8 @@ func TestSignalExternalWorkflowExecutionDecisionAttributesFuzz(t *testing.T) {
 }
 
 func TestSignalWithStartWorkflowExecutionAsyncRequestFuzz(t *testing.T) {
-	// ActiveClusterSelectionPolicy has mutually exclusive fields, WorkflowIDReusePolicy enum
 	testutils.RunMapperFuzzTest(t, FromSignalWithStartWorkflowExecutionAsyncRequest, ToSignalWithStartWorkflowExecutionAsyncRequest,
 		testutils.WithCustomFuncs(
-			ActiveClusterSelectionPolicyFuzzerNoCustom,
 			WorkflowIDReusePolicyFuzzer,
 		),
 	)
@@ -2732,7 +2698,6 @@ func TestSignalWithStartWorkflowExecutionAsyncResponseFuzz(t *testing.T) {
 func TestDescribeDomainResponseFuzz(t *testing.T) {
 	testutils.RunMapperFuzzTest(t, FromDescribeDomainResponse, ToDescribeDomainResponse,
 		testutils.WithCustomFuncs(
-			ActiveClusterSelectionPolicyFuzzerNoCustom,
 			testutils.DomainStatusFuzzer,
 			ArchivalStatusFuzzer,
 			func(r *types.DescribeDomainResponse, c fuzz.Continue) {
@@ -2788,12 +2753,10 @@ func TestStartTimeFilterFuzz(t *testing.T) {
 }
 
 func TestWorkflowExecutionContinuedAsNewEventAttributesFuzz(t *testing.T) {
-	// ActiveClusterSelectionPolicy has mutually exclusive fields
 	// JitterStartSeconds don't roundtrip correctly
 	// [BUG] FailureDetails requires FailureReason to be set
 	testutils.RunMapperFuzzTest(t, FromWorkflowExecutionContinuedAsNewEventAttributes, ToWorkflowExecutionContinuedAsNewEventAttributes,
 		testutils.WithCustomFuncs(
-			ActiveClusterSelectionPolicyFuzzerNoCustom,
 			ContinueAsNewInitiatorFuzzer,
 		),
 		testutils.WithExcludedFields("JitterStartSeconds", "FailureDetails"),
@@ -2853,12 +2816,10 @@ func TestDiagnoseWorkflowExecutionRequestFuzz(t *testing.T) {
 
 func TestWorkflowExecutionStartedEventAttributesFuzz(t *testing.T) {
 	// [BUG] FromFailure only creates a Failure object if reason is non-nil, so details without reason are dropped
-	// ActiveClusterSelectionPolicy has mutually exclusive fields
 	// JitterStartSeconds don't roundtrip
 	// Empty string fields become nil
 	testutils.RunMapperFuzzTest(t, FromWorkflowExecutionStartedEventAttributes, ToWorkflowExecutionStartedEventAttributes,
 		testutils.WithCustomFuncs(
-			ActiveClusterSelectionPolicyFuzzerNoCustom,
 			func(e *types.WorkflowExecutionStartedEventAttributes, c fuzz.Continue) {
 				c.Fuzz(e)
 				// Empty strings become nil after proto roundtrip
@@ -2892,12 +2853,10 @@ func TestClusterFailoverFuzz(t *testing.T) {
 }
 
 func TestDescribeDomainResponseDomainFuzz(t *testing.T) {
-	// ActiveClusterSelectionPolicy has mutually exclusive fields based on Strategy
 	// WorkflowExecutionRetentionPeriodInDays: nil→0 conversion
 	// [BUG] DomainInfo, Configuration, ReplicationConfiguration must be non-nil
 	testutils.RunMapperFuzzTest(t, FromDescribeDomainResponseDomain, ToDescribeDomainResponseDomain,
 		testutils.WithCustomFuncs(
-			ActiveClusterSelectionPolicyFuzzerNoCustom,
 			testutils.DomainStatusFuzzer,
 			ArchivalStatusFuzzer,
 			func(r *types.DescribeDomainResponse, c fuzz.Continue) {
@@ -2965,12 +2924,10 @@ func TestWorkflowExecutionCancelRequestedEventAttributesFuzz(t *testing.T) {
 }
 
 func TestUpdateDomainResponseFuzz(t *testing.T) {
-	// ActiveClusterSelectionPolicy has mutually exclusive fields based on Strategy
 	// WorkflowExecutionRetentionPeriodInDays: nil→0 conversion
 	// DomainInfo, Configuration, ReplicationConfiguration must be non-nil
 	testutils.RunMapperFuzzTest(t, FromUpdateDomainResponse, ToUpdateDomainResponse,
 		testutils.WithCustomFuncs(
-			ActiveClusterSelectionPolicyFuzzerNoCustom,
 			testutils.DomainStatusFuzzer,
 			ArchivalStatusFuzzer,
 			func(r *types.UpdateDomainResponse, c fuzz.Continue) {
@@ -3016,10 +2973,8 @@ func TestSignalWithStartWorkflowExecutionResponseFuzz(t *testing.T) {
 }
 
 func TestStartChildWorkflowExecutionDecisionAttributesFuzz(t *testing.T) {
-	// ActiveClusterSelectionPolicy has mutually exclusive fields, WorkflowIDReusePolicy enum
 	testutils.RunMapperFuzzTest(t, FromStartChildWorkflowExecutionDecisionAttributes, ToStartChildWorkflowExecutionDecisionAttributes,
 		testutils.WithCustomFuncs(
-			ActiveClusterSelectionPolicyFuzzerNoCustom,
 			WorkflowIDReusePolicyFuzzer,
 		),
 	)
@@ -3054,11 +3009,9 @@ func TestFailoverEventFuzz(t *testing.T) {
 
 func TestContinueAsNewWorkflowExecutionDecisionAttributesFuzz(t *testing.T) {
 	// [BUG] FromFailure only creates a Failure object if reason is non-nil, so details without reason are dropped
-	// ActiveClusterSelectionPolicy has mutually exclusive fields
 	// JitterStartSeconds doesn't roundtrip correctly
 	testutils.RunMapperFuzzTest(t, FromContinueAsNewWorkflowExecutionDecisionAttributes, ToContinueAsNewWorkflowExecutionDecisionAttributes,
 		testutils.WithCustomFuncs(
-			ActiveClusterSelectionPolicyFuzzerNoCustom,
 			ContinueAsNewInitiatorFuzzer,
 		),
 		testutils.WithExcludedFields("JitterStartSeconds", "FailureDetails"),

--- a/common/types/mapper/proto/history_test.go
+++ b/common/types/mapper/proto/history_test.go
@@ -781,8 +781,7 @@ func TestHistoryRefreshWorkflowTasksRequestFuzz(t *testing.T) {
 }
 
 func TestHistoryStartWorkflowExecutionRequestFuzz(t *testing.T) {
-	// [BUG] StartRequest contains WorkflowIDReusePolicy (out-of-range → nil) and
-	// ExternalEntityType/ExternalEntityKey fields not mapped through proto (silently dropped).
+	// [BUG] StartRequest contains WorkflowIDReusePolicy (out-of-range → nil).
 	// Exclude StartRequest; it is tested via api_test.go.
 	// ContinueAsNewInitiator is an enum (0-2); HistoryContinueAsNewInitiatorFuzzer constrains it.
 	// [BUG] ContinuedFailureDetails dropped when ContinuedFailureReason is nil (FromFailure);

--- a/service/frontend/api/handler_test.go
+++ b/service/frontend/api/handler_test.go
@@ -4943,21 +4943,6 @@ func TestConstructRestartWorkflowRequest(t *testing.T) {
 			description: "complete field validation ensures all fields are properly set",
 		},
 		{
-			name: "ActiveClusterSelectionPolicy with ExternalEntity strategy",
-			originalAttributes: &types.WorkflowExecutionStartedEventAttributes{
-				WorkflowType: &types.WorkflowType{Name: "testWorkflow"},
-				TaskList:     &types.TaskList{Name: "testTaskList"},
-				ActiveClusterSelectionPolicy: &types.ActiveClusterSelectionPolicy{
-					ClusterAttribute: &types.ClusterAttribute{Scope: "external", Name: "order-789"},
-				},
-			},
-			domain:      "test-domain",
-			identity:    "test-identity",
-			workflowID:  "test-workflow-id",
-			expectPanic: false,
-			description: "ExternalEntity policy should be completely preserved",
-		},
-		{
 			name: "nil ActiveClusterSelectionPolicy should remain nil",
 			originalAttributes: &types.WorkflowExecutionStartedEventAttributes{
 				WorkflowType:                 &types.WorkflowType{Name: "testWorkflow"},


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- IDL submodule bump to sync removal of `ActiveClusterSelectionStrategy` in IDL
- Remove usage of `ActiveClusterSelectionStrategy `and associated deprecated fields

Fixes: #8025 

**Why?**
`ActiveClusterSelectionStrategy` and associated deprecated fields are deprecated from original implementation of active-active

**How did you test it?**
Integration tests: `make test_e2e`

**Potential risks**
Removed fields were no longer used in the codebase, so the risk is minimal

**Release notes**
Removed `ActiveClusterSelectionStrategy` and associated deprecated fields

**Documentation Changes**

