### PR TITLE
feat(cli): add operational dynamic config CLI commands

### DIFF
--- a/service/frontend/admin/handler.go
+++ b/service/frontend/admin/handler.go
@@ -1655,6 +1655,7 @@ func (adh *adminHandlerImpl) UpdateOperationalDynamicConfig(ctx context.Context,
 	if err != nil {
 		return err
 	}
+	adh.logOperationalConfigChange(ctx, "Update", request.ConfigName, request.ConfigValues)
 	return adh.updateDynamicConfigValue(ctx, scope, client, request.ConfigName, request.ConfigValues)
 }
 
@@ -1669,6 +1670,7 @@ func (adh *adminHandlerImpl) RestoreOperationalDynamicConfig(ctx context.Context
 	if err != nil {
 		return err
 	}
+	adh.logOperationalConfigChange(ctx, "Restore", request.ConfigName, request.Filters)
 	return adh.restoreDynamicConfigValue(ctx, scope, client, request.ConfigName, request.Filters)
 }
 
@@ -1779,7 +1781,6 @@ func (adh *adminHandlerImpl) updateDynamicConfigValue(
 	if err != nil {
 		return err
 	}
-	adh.logOperationalConfigChange(ctx, "Update", configName, values)
 	return client.UpdateValue(keyVal, values)
 }
 
@@ -1803,7 +1804,6 @@ func (adh *adminHandlerImpl) restoreDynamicConfigValue(
 			return adh.error(validate.ErrInvalidFilters, scope)
 		}
 	}
-	adh.logOperationalConfigChange(ctx, "Restore", configName, filters)
 	return client.RestoreValue(keyVal, convFilters)
 }
 

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -1367,6 +1367,65 @@ func newAdminConfigStoreCommands() []*cli.Command {
 			Flags:   []cli.Flag{getFormatFlag()},
 			Action:  AdminListConfigKeys,
 		},
+		{
+			Name:    "operational-get",
+			Aliases: []string{"og"},
+			Usage:   "Get Operational Dynamic Config Value (cassandra-backed store)",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     FlagDynamicConfigName,
+					Usage:    "Name of Dynamic Config parameter to get value of",
+					Required: true,
+				},
+				&cli.StringFlag{
+					Name:  FlagDynamicConfigFilter,
+					Usage: fmt.Sprintf(`Optional filter map keyed by the config's filter dimensions (e.g. domainName, shardID). ex: --%s '{"domainName":"global-samples-domain", "shardID":1, "isEnabled": true}'`, FlagDynamicConfigFilter),
+				},
+			},
+			Action: AdminGetOperationalDynamicConfig,
+		},
+		{
+			Name:    "operational-update",
+			Aliases: []string{"ou"},
+			Usage:   "Update Operational Dynamic Config Value (cassandra-backed store)",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     FlagDynamicConfigName,
+					Usage:    "Name of Dynamic Config parameter to update value of",
+					Required: true,
+				},
+				&cli.StringSliceFlag{
+					Name:     FlagDynamicConfigValue,
+					Usage:    fmt.Sprintf(`Can be specified multiple times for multiple values. ex: --%s '{"Value":true,"Filters":[]}'`, FlagDynamicConfigValue),
+					Required: true,
+				},
+			},
+			Action: AdminUpdateOperationalDynamicConfig,
+		},
+		{
+			Name:    "operational-restore",
+			Aliases: []string{"or"},
+			Usage:   "Restore Operational Dynamic Config Value (cassandra-backed store)",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     FlagDynamicConfigName,
+					Usage:    "Name of Dynamic Config parameter to restore",
+					Required: true,
+				},
+				&cli.StringFlag{
+					Name:  FlagDynamicConfigFilter,
+					Usage: fmt.Sprintf(`Optional filter map keyed by the config's filter dimensions (e.g. domainName, shardID). ex: --%s '{"domainName":"global-samples-domain", "shardID":1, "isEnabled": true}'`, FlagDynamicConfigFilter),
+				},
+			},
+			Action: AdminRestoreOperationalDynamicConfig,
+		},
+		{
+			Name:    "operational-list",
+			Aliases: []string{"ol"},
+			Usage:   "List Operational Dynamic Config Value (cassandra-backed store)",
+			Flags:   []cli.Flag{},
+			Action:  AdminListOperationalDynamicConfig,
+		},
 	}
 }
 

--- a/tools/cli/admin_config_store_commands.go
+++ b/tools/cli/admin_config_store_commands.go
@@ -241,6 +241,207 @@ func AdminListDynamicConfig(c *cli.Context) error {
 	return nil
 }
 
+// AdminGetOperationalDynamicConfig gets the value of the specified operational dynamic config
+// parameter (cassandra-backed store) matching the specified filter.
+func AdminGetOperationalDynamicConfig(c *cli.Context) error {
+	adminClient, err := getDeps(c).ServerAdminClient(c)
+	if err != nil {
+		return err
+	}
+
+	configName, err := getRequiredOption(c, FlagDynamicConfigName)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
+
+	filter := c.String(FlagDynamicConfigFilter)
+
+	ctx, cancel, err := newContext(c)
+	defer cancel()
+	if err != nil {
+		return commoncli.Problem("Error in creating context: ", err)
+	}
+
+	parsedFilters, err := parseInputFilter(filter)
+	if err != nil {
+		return commoncli.Problem("Failed to parse input filter array", err)
+	}
+
+	req := &types.GetOperationalDynamicConfigRequest{
+		ConfigName: configName,
+		Filters:    parsedFilters,
+	}
+
+	val, err := adminClient.GetOperationalDynamicConfig(ctx, req)
+	if err != nil {
+		return commoncli.Problem("Failed to get operational dynamic config value", err)
+	}
+
+	if val == nil || val.Value == nil || len(val.Value.Data) == 0 {
+		fmt.Println("No values stored for the specified operational dynamic config.")
+		return nil
+	}
+
+	var umVal interface{}
+	err = json.Unmarshal(val.Value.Data, &umVal)
+	if err != nil {
+		return commoncli.Problem("Failed to unmarshal response", err)
+	}
+
+	if umVal == nil {
+		fmt.Printf("No values stored for specified operational dynamic config.\n")
+	} else {
+		prettyPrintJSONObject(getDeps(c).Output(), umVal)
+	}
+
+	return nil
+}
+
+// AdminUpdateOperationalDynamicConfig updates the specified operational dynamic config parameter
+// (cassandra-backed store) with the specified values.
+func AdminUpdateOperationalDynamicConfig(c *cli.Context) error {
+	adminClient, err := getDeps(c).ServerAdminClient(c)
+	if err != nil {
+		return err
+	}
+
+	dcName, err := getRequiredOption(c, FlagDynamicConfigName)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
+	dcValuesRaw := c.StringSlice(FlagDynamicConfigValue)
+
+	// WORKAROUND: urfave/cli v2 StringSliceFlag splits on commas by default.
+	// This breaks JSON values. Try reassembling the split pieces.
+	var dcValues []string
+	if len(dcValuesRaw) > 1 && strings.HasPrefix(dcValuesRaw[0], "{") {
+		assembled := strings.Join(dcValuesRaw, ",")
+		var test interface{}
+		if json.Unmarshal([]byte(assembled), &test) == nil {
+			dcValues = []string{assembled}
+		} else {
+			dcValues = dcValuesRaw
+		}
+	} else {
+		dcValues = dcValuesRaw
+	}
+
+	ctx, cancel, err := newContext(c)
+	defer cancel()
+	if err != nil {
+		return commoncli.Problem("Error in creating context: ", err)
+	}
+	var parsedValues []*types.DynamicConfigValue
+
+	if dcValues != nil {
+		parsedValues = make([]*types.DynamicConfigValue, 0, len(dcValues))
+
+		for _, valueString := range dcValues {
+			var parsedInputValue *cliValue
+			err := json.Unmarshal([]byte(valueString), &parsedInputValue)
+			if err != nil {
+				return commoncli.Problem("Unable to unmarshal value to inputValue", err)
+			}
+			parsedValue, err := convertFromInputValue(parsedInputValue)
+			if err != nil {
+				return commoncli.Problem("Unable to convert from inputValue to DynamicConfigValue", err)
+			}
+			parsedValues = append(parsedValues, parsedValue)
+		}
+	} else {
+		parsedValues = nil
+	}
+
+	req := &types.UpdateOperationalDynamicConfigRequest{
+		ConfigName:   dcName,
+		ConfigValues: parsedValues,
+	}
+
+	err = adminClient.UpdateOperationalDynamicConfig(ctx, req)
+	if err != nil {
+		return commoncli.Problem("Failed to update operational dynamic config value", err)
+	}
+	fmt.Printf("Operational Dynamic Config %q updated with %s \n", dcName, dcValues)
+	return nil
+}
+
+// AdminRestoreOperationalDynamicConfig removes values of the specified operational dynamic config
+// parameter (cassandra-backed store) matching the specified filter.
+func AdminRestoreOperationalDynamicConfig(c *cli.Context) error {
+	adminClient, err := getDeps(c).ServerAdminClient(c)
+	if err != nil {
+		return err
+	}
+
+	dcName, err := getRequiredOption(c, FlagDynamicConfigName)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
+	filter := c.String(FlagDynamicConfigFilter)
+
+	ctx, cancel, err := newContext(c)
+	defer cancel()
+	if err != nil {
+		return commoncli.Problem("Error in creating context: ", err)
+	}
+
+	parsedFilters, err := parseInputFilter(filter)
+	if err != nil {
+		return commoncli.Problem("Failed to parse input filter", err)
+	}
+
+	req := &types.RestoreOperationalDynamicConfigRequest{
+		ConfigName: dcName,
+		Filters:    parsedFilters,
+	}
+
+	err = adminClient.RestoreOperationalDynamicConfig(ctx, req)
+	if err != nil {
+		return commoncli.Problem("Failed to restore operational dynamic config value", err)
+	}
+	fmt.Printf("Operational Dynamic Config %q restored\n", dcName)
+	return nil
+}
+
+// AdminListOperationalDynamicConfig lists all values stored in the operational dynamic config
+// (cassandra-backed store).
+func AdminListOperationalDynamicConfig(c *cli.Context) error {
+	adminClient, err := getDeps(c).ServerAdminClient(c)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel, err := newContext(c)
+	defer cancel()
+	if err != nil {
+		return commoncli.Problem("Error in creating context: ", err)
+	}
+	req := &types.ListOperationalDynamicConfigRequest{
+		ConfigName: "", // empty string means all config values
+	}
+
+	val, err := adminClient.ListOperationalDynamicConfig(ctx, req)
+	if err != nil {
+		return commoncli.Problem("Failed to list operational dynamic config value(s)", err)
+	}
+
+	if val == nil || val.Entries == nil || len(val.Entries) == 0 {
+		fmt.Printf("No operational dynamic config values stored to list.\n")
+	} else {
+		cliEntries := make([]*cliEntry, 0, len(val.Entries))
+		for _, dcEntry := range val.Entries {
+			cliEntry, err := convertToInputEntry(dcEntry)
+			if err != nil {
+				fmt.Printf("Cannot parse list response entry, skipping.\n")
+				continue
+			}
+			cliEntries = append(cliEntries, cliEntry)
+		}
+		prettyPrintJSONObject(getDeps(c).Output(), cliEntries)
+	}
+	return nil
+}
+
 // AdminListConfigKeys lists all available dynamic config keys with description and default value
 func AdminListConfigKeys(c *cli.Context) error {
 

--- a/tools/cli/admin_config_store_commands_test.go
+++ b/tools/cli/admin_config_store_commands_test.go
@@ -389,3 +389,208 @@ func TestAdminListConfigKeys(t *testing.T) {
 		assert.NoError(t, clitest.RunCommandLine(t, td.app, "cadence admin config listall"))
 	})
 }
+
+func TestAdminGetOperationalDynamicConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		cmdline     string
+		setupMock   func(td *cliTestData)
+		errContains string
+	}{
+		{
+			name:        "missing required name flag",
+			cmdline:     `cadence admin config operational-get --name ""`,
+			setupMock:   func(td *cliTestData) {},
+			errContains: "Required flag not found",
+		},
+		{
+			name:    "server error",
+			cmdline: `cadence admin config operational-get --name test.key`,
+			setupMock: func(td *cliTestData) {
+				td.mockAdminClient.EXPECT().GetOperationalDynamicConfig(gomock.Any(), gomock.Any()).
+					Return(nil, assert.AnError)
+			},
+			errContains: "Failed to get operational dynamic config value",
+		},
+		{
+			name:    "happy path with filters",
+			cmdline: `cadence admin config operational-get --name test.key --filter '{"domainName":"d"}'`,
+			setupMock: func(td *cliTestData) {
+				td.mockAdminClient.EXPECT().GetOperationalDynamicConfig(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.GetOperationalDynamicConfigRequest, _ ...yarpc.CallOption) (*types.GetOperationalDynamicConfigResponse, error) {
+						assert.Equal(t, "test.key", req.ConfigName)
+						assert.Len(t, req.Filters, 1)
+						assert.Equal(t, "domainName", req.Filters[0].Name)
+						return &types.GetOperationalDynamicConfigResponse{
+							Value: &types.DataBlob{
+								EncodingType: types.EncodingTypeJSON.Ptr(),
+								Data:         []byte(`"v"`),
+							},
+						}, nil
+					})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			td := newCLITestData(t)
+			tt.setupMock(td)
+			err := clitest.RunCommandLine(t, td.app, tt.cmdline)
+			if tt.errContains == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.errContains)
+			}
+		})
+	}
+}
+
+func TestAdminUpdateOperationalDynamicConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		cmdline     string
+		setupMock   func(td *cliTestData)
+		errContains string
+	}{
+		{
+			name:        "missing required name flag",
+			cmdline:     `cadence admin config operational-update --name "" --value "{}"`,
+			setupMock:   func(td *cliTestData) {},
+			errContains: "Required flag not found",
+		},
+		{
+			name:    "server error",
+			cmdline: `cadence admin config operational-update --name test.key --value "{}"`,
+			setupMock: func(td *cliTestData) {
+				td.mockAdminClient.EXPECT().UpdateOperationalDynamicConfig(gomock.Any(), gomock.Any()).Return(assert.AnError)
+			},
+			errContains: "Failed to update operational dynamic config value",
+		},
+		{
+			name:    "happy path forwards parsed value",
+			cmdline: `cadence admin config operational-update --name test.key --value ` + `'{"Value":42,"Filters":[]}'`,
+			setupMock: func(td *cliTestData) {
+				td.mockAdminClient.EXPECT().UpdateOperationalDynamicConfig(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.UpdateOperationalDynamicConfigRequest, _ ...yarpc.CallOption) error {
+						assert.Equal(t, "test.key", req.ConfigName)
+						assert.Len(t, req.ConfigValues, 1)
+						var v interface{}
+						assert.NoError(t, json.Unmarshal(req.ConfigValues[0].Value.Data, &v))
+						assert.Equal(t, float64(42), v)
+						return nil
+					})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			td := newCLITestData(t)
+			tt.setupMock(td)
+			err := clitest.RunCommandLine(t, td.app, tt.cmdline)
+			if tt.errContains == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.errContains)
+			}
+		})
+	}
+}
+
+func TestAdminRestoreOperationalDynamicConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		cmdline     string
+		setupMock   func(td *cliTestData)
+		errContains string
+	}{
+		{
+			name:        "missing required name flag",
+			cmdline:     `cadence admin config operational-restore --name ""`,
+			setupMock:   func(td *cliTestData) {},
+			errContains: "Required flag not found",
+		},
+		{
+			name:    "server error",
+			cmdline: `cadence admin config operational-restore --name test.key`,
+			setupMock: func(td *cliTestData) {
+				td.mockAdminClient.EXPECT().RestoreOperationalDynamicConfig(gomock.Any(), gomock.Any()).Return(assert.AnError)
+			},
+			errContains: "Failed to restore operational dynamic config value",
+		},
+		{
+			name:    "happy path",
+			cmdline: `cadence admin config operational-restore --name test.key --filter '{"domainName":"d"}'`,
+			setupMock: func(td *cliTestData) {
+				td.mockAdminClient.EXPECT().RestoreOperationalDynamicConfig(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.RestoreOperationalDynamicConfigRequest, _ ...yarpc.CallOption) error {
+						assert.Equal(t, "test.key", req.ConfigName)
+						assert.Len(t, req.Filters, 1)
+						return nil
+					})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			td := newCLITestData(t)
+			tt.setupMock(td)
+			err := clitest.RunCommandLine(t, td.app, tt.cmdline)
+			if tt.errContains == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.errContains)
+			}
+		})
+	}
+}
+
+func TestAdminListOperationalDynamicConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupMock   func(td *cliTestData)
+		errContains string
+	}{
+		{
+			name: "server error",
+			setupMock: func(td *cliTestData) {
+				td.mockAdminClient.EXPECT().ListOperationalDynamicConfig(gomock.Any(), gomock.Any()).Return(nil, assert.AnError)
+			},
+			errContains: "Failed to list operational dynamic config value(s)",
+		},
+		{
+			name: "empty list",
+			setupMock: func(td *cliTestData) {
+				td.mockAdminClient.EXPECT().ListOperationalDynamicConfig(gomock.Any(), gomock.Any()).Return(nil, nil)
+			},
+		},
+		{
+			name: "happy path",
+			setupMock: func(td *cliTestData) {
+				td.mockAdminClient.EXPECT().ListOperationalDynamicConfig(gomock.Any(), gomock.Any()).
+					Return(&types.ListOperationalDynamicConfigResponse{
+						Entries: []*types.DynamicConfigEntry{{
+							Name: "test.key",
+							Values: []*types.DynamicConfigValue{{
+								Value: &types.DataBlob{
+									EncodingType: types.EncodingTypeJSON.Ptr(),
+									Data:         []byte(`"v"`),
+								},
+							}},
+						}},
+					}, nil)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			td := newCLITestData(t)
+			tt.setupMock(td)
+			err := clitest.RunCommandLine(t, td.app, "cadence admin config operational-list")
+			if tt.errContains == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.errContains)
+			}
+		})
+	}
+}


### PR DESCRIPTION
> **Stacked on top of #8100**, which is stacked on #8099 → #8092 → #8091. Please review in order: #8091 → #8092 → #8099 → #8100 → this PR. Until those merge, the diff here will include their commits too.

**What changed?**

Adds four new commands under `cadence admin config` that call the operational dynamic config admin RPCs added in #8100:

- `operational-get` (alias `og`) — read a value from the cassandra-backed store
- `operational-update` (alias `ou`) — write one or more values
- `operational-restore` (alias `or`) — remove a value (or a filtered subset)
- `operational-list` (alias `ol`) — list all stored entries

Flag shapes (`--name`, `--filter`, `--value`) and the JSON value/filter formats are identical to the existing `get` / `update` / `restore` / `list` commands so operators don't need to learn a new payload format.

**Why?**

Operators need a CLI surface to manage values in the cassandra-backed operational config store — same ergonomics as the existing dynamic config commands, just pointed at the new admin RPCs.

**How did you test it?**

- `go build ./...` clean.
- `go test -count=1 ./tools/cli/...` all pass.
- New table-tests cover each command: missing required flag, server error, and happy-path forwarding (with filter parsing for get/restore and value parsing for update).
- Coverage on new actions: 80-86%.

**Potential risks**

- Adds four sibling commands to the existing `cadence admin config` tree; no existing command names changed.
- Currently a thin wrapper over the admin RPCs added in #8100; the operational store needs to be available on the persistence backend for the commands to do anything (else the server returns `BadRequestError`).

**Release notes**

N/A — operator-facing CLI surface for the upcoming operational dynamic config rollout.

**Documentation Changes**

N/A.

