### PR TITLE
chore: replace x/exp/maps with maps

### DIFF
--- a/client/history/peer_resolver_test.go
+++ b/client/history/peer_resolver_test.go
@@ -22,6 +22,7 @@ package history
 
 import (
 	"errors"
+	"maps"
 	"slices"
 	"testing"
 
@@ -30,7 +31,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uber/ringpop-go/hashring"
 	gomock "go.uber.org/mock/gomock"
-	"golang.org/x/exp/maps"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/membership"
@@ -295,7 +295,7 @@ func TestPeerResolver(t *testing.T) {
 
 			// small sanity check: sharded response should return all inputs
 			assertAllKeysPresent := func(t *testing.T, sharded map[Peer][]string, limits []string) {
-				responded := maps.Values(sharded)
+				responded := slices.Collect(maps.Values(sharded))
 				assert.ElementsMatchf(t,
 					limits,
 					slices.Concat(responded...), // flatten the [][]string

--- a/common/archiver/gcloud/go.sum
+++ b/common/archiver/gcloud/go.sum
@@ -433,8 +433,6 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20231226003508-02704c960a9b h1:kLiC65FbiHWFAOu+lxwNPujcsl8VYyTYYEZnsOO1WK4=
-golang.org/x/exp v0.0.0-20231226003508-02704c960a9b/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 h1:1P7xPZEwZMoBoz0Yze5Nx2/4pxj6nw9ZqHWXqP0iRgQ=
 golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=

--- a/common/metrics/config_test.go
+++ b/common/metrics/config_test.go
@@ -1,11 +1,11 @@
 package metrics
 
 import (
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 )
 
 func TestHistogramMigrationMetricsExist(t *testing.T) {

--- a/common/quotas/global/algorithm/requestweighted_fuzz_test.go
+++ b/common/quotas/global/algorithm/requestweighted_fuzz_test.go
@@ -24,12 +24,11 @@ package algorithm
 
 import (
 	"encoding/binary"
+	"maps"
 	"math"
+	"slices"
 	"testing"
 	"time"
-
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log/testlogger"
@@ -114,8 +113,8 @@ func FuzzMultiUpdate(f *testing.F) {
 				t.Error("no keys")
 			}
 
-			keys := maps.Keys(keySet)
-			idents := maps.Keys(identSet)
+			keys := slices.Collect(maps.Keys(keySet))
+			idents := slices.Collect(maps.Keys(identSet))
 			slices.Sort(keys)
 			slices.Sort(idents)
 

--- a/common/quotas/global/algorithm/requestweighted_test.go
+++ b/common/quotas/global/algorithm/requestweighted_test.go
@@ -24,8 +24,10 @@ package algorithm
 
 import (
 	"fmt"
+	"maps"
 	"math"
 	"math/rand"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -35,7 +37,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
 	"go.uber.org/multierr"
-	"golang.org/x/exp/maps"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/clock"
@@ -614,7 +615,7 @@ func TestConcurrent(t *testing.T) {
 					err := agg.Update(UpdateParams{ID: host, Load: updates, Elapsed: updateRate})
 					require.NoError(t, err)
 				} else {
-					_, err := agg.HostUsage(host, maps.Keys(updates))
+					_, err := agg.HostUsage(host, slices.Collect(maps.Keys(updates)))
 					require.NoError(t, err)
 				}
 			}
@@ -1045,7 +1046,7 @@ func BenchmarkNormalUse(b *testing.B) {
 		rounds = append(rounds, round{
 			host:    Identity(fmt.Sprintf("host %d", rand.Intn(hosts))),
 			load:    reqs,
-			keys:    maps.Keys(reqs),
+			keys:    slices.Collect(maps.Keys(reqs)),
 			elapsed: time.Duration(rand.Int63n(updateRate.Nanoseconds())),
 		})
 	}

--- a/common/quotas/global/rpc/client_test.go
+++ b/common/quotas/global/rpc/client_test.go
@@ -26,15 +26,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"reflect"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/yarpc"
-	"golang.org/x/exp/maps"
 
 	"github.com/uber/cadence/client/history"
 	"github.com/uber/cadence/common/log/testlogger"
@@ -179,7 +180,7 @@ func (a matchrequest) Matches(x interface{}) bool {
 		keys[k] = struct{}{}
 	}
 	gotKeys := map[string]struct{}{}
-	for _, k := range stringy(maps.Keys(up.Load)) {
+	for _, k := range stringy(slices.Collect(maps.Keys(up.Load))) {
 		gotKeys[k] = struct{}{}
 	}
 	a.t.Logf("want keys: %v, got keys: %v", maps.Keys(keys), maps.Keys(gotKeys))

--- a/common/quotas/global/rpc/client_test.go
+++ b/common/quotas/global/rpc/client_test.go
@@ -183,7 +183,7 @@ func (a matchrequest) Matches(x interface{}) bool {
 	for _, k := range stringy(slices.Collect(maps.Keys(up.Load))) {
 		gotKeys[k] = struct{}{}
 	}
-	a.t.Logf("want keys: %v, got keys: %v", maps.Keys(keys), maps.Keys(gotKeys))
+	a.t.Logf("want keys: %v, got keys: %v", slices.Collect(maps.Keys(keys)), slices.Collect(maps.Keys(gotKeys)))
 	return reflect.DeepEqual(keys, gotKeys)
 }
 

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -26,9 +26,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math/rand"
 	"reflect"
 	"runtime"
+	"slices"
 	"strconv"
 	"sync"
 	"testing"
@@ -40,7 +42,6 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/yarpc/yarpcerrors"
-	"golang.org/x/exp/maps"
 
 	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/constants"
@@ -1657,7 +1658,7 @@ func TestCheckEventBlobSizeLimit(t *testing.T) {
 			assertMetrics: func(snapshot tally.Snapshot) {
 				counters := snapshot.Counters()
 				assert.Len(t, counters, 1)
-				values := maps.Values(counters)
+				values := slices.Collect(maps.Values(counters))
 				assert.Equal(t, "test.blob_size_exceed_limit", values[0].Name())
 				assert.Equal(t, int64(1), values[0].Value())
 			},

--- a/service/history/decision/checker_test.go
+++ b/service/history/decision/checker_test.go
@@ -23,7 +23,8 @@
 package decision
 
 import (
-	"sort"
+	"maps"
+	"slices"
 	"testing"
 	"time"
 
@@ -33,7 +34,6 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap/zaptest/observer"
-	"golang.org/x/exp/maps"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
@@ -812,7 +812,7 @@ func TestWorkflowSizeChecker_failWorkflowIfBlobSizeExceedsLimit(t *testing.T) {
 			assertLogsAndMetrics: func(t *testing.T, logs *observer.ObservedLogs, scope tally.TestScope) {
 				assert.Empty(t, logs.All())
 				// ensure metrics with the size is emitted.
-				timerData := maps.Values(scope.Snapshot().Timers())
+				timerData := slices.Collect(maps.Values(scope.Snapshot().Timers()))
 				assert.Len(t, timerData, 2)
 				assert.Equal(t, "test.event_blob_size", timerData[0].Name())
 			},
@@ -904,13 +904,13 @@ func TestWorkflowSizeChecker_failWorkflowSizeExceedsLimit(t *testing.T) {
 			assertLogsAndMetrics: func(t *testing.T, logs *observer.ObservedLogs, scope tally.TestScope) {
 				assert.Empty(t, logs.All())
 				// ensure metrics with the size is emitted.
-				timerData := maps.Values(scope.Snapshot().Timers())
+				timerData := slices.Collect(maps.Values(scope.Snapshot().Timers()))
 				assert.Len(t, timerData, 4)
 				timerNames := make([]string, 0, 4)
 				for _, timer := range timerData {
 					timerNames = append(timerNames, timer.Name())
 				}
-				sort.Strings(timerNames)
+				slices.Sort(timerNames)
 
 				// timers are duplicated for specific domain and domain: all
 				assert.Equal(t, []string{"test.history_count", "test.history_count", "test.history_size", "test.history_size"}, timerNames)

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -24,12 +24,13 @@ package execution
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math/rand"
 	"runtime/debug"
+	"slices"
 	"time"
 
 	"github.com/pborman/uuid"
-	"golang.org/x/exp/maps"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
@@ -1453,18 +1454,18 @@ func (e *mutableStateBuilder) CloseTransactionAsMutation(
 		ExecutionInfo:    e.executionInfo,
 		VersionHistories: e.versionHistories,
 
-		UpsertActivityInfos:       maps.Values(e.updateActivityInfos),
-		DeleteActivityInfos:       maps.Keys(e.deleteActivityInfos),
-		UpsertTimerInfos:          maps.Values(e.updateTimerInfos),
-		DeleteTimerInfos:          maps.Keys(e.deleteTimerInfos),
-		UpsertChildExecutionInfos: maps.Values(e.updateChildExecutionInfos),
-		DeleteChildExecutionInfos: maps.Keys(e.deleteChildExecutionInfos),
-		UpsertRequestCancelInfos:  maps.Values(e.updateRequestCancelInfos),
-		DeleteRequestCancelInfos:  maps.Keys(e.deleteRequestCancelInfos),
-		UpsertSignalInfos:         maps.Values(e.updateSignalInfos),
-		DeleteSignalInfos:         maps.Keys(e.deleteSignalInfos),
-		UpsertSignalRequestedIDs:  maps.Keys(e.updateSignalRequestedIDs),
-		DeleteSignalRequestedIDs:  maps.Keys(e.deleteSignalRequestedIDs),
+		UpsertActivityInfos:       slices.Collect(maps.Values(e.updateActivityInfos)),
+		DeleteActivityInfos:       slices.Collect(maps.Keys(e.deleteActivityInfos)),
+		UpsertTimerInfos:          slices.Collect(maps.Values(e.updateTimerInfos)),
+		DeleteTimerInfos:          slices.Collect(maps.Keys(e.deleteTimerInfos)),
+		UpsertChildExecutionInfos: slices.Collect(maps.Values(e.updateChildExecutionInfos)),
+		DeleteChildExecutionInfos: slices.Collect(maps.Keys(e.deleteChildExecutionInfos)),
+		UpsertRequestCancelInfos:  slices.Collect(maps.Values(e.updateRequestCancelInfos)),
+		DeleteRequestCancelInfos:  slices.Collect(maps.Keys(e.deleteRequestCancelInfos)),
+		UpsertSignalInfos:         slices.Collect(maps.Values(e.updateSignalInfos)),
+		DeleteSignalInfos:         slices.Collect(maps.Keys(e.deleteSignalInfos)),
+		UpsertSignalRequestedIDs:  slices.Collect(maps.Keys(e.updateSignalRequestedIDs)),
+		DeleteSignalRequestedIDs:  slices.Collect(maps.Keys(e.deleteSignalRequestedIDs)),
 		NewBufferedEvents:         e.updateBufferedEvents,
 		ClearBufferedEvents:       e.clearBufferedEvents,
 
@@ -1542,12 +1543,12 @@ func (e *mutableStateBuilder) CloseTransactionAsSnapshot(
 		ExecutionInfo:    e.executionInfo,
 		VersionHistories: e.versionHistories,
 
-		ActivityInfos:       maps.Values(e.pendingActivityInfoIDs),
-		TimerInfos:          maps.Values(e.pendingTimerInfoIDs),
-		ChildExecutionInfos: maps.Values(e.pendingChildExecutionInfoIDs),
-		RequestCancelInfos:  maps.Values(e.pendingRequestCancelInfoIDs),
-		SignalInfos:         maps.Values(e.pendingSignalInfoIDs),
-		SignalRequestedIDs:  maps.Keys(e.pendingSignalRequestedIDs),
+		ActivityInfos:       slices.Collect(maps.Values(e.pendingActivityInfoIDs)),
+		TimerInfos:          slices.Collect(maps.Values(e.pendingTimerInfoIDs)),
+		ChildExecutionInfos: slices.Collect(maps.Values(e.pendingChildExecutionInfoIDs)),
+		RequestCancelInfos:  slices.Collect(maps.Values(e.pendingRequestCancelInfoIDs)),
+		SignalInfos:         slices.Collect(maps.Values(e.pendingSignalInfoIDs)),
+		SignalRequestedIDs:  slices.Collect(maps.Keys(e.pendingSignalRequestedIDs)),
 
 		TasksByCategory: map[persistence.HistoryTaskCategory][]persistence.Task{
 			persistence.HistoryTaskCategoryTransfer:    e.insertTransferTasks,

--- a/service/history/execution/mutable_state_builder_test.go
+++ b/service/history/execution/mutable_state_builder_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -3619,7 +3621,9 @@ func TestCloseTransactionAsMutation(t *testing.T) {
 			td.shardContextExpectations(mockCache, shardContext, mockDomainCache)
 
 			mutation, workflowEvents, err := ms.CloseTransactionAsMutation(now, td.transactionPolicy)
-			assert.Equal(t, td.expectedMutation, mutation)
+			if diff := cmp.Diff(td.expectedMutation, mutation, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("mutation mismatch (-want +got):\n%s", diff)
+			}
 			assert.Equal(t, td.expectedEvent, workflowEvents)
 			assert.Equal(t, td.expectedErr, err)
 		})

--- a/service/history/execution/mutable_state_util_test_helpers.go
+++ b/service/history/execution/mutable_state_util_test_helpers.go
@@ -24,9 +24,8 @@ package execution
 
 import (
 	"encoding/json"
+	"slices"
 	"testing"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/persistence"

--- a/service/history/execution/workflow_repairer.go
+++ b/service/history/execution/workflow_repairer.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"maps"
 	"math/rand"
+	"slices"
 	"sync"
 	"time"
 
@@ -432,11 +433,11 @@ func (r *workflowRepairerImpl) logChecksumMismatchDetected(
 
 	// Add pending item counts for additional diagnostics
 	logTags = append(logTags,
-		tag.Dynamic("timerIDs", maps.Keys(mutableState.GetPendingTimerInfos())),
-		tag.Dynamic("activityIDs", maps.Keys(mutableState.GetPendingActivityInfos())),
-		tag.Dynamic("childIDs", maps.Keys(mutableState.GetPendingChildExecutionInfos())),
-		tag.Dynamic("signalIDs", maps.Keys(mutableState.GetPendingSignalExternalInfos())),
-		tag.Dynamic("cancelIDs", maps.Keys(mutableState.GetPendingRequestCancelExternalInfos())),
+		tag.Dynamic("timerIDs", slices.Collect(maps.Keys(mutableState.GetPendingTimerInfos()))),
+		tag.Dynamic("activityIDs", slices.Collect(maps.Keys(mutableState.GetPendingActivityInfos()))),
+		tag.Dynamic("childIDs", slices.Collect(maps.Keys(mutableState.GetPendingChildExecutionInfos()))),
+		tag.Dynamic("signalIDs", slices.Collect(maps.Keys(mutableState.GetPendingSignalExternalInfos()))),
+		tag.Dynamic("cancelIDs", slices.Collect(maps.Keys(mutableState.GetPendingRequestCancelExternalInfos()))),
 	)
 
 	r.logger.Warn("Mutable state corruption detected: checksum mismatch", logTags...)

--- a/service/history/handler/handler.go
+++ b/service/history/handler/handler.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -31,7 +32,6 @@ import (
 
 	"github.com/pborman/uuid"
 	"go.uber.org/yarpc/yarpcerrors"
-	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/uber/cadence/common"
@@ -2115,7 +2115,7 @@ func (h *handlerImpl) RatelimitUpdate(
 	//
 	// "_" is ignoring "used RPS" data here.  it is likely useful for being friendlier
 	// to brief, bursty-but-within-limits load, but that has not yet been built.
-	weights, err := h.ratelimitAggregator.HostUsage(arg.ID, maps.Keys(arg.Load))
+	weights, err := h.ratelimitAggregator.HostUsage(arg.ID, slices.Collect(maps.Keys(arg.Load)))
 	if err != nil {
 		return nil, h.error(fmt.Errorf("failed to retrieve updated weights: %w", err), scope, "", "", "")
 	}

--- a/service/history/queuev2/convert.go
+++ b/service/history/queuev2/convert.go
@@ -2,10 +2,9 @@ package queuev2
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"time"
-
-	"golang.org/x/exp/maps"
 
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
@@ -113,7 +112,7 @@ func ToPersistencePredicate(predicate Predicate) *types.Predicate {
 	case *emptyPredicate:
 		return &types.Predicate{PredicateType: types.PredicateTypeEmpty, EmptyPredicateAttributes: &types.EmptyPredicateAttributes{}}
 	case *domainIDPredicate:
-		domainIDs := maps.Keys(p.domainIDs)
+		domainIDs := slices.Collect(maps.Keys(p.domainIDs))
 		slices.Sort(domainIDs)
 		return &types.Predicate{PredicateType: types.PredicateTypeDomainID, DomainIDPredicateAttributes: &types.DomainIDPredicateAttributes{DomainIDs: domainIDs, IsExclusive: &p.isExclusive}}
 	default:

--- a/service/history/task/timer_standby_task_executor_test.go
+++ b/service/history/task/timer_standby_task_executor_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -593,7 +595,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessActivityTimeout_Multiple_CanU
 		input.UpdateWorkflowMutation.ExecutionInfo.LastEventTaskID = 0
 		mutableState.GetExecutionInfo().LastEventTaskID = 0
 		mutableState.GetExecutionInfo().DecisionOriginalScheduledTimestamp = input.UpdateWorkflowMutation.ExecutionInfo.DecisionOriginalScheduledTimestamp
-		s.Equal(&persistence.UpdateWorkflowExecutionRequest{
+		expected := &persistence.UpdateWorkflowExecutionRequest{
 			ShardID: common.Ptr(0),
 			UpdateWorkflowMutation: persistence.WorkflowMutation{
 				ExecutionInfo:             mutableState.GetExecutionInfo(),
@@ -621,7 +623,10 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessActivityTimeout_Multiple_CanU
 			WorkflowRequestMode: persistence.CreateWorkflowRequestModeReplicated,
 			Encoding:            commonconstants.EncodingType(s.mockShard.GetConfig().EventEncodingType(s.domainID)),
 			DomainName:          constants.TestDomainName,
-		}, input)
+		}
+		if diff := cmp.Diff(expected, input, cmpopts.EquateEmpty()); diff != "" {
+			s.Failf("UpdateWorkflowExecution input mismatch", "(-want +got):\n%s", diff)
+		}
 		return true
 	})).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 

--- a/service/matching/tasklist/isolation_balancer.go
+++ b/service/matching/tasklist/isolation_balancer.go
@@ -23,10 +23,9 @@
 package tasklist
 
 import (
+	"maps"
 	"math"
 	"slices"
-
-	"golang.org/x/exp/maps"
 
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/metrics"
@@ -84,7 +83,7 @@ func (i *isolationBalancer) adjustWritePartitions(metrics *aggregatePartitionMet
 }
 
 func (i *isolationBalancer) reset() {
-	maps.Clear(i.groupState)
+	clear(i.groupState)
 }
 
 func (i *isolationBalancer) refreshGroups(metrics *aggregatePartitionMetrics, writePartitions map[int]*types.TaskListPartition) {
@@ -243,7 +242,7 @@ func (i *isolationBalancer) applyGroupChanges(m *aggregatePartitionMetrics, part
 		if len(groups) == 0 {
 			result[id] = &types.TaskListPartition{}
 		} else {
-			asSlice := maps.Keys(groups)
+			asSlice := slices.Collect(maps.Keys(groups))
 			// Sort for the sake of stability
 			slices.Sort(asSlice)
 			result[id] = &types.TaskListPartition{IsolationGroups: asSlice}
@@ -303,7 +302,7 @@ func ensureMinimumGroupsPerPartition(minGroups int, groupSizePerPartition map[st
 	// in size, so we use a simple heuristic of minimizing the difference in total size between the two partitions that
 	// we're considering.
 	changed := false
-	partitionIDsByGroupCount := maps.Keys(groupsByPartitionID)
+	partitionIDsByGroupCount := slices.Collect(maps.Keys(groupsByPartitionID))
 	slices.SortFunc(partitionIDsByGroupCount, func(a, b int) int {
 		aLen := len(groupsByPartitionID[a])
 		bLen := len(groupsByPartitionID[b])

--- a/simulation/matching/matching_simulation_test.go
+++ b/simulation/matching/matching_simulation_test.go
@@ -41,6 +41,7 @@ import (
 	"math/rand"
 	"os"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -53,7 +54,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/yarpc"
-	"golang.org/x/exp/slices"
 	"golang.org/x/time/rate"
 
 	"github.com/uber/cadence/client/history"

--- a/tools/cli/admin_task_list_commands.go
+++ b/tools/cli/admin_task_list_commands.go
@@ -24,13 +24,13 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"slices"
 	"strings"
 
 	"github.com/urfave/cli/v2"
 	"go.uber.org/multierr"
-	"golang.org/x/exp/maps"
 
 	"github.com/uber/cadence/client/frontend"
 	"github.com/uber/cadence/common/constants"
@@ -161,7 +161,7 @@ func AdminListTaskList(c *cli.Context) error {
 		row.ActivityPollerCount = len(taskList.GetPollers())
 		tlByName[name] = row
 	}
-	table := maps.Values(tlByName)
+	table := slices.Collect(maps.Values(tlByName))
 	slices.SortFunc(table, func(a, b TaskListRow) int {
 		return strings.Compare(a.Name, b.Name)
 	})


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Replace x/exp/maps with maps

Delivers https://github.com/cadence-workflow/cadence/pull/7309

**Why?**
Use the default maps instead of x/exp/maps

**How did you test it?**
go test -race ./client/history/... \
    ./common/quotas/global/... \
    ./common/metrics/... \
    ./common/... \
    ./service/history/... \
    ./service/matching/tasklist/... \
    ./tools/cli/... \
    ./simulation/matching/...

**Potential risks**
Pretty straightforward, except that import "maps" returns a sequence rather than a slice, so all this also needs slices.Collect

**Release notes**
N/A

**Documentation Changes**
N/A
