### PR TITLE
feat(queuev2): add GetReadLevel to VirtualSlice and GetMinReadLevel to VirtualQueueManager

### DIFF
--- a/service/history/queuev2/virtual_queue_manager.go
+++ b/service/history/queuev2/virtual_queue_manager.go
@@ -34,6 +34,7 @@ import (
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/quotas"
 	"github.com/uber/cadence/service/history/task"
 )
@@ -56,6 +57,9 @@ type (
 		// Add a new virtual slice to the root queue. This is used when new tasks are generated and max read level is updated.
 		// By default, all new tasks belong to the root queue, so we need to add a new virtual slice to the root queue.
 		AddNewVirtualSliceToRootQueue(VirtualSlice)
+		// GetMinReadLevel returns the minimum read level across all virtual queues and their slices.
+		// Returns persistence.MaximumHistoryTaskKey if there are no virtual queues or slices.
+		GetMinReadLevel() persistence.HistoryTaskKey
 	}
 
 	virtualQueueManagerImpl struct {
@@ -216,6 +220,22 @@ func (m *virtualQueueManagerImpl) AddNewVirtualSliceToRootQueue(s VirtualSlice) 
 
 	m.virtualQueues[rootQueueID] = m.createVirtualQueueFn(rootQueueID, s)
 	m.virtualQueues[rootQueueID].Start()
+}
+
+func (m *virtualQueueManagerImpl) GetMinReadLevel() persistence.HistoryTaskKey {
+	m.RLock()
+	defer m.RUnlock()
+
+	minReadLevel := persistence.MaximumHistoryTaskKey
+	for _, vq := range m.virtualQueues {
+		vq.IterateSlices(func(s VirtualSlice) {
+			readLevel := s.GetReadLevel()
+			if readLevel.Compare(minReadLevel) < 0 {
+				minReadLevel = readLevel
+			}
+		})
+	}
+	return minReadLevel
 }
 
 func (m *virtualQueueManagerImpl) appendOrMergeSlice(vq VirtualQueue, s VirtualSlice) {

--- a/service/history/queuev2/virtual_queue_manager_mock.go
+++ b/service/history/queuev2/virtual_queue_manager_mock.go
@@ -13,6 +13,8 @@ import (
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
+
+	persistence "github.com/uber/cadence/common/persistence"
 )
 
 // MockVirtualQueueManager is a mock of VirtualQueueManager interface.
@@ -49,6 +51,20 @@ func (m *MockVirtualQueueManager) AddNewVirtualSliceToRootQueue(arg0 VirtualSlic
 func (mr *MockVirtualQueueManagerMockRecorder) AddNewVirtualSliceToRootQueue(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNewVirtualSliceToRootQueue", reflect.TypeOf((*MockVirtualQueueManager)(nil).AddNewVirtualSliceToRootQueue), arg0)
+}
+
+// GetMinReadLevel mocks base method.
+func (m *MockVirtualQueueManager) GetMinReadLevel() persistence.HistoryTaskKey {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMinReadLevel")
+	ret0, _ := ret[0].(persistence.HistoryTaskKey)
+	return ret0
+}
+
+// GetMinReadLevel indicates an expected call of GetMinReadLevel.
+func (mr *MockVirtualQueueManagerMockRecorder) GetMinReadLevel() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMinReadLevel", reflect.TypeOf((*MockVirtualQueueManager)(nil).GetMinReadLevel))
 }
 
 // GetOrCreateVirtualQueue mocks base method.

--- a/service/history/queuev2/virtual_queue_manager_test.go
+++ b/service/history/queuev2/virtual_queue_manager_test.go
@@ -611,3 +611,79 @@ func TestVirtualQueueManager_AddNewVirtualSlice(t *testing.T) {
 		})
 	}
 }
+
+func TestVirtualQueueManager_GetMinReadLevel(t *testing.T) {
+	tests := []struct {
+		name               string
+		setupVirtualQueues func(ctrl *gomock.Controller) map[int64]VirtualQueue
+		expectedReadLevel  persistence.HistoryTaskKey
+	}{
+		{
+			name: "no virtual queues returns MaximumHistoryTaskKey",
+			setupVirtualQueues: func(ctrl *gomock.Controller) map[int64]VirtualQueue {
+				return map[int64]VirtualQueue{}
+			},
+			expectedReadLevel: persistence.MaximumHistoryTaskKey,
+		},
+		{
+			name: "single queue with one slice returns that slice read level",
+			setupVirtualQueues: func(ctrl *gomock.Controller) map[int64]VirtualQueue {
+				mockSlice := NewMockVirtualSlice(ctrl)
+				mockSlice.EXPECT().GetReadLevel().Return(persistence.NewImmediateTaskKey(5))
+
+				mockQueue := NewMockVirtualQueue(ctrl)
+				mockQueue.EXPECT().IterateSlices(gomock.Any()).Do(func(fn func(VirtualSlice)) {
+					fn(mockSlice)
+				})
+
+				return map[int64]VirtualQueue{
+					0: mockQueue,
+				}
+			},
+			expectedReadLevel: persistence.NewImmediateTaskKey(5),
+		},
+		{
+			name: "multiple queues returns minimum read level across all slices",
+			setupVirtualQueues: func(ctrl *gomock.Controller) map[int64]VirtualQueue {
+				mockSlice1 := NewMockVirtualSlice(ctrl)
+				mockSlice1.EXPECT().GetReadLevel().Return(persistence.NewImmediateTaskKey(10))
+
+				mockSlice2 := NewMockVirtualSlice(ctrl)
+				mockSlice2.EXPECT().GetReadLevel().Return(persistence.NewImmediateTaskKey(3))
+
+				mockSlice3 := NewMockVirtualSlice(ctrl)
+				mockSlice3.EXPECT().GetReadLevel().Return(persistence.NewImmediateTaskKey(7))
+
+				mockQueue1 := NewMockVirtualQueue(ctrl)
+				mockQueue1.EXPECT().IterateSlices(gomock.Any()).Do(func(fn func(VirtualSlice)) {
+					fn(mockSlice1)
+					fn(mockSlice2)
+				})
+
+				mockQueue2 := NewMockVirtualQueue(ctrl)
+				mockQueue2.EXPECT().IterateSlices(gomock.Any()).Do(func(fn func(VirtualSlice)) {
+					fn(mockSlice3)
+				})
+
+				return map[int64]VirtualQueue{
+					0: mockQueue1,
+					1: mockQueue2,
+				}
+			},
+			expectedReadLevel: persistence.NewImmediateTaskKey(3),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			manager := &virtualQueueManagerImpl{
+				virtualQueues: tt.setupVirtualQueues(ctrl),
+			}
+
+			result := manager.GetMinReadLevel()
+			assert.Equal(t, tt.expectedReadLevel, result)
+		})
+	}
+}

--- a/service/history/queuev2/virtual_slice.go
+++ b/service/history/queuev2/virtual_slice.go
@@ -40,6 +40,7 @@ type (
 		HasMoreTasks() bool
 		UpdateAndGetState() VirtualSliceState
 		GetPendingTaskCount() int
+		GetReadLevel() persistence.HistoryTaskKey
 		Clear()
 		PendingTaskStats() PendingTaskStats
 
@@ -97,6 +98,13 @@ func (s *virtualSliceImpl) GetState() VirtualSliceState {
 
 func (s *virtualSliceImpl) GetPendingTaskCount() int {
 	return s.pendingTaskTracker.GetPendingTaskCount()
+}
+
+func (s *virtualSliceImpl) GetReadLevel() persistence.HistoryTaskKey {
+	if len(s.progress) > 0 {
+		return s.progress[0].NextTaskKey
+	}
+	return s.state.Range.ExclusiveMaxTaskKey
 }
 
 func (s *virtualSliceImpl) IsEmpty() bool {

--- a/service/history/queuev2/virtual_slice_mock.go
+++ b/service/history/queuev2/virtual_slice_mock.go
@@ -69,6 +69,20 @@ func (mr *MockVirtualSliceMockRecorder) GetPendingTaskCount() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPendingTaskCount", reflect.TypeOf((*MockVirtualSlice)(nil).GetPendingTaskCount))
 }
 
+// GetReadLevel mocks base method.
+func (m *MockVirtualSlice) GetReadLevel() persistence.HistoryTaskKey {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetReadLevel")
+	ret0, _ := ret[0].(persistence.HistoryTaskKey)
+	return ret0
+}
+
+// GetReadLevel indicates an expected call of GetReadLevel.
+func (mr *MockVirtualSliceMockRecorder) GetReadLevel() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReadLevel", reflect.TypeOf((*MockVirtualSlice)(nil).GetReadLevel))
+}
+
 // GetState mocks base method.
 func (m *MockVirtualSlice) GetState() VirtualSliceState {
 	m.ctrl.T.Helper()

--- a/service/history/queuev2/virtual_slice_test.go
+++ b/service/history/queuev2/virtual_slice_test.go
@@ -3472,3 +3472,54 @@ func TestMergeVirtualSlicesWithDifferentPredicate(t *testing.T) {
 		})
 	}
 }
+
+func TestVirtualSlice_GetReadLevel(t *testing.T) {
+	tests := []struct {
+		name     string
+		slice    *virtualSliceImpl
+		expected persistence.HistoryTaskKey
+	}{
+		{
+			name: "slice with progress returns progress[0].NextTaskKey",
+			slice: &virtualSliceImpl{
+				state: VirtualSliceState{
+					Range: Range{
+						InclusiveMinTaskKey: persistence.NewImmediateTaskKey(1),
+						ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(10),
+					},
+					Predicate: NewUniversalPredicate(),
+				},
+				progress: []*GetTaskProgress{
+					{
+						Range: Range{
+							InclusiveMinTaskKey: persistence.NewImmediateTaskKey(1),
+							ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(10),
+						},
+						NextTaskKey: persistence.NewImmediateTaskKey(5),
+					},
+				},
+			},
+			expected: persistence.NewImmediateTaskKey(5),
+		},
+		{
+			name: "slice with empty progress returns state.Range.ExclusiveMaxTaskKey",
+			slice: &virtualSliceImpl{
+				state: VirtualSliceState{
+					Range: Range{
+						InclusiveMinTaskKey: persistence.NewImmediateTaskKey(1),
+						ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(10),
+					},
+					Predicate: NewUniversalPredicate(),
+				},
+				progress: []*GetTaskProgress{},
+			},
+			expected: persistence.NewImmediateTaskKey(10),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.slice.GetReadLevel())
+		})
+	}
+}


### PR DESCRIPTION
**What changed?**

Added `GetReadLevel() persistence.HistoryTaskKey` to the `VirtualSlice` interface and `GetMinReadLevel() persistence.HistoryTaskKey` to the `VirtualQueueManager` interface, along with their implementations and unit tests.

- `VirtualSlice.GetReadLevel()` returns the current read level of the slice: the `NextTaskKey` of the first in-progress load if one is active, or `ExclusiveMaxTaskKey` of the slice's range if no load is in progress.
- `VirtualQueueManager.GetMinReadLevel()` iterates all virtual queues and their slices to return the minimum read level across all of them. Returns `persistence.MaximumHistoryTaskKey` if there are no queues or slices.

**Why?**

These methods are needed by the lookahead queue reader to determine how far ahead it can safely read. The lookahead reader needs to know the minimum read level across all active virtual slices to avoid reading tasks that have not yet been processed, ensuring correct ordering and preventing task loss.

Part of changes implementing Timer Task Read Optimization https://github.com/cadence-workflow/cadence/issues/7953.

**How did you test it?**

Unit tests added for both methods:

```
go test -race ./service/history/queuev2/...
```

- `TestVirtualSliceGetReadLevel` in `virtual_slice_test.go`: verifies that `GetReadLevel` returns `progress[0].NextTaskKey` when a load is in progress, and `ExclusiveMaxTaskKey` when no load is active.
- `TestVirtualQueueManagerGetMinReadLevel` in `virtual_queue_manager_test.go`: verifies that `GetMinReadLevel` returns `MaximumHistoryTaskKey` when there are no queues, and the correct minimum across multiple queues/slices with varied read levels.

**Potential risks**

N/A. Read-only methods added to existing interfaces. The mock implementations are updated to match. No behavioral changes to existing logic.

**Release notes**

N/A — internal queue management interface extension, not user-facing.

**Documentation Changes**

N/A