### PR TITLE
feat(dynamicconfig): expose operational dynamic config Collection on Resource

### DIFF
--- a/common/resource/resource_impl.go
+++ b/common/resource/resource_impl.go
@@ -145,6 +145,7 @@ type Impl struct {
 	isolationGroups           isolationgroup.State
 	isolationGroupConfigStore configstore.Client
 	operationalConfigStore    configstore.Client
+	operationalDynamicConfig  *dynamicconfig.Collection
 
 	asyncWorkflowQueueProvider queue.Provider
 
@@ -338,6 +339,7 @@ func New(
 
 	isolationGroupStore := createConfigStoreOrDefault(params, dynamicCollection)
 	operationalConfigStore := createOperationalConfigStoreOrDefault(params, dynamicCollection)
+	operationalDynamicConfig := newOperationalDynamicConfigCollection(operationalConfigStore, logger, params.ClusterMetadata.GetCurrentClusterName())
 
 	isolationGroupState, err := ensureIsolationGroupStateHandlerOrDefault(
 		params,
@@ -421,6 +423,7 @@ func New(
 		isolationGroups:           isolationGroupState,
 		isolationGroupConfigStore: isolationGroupStore,    // can be nil where persistence is not available
 		operationalConfigStore:    operationalConfigStore, // can be nil where persistence is not available
+		operationalDynamicConfig:  operationalDynamicConfig,
 
 		asyncWorkflowQueueProvider: params.AsyncWorkflowQueueProvider,
 
@@ -739,6 +742,14 @@ func (h *Impl) GetOperationalConfigStore() configstore.Client {
 	return h.operationalConfigStore
 }
 
+// GetOperationalDynamicConfig returns a Collection wrapping the operational
+// dynamic config store. It is always non-nil: when the underlying store is
+// unavailable, the Collection is backed by a no-op client that returns
+// default values, so callers can read operational values unconditionally.
+func (h *Impl) GetOperationalDynamicConfig() *dynamicconfig.Collection {
+	return h.operationalDynamicConfig
+}
+
 // GetAsyncWorkflowQueueProvider returns the async workflow queue provider
 func (h *Impl) GetAsyncWorkflowQueueProvider() queue.Provider {
 	return h.asyncWorkflowQueueProvider
@@ -800,6 +811,25 @@ func createOperationalConfigStoreOrDefault(
 		return nil
 	}
 	return cfgStoreClient
+}
+
+// newOperationalDynamicConfigCollection wraps the operational config store in a
+// Collection. Falls back to a no-op client when the store is unavailable, so
+// callers always get a usable Collection that returns defaults.
+func newOperationalDynamicConfigCollection(
+	store configstore.Client,
+	logger log.Logger,
+	currentClusterName string,
+) *dynamicconfig.Collection {
+	var client dynamicconfig.Client = store
+	if store == nil {
+		client = dynamicconfig.NewNopClient()
+	}
+	return dynamicconfig.NewCollection(
+		client,
+		logger,
+		dynamicproperties.ClusterNameFilter(currentClusterName),
+	)
 }
 
 // Use the provided IsolationGroupStateHandler or the default one

--- a/common/resource/resource_impl_test.go
+++ b/common/resource/resource_impl_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
 	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
@@ -256,6 +257,7 @@ func TestStartStop(t *testing.T) {
 	assert.NotNil(t, i.GetIsolationGroupState())
 	assert.Nil(t, i.GetIsolationGroupStore())
 	assert.Nil(t, i.GetOperationalConfigStore())
+	assert.NotNil(t, i.GetOperationalDynamicConfig())
 	assert.Equal(t, params.AsyncWorkflowQueueProvider, i.GetAsyncWorkflowQueueProvider())
 }
 
@@ -276,4 +278,27 @@ func TestCreateOperationalConfigStoreOrDefault_NilWhenPersistenceUnsupported(t *
 		PersistenceConfig: config.Persistence{},
 	}, dc)
 	assert.Nil(t, got)
+}
+
+func TestNewOperationalDynamicConfigCollection_NilStoreFallsBackToNop(t *testing.T) {
+	logger := testlogger.New(t)
+	dc := newOperationalDynamicConfigCollection(nil, logger, "primary-cluster")
+	require.NotNil(t, dc)
+	// A no-op client returns defaults; for an unset Int property that means 0.
+	v := dc.GetIntProperty(dynamicproperties.MatchingPercentageOnboardedToShardManager)()
+	assert.Equal(t, 0, v)
+}
+
+func TestNewOperationalDynamicConfigCollection_UsesStoreWhenPresent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	logger := testlogger.New(t)
+	store := configstore.NewMockClient(ctrl)
+	store.EXPECT().GetIntValue(
+		dynamicproperties.MatchingPercentageOnboardedToShardManager,
+		gomock.Any(),
+	).Return(42, nil)
+
+	dc := newOperationalDynamicConfigCollection(store, logger, "primary-cluster")
+	require.NotNil(t, dc)
+	assert.Equal(t, 42, dc.GetIntProperty(dynamicproperties.MatchingPercentageOnboardedToShardManager)())
 }

--- a/common/resource/resource_mock.go
+++ b/common/resource/resource_mock.go
@@ -31,6 +31,7 @@ import (
 	clock "github.com/uber/cadence/common/clock"
 	cluster "github.com/uber/cadence/common/cluster"
 	domain "github.com/uber/cadence/common/domain"
+	dynamicconfig "github.com/uber/cadence/common/dynamicconfig"
 	configstore "github.com/uber/cadence/common/dynamicconfig/configstore"
 	isolationgroup "github.com/uber/cadence/common/isolationgroup"
 	log "github.com/uber/cadence/common/log"
@@ -554,6 +555,20 @@ func (m *MockResource) GetOperationalConfigStore() configstore.Client {
 func (mr *MockResourceMockRecorder) GetOperationalConfigStore() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperationalConfigStore", reflect.TypeOf((*MockResource)(nil).GetOperationalConfigStore))
+}
+
+// GetOperationalDynamicConfig mocks base method.
+func (m *MockResource) GetOperationalDynamicConfig() *dynamicconfig.Collection {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOperationalDynamicConfig")
+	ret0, _ := ret[0].(*dynamicconfig.Collection)
+	return ret0
+}
+
+// GetOperationalDynamicConfig indicates an expected call of GetOperationalDynamicConfig.
+func (mr *MockResourceMockRecorder) GetOperationalDynamicConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperationalDynamicConfig", reflect.TypeOf((*MockResource)(nil).GetOperationalDynamicConfig))
 }
 
 // GetPayloadSerializer mocks base method.

--- a/common/resource/resource_test_utils.go
+++ b/common/resource/resource_test_utils.go
@@ -46,6 +46,7 @@ import (
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/domain"
+	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/dynamicconfig/configstore"
 	"github.com/uber/cadence/common/isolationgroup"
 	"github.com/uber/cadence/common/log"
@@ -482,6 +483,11 @@ func (s *Test) GetIsolationGroupStore() configstore.Client {
 // GetOperationalConfigStore returns the operational dynamic config store
 func (s *Test) GetOperationalConfigStore() configstore.Client {
 	return s.OperationalConfigStore
+}
+
+// GetOperationalDynamicConfig returns a Collection backed by a no-op client for tests.
+func (s *Test) GetOperationalDynamicConfig() *dynamicconfig.Collection {
+	return dynamicconfig.NewCollection(dynamicconfig.NewNopClient(), s.Logger)
 }
 
 func (s *Test) GetAsyncWorkflowQueueProvider() queue.Provider {

--- a/common/resource/types.go
+++ b/common/resource/types.go
@@ -42,6 +42,7 @@ import (
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/domain"
+	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/dynamicconfig/configstore"
 	"github.com/uber/cadence/common/isolationgroup"
 	"github.com/uber/cadence/common/log"
@@ -129,6 +130,7 @@ type Resource interface {
 	GetIsolationGroupState() isolationgroup.State
 	GetIsolationGroupStore() configstore.Client
 	GetOperationalConfigStore() configstore.Client
+	GetOperationalDynamicConfig() *dynamicconfig.Collection
 
 	GetAsyncWorkflowQueueProvider() queue.Provider
 

--- a/service/history/resource/resource_mock.go
+++ b/service/history/resource/resource_mock.go
@@ -31,6 +31,7 @@ import (
 	clock "github.com/uber/cadence/common/clock"
 	cluster "github.com/uber/cadence/common/cluster"
 	domain "github.com/uber/cadence/common/domain"
+	dynamicconfig "github.com/uber/cadence/common/dynamicconfig"
 	configstore "github.com/uber/cadence/common/dynamicconfig/configstore"
 	isolationgroup "github.com/uber/cadence/common/isolationgroup"
 	log "github.com/uber/cadence/common/log"
@@ -545,6 +546,20 @@ func (m *MockResource) GetOperationalConfigStore() configstore.Client {
 func (mr *MockResourceMockRecorder) GetOperationalConfigStore() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperationalConfigStore", reflect.TypeOf((*MockResource)(nil).GetOperationalConfigStore))
+}
+
+// GetOperationalDynamicConfig mocks base method.
+func (m *MockResource) GetOperationalDynamicConfig() *dynamicconfig.Collection {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOperationalDynamicConfig")
+	ret0, _ := ret[0].(*dynamicconfig.Collection)
+	return ret0
+}
+
+// GetOperationalDynamicConfig indicates an expected call of GetOperationalDynamicConfig.
+func (mr *MockResourceMockRecorder) GetOperationalDynamicConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperationalDynamicConfig", reflect.TypeOf((*MockResource)(nil).GetOperationalDynamicConfig))
 }
 
 // GetPayloadSerializer mocks base method.


### PR DESCRIPTION
> **Stacked on top of #8092**, which is stacked on #8091. Please review in order: #8091 → #8092 → this PR. Until #8091 and #8092 merge, the diff here will include those commits too.

**What changed?**

Adds `Resource.GetOperationalDynamicConfig() *dynamicconfig.Collection`, wrapping the operational configstore client added in #8092 so service code can read operational dynamic config values with the same typed-accessor ergonomics used for the primary dynamic config.

The Collection is always non-nil: when the underlying configstore client is unavailable (persistence layer doesn't support a config store), it is backed by a `NopClient` so callers get default values rather than having to nil-check. This mirrors the existing fallback for the primary dynamic config client. The cluster-name filter is applied, matching how the primary Collection is constructed.

**Why?**

Services need a typed entry point to read operational dynamic config (the values written via the upcoming `UpdateOperationalDynamicConfig` admin endpoint). Exposing it on `Resource` lets each service consume it the same way it consumes the primary Collection, with no nil-handling boilerplate at the call site.

**How did you test it?**

- `go build ./...` clean.
- `go test -count=1 -race ./common/resource/... ./common/dynamicconfig/... ./common/persistence/ ./service/history/resource/... ./service/history/handler/...` all pass.
- Coverage on new lines: `GetOperationalDynamicConfig` 100%, `newOperationalDynamicConfigCollection` 100%.
- Extended `TestStartStop` to assert the getter returns non-nil even when the underlying store is nil; two focused new tests on `newOperationalDynamicConfigCollection` (nil-store-falls-back-to-nop and uses-store-when-present).

**Potential risks**

- Adds one method to the `Resource` interface and `service/history/resource.Resource` mock — both regenerated mocks are in the diff. No production code consumes the new Collection yet.
- The no-op fallback hides the "operational store unavailable" condition from consumers reading via the Collection — callers that need to detect this should use `GetOperationalConfigStore()` (returns nil when unavailable) instead.

**Release notes**

N/A — preparation for a follow-up feature; no user-visible change.

**Documentation Changes**

N/A.