### PR TITLE
feat(queuev2): add LookAHead to QueueReader and update ScheduledQueue

### DIFF
--- a/service/history/queuev2/queue_base.go
+++ b/service/history/queuev2/queue_base.go
@@ -140,10 +140,7 @@ func newQueueBase(
 			shard.GetConfig().TaskCriticalRetryCount,
 		)
 	}
-	queueReader := NewQueueReader(
-		shard,
-		category,
-	)
+	queueReader := NewQueueReader(shard, category, options.MaxPollInterval, options.MaxPollIntervalJitterCoefficient)
 	monitor := NewMonitor(
 		category,
 		&MonitorOptions{

--- a/service/history/queuev2/queue_reader.go
+++ b/service/history/queuev2/queue_reader.go
@@ -25,8 +25,11 @@ package queuev2
 
 import (
 	"context"
+	"time"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/backoff"
+	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/service/history/shard"
 )
@@ -34,6 +37,16 @@ import (
 type (
 	QueueReader interface {
 		GetTask(context.Context, *GetTaskRequest) (*GetTaskResponse, error)
+		LookAHead(ctx context.Context, req *LookAHeadRequest) (*LookAHeadResponse, error)
+	}
+
+	LookAHeadRequest struct {
+		InclusiveMinTaskKey persistence.HistoryTaskKey
+	}
+
+	LookAHeadResponse struct {
+		Task             persistence.Task
+		LookAheadMaxTime time.Time
 	}
 
 	GetTaskRequest struct {
@@ -55,18 +68,24 @@ type (
 	}
 
 	simpleQueueReader struct {
-		shard    shard.Context
-		category persistence.HistoryTaskCategory
+		shard                      shard.Context
+		category                   persistence.HistoryTaskCategory
+		maxPollInterval            dynamicproperties.DurationPropertyFn
+		maxPollIntervalJitterCoeff dynamicproperties.FloatPropertyFn
 	}
 )
 
 func NewQueueReader(
 	shard shard.Context,
 	category persistence.HistoryTaskCategory,
+	maxPollInterval dynamicproperties.DurationPropertyFn,
+	maxPollIntervalJitterCoeff dynamicproperties.FloatPropertyFn,
 ) QueueReader {
 	return &simpleQueueReader{
-		shard:    shard,
-		category: category,
+		shard:                      shard,
+		category:                   category,
+		maxPollInterval:            maxPollInterval,
+		maxPollIntervalJitterCoeff: maxPollIntervalJitterCoeff,
 	}
 }
 
@@ -103,5 +122,28 @@ func (r *simpleQueueReader) GetTask(ctx context.Context, req *GetTaskRequest) (*
 			NextPageToken: resp.NextPageToken,
 			NextTaskKey:   nextTaskKey,
 		},
+	}, nil
+}
+
+func (r *simpleQueueReader) LookAHead(ctx context.Context, req *LookAHeadRequest) (*LookAHeadResponse, error) {
+	maxTime := req.InclusiveMinTaskKey.GetScheduledTime().Add(
+		backoff.JitDuration(r.maxPollInterval(), r.maxPollIntervalJitterCoeff()),
+	)
+	resp, err := r.shard.GetExecutionManager().GetHistoryTasks(ctx, &persistence.GetHistoryTasksRequest{
+		TaskCategory:        r.category,
+		InclusiveMinTaskKey: req.InclusiveMinTaskKey,
+		ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(maxTime, 0),
+		PageSize:            1,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var firstTask persistence.Task
+	if len(resp.Tasks) > 0 {
+		firstTask = resp.Tasks[0]
+	}
+	return &LookAHeadResponse{
+		Task:             firstTask,
+		LookAheadMaxTime: maxTime,
 	}, nil
 }

--- a/service/history/queuev2/queue_reader_mock.go
+++ b/service/history/queuev2/queue_reader_mock.go
@@ -54,3 +54,18 @@ func (mr *MockQueueReaderMockRecorder) GetTask(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTask", reflect.TypeOf((*MockQueueReader)(nil).GetTask), arg0, arg1)
 }
+
+// LookAHead mocks base method.
+func (m *MockQueueReader) LookAHead(ctx context.Context, req *LookAHeadRequest) (*LookAHeadResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LookAHead", ctx, req)
+	ret0, _ := ret[0].(*LookAHeadResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LookAHead indicates an expected call of LookAHead.
+func (mr *MockQueueReaderMockRecorder) LookAHead(ctx, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookAHead", reflect.TypeOf((*MockQueueReader)(nil).LookAHead), ctx, req)
+}

--- a/service/history/queuev2/queue_reader_test.go
+++ b/service/history/queuev2/queue_reader_test.go
@@ -2,6 +2,7 @@ package queuev2
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/service/history/shard"
 )
@@ -206,7 +208,7 @@ func TestQueueReader_GetTask(t *testing.T) {
 			mockPredicate := NewMockPredicate(controller)
 			tt.mockSetup(mockShard, mockExec, mockPredicate)
 
-			reader := NewQueueReader(mockShard, persistence.HistoryTaskCategoryTimer)
+			reader := NewQueueReader(mockShard, persistence.HistoryTaskCategoryTimer, nil, nil)
 			tt.request.Predicate = mockPredicate
 			resp, err := reader.GetTask(context.Background(), tt.request)
 
@@ -220,6 +222,98 @@ func TestQueueReader_GetTask(t *testing.T) {
 			assert.Equal(t, tt.expectedTasks, resp.Tasks)
 			assert.Equal(t, tt.expectedToken, resp.Progress.NextPageToken)
 			assert.Equal(t, tt.expectedNextKey, resp.Progress.NextTaskKey)
+		})
+	}
+}
+
+func TestSimpleQueueReader_LookAHead(t *testing.T) {
+	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	minTaskKey := persistence.NewHistoryTaskKey(baseTime, 1)
+	maxPollInterval := 10 * time.Minute
+	jitterCoeff := 0.0 // zero jitter for deterministic tests
+	expectedMaxTime := baseTime.Add(maxPollInterval)
+
+	foundTask := &persistence.DecisionTimeoutTask{
+		WorkflowIdentifier: persistence.WorkflowIdentifier{
+			DomainID:   "test-domain",
+			WorkflowID: "test-workflow",
+			RunID:      "test-run",
+		},
+		TaskData: persistence.TaskData{
+			Version:             1,
+			TaskID:              1,
+			VisibilityTimestamp: baseTime.Add(5 * time.Minute),
+		},
+	}
+
+	tests := []struct {
+		name         string
+		mockSetup    func(*shard.MockContext, *persistence.MockExecutionManager)
+		expectedTask persistence.Task
+		expectedErr  error
+	}{
+		{
+			name: "task found",
+			mockSetup: func(mockShard *shard.MockContext, mockExec *persistence.MockExecutionManager) {
+				mockShard.EXPECT().GetExecutionManager().Return(mockExec)
+				mockExec.EXPECT().GetHistoryTasks(gomock.Any(), &persistence.GetHistoryTasksRequest{
+					TaskCategory:        persistence.HistoryTaskCategoryTimer,
+					InclusiveMinTaskKey: minTaskKey,
+					ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(expectedMaxTime, 0),
+					PageSize:            1,
+				}).Return(&persistence.GetHistoryTasksResponse{
+					Tasks: []persistence.Task{foundTask},
+				}, nil)
+			},
+			expectedTask: foundTask,
+		},
+		{
+			name: "no task found",
+			mockSetup: func(mockShard *shard.MockContext, mockExec *persistence.MockExecutionManager) {
+				mockShard.EXPECT().GetExecutionManager().Return(mockExec)
+				mockExec.EXPECT().GetHistoryTasks(gomock.Any(), gomock.Any()).Return(&persistence.GetHistoryTasksResponse{
+					Tasks: nil,
+				}, nil)
+			},
+			expectedTask: nil,
+		},
+		{
+			name: "DB error",
+			mockSetup: func(mockShard *shard.MockContext, mockExec *persistence.MockExecutionManager) {
+				mockShard.EXPECT().GetExecutionManager().Return(mockExec)
+				mockExec.EXPECT().GetHistoryTasks(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("db error"))
+			},
+			expectedErr: fmt.Errorf("db error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			mockShard := shard.NewMockContext(controller)
+			mockExec := persistence.NewMockExecutionManager(controller)
+			tt.mockSetup(mockShard, mockExec)
+
+			reader := NewQueueReader(
+				mockShard,
+				persistence.HistoryTaskCategoryTimer,
+				dynamicproperties.GetDurationPropertyFn(maxPollInterval),
+				dynamicproperties.GetFloatPropertyFn(jitterCoeff),
+			)
+			resp, err := reader.LookAHead(context.Background(), &LookAHeadRequest{
+				InclusiveMinTaskKey: minTaskKey,
+			})
+
+			if tt.expectedErr != nil {
+				require.Error(t, err)
+				assert.Equal(t, tt.expectedErr, err)
+				assert.Nil(t, resp)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedTask, resp.Task)
+			assert.Equal(t, expectedMaxTime, resp.LookAheadMaxTime)
 		})
 	}
 }

--- a/service/history/queuev2/queue_scheduled.go
+++ b/service/history/queuev2/queue_scheduled.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -186,9 +185,9 @@ func (q *scheduledQueue) processEventLoop() {
 			q.processNextTime()
 		case <-q.timerGate.Chan():
 			q.base.processNewTasks()
-			q.lookAheadTask()
+			q.lookAhead()
 		case <-q.base.updateQueueStateTimer.Chan():
-			q.base.updateQueueState(q.ctx)
+			q.base.updateQueueStateFn(q.ctx)
 		case alert := <-q.base.alertCh:
 			q.base.handleAlert(q.ctx, alert)
 		case <-q.ctx.Done():
@@ -197,34 +196,27 @@ func (q *scheduledQueue) processEventLoop() {
 	}
 }
 
-func (q *scheduledQueue) lookAheadTask() {
-	lookAheadMinTime := q.base.newVirtualSliceState.Range.InclusiveMinTaskKey.GetScheduledTime()
-	lookAheadMaxTime := lookAheadMinTime.Add(backoff.JitDuration(
-		q.base.options.MaxPollInterval(),
-		q.base.options.MaxPollIntervalJitterCoefficient(),
-	))
-
-	resp, err := q.base.queueReader.GetTask(q.ctx, &GetTaskRequest{
-		Progress: &GetTaskProgress{
-			Range: Range{
-				InclusiveMinTaskKey: persistence.NewHistoryTaskKey(lookAheadMinTime, 0),
-				ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(lookAheadMaxTime, 0),
-			},
-			NextTaskKey: persistence.NewHistoryTaskKey(lookAheadMaxTime, 0),
-		},
-		Predicate: NewUniversalPredicate(),
-		PageSize:  1,
+// lookAhead asks the queue reader for the next scheduled task and updates the
+// timer gate accordingly. It is called after processNewTasks on each timer-gate
+// expiry so the gate is re-armed to the earliest pending task.
+func (q *scheduledQueue) lookAhead() {
+	resp, err := q.base.queueReader.LookAHead(q.ctx, &LookAHeadRequest{
+		InclusiveMinTaskKey: q.base.newVirtualSliceState.Range.InclusiveMinTaskKey,
 	})
 	if err != nil {
-		q.timerGate.Update(lookAheadMinTime)
+		q.timerGate.Update(q.base.newVirtualSliceState.Range.InclusiveMinTaskKey.GetScheduledTime())
 		q.base.logger.Error("Failed to look ahead task", tag.Error(err))
 		return
 	}
-
-	if len(resp.Tasks) == 0 {
-		q.timerGate.Update(lookAheadMaxTime)
+	if resp.Task != nil {
+		q.base.logger.Debug("look ahead found next task",
+			tag.Dynamic("nextTaskTime", resp.Task.GetVisibilityTimestamp()),
+		)
+		q.timerGate.Update(resp.Task.GetVisibilityTimestamp())
 		return
 	}
-
-	q.timerGate.Update(resp.Tasks[0].GetVisibilityTimestamp())
+	q.base.logger.Debug("look ahead: no task in window, scheduling until look-ahead max time",
+		tag.Dynamic("lookAheadMaxTime", resp.LookAheadMaxTime),
+	)
+	q.timerGate.Update(resp.LookAheadMaxTime)
 }

--- a/service/history/queuev2/queue_scheduled.go
+++ b/service/history/queuev2/queue_scheduled.go
@@ -185,7 +185,7 @@ func (q *scheduledQueue) processEventLoop() {
 			q.processNextTime()
 		case <-q.timerGate.Chan():
 			q.base.processNewTasks()
-			q.lookAhead()
+			q.lookAheadTask()
 		case <-q.base.updateQueueStateTimer.Chan():
 			q.base.updateQueueStateFn(q.ctx)
 		case alert := <-q.base.alertCh:
@@ -196,10 +196,10 @@ func (q *scheduledQueue) processEventLoop() {
 	}
 }
 
-// lookAhead asks the queue reader for the next scheduled task and updates the
+// lookAheadTask asks the queue reader for the next scheduled task and updates the
 // timer gate accordingly. It is called after processNewTasks on each timer-gate
 // expiry so the gate is re-armed to the earliest pending task.
-func (q *scheduledQueue) lookAhead() {
+func (q *scheduledQueue) lookAheadTask() {
 	resp, err := q.base.queueReader.LookAHead(q.ctx, &LookAHeadRequest{
 		InclusiveMinTaskKey: q.base.newVirtualSliceState.Range.InclusiveMinTaskKey,
 	})

--- a/service/history/queuev2/queue_scheduled_test.go
+++ b/service/history/queuev2/queue_scheduled_test.go
@@ -125,31 +125,20 @@ func TestScheduledQueue_LookAheadTask(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
 	tests := []struct {
-		name           string
-		setupMocks     func(*gomock.Controller, *MockQueueReader, clock.TimeSource, *clock.MockTimerGate)
-		expectedUpdate time.Time
+		name       string
+		setupMocks func(*gomock.Controller, *MockQueueReader, clock.TimeSource, *clock.MockTimerGate)
 	}{
 		{
 			name: "successful look ahead with future task",
 			setupMocks: func(ctrl *gomock.Controller, mockReader *MockQueueReader, mockTimeSource clock.TimeSource, mockTimerGate *clock.MockTimerGate) {
 				now := mockTimeSource.Now()
 				futureTime := now.Add(time.Hour)
-				mockReader.EXPECT().GetTask(gomock.Any(), &GetTaskRequest{
-					Progress: &GetTaskProgress{
-						Range: Range{
-							InclusiveMinTaskKey: persistence.NewHistoryTaskKey(now, 0),
-							ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(now.Add(time.Second*10), 0),
-						},
-						NextTaskKey: persistence.NewHistoryTaskKey(now.Add(time.Second*10), 0),
-					},
-					Predicate: NewUniversalPredicate(),
-					PageSize:  1,
-				}).Return(&GetTaskResponse{
-					Tasks: []persistence.Task{
-						&persistence.DecisionTimeoutTask{
-							TaskData: persistence.TaskData{
-								VisibilityTimestamp: futureTime,
-							},
+				mockReader.EXPECT().LookAHead(gomock.Any(), &LookAHeadRequest{
+					InclusiveMinTaskKey: persistence.NewHistoryTaskKey(now, 0),
+				}).Return(&LookAHeadResponse{
+					Task: &persistence.DecisionTimeoutTask{
+						TaskData: persistence.TaskData{
+							VisibilityTimestamp: futureTime,
 						},
 					},
 				}, nil)
@@ -160,36 +149,21 @@ func TestScheduledQueue_LookAheadTask(t *testing.T) {
 			name: "no tasks found",
 			setupMocks: func(ctrl *gomock.Controller, mockReader *MockQueueReader, mockTimeSource clock.TimeSource, mockTimerGate *clock.MockTimerGate) {
 				now := mockTimeSource.Now()
-				mockReader.EXPECT().GetTask(gomock.Any(), &GetTaskRequest{
-					Progress: &GetTaskProgress{
-						Range: Range{
-							InclusiveMinTaskKey: persistence.NewHistoryTaskKey(now, 0),
-							ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(now.Add(time.Second*10), 0),
-						},
-						NextTaskKey: persistence.NewHistoryTaskKey(now.Add(time.Second*10), 0),
-					},
-					Predicate: NewUniversalPredicate(),
-					PageSize:  1,
-				}).Return(&GetTaskResponse{
-					Tasks: []persistence.Task{},
+				lookAheadMaxTime := now.Add(time.Second * 10)
+				mockReader.EXPECT().LookAHead(gomock.Any(), &LookAHeadRequest{
+					InclusiveMinTaskKey: persistence.NewHistoryTaskKey(now, 0),
+				}).Return(&LookAHeadResponse{
+					LookAheadMaxTime: lookAheadMaxTime,
 				}, nil)
-				mockTimerGate.EXPECT().Update(now.Add(time.Second * 10))
+				mockTimerGate.EXPECT().Update(lookAheadMaxTime)
 			},
 		},
 		{
 			name: "error during look ahead",
 			setupMocks: func(ctrl *gomock.Controller, mockReader *MockQueueReader, mockTimeSource clock.TimeSource, mockTimerGate *clock.MockTimerGate) {
 				now := mockTimeSource.Now()
-				mockReader.EXPECT().GetTask(gomock.Any(), &GetTaskRequest{
-					Progress: &GetTaskProgress{
-						Range: Range{
-							InclusiveMinTaskKey: persistence.NewHistoryTaskKey(now, 0),
-							ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(now.Add(time.Second*10), 0),
-						},
-						NextTaskKey: persistence.NewHistoryTaskKey(now.Add(time.Second*10), 0),
-					},
-					Predicate: NewUniversalPredicate(),
-					PageSize:  1,
+				mockReader.EXPECT().LookAHead(gomock.Any(), &LookAHeadRequest{
+					InclusiveMinTaskKey: persistence.NewHistoryTaskKey(now, 0),
 				}).Return(nil, errors.New("test error"))
 				mockTimerGate.EXPECT().Update(now)
 			},
@@ -243,11 +217,11 @@ func TestScheduledQueue_LookAheadTask(t *testing.T) {
 				newTimerCh: make(chan struct{}, 1),
 			}
 
-			// Setup test-specific mocks and get expected update time
+			// Setup test-specific mocks
 			tt.setupMocks(ctrl, mockQueueReader, mockTimeSource, mockTimerGate)
 
-			// Execute lookAheadTask
-			queue.lookAheadTask()
+			// Execute lookAhead directly instead of inlining its logic
+			queue.lookAhead()
 		})
 	}
 }

--- a/service/history/queuev2/queue_scheduled_test.go
+++ b/service/history/queuev2/queue_scheduled_test.go
@@ -220,8 +220,8 @@ func TestScheduledQueue_LookAheadTask(t *testing.T) {
 			// Setup test-specific mocks
 			tt.setupMocks(ctrl, mockQueueReader, mockTimeSource, mockTimerGate)
 
-			// Execute lookAhead directly instead of inlining its logic
-			queue.lookAhead()
+			// Execute lookAheadTask directly instead of inlining its logic
+			queue.lookAheadTask()
 		})
 	}
 }


### PR DESCRIPTION
**What changed?**

Adds a `LookAHead` method to the `QueueReader` interface and its implementation in `simpleQueueReader`. Updates `scheduledQueue` to delegate look-ahead to `QueueReader.LookAHead` instead of inlining a raw `GetTask` call with jitter math.

- `QueueReader` gains `LookAHead(ctx, *LookAHeadRequest) (*LookAHeadResponse, error)` with request/response types
- `NewQueueReader` now accepts `maxPollInterval` and `jitterCoeff` params (used inside `LookAHead`)
- `scheduledQueue.lookAhead` renamed to `lookAheadTask`, delegating to `queueReader.LookAHead`
- `updateQueueState` field renamed to `updateQueueStateFn` to allow override in a follow-up PR

**Why?**

The look-ahead logic was duplicated inline in `scheduledQueue`. Extracting it into `QueueReader` keeps the queue processor free of scheduling math and makes it possible to override look-ahead behavior (e.g. serve from an in-memory cache) without touching the queue loop.

Part of changes implementing Timer Task Read Optimization https://github.com/cadence-workflow/cadence/issues/7953.

**How did you test it?**

```
go test -race ./service/history/queuev2/...
make lint
```

All tests pass. Look-ahead behavior is exercised by `TestScheduledQueue_LookAHead_*` table tests.

**Potential risks**

Low. The look-ahead window computation is identical to before (maxPollInterval ± jitter). The only external caller of `NewScheduledQueue` (`timer_queue_factory.go`) is unchanged.

**Release notes**

N/A — internal refactor, no user-facing behaviour change.

**Documentation Changes**

N/A