### PR TITLE
feat(dynamicconfig): add matching.percentageOnboardedReadFromOperationalStore flag

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -2385,6 +2385,16 @@ const (
 	// Default value: false
 	// Allowed filters: N/A
 	MatchingEmergencyOffboardingFromShardManager
+	// MatchingPercentageOnboardedReadFromOperationalStore selects the source of
+	// MatchingPercentageOnboardedToShardManager during the migration to the cassandra-backed
+	// operational dynamic config store.
+	// When false (default), cadence reads the value from the generic dynamic config.
+	// When true, cadence reads the value from the operational dynamic config store.
+	// KeyName: matching.percentageOnboardedReadFromOperationalStore
+	// Value type: Bool
+	// Default value: false
+	// Allowed filters: N/A
+	MatchingPercentageOnboardedReadFromOperationalStore
 
 	// EnableHierarchicalWeightedRoundRobinTaskScheduler is to enable hierarchical weighted round robin task scheduler
 	// KeyName: history.enableHierarchicalWeightedRoundRobinTaskScheduler
@@ -5267,6 +5277,11 @@ var BoolKeys = map[BoolKey]DynamicBool{
 	MatchingEmergencyOffboardingFromShardManager: {
 		KeyName:      "matching.emergencyOffboardingFromShardManager",
 		Description:  "MatchingEmergencyOffboardingFromShardManager is a kill switch to immediately offboard all task lists from the shard manager, ignoring the onboarding percentage",
+		DefaultValue: false,
+	},
+	MatchingPercentageOnboardedReadFromOperationalStore: {
+		KeyName:      "matching.percentageOnboardedReadFromOperationalStore",
+		Description:  "MatchingPercentageOnboardedReadFromOperationalStore selects the source of MatchingPercentageOnboardedToShardManager: false (default) reads from the generic dynamic config, true reads from the cassandra-backed operational dynamic config store",
 		DefaultValue: false,
 	},
 	EnableHierarchicalWeightedRoundRobinTaskScheduler: {


### PR DESCRIPTION
**What changed?**

Adds a new bool dynamic config key, `matching.percentageOnboardedReadFromOperationalStore`, that selects the source of `matching.percentageOnboardedToShardManager`:

- `false` (default) — cadence reads the value from the generic dynamic config (current behavior).
- `true` — cadence reads from the cassandra-backed operational dynamic config store.

No reads of the flag yet; this PR is just the key declaration + registration.

**Why?**

The shard-manager onboarding percentage is being migrated to the cassandra-backed operational dynamic config store. The flag gives us a single switch to flip during the rollout — flipped off, the system behaves exactly as today; flipped on, cadence reads from the new source. The migration plan is to deploy with both reads + comparison metrics first, then flip the flag once the values agree in production, then remove the legacy path entirely.

**How did you test it?**

- `go build ./...` clean.
- `go test ./common/dynamicconfig/dynamicproperties/... -count=1` passes; the new key is picked up by the existing key-iteration tests (`ListAllProductionKeys`, `GetAllKeys`).

**Potential risks**

- Pure additive change. Default is `false`, so behavior is unchanged everywhere until a follow-up PR wires the flag into the read path.
- The key is independent of the in-flight operational-config admin/CLI stack and can land in any order.

**Release notes**

N/A — preparation for the upcoming cutover; no behavior change.

**Documentation Changes**

N/A.