### PR TITLE
fix: use ExponentialHistogram when emit histogram metrics

### DIFF
--- a/client/templates/metered.tmpl
+++ b/client/templates/metered.tmpl
@@ -49,7 +49,7 @@ func (c *{{$decorator}}) {{$method.Declaration}} {
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	{{$method.ResultsNames}} = c.client.{{$method.Call}}
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)

--- a/client/wrappers/metered/admin_generated.go
+++ b/client/wrappers/metered/admin_generated.go
@@ -45,7 +45,7 @@ func (c *adminClient) AddSearchAttribute(ctx context.Context, ap1 *types.AddSear
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.AddSearchAttribute(ctx, ap1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -69,7 +69,7 @@ func (c *adminClient) CloseShard(ctx context.Context, cp1 *types.CloseShardReque
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.CloseShard(ctx, cp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -93,7 +93,7 @@ func (c *adminClient) CountDLQMessages(ctx context.Context, cp1 *types.CountDLQM
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	cp2, err = c.client.CountDLQMessages(ctx, cp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -117,7 +117,7 @@ func (c *adminClient) DeleteWorkflow(ctx context.Context, ap1 *types.AdminDelete
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	ap2, err = c.client.DeleteWorkflow(ctx, ap1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -141,7 +141,7 @@ func (c *adminClient) DescribeCluster(ctx context.Context, p1 ...yarpc.CallOptio
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	dp1, err = c.client.DescribeCluster(ctx, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -165,7 +165,7 @@ func (c *adminClient) DescribeHistoryHost(ctx context.Context, dp1 *types.Descri
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	dp2, err = c.client.DescribeHistoryHost(ctx, dp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -189,7 +189,7 @@ func (c *adminClient) DescribeQueue(ctx context.Context, dp1 *types.DescribeQueu
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	dp2, err = c.client.DescribeQueue(ctx, dp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -213,7 +213,7 @@ func (c *adminClient) DescribeShardDistribution(ctx context.Context, dp1 *types.
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	dp2, err = c.client.DescribeShardDistribution(ctx, dp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -237,7 +237,7 @@ func (c *adminClient) DescribeWorkflowExecution(ctx context.Context, ap1 *types.
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	ap2, err = c.client.DescribeWorkflowExecution(ctx, ap1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -261,7 +261,7 @@ func (c *adminClient) GetDLQReplicationMessages(ctx context.Context, gp1 *types.
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	gp2, err = c.client.GetDLQReplicationMessages(ctx, gp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -285,7 +285,7 @@ func (c *adminClient) GetDomainAsyncWorkflowConfiguraton(ctx context.Context, re
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	gp1, err = c.client.GetDomainAsyncWorkflowConfiguraton(ctx, request, opts...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -309,7 +309,7 @@ func (c *adminClient) GetDomainIsolationGroups(ctx context.Context, request *typ
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	gp1, err = c.client.GetDomainIsolationGroups(ctx, request, opts...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -333,7 +333,7 @@ func (c *adminClient) GetDomainReplicationMessages(ctx context.Context, gp1 *typ
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	gp2, err = c.client.GetDomainReplicationMessages(ctx, gp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -357,7 +357,7 @@ func (c *adminClient) GetDynamicConfig(ctx context.Context, gp1 *types.GetDynami
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	gp2, err = c.client.GetDynamicConfig(ctx, gp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -381,7 +381,7 @@ func (c *adminClient) GetGlobalIsolationGroups(ctx context.Context, request *typ
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	gp1, err = c.client.GetGlobalIsolationGroups(ctx, request, opts...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -429,7 +429,7 @@ func (c *adminClient) GetReplicationMessages(ctx context.Context, gp1 *types.Get
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	gp2, err = c.client.GetReplicationMessages(ctx, gp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -453,7 +453,7 @@ func (c *adminClient) GetWorkflowExecutionRawHistoryV2(ctx context.Context, gp1 
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	gp2, err = c.client.GetWorkflowExecutionRawHistoryV2(ctx, gp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -477,7 +477,7 @@ func (c *adminClient) ListDynamicConfig(ctx context.Context, lp1 *types.ListDyna
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	lp2, err = c.client.ListDynamicConfig(ctx, lp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -525,7 +525,7 @@ func (c *adminClient) MaintainCorruptWorkflow(ctx context.Context, ap1 *types.Ad
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	ap2, err = c.client.MaintainCorruptWorkflow(ctx, ap1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -549,7 +549,7 @@ func (c *adminClient) MergeDLQMessages(ctx context.Context, mp1 *types.MergeDLQM
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	mp2, err = c.client.MergeDLQMessages(ctx, mp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -573,7 +573,7 @@ func (c *adminClient) PurgeDLQMessages(ctx context.Context, pp1 *types.PurgeDLQM
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.PurgeDLQMessages(ctx, pp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -597,7 +597,7 @@ func (c *adminClient) ReadDLQMessages(ctx context.Context, rp1 *types.ReadDLQMes
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	rp2, err = c.client.ReadDLQMessages(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -621,7 +621,7 @@ func (c *adminClient) ReapplyEvents(ctx context.Context, rp1 *types.ReapplyEvent
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.ReapplyEvents(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -645,7 +645,7 @@ func (c *adminClient) RefreshWorkflowTasks(ctx context.Context, rp1 *types.Refre
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RefreshWorkflowTasks(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -669,7 +669,7 @@ func (c *adminClient) RemoveTask(ctx context.Context, rp1 *types.RemoveTaskReque
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RemoveTask(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -693,7 +693,7 @@ func (c *adminClient) ResendReplicationTasks(ctx context.Context, rp1 *types.Res
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.ResendReplicationTasks(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -717,7 +717,7 @@ func (c *adminClient) ResetQueue(ctx context.Context, rp1 *types.ResetQueueReque
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.ResetQueue(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -741,7 +741,7 @@ func (c *adminClient) RestoreDynamicConfig(ctx context.Context, rp1 *types.Resto
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RestoreDynamicConfig(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -789,7 +789,7 @@ func (c *adminClient) UpdateDomainAsyncWorkflowConfiguraton(ctx context.Context,
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	up1, err = c.client.UpdateDomainAsyncWorkflowConfiguraton(ctx, request, opts...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -813,7 +813,7 @@ func (c *adminClient) UpdateDomainIsolationGroups(ctx context.Context, request *
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	up1, err = c.client.UpdateDomainIsolationGroups(ctx, request, opts...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -837,7 +837,7 @@ func (c *adminClient) UpdateDynamicConfig(ctx context.Context, up1 *types.Update
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.UpdateDynamicConfig(ctx, up1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -861,7 +861,7 @@ func (c *adminClient) UpdateGlobalIsolationGroups(ctx context.Context, request *
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	up1, err = c.client.UpdateGlobalIsolationGroups(ctx, request, opts...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -909,7 +909,7 @@ func (c *adminClient) UpdateTaskListPartitionConfig(ctx context.Context, request
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	up1, err = c.client.UpdateTaskListPartitionConfig(ctx, request, opts...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)

--- a/client/wrappers/metered/admin_generated.go
+++ b/client/wrappers/metered/admin_generated.go
@@ -405,7 +405,7 @@ func (c *adminClient) GetOperationalDynamicConfig(ctx context.Context, gp1 *type
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	gp2, err = c.client.GetOperationalDynamicConfig(ctx, gp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -501,7 +501,7 @@ func (c *adminClient) ListOperationalDynamicConfig(ctx context.Context, lp1 *typ
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	lp2, err = c.client.ListOperationalDynamicConfig(ctx, lp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -765,7 +765,7 @@ func (c *adminClient) RestoreOperationalDynamicConfig(ctx context.Context, rp1 *
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RestoreOperationalDynamicConfig(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -885,7 +885,7 @@ func (c *adminClient) UpdateOperationalDynamicConfig(ctx context.Context, up1 *t
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.UpdateOperationalDynamicConfig(ctx, up1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)

--- a/client/wrappers/metered/frontend_generated.go
+++ b/client/wrappers/metered/frontend_generated.go
@@ -45,7 +45,7 @@ func (c *frontendClient) BackfillSchedule(ctx context.Context, bp1 *types.Backfi
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	bp2, err = c.client.BackfillSchedule(ctx, bp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -69,7 +69,7 @@ func (c *frontendClient) CountWorkflowExecutions(ctx context.Context, cp1 *types
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	cp2, err = c.client.CountWorkflowExecutions(ctx, cp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -93,7 +93,7 @@ func (c *frontendClient) CreateSchedule(ctx context.Context, cp1 *types.CreateSc
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	cp2, err = c.client.CreateSchedule(ctx, cp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -117,7 +117,7 @@ func (c *frontendClient) DeleteDomain(ctx context.Context, dp1 *types.DeleteDoma
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.DeleteDomain(ctx, dp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -141,7 +141,7 @@ func (c *frontendClient) DeleteSchedule(ctx context.Context, dp1 *types.DeleteSc
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	dp2, err = c.client.DeleteSchedule(ctx, dp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -165,7 +165,7 @@ func (c *frontendClient) DeprecateDomain(ctx context.Context, dp1 *types.Depreca
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.DeprecateDomain(ctx, dp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -189,7 +189,7 @@ func (c *frontendClient) DescribeDomain(ctx context.Context, dp1 *types.Describe
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	dp2, err = c.client.DescribeDomain(ctx, dp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -213,7 +213,7 @@ func (c *frontendClient) DescribeSchedule(ctx context.Context, dp1 *types.Descri
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	dp2, err = c.client.DescribeSchedule(ctx, dp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -237,7 +237,7 @@ func (c *frontendClient) DescribeTaskList(ctx context.Context, dp1 *types.Descri
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	dp2, err = c.client.DescribeTaskList(ctx, dp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -261,7 +261,7 @@ func (c *frontendClient) DescribeWorkflowExecution(ctx context.Context, dp1 *typ
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	dp2, err = c.client.DescribeWorkflowExecution(ctx, dp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -285,7 +285,7 @@ func (c *frontendClient) DiagnoseWorkflowExecution(ctx context.Context, dp1 *typ
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	dp2, err = c.client.DiagnoseWorkflowExecution(ctx, dp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -309,7 +309,7 @@ func (c *frontendClient) FailoverDomain(ctx context.Context, fp1 *types.Failover
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	fp2, err = c.client.FailoverDomain(ctx, fp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -333,7 +333,7 @@ func (c *frontendClient) GetClusterInfo(ctx context.Context, p1 ...yarpc.CallOpt
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	cp1, err = c.client.GetClusterInfo(ctx, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -357,7 +357,7 @@ func (c *frontendClient) GetSearchAttributes(ctx context.Context, p1 ...yarpc.Ca
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	gp1, err = c.client.GetSearchAttributes(ctx, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -381,7 +381,7 @@ func (c *frontendClient) GetTaskListsByDomain(ctx context.Context, gp1 *types.Ge
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	gp2, err = c.client.GetTaskListsByDomain(ctx, gp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -405,7 +405,7 @@ func (c *frontendClient) GetWorkflowExecutionHistory(ctx context.Context, gp1 *t
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	gp2, err = c.client.GetWorkflowExecutionHistory(ctx, gp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -429,7 +429,7 @@ func (c *frontendClient) ListArchivedWorkflowExecutions(ctx context.Context, lp1
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	lp2, err = c.client.ListArchivedWorkflowExecutions(ctx, lp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -453,7 +453,7 @@ func (c *frontendClient) ListClosedWorkflowExecutions(ctx context.Context, lp1 *
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	lp2, err = c.client.ListClosedWorkflowExecutions(ctx, lp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -477,7 +477,7 @@ func (c *frontendClient) ListDomains(ctx context.Context, lp1 *types.ListDomains
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	lp2, err = c.client.ListDomains(ctx, lp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -501,7 +501,7 @@ func (c *frontendClient) ListFailoverHistory(ctx context.Context, lp1 *types.Lis
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	lp2, err = c.client.ListFailoverHistory(ctx, lp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -525,7 +525,7 @@ func (c *frontendClient) ListOpenWorkflowExecutions(ctx context.Context, lp1 *ty
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	lp2, err = c.client.ListOpenWorkflowExecutions(ctx, lp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -549,7 +549,7 @@ func (c *frontendClient) ListSchedules(ctx context.Context, lp1 *types.ListSched
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	lp2, err = c.client.ListSchedules(ctx, lp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -573,7 +573,7 @@ func (c *frontendClient) ListTaskListPartitions(ctx context.Context, lp1 *types.
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	lp2, err = c.client.ListTaskListPartitions(ctx, lp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -597,7 +597,7 @@ func (c *frontendClient) ListWorkflowExecutions(ctx context.Context, lp1 *types.
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	lp2, err = c.client.ListWorkflowExecutions(ctx, lp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -621,7 +621,7 @@ func (c *frontendClient) PauseSchedule(ctx context.Context, pp1 *types.PauseSche
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	pp2, err = c.client.PauseSchedule(ctx, pp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -645,7 +645,7 @@ func (c *frontendClient) PollForActivityTask(ctx context.Context, pp1 *types.Pol
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	pp2, err = c.client.PollForActivityTask(ctx, pp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -669,7 +669,7 @@ func (c *frontendClient) PollForDecisionTask(ctx context.Context, pp1 *types.Pol
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	pp2, err = c.client.PollForDecisionTask(ctx, pp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -693,7 +693,7 @@ func (c *frontendClient) QueryWorkflow(ctx context.Context, qp1 *types.QueryWork
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	qp2, err = c.client.QueryWorkflow(ctx, qp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -717,7 +717,7 @@ func (c *frontendClient) RecordActivityTaskHeartbeat(ctx context.Context, rp1 *t
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	rp2, err = c.client.RecordActivityTaskHeartbeat(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -741,7 +741,7 @@ func (c *frontendClient) RecordActivityTaskHeartbeatByID(ctx context.Context, rp
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	rp2, err = c.client.RecordActivityTaskHeartbeatByID(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -765,7 +765,7 @@ func (c *frontendClient) RefreshWorkflowTasks(ctx context.Context, rp1 *types.Re
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RefreshWorkflowTasks(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -789,7 +789,7 @@ func (c *frontendClient) RegisterDomain(ctx context.Context, rp1 *types.Register
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RegisterDomain(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -813,7 +813,7 @@ func (c *frontendClient) RequestCancelWorkflowExecution(ctx context.Context, rp1
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RequestCancelWorkflowExecution(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -837,7 +837,7 @@ func (c *frontendClient) ResetStickyTaskList(ctx context.Context, rp1 *types.Res
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	rp2, err = c.client.ResetStickyTaskList(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -861,7 +861,7 @@ func (c *frontendClient) ResetWorkflowExecution(ctx context.Context, rp1 *types.
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	rp2, err = c.client.ResetWorkflowExecution(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -885,7 +885,7 @@ func (c *frontendClient) RespondActivityTaskCanceled(ctx context.Context, rp1 *t
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RespondActivityTaskCanceled(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -909,7 +909,7 @@ func (c *frontendClient) RespondActivityTaskCanceledByID(ctx context.Context, rp
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RespondActivityTaskCanceledByID(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -933,7 +933,7 @@ func (c *frontendClient) RespondActivityTaskCompleted(ctx context.Context, rp1 *
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RespondActivityTaskCompleted(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -957,7 +957,7 @@ func (c *frontendClient) RespondActivityTaskCompletedByID(ctx context.Context, r
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RespondActivityTaskCompletedByID(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -981,7 +981,7 @@ func (c *frontendClient) RespondActivityTaskFailed(ctx context.Context, rp1 *typ
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RespondActivityTaskFailed(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -1005,7 +1005,7 @@ func (c *frontendClient) RespondActivityTaskFailedByID(ctx context.Context, rp1 
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RespondActivityTaskFailedByID(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -1029,7 +1029,7 @@ func (c *frontendClient) RespondDecisionTaskCompleted(ctx context.Context, rp1 *
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	rp2, err = c.client.RespondDecisionTaskCompleted(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -1053,7 +1053,7 @@ func (c *frontendClient) RespondDecisionTaskFailed(ctx context.Context, rp1 *typ
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RespondDecisionTaskFailed(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -1077,7 +1077,7 @@ func (c *frontendClient) RespondQueryTaskCompleted(ctx context.Context, rp1 *typ
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RespondQueryTaskCompleted(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -1101,7 +1101,7 @@ func (c *frontendClient) RestartWorkflowExecution(ctx context.Context, rp1 *type
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	rp2, err = c.client.RestartWorkflowExecution(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -1125,7 +1125,7 @@ func (c *frontendClient) ScanWorkflowExecutions(ctx context.Context, lp1 *types.
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	lp2, err = c.client.ScanWorkflowExecutions(ctx, lp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -1149,7 +1149,7 @@ func (c *frontendClient) SignalWithStartWorkflowExecution(ctx context.Context, s
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	sp2, err = c.client.SignalWithStartWorkflowExecution(ctx, sp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -1173,7 +1173,7 @@ func (c *frontendClient) SignalWithStartWorkflowExecutionAsync(ctx context.Conte
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	sp2, err = c.client.SignalWithStartWorkflowExecutionAsync(ctx, sp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -1197,7 +1197,7 @@ func (c *frontendClient) SignalWorkflowExecution(ctx context.Context, sp1 *types
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.SignalWorkflowExecution(ctx, sp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -1221,7 +1221,7 @@ func (c *frontendClient) StartWorkflowExecution(ctx context.Context, sp1 *types.
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	sp2, err = c.client.StartWorkflowExecution(ctx, sp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -1245,7 +1245,7 @@ func (c *frontendClient) StartWorkflowExecutionAsync(ctx context.Context, sp1 *t
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	sp2, err = c.client.StartWorkflowExecutionAsync(ctx, sp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -1269,7 +1269,7 @@ func (c *frontendClient) TerminateWorkflowExecution(ctx context.Context, tp1 *ty
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.TerminateWorkflowExecution(ctx, tp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -1293,7 +1293,7 @@ func (c *frontendClient) UnpauseSchedule(ctx context.Context, up1 *types.Unpause
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	up2, err = c.client.UnpauseSchedule(ctx, up1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -1317,7 +1317,7 @@ func (c *frontendClient) UpdateDomain(ctx context.Context, up1 *types.UpdateDoma
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	up2, err = c.client.UpdateDomain(ctx, up1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -1341,7 +1341,7 @@ func (c *frontendClient) UpdateSchedule(ctx context.Context, up1 *types.UpdateSc
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	up2, err = c.client.UpdateSchedule(ctx, up1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)

--- a/client/wrappers/metered/history_generated.go
+++ b/client/wrappers/metered/history_generated.go
@@ -45,7 +45,7 @@ func (c *historyClient) CloseShard(ctx context.Context, cp1 *types.CloseShardReq
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.CloseShard(ctx, cp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -69,7 +69,7 @@ func (c *historyClient) CountDLQMessages(ctx context.Context, cp1 *types.CountDL
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	hp1, err = c.client.CountDLQMessages(ctx, cp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -93,7 +93,7 @@ func (c *historyClient) DescribeHistoryHost(ctx context.Context, dp1 *types.Desc
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	dp2, err = c.client.DescribeHistoryHost(ctx, dp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -117,7 +117,7 @@ func (c *historyClient) DescribeMutableState(ctx context.Context, dp1 *types.Des
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	dp2, err = c.client.DescribeMutableState(ctx, dp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -141,7 +141,7 @@ func (c *historyClient) DescribeQueue(ctx context.Context, dp1 *types.DescribeQu
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	dp2, err = c.client.DescribeQueue(ctx, dp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -165,7 +165,7 @@ func (c *historyClient) DescribeWorkflowExecution(ctx context.Context, hp1 *type
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	dp1, err = c.client.DescribeWorkflowExecution(ctx, hp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -189,7 +189,7 @@ func (c *historyClient) GetCrossClusterTasks(ctx context.Context, gp1 *types.Get
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	gp2, err = c.client.GetCrossClusterTasks(ctx, gp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -213,7 +213,7 @@ func (c *historyClient) GetDLQReplicationMessages(ctx context.Context, gp1 *type
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	gp2, err = c.client.GetDLQReplicationMessages(ctx, gp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -237,7 +237,7 @@ func (c *historyClient) GetFailoverInfo(ctx context.Context, gp1 *types.GetFailo
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	gp2, err = c.client.GetFailoverInfo(ctx, gp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -261,7 +261,7 @@ func (c *historyClient) GetMutableState(ctx context.Context, gp1 *types.GetMutab
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	gp2, err = c.client.GetMutableState(ctx, gp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -285,7 +285,7 @@ func (c *historyClient) GetReplicationMessages(ctx context.Context, gp1 *types.G
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	gp2, err = c.client.GetReplicationMessages(ctx, gp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -309,7 +309,7 @@ func (c *historyClient) MergeDLQMessages(ctx context.Context, mp1 *types.MergeDL
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	mp2, err = c.client.MergeDLQMessages(ctx, mp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -333,7 +333,7 @@ func (c *historyClient) NotifyFailoverMarkers(ctx context.Context, np1 *types.No
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.NotifyFailoverMarkers(ctx, np1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -357,7 +357,7 @@ func (c *historyClient) PollMutableState(ctx context.Context, pp1 *types.PollMut
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	pp2, err = c.client.PollMutableState(ctx, pp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -381,7 +381,7 @@ func (c *historyClient) PurgeDLQMessages(ctx context.Context, pp1 *types.PurgeDL
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.PurgeDLQMessages(ctx, pp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -405,7 +405,7 @@ func (c *historyClient) QueryWorkflow(ctx context.Context, hp1 *types.HistoryQue
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	hp2, err = c.client.QueryWorkflow(ctx, hp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -429,7 +429,7 @@ func (c *historyClient) RatelimitUpdate(ctx context.Context, request *types.Rate
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	rp1, err = c.client.RatelimitUpdate(ctx, request, opts...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -453,7 +453,7 @@ func (c *historyClient) ReadDLQMessages(ctx context.Context, rp1 *types.ReadDLQM
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	rp2, err = c.client.ReadDLQMessages(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -477,7 +477,7 @@ func (c *historyClient) ReapplyEvents(ctx context.Context, hp1 *types.HistoryRea
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.ReapplyEvents(ctx, hp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -501,7 +501,7 @@ func (c *historyClient) RecordActivityTaskHeartbeat(ctx context.Context, hp1 *ty
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	rp1, err = c.client.RecordActivityTaskHeartbeat(ctx, hp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -525,7 +525,7 @@ func (c *historyClient) RecordActivityTaskStarted(ctx context.Context, rp1 *type
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	rp2, err = c.client.RecordActivityTaskStarted(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -549,7 +549,7 @@ func (c *historyClient) RecordChildExecutionCompleted(ctx context.Context, rp1 *
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RecordChildExecutionCompleted(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -573,7 +573,7 @@ func (c *historyClient) RecordDecisionTaskStarted(ctx context.Context, rp1 *type
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	rp2, err = c.client.RecordDecisionTaskStarted(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -597,7 +597,7 @@ func (c *historyClient) RefreshWorkflowTasks(ctx context.Context, hp1 *types.His
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RefreshWorkflowTasks(ctx, hp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -621,7 +621,7 @@ func (c *historyClient) RemoveSignalMutableState(ctx context.Context, rp1 *types
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RemoveSignalMutableState(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -645,7 +645,7 @@ func (c *historyClient) RemoveTask(ctx context.Context, rp1 *types.RemoveTaskReq
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RemoveTask(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -669,7 +669,7 @@ func (c *historyClient) ReplicateEventsV2(ctx context.Context, rp1 *types.Replic
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.ReplicateEventsV2(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -693,7 +693,7 @@ func (c *historyClient) RequestCancelWorkflowExecution(ctx context.Context, hp1 
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RequestCancelWorkflowExecution(ctx, hp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -717,7 +717,7 @@ func (c *historyClient) ResetQueue(ctx context.Context, rp1 *types.ResetQueueReq
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.ResetQueue(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -741,7 +741,7 @@ func (c *historyClient) ResetStickyTaskList(ctx context.Context, hp1 *types.Hist
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	hp2, err = c.client.ResetStickyTaskList(ctx, hp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -765,7 +765,7 @@ func (c *historyClient) ResetWorkflowExecution(ctx context.Context, hp1 *types.H
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	rp1, err = c.client.ResetWorkflowExecution(ctx, hp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -789,7 +789,7 @@ func (c *historyClient) RespondActivityTaskCanceled(ctx context.Context, hp1 *ty
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RespondActivityTaskCanceled(ctx, hp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -813,7 +813,7 @@ func (c *historyClient) RespondActivityTaskCompleted(ctx context.Context, hp1 *t
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RespondActivityTaskCompleted(ctx, hp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -837,7 +837,7 @@ func (c *historyClient) RespondActivityTaskFailed(ctx context.Context, hp1 *type
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RespondActivityTaskFailed(ctx, hp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -861,7 +861,7 @@ func (c *historyClient) RespondCrossClusterTasksCompleted(ctx context.Context, r
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	rp2, err = c.client.RespondCrossClusterTasksCompleted(ctx, rp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -885,7 +885,7 @@ func (c *historyClient) RespondDecisionTaskCompleted(ctx context.Context, hp1 *t
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	hp2, err = c.client.RespondDecisionTaskCompleted(ctx, hp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -909,7 +909,7 @@ func (c *historyClient) RespondDecisionTaskFailed(ctx context.Context, hp1 *type
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RespondDecisionTaskFailed(ctx, hp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -933,7 +933,7 @@ func (c *historyClient) ScheduleDecisionTask(ctx context.Context, sp1 *types.Sch
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.ScheduleDecisionTask(ctx, sp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -957,7 +957,7 @@ func (c *historyClient) SignalWithStartWorkflowExecution(ctx context.Context, hp
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	sp1, err = c.client.SignalWithStartWorkflowExecution(ctx, hp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -981,7 +981,7 @@ func (c *historyClient) SignalWorkflowExecution(ctx context.Context, hp1 *types.
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.SignalWorkflowExecution(ctx, hp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -1005,7 +1005,7 @@ func (c *historyClient) StartWorkflowExecution(ctx context.Context, hp1 *types.H
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	sp1, err = c.client.StartWorkflowExecution(ctx, hp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -1029,7 +1029,7 @@ func (c *historyClient) SyncActivity(ctx context.Context, sp1 *types.SyncActivit
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.SyncActivity(ctx, sp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -1053,7 +1053,7 @@ func (c *historyClient) SyncShardStatus(ctx context.Context, sp1 *types.SyncShar
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.SyncShardStatus(ctx, sp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -1077,7 +1077,7 @@ func (c *historyClient) TerminateWorkflowExecution(ctx context.Context, hp1 *typ
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.TerminateWorkflowExecution(ctx, hp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)

--- a/client/wrappers/metered/matching_generated.go
+++ b/client/wrappers/metered/matching_generated.go
@@ -48,7 +48,7 @@ func (c *matchingClient) AddActivityTask(ctx context.Context, ap1 *types.AddActi
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	ap2, err = c.client.AddActivityTask(ctx, ap1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -73,7 +73,7 @@ func (c *matchingClient) AddDecisionTask(ctx context.Context, ap1 *types.AddDeci
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	ap2, err = c.client.AddDecisionTask(ctx, ap1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -98,7 +98,7 @@ func (c *matchingClient) CancelOutstandingPoll(ctx context.Context, cp1 *types.C
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.CancelOutstandingPoll(ctx, cp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -123,7 +123,7 @@ func (c *matchingClient) DescribeTaskList(ctx context.Context, mp1 *types.Matchi
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	dp1, err = c.client.DescribeTaskList(ctx, mp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -148,7 +148,7 @@ func (c *matchingClient) GetTaskListsByDomain(ctx context.Context, gp1 *types.Ge
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	gp2, err = c.client.GetTaskListsByDomain(ctx, gp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -173,7 +173,7 @@ func (c *matchingClient) ListTaskListPartitions(ctx context.Context, mp1 *types.
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	lp1, err = c.client.ListTaskListPartitions(ctx, mp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -198,7 +198,7 @@ func (c *matchingClient) PollForActivityTask(ctx context.Context, mp1 *types.Mat
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	mp2, err = c.client.PollForActivityTask(ctx, mp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -223,7 +223,7 @@ func (c *matchingClient) PollForDecisionTask(ctx context.Context, mp1 *types.Mat
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	mp2, err = c.client.PollForDecisionTask(ctx, mp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -248,7 +248,7 @@ func (c *matchingClient) QueryWorkflow(ctx context.Context, mp1 *types.MatchingQ
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	mp2, err = c.client.QueryWorkflow(ctx, mp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -273,7 +273,7 @@ func (c *matchingClient) RefreshTaskListPartitionConfig(ctx context.Context, mp1
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	mp2, err = c.client.RefreshTaskListPartitionConfig(ctx, mp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -298,7 +298,7 @@ func (c *matchingClient) RespondQueryTaskCompleted(ctx context.Context, mp1 *typ
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	err = c.client.RespondQueryTaskCompleted(ctx, mp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -323,7 +323,7 @@ func (c *matchingClient) UpdateTaskListPartitionConfig(ctx context.Context, mp1 
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	mp2, err = c.client.UpdateTaskListPartitionConfig(ctx, mp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)

--- a/client/wrappers/metered/sharddistributor_generated.go
+++ b/client/wrappers/metered/sharddistributor_generated.go
@@ -45,7 +45,7 @@ func (c *sharddistributorClient) GetShardOwner(ctx context.Context, gp1 *types.G
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	gp2, err = c.client.GetShardOwner(ctx, gp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)
@@ -69,7 +69,7 @@ func (c *sharddistributorClient) WatchNamespaceState(ctx context.Context, wp1 *t
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	w1, err = c.client.WatchNamespaceState(ctx, wp1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)

--- a/client/wrappers/metered/sharddistributorexecutor_generated.go
+++ b/client/wrappers/metered/sharddistributorexecutor_generated.go
@@ -45,7 +45,7 @@ func (c *sharddistributorexecutorClient) Heartbeat(ctx context.Context, ep1 *typ
 	sw := scope.StartTimer(metrics.CadenceClientLatency)
 	ep2, err = c.client.Heartbeat(ctx, ep1, p1...)
 	sw.Stop()
-	scope.RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
+	scope.ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(clientLatencyStart))
 
 	if err != nil {
 		scope.IncCounter(metrics.CadenceClientFailures)

--- a/common/asyncworkflow/queue/consumer/default_consumer.go
+++ b/common/asyncworkflow/queue/consumer/default_consumer.go
@@ -160,7 +160,7 @@ func (c *DefaultConsumer) processMessage(msg messaging.Message) {
 	sw := c.scope.StartTimer(metrics.AsyncWorkflowProcessMsgLatency)
 	defer func() {
 		sw.Stop()
-		c.scope.RecordHistogramDuration(metrics.AsyncWorkflowProcessMsgLatencyHistogram, time.Since(asyncProcessStart))
+		c.scope.ExponentialHistogram(metrics.AsyncWorkflowProcessMsgLatencyHistogram, time.Since(asyncProcessStart))
 	}()
 
 	var request sqlblobs.AsyncRequestMessage

--- a/common/cache/domainCache.go
+++ b/common/cache/domainCache.go
@@ -682,7 +682,7 @@ func (c *DefaultDomainCache) triggerDomainChangePrepareCallbackLocked() {
 	sw := c.scope.StartTimer(metrics.DomainCachePrepareCallbacksLatency)
 	defer func() {
 		sw.Stop()
-		c.scope.RecordHistogramDuration(metrics.DomainCachePrepareCallbacksLatencyHistogram, time.Since(start))
+		c.scope.ExponentialHistogram(metrics.DomainCachePrepareCallbacksLatencyHistogram, time.Since(start))
 	}()
 
 	for _, prepareCallback := range c.prepareCallbacks {
@@ -695,7 +695,7 @@ func (c *DefaultDomainCache) triggerDomainChangeCallbackLocked(nextDomains []*Do
 	sw := c.scope.StartTimer(metrics.DomainCacheCallbacksLatency)
 	defer func() {
 		sw.Stop()
-		c.scope.RecordHistogramDuration(metrics.DomainCacheCallbacksLatencyHistogram, time.Since(start))
+		c.scope.ExponentialHistogram(metrics.DomainCacheCallbacksLatencyHistogram, time.Since(start))
 	}()
 
 	c.logger.Debug("Domain change callbacks are going to triggered", tag.Number(int64(len(nextDomains))))

--- a/common/metrics/scope.go
+++ b/common/metrics/scope.go
@@ -152,9 +152,14 @@ func (m *metricsScope) ExponentialHistogram(id MetricIdx, value time.Duration) {
 	if m.migrationConfig.Histogram.EmitHistogram(def.metricName.String()) {
 		m.scope.Tagged(def.exponentialBuckets.tags()).Histogram(def.metricName.String(), def.exponentialBuckets.buckets()).RecordDuration(value)
 	}
-	if !def.metricRollupName.Empty() {
+	switch {
+	case !def.metricRollupName.Empty():
 		if m.migrationConfig.Histogram.EmitHistogram(def.metricRollupName.String()) {
 			m.rootScope.Tagged(def.exponentialBuckets.tags()).Histogram(def.metricRollupName.String(), def.exponentialBuckets.buckets()).RecordDuration(value)
+		}
+	case m.isDomainTagged:
+		if m.migrationConfig.Histogram.EmitHistogram(def.metricName.String()) {
+			m.scope.Tagged(def.exponentialBuckets.tags()).Tagged(map[string]string{domain: allValue}).Histogram(def.metricName.String(), def.exponentialBuckets.buckets()).RecordDuration(value)
 		}
 	}
 }
@@ -164,9 +169,14 @@ func (m *metricsScope) IntExponentialHistogram(id MetricIdx, value int) {
 	if m.migrationConfig.Histogram.EmitHistogram(def.metricName.String()) {
 		m.scope.Tagged(def.intExponentialBuckets.tags()).Histogram(def.metricName.String(), def.intExponentialBuckets.buckets()).RecordDuration(time.Duration(value))
 	}
-	if !def.metricRollupName.Empty() {
+	switch {
+	case !def.metricRollupName.Empty():
 		if m.migrationConfig.Histogram.EmitHistogram(def.metricRollupName.String()) {
 			m.rootScope.Tagged(def.intExponentialBuckets.tags()).Histogram(def.metricRollupName.String(), def.intExponentialBuckets.buckets()).RecordDuration(time.Duration(value))
+		}
+	case m.isDomainTagged:
+		if m.migrationConfig.Histogram.EmitHistogram(def.metricName.String()) {
+			m.scope.Tagged(def.intExponentialBuckets.tags()).Tagged(map[string]string{domain: allValue}).Histogram(def.metricName.String(), def.intExponentialBuckets.buckets()).RecordDuration(time.Duration(value))
 		}
 	}
 }

--- a/common/persistence/pinot/pinot_visibility_metric_clients.go
+++ b/common/persistence/pinot/pinot_visibility_metric_clients.go
@@ -64,7 +64,7 @@ func (p *pinotVisibilityMetricsClient) RecordWorkflowExecutionStarted(
 	sw := scopeWithDomainTag.StartTimer(metrics.PinotLatencyPerDomain)
 	defer func() {
 		sw.Stop()
-		scopeWithDomainTag.RecordHistogramDuration(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
+		scopeWithDomainTag.ExponentialHistogram(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
 	}()
 	err := p.persistence.RecordWorkflowExecutionStarted(ctx, request)
 
@@ -87,7 +87,7 @@ func (p *pinotVisibilityMetricsClient) RecordWorkflowExecutionClosed(
 	sw := scopeWithDomainTag.StartTimer(metrics.PinotLatencyPerDomain)
 	defer func() {
 		sw.Stop()
-		scopeWithDomainTag.RecordHistogramDuration(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
+		scopeWithDomainTag.ExponentialHistogram(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
 	}()
 	err := p.persistence.RecordWorkflowExecutionClosed(ctx, request)
 
@@ -110,7 +110,7 @@ func (p *pinotVisibilityMetricsClient) RecordWorkflowExecutionUninitialized(
 	sw := scopeWithDomainTag.StartTimer(metrics.PinotLatencyPerDomain)
 	defer func() {
 		sw.Stop()
-		scopeWithDomainTag.RecordHistogramDuration(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
+		scopeWithDomainTag.ExponentialHistogram(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
 	}()
 	err := p.persistence.RecordWorkflowExecutionUninitialized(ctx, request)
 
@@ -133,7 +133,7 @@ func (p *pinotVisibilityMetricsClient) UpsertWorkflowExecution(
 	sw := scopeWithDomainTag.StartTimer(metrics.PinotLatencyPerDomain)
 	defer func() {
 		sw.Stop()
-		scopeWithDomainTag.RecordHistogramDuration(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
+		scopeWithDomainTag.ExponentialHistogram(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
 	}()
 	err := p.persistence.UpsertWorkflowExecution(ctx, request)
 
@@ -156,7 +156,7 @@ func (p *pinotVisibilityMetricsClient) ListOpenWorkflowExecutions(
 	sw := scopeWithDomainTag.StartTimer(metrics.PinotLatencyPerDomain)
 	defer func() {
 		sw.Stop()
-		scopeWithDomainTag.RecordHistogramDuration(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
+		scopeWithDomainTag.ExponentialHistogram(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
 	}()
 	response, err := p.persistence.ListOpenWorkflowExecutions(ctx, request)
 
@@ -179,7 +179,7 @@ func (p *pinotVisibilityMetricsClient) ListClosedWorkflowExecutions(
 	sw := scopeWithDomainTag.StartTimer(metrics.PinotLatencyPerDomain)
 	defer func() {
 		sw.Stop()
-		scopeWithDomainTag.RecordHistogramDuration(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
+		scopeWithDomainTag.ExponentialHistogram(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
 	}()
 	response, err := p.persistence.ListClosedWorkflowExecutions(ctx, request)
 
@@ -202,7 +202,7 @@ func (p *pinotVisibilityMetricsClient) ListOpenWorkflowExecutionsByType(
 	sw := scopeWithDomainTag.StartTimer(metrics.PinotLatencyPerDomain)
 	defer func() {
 		sw.Stop()
-		scopeWithDomainTag.RecordHistogramDuration(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
+		scopeWithDomainTag.ExponentialHistogram(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
 	}()
 	response, err := p.persistence.ListOpenWorkflowExecutionsByType(ctx, request)
 
@@ -224,7 +224,7 @@ func (p *pinotVisibilityMetricsClient) ListClosedWorkflowExecutionsByType(
 	sw := scopeWithDomainTag.StartTimer(metrics.PinotLatencyPerDomain)
 	defer func() {
 		sw.Stop()
-		scopeWithDomainTag.RecordHistogramDuration(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
+		scopeWithDomainTag.ExponentialHistogram(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
 	}()
 	response, err := p.persistence.ListClosedWorkflowExecutionsByType(ctx, request)
 
@@ -246,7 +246,7 @@ func (p *pinotVisibilityMetricsClient) ListOpenWorkflowExecutionsByWorkflowID(
 	sw := scopeWithDomainTag.StartTimer(metrics.PinotLatencyPerDomain)
 	defer func() {
 		sw.Stop()
-		scopeWithDomainTag.RecordHistogramDuration(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
+		scopeWithDomainTag.ExponentialHistogram(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
 	}()
 	response, err := p.persistence.ListOpenWorkflowExecutionsByWorkflowID(ctx, request)
 
@@ -268,7 +268,7 @@ func (p *pinotVisibilityMetricsClient) ListClosedWorkflowExecutionsByWorkflowID(
 	sw := scopeWithDomainTag.StartTimer(metrics.PinotLatencyPerDomain)
 	defer func() {
 		sw.Stop()
-		scopeWithDomainTag.RecordHistogramDuration(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
+		scopeWithDomainTag.ExponentialHistogram(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
 	}()
 	response, err := p.persistence.ListClosedWorkflowExecutionsByWorkflowID(ctx, request)
 
@@ -290,7 +290,7 @@ func (p *pinotVisibilityMetricsClient) ListClosedWorkflowExecutionsByStatus(
 	sw := scopeWithDomainTag.StartTimer(metrics.PinotLatencyPerDomain)
 	defer func() {
 		sw.Stop()
-		scopeWithDomainTag.RecordHistogramDuration(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
+		scopeWithDomainTag.ExponentialHistogram(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
 	}()
 	response, err := p.persistence.ListClosedWorkflowExecutionsByStatus(ctx, request)
 
@@ -312,7 +312,7 @@ func (p *pinotVisibilityMetricsClient) GetClosedWorkflowExecution(
 	sw := scopeWithDomainTag.StartTimer(metrics.PinotLatencyPerDomain)
 	defer func() {
 		sw.Stop()
-		scopeWithDomainTag.RecordHistogramDuration(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
+		scopeWithDomainTag.ExponentialHistogram(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
 	}()
 	response, err := p.persistence.GetClosedWorkflowExecution(ctx, request)
 
@@ -334,7 +334,7 @@ func (p *pinotVisibilityMetricsClient) ListWorkflowExecutions(
 	sw := scopeWithDomainTag.StartTimer(metrics.PinotLatencyPerDomain)
 	defer func() {
 		sw.Stop()
-		scopeWithDomainTag.RecordHistogramDuration(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
+		scopeWithDomainTag.ExponentialHistogram(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
 	}()
 	response, err := p.persistence.ListWorkflowExecutions(ctx, request)
 
@@ -356,7 +356,7 @@ func (p *pinotVisibilityMetricsClient) ScanWorkflowExecutions(
 	sw := scopeWithDomainTag.StartTimer(metrics.PinotLatencyPerDomain)
 	defer func() {
 		sw.Stop()
-		scopeWithDomainTag.RecordHistogramDuration(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
+		scopeWithDomainTag.ExponentialHistogram(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
 	}()
 	response, err := p.persistence.ScanWorkflowExecutions(ctx, request)
 
@@ -378,7 +378,7 @@ func (p *pinotVisibilityMetricsClient) CountWorkflowExecutions(
 	sw := scopeWithDomainTag.StartTimer(metrics.PinotLatencyPerDomain)
 	defer func() {
 		sw.Stop()
-		scopeWithDomainTag.RecordHistogramDuration(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
+		scopeWithDomainTag.ExponentialHistogram(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
 	}()
 	response, err := p.persistence.CountWorkflowExecutions(ctx, request)
 
@@ -400,7 +400,7 @@ func (p *pinotVisibilityMetricsClient) DeleteWorkflowExecution(
 	sw := scopeWithDomainTag.StartTimer(metrics.PinotLatencyPerDomain)
 	defer func() {
 		sw.Stop()
-		scopeWithDomainTag.RecordHistogramDuration(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
+		scopeWithDomainTag.ExponentialHistogram(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
 	}()
 	err := p.persistence.DeleteWorkflowExecution(ctx, request)
 
@@ -422,7 +422,7 @@ func (p *pinotVisibilityMetricsClient) DeleteUninitializedWorkflowExecution(
 	sw := scopeWithDomainTag.StartTimer(metrics.PinotLatencyPerDomain)
 	defer func() {
 		sw.Stop()
-		scopeWithDomainTag.RecordHistogramDuration(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
+		scopeWithDomainTag.ExponentialHistogram(metrics.PinotLatencyPerDomainHistogram, time.Since(pinotStart))
 	}()
 	err := p.persistence.DeleteWorkflowExecution(ctx, request)
 

--- a/common/persistence/pinot/pinot_visibility_metric_clients_test.go
+++ b/common/persistence/pinot/pinot_visibility_metric_clients_test.go
@@ -128,7 +128,7 @@ func TestMetricClientRecordWorkflowExecutionStarted(t *testing.T) {
 			// mock behaviors
 			mockMetricClient.On("Scope", mock.Anything, mock.Anything).Return(mockScope).Once()
 			mockScope.On("StartTimer", mock.Anything, mock.Anything).Return(testStopwatch).Once()
-			mockScope.On("RecordHistogramDuration", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
+			mockScope.On("ExponentialHistogram", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
 			test.producerMockAffordance(mockProducer)
 			test.scopeMockAffordance(mockScope)
 
@@ -215,7 +215,7 @@ func TestMetricClientRecordWorkflowExecutionClosed(t *testing.T) {
 			// mock behaviors
 			mockMetricClient.On("Scope", mock.Anything, mock.Anything).Return(mockScope).Once()
 			mockScope.On("StartTimer", mock.Anything, mock.Anything).Return(testStopwatch).Once()
-			mockScope.On("RecordHistogramDuration", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
+			mockScope.On("ExponentialHistogram", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
 			test.producerMockAffordance(mockProducer)
 			test.scopeMockAffordance(mockScope)
 
@@ -292,7 +292,7 @@ func TestMetricClientRecordWorkflowExecutionUninitialized(t *testing.T) {
 			// mock behaviors
 			mockMetricClient.On("Scope", mock.Anything, mock.Anything).Return(mockScope).Once()
 			mockScope.On("StartTimer", mock.Anything, mock.Anything).Return(testStopwatch).Once()
-			mockScope.On("RecordHistogramDuration", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
+			mockScope.On("ExponentialHistogram", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
 			test.producerMockAffordance(mockProducer)
 			test.scopeMockAffordance(mockScope)
 
@@ -369,7 +369,7 @@ func TestMetricClientUpsertWorkflowExecution(t *testing.T) {
 			// mock behaviors
 			mockMetricClient.On("Scope", mock.Anything, mock.Anything).Return(mockScope).Once()
 			mockScope.On("StartTimer", mock.Anything, mock.Anything).Return(testStopwatch).Once()
-			mockScope.On("RecordHistogramDuration", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
+			mockScope.On("ExponentialHistogram", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
 			test.producerMockAffordance(mockProducer)
 			test.scopeMockAffordance(mockScope)
 
@@ -444,7 +444,7 @@ func TestMetricClientListOpenWorkflowExecutions(t *testing.T) {
 			// mock behaviors
 			mockMetricClient.On("Scope", mock.Anything, mock.Anything).Return(mockScope).Once()
 			mockScope.On("StartTimer", mock.Anything, mock.Anything).Return(testStopwatch).Once()
-			mockScope.On("RecordHistogramDuration", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
+			mockScope.On("ExponentialHistogram", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
 			test.pinotClientMockAffordance(mockPinotClient)
 			test.scopeMockAffordance(mockScope)
 
@@ -519,7 +519,7 @@ func TestMetricClientListClosedWorkflowExecutions(t *testing.T) {
 			// mock behaviors
 			mockMetricClient.On("Scope", mock.Anything, mock.Anything).Return(mockScope).Once()
 			mockScope.On("StartTimer", mock.Anything, mock.Anything).Return(testStopwatch).Once()
-			mockScope.On("RecordHistogramDuration", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
+			mockScope.On("ExponentialHistogram", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
 			test.pinotClientMockAffordance(mockPinotClient)
 			test.scopeMockAffordance(mockScope)
 
@@ -595,7 +595,7 @@ func TestMetricClientListOpenWorkflowExecutionsByType(t *testing.T) {
 			// mock behaviors
 			mockMetricClient.On("Scope", mock.Anything, mock.Anything).Return(mockScope).Once()
 			mockScope.On("StartTimer", mock.Anything, mock.Anything).Return(testStopwatch).Once()
-			mockScope.On("RecordHistogramDuration", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
+			mockScope.On("ExponentialHistogram", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
 			test.pinotClientMockAffordance(mockPinotClient)
 			test.scopeMockAffordance(mockScope)
 
@@ -671,7 +671,7 @@ func TestMetricClientListClosedWorkflowExecutionsByType(t *testing.T) {
 			// mock behaviors
 			mockMetricClient.On("Scope", mock.Anything, mock.Anything).Return(mockScope).Once()
 			mockScope.On("StartTimer", mock.Anything, mock.Anything).Return(testStopwatch).Once()
-			mockScope.On("RecordHistogramDuration", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
+			mockScope.On("ExponentialHistogram", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
 			test.pinotClientMockAffordance(mockPinotClient)
 			test.scopeMockAffordance(mockScope)
 
@@ -746,7 +746,7 @@ func TestMetricClientListOpenWorkflowExecutionsByWorkflowID(t *testing.T) {
 			// mock behaviors
 			mockMetricClient.On("Scope", mock.Anything, mock.Anything).Return(mockScope).Once()
 			mockScope.On("StartTimer", mock.Anything, mock.Anything).Return(testStopwatch).Once()
-			mockScope.On("RecordHistogramDuration", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
+			mockScope.On("ExponentialHistogram", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
 			test.pinotClientMockAffordance(mockPinotClient)
 			test.scopeMockAffordance(mockScope)
 
@@ -821,7 +821,7 @@ func TestMetricClientListClosedWorkflowExecutionsByWorkflowID(t *testing.T) {
 			// mock behaviors
 			mockMetricClient.On("Scope", mock.Anything, mock.Anything).Return(mockScope).Once()
 			mockScope.On("StartTimer", mock.Anything, mock.Anything).Return(testStopwatch).Once()
-			mockScope.On("RecordHistogramDuration", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
+			mockScope.On("ExponentialHistogram", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
 			test.pinotClientMockAffordance(mockPinotClient)
 			test.scopeMockAffordance(mockScope)
 
@@ -900,7 +900,7 @@ func TestMetricClientListClosedWorkflowExecutionsByStatus(t *testing.T) {
 			// mock behaviors
 			mockMetricClient.On("Scope", mock.Anything, mock.Anything).Return(mockScope).Once()
 			mockScope.On("StartTimer", mock.Anything, mock.Anything).Return(testStopwatch).Once()
-			mockScope.On("RecordHistogramDuration", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
+			mockScope.On("ExponentialHistogram", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
 			test.pinotClientMockAffordance(mockPinotClient)
 			test.scopeMockAffordance(mockScope)
 
@@ -977,7 +977,7 @@ func TestMetricClientGetClosedWorkflowExecution(t *testing.T) {
 			// mock behaviors
 			mockMetricClient.On("Scope", mock.Anything, mock.Anything).Return(mockScope).Once()
 			mockScope.On("StartTimer", mock.Anything, mock.Anything).Return(testStopwatch).Once()
-			mockScope.On("RecordHistogramDuration", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
+			mockScope.On("ExponentialHistogram", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
 			test.pinotClientMockAffordance(mockPinotClient)
 			test.scopeMockAffordance(mockScope)
 
@@ -1050,7 +1050,7 @@ func TestMetricClientListWorkflowExecutions(t *testing.T) {
 			// mock behaviors
 			mockMetricClient.On("Scope", mock.Anything, mock.Anything).Return(mockScope).Once()
 			mockScope.On("StartTimer", mock.Anything, mock.Anything).Return(testStopwatch).Once()
-			mockScope.On("RecordHistogramDuration", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
+			mockScope.On("ExponentialHistogram", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
 			test.pinotClientMockAffordance(mockPinotClient)
 			test.scopeMockAffordance(mockScope)
 
@@ -1119,7 +1119,7 @@ func TestMetricClientScanWorkflowExecutions(t *testing.T) {
 			// mock behaviors
 			mockMetricClient.On("Scope", mock.Anything, mock.Anything).Return(mockScope).Once()
 			mockScope.On("StartTimer", mock.Anything, mock.Anything).Return(testStopwatch).Once()
-			mockScope.On("RecordHistogramDuration", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
+			mockScope.On("ExponentialHistogram", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
 			test.pinotClientMockAffordance(mockPinotClient)
 			test.scopeMockAffordance(mockScope)
 
@@ -1188,7 +1188,7 @@ func TestMetricClientCountWorkflowExecutions(t *testing.T) {
 			// mock behaviors
 			mockMetricClient.On("Scope", mock.Anything, mock.Anything).Return(mockScope).Once()
 			mockScope.On("StartTimer", mock.Anything, mock.Anything).Return(testStopwatch).Once()
-			mockScope.On("RecordHistogramDuration", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
+			mockScope.On("ExponentialHistogram", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
 			test.pinotClientMockAffordance(mockPinotClient)
 			test.scopeMockAffordance(mockScope)
 
@@ -1265,7 +1265,7 @@ func TestMetricClientDeleteWorkflowExecution(t *testing.T) {
 			// mock behaviors
 			mockMetricClient.On("Scope", mock.Anything, mock.Anything).Return(mockScope).Once()
 			mockScope.On("StartTimer", mock.Anything, mock.Anything).Return(testStopwatch).Once()
-			mockScope.On("RecordHistogramDuration", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
+			mockScope.On("ExponentialHistogram", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
 			test.producerMockAffordance(mockProducer)
 			test.scopeMockAffordance(mockScope)
 
@@ -1338,7 +1338,7 @@ func TestMetricClientDeleteUninitializedWorkflowExecution(t *testing.T) {
 			// mock behaviors
 			mockMetricClient.On("Scope", mock.Anything, mock.Anything).Return(mockScope).Once()
 			mockScope.On("StartTimer", mock.Anything, mock.Anything).Return(testStopwatch).Once()
-			mockScope.On("RecordHistogramDuration", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
+			mockScope.On("ExponentialHistogram", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Once()
 			test.producerMockAffordance(mockProducer)
 			test.scopeMockAffordance(mockScope)
 

--- a/common/persistence/wrappers/metered/base.go
+++ b/common/persistence/wrappers/metered/base.go
@@ -144,10 +144,10 @@ func (p *base) call(scope metrics.ScopeIdx, op func() error, tags ...metrics.Tag
 	duration := time.Since(before)
 	if len(tags) > 0 {
 		metricsScope.RecordTimer(metrics.PersistenceLatencyPerDomain, duration)
-		metricsScope.RecordHistogramDuration(metrics.PersistenceLatencyPerDomainHistogram, duration)
+		metricsScope.ExponentialHistogram(metrics.PersistenceLatencyPerDomainHistogram, duration)
 	} else {
 		metricsScope.RecordTimer(metrics.PersistenceLatency, duration)
-		metricsScope.RecordHistogramDuration(metrics.PersistenceLatencyHistogram, duration)
+		metricsScope.ExponentialHistogram(metrics.PersistenceLatencyHistogram, duration)
 	}
 	p.recordLatencyHistogram(scope, duration)
 
@@ -169,7 +169,7 @@ func (p *base) callWithoutDomainTag(scope metrics.ScopeIdx, op func() error, tag
 	err := op()
 	duration := time.Since(before)
 	metricsScope.RecordTimer(metrics.PersistenceLatency, duration)
-	metricsScope.RecordHistogramDuration(metrics.PersistenceLatencyHistogram, duration)
+	metricsScope.ExponentialHistogram(metrics.PersistenceLatencyHistogram, duration)
 	p.recordLatencyHistogram(scope, duration)
 
 	if err != nil {
@@ -193,13 +193,13 @@ func (p *base) callWithDomainAndShardScope(scope metrics.ScopeIdx, op func() err
 	duration := time.Since(before)
 
 	domainMetricsScope.RecordTimer(metrics.PersistenceLatencyPerDomain, duration)
-	domainMetricsScope.RecordHistogramDuration(metrics.PersistenceLatencyPerDomainHistogram, duration)
-	overallScope.RecordHistogramDuration(metrics.PersistenceLatencyHistogram, duration)
+	domainMetricsScope.ExponentialHistogram(metrics.PersistenceLatencyPerDomainHistogram, duration)
+	overallScope.ExponentialHistogram(metrics.PersistenceLatencyHistogram, duration)
 	shardOperationsMetricsScope.RecordTimer(metrics.PersistenceLatencyPerShard, duration)
-	shardOperationsMetricsScope.RecordHistogramDuration(metrics.PersistenceLatencyPerShardHistogram, duration)
+	shardOperationsMetricsScope.ExponentialHistogram(metrics.PersistenceLatencyPerShardHistogram, duration)
 
 	shardOverallMetricsScope.RecordTimer(metrics.PersistenceLatencyPerShard, duration)
-	shardOverallMetricsScope.RecordHistogramDuration(metrics.PersistenceLatencyPerShardHistogram, duration)
+	shardOverallMetricsScope.ExponentialHistogram(metrics.PersistenceLatencyPerShardHistogram, duration)
 	p.recordLatencyHistogram(scope, duration)
 
 	if err != nil {

--- a/common/quotas/global/collection/collection.go
+++ b/common/quotas/global/collection/collection.go
@@ -411,7 +411,7 @@ func (c *Collection) backgroundUpdateLoop() {
 				sw := c.scope.StartTimer(metrics.GlobalRatelimiterUpdateLatency)
 				c.doUpdate(now.Sub(lastGatherTime), usage)
 				sw.Stop()
-				c.scope.RecordHistogramDuration(metrics.GlobalRatelimiterUpdateLatencyHistogram, time.Since(ratelimiterUpdateStart))
+				c.scope.ExponentialHistogram(metrics.GlobalRatelimiterUpdateLatencyHistogram, time.Since(ratelimiterUpdateStart))
 			}
 
 			<-localMetricsDone // should be much faster than doUpdate, unless it's no-opped

--- a/common/task/fifo_task_scheduler.go
+++ b/common/task/fifo_task_scheduler.go
@@ -114,7 +114,7 @@ func (f *fifoTaskSchedulerImpl[T]) Submit(task T) error {
 	sw := f.metricsScope.StartTimer(metrics.ParallelTaskSubmitLatency)
 	defer func() {
 		sw.Stop()
-		f.metricsScope.RecordHistogramDuration(metrics.ParallelTaskSubmitLatencyHistogram, time.Since(submitStart))
+		f.metricsScope.ExponentialHistogram(metrics.ParallelTaskSubmitLatencyHistogram, time.Since(submitStart))
 	}()
 
 	if f.isStopped() {

--- a/common/task/hierarchical_weighted_round_robin_task_scheduler.go
+++ b/common/task/hierarchical_weighted_round_robin_task_scheduler.go
@@ -120,7 +120,7 @@ func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K, T]) Submit(task T) e
 	sw := w.metricsScope.StartTimer(metrics.PriorityTaskSubmitLatency)
 	defer func() {
 		sw.Stop()
-		w.metricsScope.RecordHistogramDuration(metrics.PriorityTaskSubmitLatencyHistogram, time.Since(submitStart))
+		w.metricsScope.ExponentialHistogram(metrics.PriorityTaskSubmitLatencyHistogram, time.Since(submitStart))
 	}()
 
 	w.RLock()
@@ -145,7 +145,7 @@ func (w *hierarchicalWeightedRoundRobinTaskSchedulerImpl[K, T]) TrySubmit(
 	sw := w.metricsScope.StartTimer(metrics.PriorityTaskSubmitLatency)
 	defer func() {
 		sw.Stop()
-		w.metricsScope.RecordHistogramDuration(metrics.PriorityTaskSubmitLatencyHistogram, time.Since(submitStart))
+		w.metricsScope.ExponentialHistogram(metrics.PriorityTaskSubmitLatencyHistogram, time.Since(submitStart))
 	}()
 
 	w.RLock()

--- a/common/task/parallel_task_processor.go
+++ b/common/task/parallel_task_processor.go
@@ -123,7 +123,7 @@ func (p *parallelTaskProcessorImpl) Submit(task Task) error {
 	sw := p.metricsScope.StartTimer(metrics.ParallelTaskSubmitLatency)
 	defer func() {
 		sw.Stop()
-		p.metricsScope.RecordHistogramDuration(metrics.ParallelTaskSubmitLatencyHistogram, time.Since(submitStart))
+		p.metricsScope.ExponentialHistogram(metrics.ParallelTaskSubmitLatencyHistogram, time.Since(submitStart))
 	}()
 
 	if p.isStopped() {
@@ -159,7 +159,7 @@ func (p *parallelTaskProcessorImpl) executeTask(task Task, shutdownCh chan struc
 	sw := p.metricsScope.StartTimer(metrics.ParallelTaskTaskProcessingLatency)
 	defer func() {
 		sw.Stop()
-		p.metricsScope.RecordHistogramDuration(metrics.ParallelTaskTaskProcessingLatencyHistogram, time.Since(processStart))
+		p.metricsScope.ExponentialHistogram(metrics.ParallelTaskTaskProcessingLatencyHistogram, time.Since(processStart))
 	}()
 
 	defer func() {

--- a/common/task/sequential_task_processor.go
+++ b/common/task/sequential_task_processor.go
@@ -100,7 +100,7 @@ func (t *sequentialTaskProcessorImpl) Submit(task Task) error {
 	metricsTimer := t.metricsScope.StartTimer(metrics.SequentialTaskSubmitLatency)
 	defer func() {
 		metricsTimer.Stop()
-		t.metricsScope.RecordHistogramDuration(metrics.SequentialTaskSubmitLatencyHistogram, time.Since(submitStart))
+		t.metricsScope.ExponentialHistogram(metrics.SequentialTaskSubmitLatencyHistogram, time.Since(submitStart))
 	}()
 
 	taskqueue := t.taskQueueFactory(task)
@@ -147,7 +147,7 @@ func (t *sequentialTaskProcessorImpl) pollAndProcessTaskQueue() {
 			metricsTimer := t.metricsScope.StartTimer(metrics.SequentialTaskQueueProcessingLatency)
 			t.processTaskQueue(taskqueue)
 			metricsTimer.Stop()
-			t.metricsScope.RecordHistogramDuration(metrics.SequentialTaskQueueProcessingLatencyHistogram, time.Since(queueProcessingStart))
+			t.metricsScope.ExponentialHistogram(metrics.SequentialTaskQueueProcessingLatencyHistogram, time.Since(queueProcessingStart))
 		}
 	}
 }
@@ -184,7 +184,7 @@ func (t *sequentialTaskProcessorImpl) processTaskOnce(taskqueue SequentialTaskQu
 	metricsTimer := t.metricsScope.StartTimer(metrics.SequentialTaskTaskProcessingLatency)
 	defer func() {
 		metricsTimer.Stop()
-		t.metricsScope.RecordHistogramDuration(metrics.SequentialTaskTaskProcessingLatencyHistogram, time.Since(taskProcessingStart))
+		t.metricsScope.ExponentialHistogram(metrics.SequentialTaskTaskProcessingLatencyHistogram, time.Since(taskProcessingStart))
 	}()
 
 	task := taskqueue.Remove()

--- a/common/task/weighted_round_robin_task_scheduler.go
+++ b/common/task/weighted_round_robin_task_scheduler.go
@@ -129,7 +129,7 @@ func (w *weightedRoundRobinTaskSchedulerImpl[K, T]) Submit(task T) error {
 	sw := w.metricsScope.StartTimer(metrics.PriorityTaskSubmitLatency)
 	defer func() {
 		sw.Stop()
-		w.metricsScope.RecordHistogramDuration(metrics.PriorityTaskSubmitLatencyHistogram, time.Since(submitStart))
+		w.metricsScope.ExponentialHistogram(metrics.PriorityTaskSubmitLatencyHistogram, time.Since(submitStart))
 	}()
 
 	if w.isStopped() {

--- a/service/frontend/templates/metered.tmpl
+++ b/service/frontend/templates/metered.tmpl
@@ -88,18 +88,18 @@ func (h *{{$decorator}}) {{$method.Declaration}} {
 	scope.IncCounter(metrics.CadenceRequestsPerTaskListWithoutRollup)
 	swPerTLStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatencyPerTaskList)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swPerTLStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swPerTLStart)) }()
 	scopePerDomain := h.metricsClient.Scope({{$scope}}).Tagged(append(metrics.GetContextTags(ctx), {{$domainMetricTag}})...)
 	scopePerDomain.IncCounter(metrics.CadenceRequests)
 	swPerDomainStart := time.Now()
 	swPerDomain := scopePerDomain.StartTimer(metrics.CadenceLatency)
-	defer func() { swPerDomain.Stop(); scopePerDomain.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swPerDomainStart)) }()
+	defer func() { swPerDomain.Stop(); scopePerDomain.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swPerDomainStart)) }()
 	{{- else}}
 	scope := h.metricsClient.Scope({{$scope}}).Tagged(append(metrics.GetContextTags(ctx), {{$domainMetricTag}})...)
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	{{- end}}
 	logger := h.logger.WithTags(tags...)
 

--- a/service/frontend/wrappers/accesscontrolled/access_controlled.go
+++ b/service/frontend/wrappers/accesscontrolled/access_controlled.go
@@ -51,7 +51,7 @@ func (a *apiHandler) isAuthorized(
 	sw := scope.StartTimer(metrics.CadenceAuthorizationLatency)
 	defer func() {
 		sw.Stop()
-		scope.RecordHistogramDuration(metrics.CadenceAuthorizationLatencyHistogram, time.Since(authStart))
+		scope.ExponentialHistogram(metrics.CadenceAuthorizationLatencyHistogram, time.Since(authStart))
 	}()
 
 	result, err := a.authorizer.Authorize(ctx, attr)

--- a/service/frontend/wrappers/accesscontrolled/access_controlled_test.go
+++ b/service/frontend/wrappers/accesscontrolled/access_controlled_test.go
@@ -50,7 +50,7 @@ func TestIsAuthorized(t *testing.T) {
 			mockSetup: func(authorizer *authorization.MockAuthorizer, scope *mocks.Scope) {
 				authorizer.EXPECT().Authorize(gomock.Any(), gomock.Any()).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil)
 				scope.On("StartTimer", metrics.CadenceAuthorizationLatency).Return(metrics.NewTestStopwatch()).Once()
-				scope.On("RecordHistogramDuration", metrics.CadenceAuthorizationLatencyHistogram, mock.AnythingOfType("time.Duration")).Return().Once()
+				scope.On("ExponentialHistogram", metrics.CadenceAuthorizationLatencyHistogram, mock.AnythingOfType("time.Duration")).Return().Once()
 			},
 			isAuthorized: true,
 			wantErr:      false,
@@ -60,7 +60,7 @@ func TestIsAuthorized(t *testing.T) {
 			mockSetup: func(authorizer *authorization.MockAuthorizer, scope *mocks.Scope) {
 				authorizer.EXPECT().Authorize(gomock.Any(), gomock.Any()).Return(authorization.Result{Decision: authorization.DecisionDeny}, nil)
 				scope.On("StartTimer", metrics.CadenceAuthorizationLatency).Return(metrics.NewTestStopwatch()).Once()
-				scope.On("RecordHistogramDuration", metrics.CadenceAuthorizationLatencyHistogram, mock.AnythingOfType("time.Duration")).Return().Once()
+				scope.On("ExponentialHistogram", metrics.CadenceAuthorizationLatencyHistogram, mock.AnythingOfType("time.Duration")).Return().Once()
 				scope.On("IncCounter", metrics.CadenceErrUnauthorizedCounter).Return().Once()
 			},
 			isAuthorized: false,
@@ -71,7 +71,7 @@ func TestIsAuthorized(t *testing.T) {
 			mockSetup: func(authorizer *authorization.MockAuthorizer, scope *mocks.Scope) {
 				authorizer.EXPECT().Authorize(gomock.Any(), gomock.Any()).Return(authorization.Result{}, errors.New("some random error"))
 				scope.On("StartTimer", metrics.CadenceAuthorizationLatency).Return(metrics.NewTestStopwatch()).Once()
-				scope.On("RecordHistogramDuration", metrics.CadenceAuthorizationLatencyHistogram, mock.AnythingOfType("time.Duration")).Return().Once()
+				scope.On("ExponentialHistogram", metrics.CadenceAuthorizationLatencyHistogram, mock.AnythingOfType("time.Duration")).Return().Once()
 				scope.On("IncCounter", metrics.CadenceErrAuthorizeFailedCounter).Return().Once()
 			},
 			isAuthorized: false,

--- a/service/frontend/wrappers/clusterredirection/callwrappers.go
+++ b/service/frontend/wrappers/clusterredirection/callwrappers.go
@@ -62,7 +62,7 @@ func (handler *clusterRedirectionHandler) afterCall(
 	scope.IncCounter(metrics.CadenceDcRedirectionClientRequests)
 	elapsed := handler.GetTimeSource().Now().Sub(startTime)
 	scope.RecordTimer(metrics.CadenceDcRedirectionClientLatency, elapsed)
-	scope.RecordHistogramDuration(metrics.CadenceDcRedirectionClientLatencyHistogram, elapsed)
+	scope.ExponentialHistogram(metrics.CadenceDcRedirectionClientLatencyHistogram, elapsed)
 	if *retError != nil {
 		scope.IncCounter(metrics.CadenceDcRedirectionClientFailures)
 	}

--- a/service/frontend/wrappers/metered/api_generated.go
+++ b/service/frontend/wrappers/metered/api_generated.go
@@ -48,7 +48,7 @@ func (h *apiHandler) BackfillSchedule(ctx context.Context, bp1 *types.BackfillSc
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	bp2, err = h.handler.BackfillSchedule(ctx, bp1)
@@ -65,7 +65,7 @@ func (h *apiHandler) CountWorkflowExecutions(ctx context.Context, cp1 *types.Cou
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	cp2, err = h.handler.CountWorkflowExecutions(ctx, cp1)
@@ -82,7 +82,7 @@ func (h *apiHandler) CreateSchedule(ctx context.Context, cp1 *types.CreateSchedu
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	cp2, err = h.handler.CreateSchedule(ctx, cp1)
@@ -98,7 +98,7 @@ func (h *apiHandler) DeleteDomain(ctx context.Context, dp1 *types.DeleteDomainRe
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	err = h.handler.DeleteDomain(ctx, dp1)
@@ -115,7 +115,7 @@ func (h *apiHandler) DeleteSchedule(ctx context.Context, dp1 *types.DeleteSchedu
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	dp2, err = h.handler.DeleteSchedule(ctx, dp1)
@@ -131,7 +131,7 @@ func (h *apiHandler) DeprecateDomain(ctx context.Context, dp1 *types.DeprecateDo
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	err = h.handler.DeprecateDomain(ctx, dp1)
@@ -147,7 +147,7 @@ func (h *apiHandler) DescribeDomain(ctx context.Context, dp1 *types.DescribeDoma
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	dp2, err = h.handler.DescribeDomain(ctx, dp1)
@@ -164,7 +164,7 @@ func (h *apiHandler) DescribeSchedule(ctx context.Context, dp1 *types.DescribeSc
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	dp2, err = h.handler.DescribeSchedule(ctx, dp1)
@@ -183,7 +183,7 @@ func (h *apiHandler) DescribeTaskList(ctx context.Context, dp1 *types.DescribeTa
 	sw := scope.StartTimer(metrics.CadenceLatencyPerTaskList)
 	defer func() {
 		sw.Stop()
-		scope.RecordHistogramDuration(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swPerTLStart))
+		scope.ExponentialHistogram(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swPerTLStart))
 	}()
 	scopePerDomain := h.metricsClient.Scope(metrics.FrontendDescribeTaskListScope).Tagged(append(metrics.GetContextTags(ctx), metrics.DomainTag(dp1.GetDomain()))...)
 	scopePerDomain.IncCounter(metrics.CadenceRequests)
@@ -191,7 +191,7 @@ func (h *apiHandler) DescribeTaskList(ctx context.Context, dp1 *types.DescribeTa
 	swPerDomain := scopePerDomain.StartTimer(metrics.CadenceLatency)
 	defer func() {
 		swPerDomain.Stop()
-		scopePerDomain.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swPerDomainStart))
+		scopePerDomain.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swPerDomainStart))
 	}()
 	logger := h.logger.WithTags(tags...)
 
@@ -209,7 +209,7 @@ func (h *apiHandler) DescribeWorkflowExecution(ctx context.Context, dp1 *types.D
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	dp2, err = h.handler.DescribeWorkflowExecution(ctx, dp1)
@@ -226,7 +226,7 @@ func (h *apiHandler) DiagnoseWorkflowExecution(ctx context.Context, dp1 *types.D
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	dp2, err = h.handler.DiagnoseWorkflowExecution(ctx, dp1)
@@ -243,7 +243,7 @@ func (h *apiHandler) FailoverDomain(ctx context.Context, fp1 *types.FailoverDoma
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	fp2, err = h.handler.FailoverDomain(ctx, fp1)
@@ -259,7 +259,7 @@ func (h *apiHandler) GetClusterInfo(ctx context.Context) (cp1 *types.ClusterInfo
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	cp1, err = h.handler.GetClusterInfo(ctx)
@@ -275,7 +275,7 @@ func (h *apiHandler) GetSearchAttributes(ctx context.Context) (gp1 *types.GetSea
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	gp1, err = h.handler.GetSearchAttributes(ctx)
@@ -292,7 +292,7 @@ func (h *apiHandler) GetTaskListsByDomain(ctx context.Context, gp1 *types.GetTas
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	gp2, err = h.handler.GetTaskListsByDomain(ctx, gp1)
@@ -309,7 +309,7 @@ func (h *apiHandler) GetWorkflowExecutionHistory(ctx context.Context, gp1 *types
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	gp2, err = h.handler.GetWorkflowExecutionHistory(ctx, gp1)
@@ -329,7 +329,7 @@ func (h *apiHandler) ListArchivedWorkflowExecutions(ctx context.Context, lp1 *ty
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	lp2, err = h.handler.ListArchivedWorkflowExecutions(ctx, lp1)
@@ -346,7 +346,7 @@ func (h *apiHandler) ListClosedWorkflowExecutions(ctx context.Context, lp1 *type
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	lp2, err = h.handler.ListClosedWorkflowExecutions(ctx, lp1)
@@ -362,7 +362,7 @@ func (h *apiHandler) ListDomains(ctx context.Context, lp1 *types.ListDomainsRequ
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	lp2, err = h.handler.ListDomains(ctx, lp1)
@@ -378,7 +378,7 @@ func (h *apiHandler) ListFailoverHistory(ctx context.Context, lp1 *types.ListFai
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	lp2, err = h.handler.ListFailoverHistory(ctx, lp1)
@@ -395,7 +395,7 @@ func (h *apiHandler) ListOpenWorkflowExecutions(ctx context.Context, lp1 *types.
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	lp2, err = h.handler.ListOpenWorkflowExecutions(ctx, lp1)
@@ -412,7 +412,7 @@ func (h *apiHandler) ListSchedules(ctx context.Context, lp1 *types.ListSchedules
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	lp2, err = h.handler.ListSchedules(ctx, lp1)
@@ -431,7 +431,7 @@ func (h *apiHandler) ListTaskListPartitions(ctx context.Context, lp1 *types.List
 	sw := scope.StartTimer(metrics.CadenceLatencyPerTaskList)
 	defer func() {
 		sw.Stop()
-		scope.RecordHistogramDuration(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swPerTLStart))
+		scope.ExponentialHistogram(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swPerTLStart))
 	}()
 	scopePerDomain := h.metricsClient.Scope(metrics.FrontendListTaskListPartitionsScope).Tagged(append(metrics.GetContextTags(ctx), metrics.DomainTag(lp1.GetDomain()))...)
 	scopePerDomain.IncCounter(metrics.CadenceRequests)
@@ -439,7 +439,7 @@ func (h *apiHandler) ListTaskListPartitions(ctx context.Context, lp1 *types.List
 	swPerDomain := scopePerDomain.StartTimer(metrics.CadenceLatency)
 	defer func() {
 		swPerDomain.Stop()
-		scopePerDomain.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swPerDomainStart))
+		scopePerDomain.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swPerDomainStart))
 	}()
 	logger := h.logger.WithTags(tags...)
 
@@ -457,7 +457,7 @@ func (h *apiHandler) ListWorkflowExecutions(ctx context.Context, lp1 *types.List
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	lp2, err = h.handler.ListWorkflowExecutions(ctx, lp1)
@@ -474,7 +474,7 @@ func (h *apiHandler) PauseSchedule(ctx context.Context, pp1 *types.PauseSchedule
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	pp2, err = h.handler.PauseSchedule(ctx, pp1)
@@ -493,7 +493,7 @@ func (h *apiHandler) PollForActivityTask(ctx context.Context, pp1 *types.PollFor
 	sw := scope.StartTimer(metrics.CadenceLatencyPerTaskList)
 	defer func() {
 		sw.Stop()
-		scope.RecordHistogramDuration(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swPerTLStart))
+		scope.ExponentialHistogram(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swPerTLStart))
 	}()
 	scopePerDomain := h.metricsClient.Scope(metrics.FrontendPollForActivityTaskScope).Tagged(append(metrics.GetContextTags(ctx), metrics.DomainTag(pp1.GetDomain()))...)
 	scopePerDomain.IncCounter(metrics.CadenceRequests)
@@ -501,7 +501,7 @@ func (h *apiHandler) PollForActivityTask(ctx context.Context, pp1 *types.PollFor
 	swPerDomain := scopePerDomain.StartTimer(metrics.CadenceLatency)
 	defer func() {
 		swPerDomain.Stop()
-		scopePerDomain.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swPerDomainStart))
+		scopePerDomain.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swPerDomainStart))
 	}()
 	logger := h.logger.WithTags(tags...)
 
@@ -521,7 +521,7 @@ func (h *apiHandler) PollForDecisionTask(ctx context.Context, pp1 *types.PollFor
 	sw := scope.StartTimer(metrics.CadenceLatencyPerTaskList)
 	defer func() {
 		sw.Stop()
-		scope.RecordHistogramDuration(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swPerTLStart))
+		scope.ExponentialHistogram(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swPerTLStart))
 	}()
 	scopePerDomain := h.metricsClient.Scope(metrics.FrontendPollForDecisionTaskScope).Tagged(append(metrics.GetContextTags(ctx), metrics.DomainTag(pp1.GetDomain()))...)
 	scopePerDomain.IncCounter(metrics.CadenceRequests)
@@ -529,7 +529,7 @@ func (h *apiHandler) PollForDecisionTask(ctx context.Context, pp1 *types.PollFor
 	swPerDomain := scopePerDomain.StartTimer(metrics.CadenceLatency)
 	defer func() {
 		swPerDomain.Stop()
-		scopePerDomain.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swPerDomainStart))
+		scopePerDomain.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swPerDomainStart))
 	}()
 	logger := h.logger.WithTags(tags...)
 
@@ -547,7 +547,7 @@ func (h *apiHandler) QueryWorkflow(ctx context.Context, qp1 *types.QueryWorkflow
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	qp2, err = h.handler.QueryWorkflow(ctx, qp1)
@@ -572,7 +572,7 @@ func (h *apiHandler) RecordActivityTaskHeartbeat(ctx context.Context, rp1 *types
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	rp2, err = h.handler.RecordActivityTaskHeartbeat(ctx, rp1)
@@ -589,7 +589,7 @@ func (h *apiHandler) RecordActivityTaskHeartbeatByID(ctx context.Context, rp1 *t
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	rp2, err = h.handler.RecordActivityTaskHeartbeatByID(ctx, rp1)
@@ -606,7 +606,7 @@ func (h *apiHandler) RefreshWorkflowTasks(ctx context.Context, rp1 *types.Refres
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	err = h.handler.RefreshWorkflowTasks(ctx, rp1)
@@ -622,7 +622,7 @@ func (h *apiHandler) RegisterDomain(ctx context.Context, rp1 *types.RegisterDoma
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	err = h.handler.RegisterDomain(ctx, rp1)
@@ -639,7 +639,7 @@ func (h *apiHandler) RequestCancelWorkflowExecution(ctx context.Context, rp1 *ty
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	err = h.handler.RequestCancelWorkflowExecution(ctx, rp1)
@@ -656,7 +656,7 @@ func (h *apiHandler) ResetStickyTaskList(ctx context.Context, rp1 *types.ResetSt
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	rp2, err = h.handler.ResetStickyTaskList(ctx, rp1)
@@ -673,7 +673,7 @@ func (h *apiHandler) ResetWorkflowExecution(ctx context.Context, rp1 *types.Rese
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	rp2, err = h.handler.ResetWorkflowExecution(ctx, rp1)
@@ -698,7 +698,7 @@ func (h *apiHandler) RespondActivityTaskCanceled(ctx context.Context, rp1 *types
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	err = h.handler.RespondActivityTaskCanceled(ctx, rp1)
@@ -715,7 +715,7 @@ func (h *apiHandler) RespondActivityTaskCanceledByID(ctx context.Context, rp1 *t
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	err = h.handler.RespondActivityTaskCanceledByID(ctx, rp1)
@@ -740,7 +740,7 @@ func (h *apiHandler) RespondActivityTaskCompleted(ctx context.Context, rp1 *type
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	err = h.handler.RespondActivityTaskCompleted(ctx, rp1)
@@ -757,7 +757,7 @@ func (h *apiHandler) RespondActivityTaskCompletedByID(ctx context.Context, rp1 *
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	err = h.handler.RespondActivityTaskCompletedByID(ctx, rp1)
@@ -782,7 +782,7 @@ func (h *apiHandler) RespondActivityTaskFailed(ctx context.Context, rp1 *types.R
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	err = h.handler.RespondActivityTaskFailed(ctx, rp1)
@@ -799,7 +799,7 @@ func (h *apiHandler) RespondActivityTaskFailedByID(ctx context.Context, rp1 *typ
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	err = h.handler.RespondActivityTaskFailedByID(ctx, rp1)
@@ -824,7 +824,7 @@ func (h *apiHandler) RespondDecisionTaskCompleted(ctx context.Context, rp1 *type
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	rp2, err = h.handler.RespondDecisionTaskCompleted(ctx, rp1)
@@ -849,7 +849,7 @@ func (h *apiHandler) RespondDecisionTaskFailed(ctx context.Context, rp1 *types.R
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	err = h.handler.RespondDecisionTaskFailed(ctx, rp1)
@@ -874,7 +874,7 @@ func (h *apiHandler) RespondQueryTaskCompleted(ctx context.Context, rp1 *types.R
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	err = h.handler.RespondQueryTaskCompleted(ctx, rp1)
@@ -891,7 +891,7 @@ func (h *apiHandler) RestartWorkflowExecution(ctx context.Context, rp1 *types.Re
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	rp2, err = h.handler.RestartWorkflowExecution(ctx, rp1)
@@ -908,7 +908,7 @@ func (h *apiHandler) ScanWorkflowExecutions(ctx context.Context, lp1 *types.List
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	lp2, err = h.handler.ScanWorkflowExecutions(ctx, lp1)
@@ -927,7 +927,7 @@ func (h *apiHandler) SignalWithStartWorkflowExecution(ctx context.Context, sp1 *
 	sw := scope.StartTimer(metrics.CadenceLatencyPerTaskList)
 	defer func() {
 		sw.Stop()
-		scope.RecordHistogramDuration(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swPerTLStart))
+		scope.ExponentialHistogram(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swPerTLStart))
 	}()
 	scopePerDomain := h.metricsClient.Scope(metrics.FrontendSignalWithStartWorkflowExecutionScope).Tagged(append(metrics.GetContextTags(ctx), metrics.DomainTag(sp1.GetDomain()))...)
 	scopePerDomain.IncCounter(metrics.CadenceRequests)
@@ -935,7 +935,7 @@ func (h *apiHandler) SignalWithStartWorkflowExecution(ctx context.Context, sp1 *
 	swPerDomain := scopePerDomain.StartTimer(metrics.CadenceLatency)
 	defer func() {
 		swPerDomain.Stop()
-		scopePerDomain.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swPerDomainStart))
+		scopePerDomain.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swPerDomainStart))
 	}()
 	logger := h.logger.WithTags(tags...)
 
@@ -955,7 +955,7 @@ func (h *apiHandler) SignalWithStartWorkflowExecutionAsync(ctx context.Context, 
 	sw := scope.StartTimer(metrics.CadenceLatencyPerTaskList)
 	defer func() {
 		sw.Stop()
-		scope.RecordHistogramDuration(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swPerTLStart))
+		scope.ExponentialHistogram(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swPerTLStart))
 	}()
 	scopePerDomain := h.metricsClient.Scope(metrics.FrontendSignalWithStartWorkflowExecutionAsyncScope).Tagged(append(metrics.GetContextTags(ctx), metrics.DomainTag(sp1.GetDomain()))...)
 	scopePerDomain.IncCounter(metrics.CadenceRequests)
@@ -963,7 +963,7 @@ func (h *apiHandler) SignalWithStartWorkflowExecutionAsync(ctx context.Context, 
 	swPerDomain := scopePerDomain.StartTimer(metrics.CadenceLatency)
 	defer func() {
 		swPerDomain.Stop()
-		scopePerDomain.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swPerDomainStart))
+		scopePerDomain.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swPerDomainStart))
 	}()
 	logger := h.logger.WithTags(tags...)
 
@@ -982,7 +982,7 @@ func (h *apiHandler) SignalWorkflowExecution(ctx context.Context, sp1 *types.Sig
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	err = h.handler.SignalWorkflowExecution(ctx, sp1)
@@ -1001,7 +1001,7 @@ func (h *apiHandler) StartWorkflowExecution(ctx context.Context, sp1 *types.Star
 	sw := scope.StartTimer(metrics.CadenceLatencyPerTaskList)
 	defer func() {
 		sw.Stop()
-		scope.RecordHistogramDuration(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swPerTLStart))
+		scope.ExponentialHistogram(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swPerTLStart))
 	}()
 	scopePerDomain := h.metricsClient.Scope(metrics.FrontendStartWorkflowExecutionScope).Tagged(append(metrics.GetContextTags(ctx), metrics.DomainTag(sp1.GetDomain()))...)
 	scopePerDomain.IncCounter(metrics.CadenceRequests)
@@ -1009,7 +1009,7 @@ func (h *apiHandler) StartWorkflowExecution(ctx context.Context, sp1 *types.Star
 	swPerDomain := scopePerDomain.StartTimer(metrics.CadenceLatency)
 	defer func() {
 		swPerDomain.Stop()
-		scopePerDomain.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swPerDomainStart))
+		scopePerDomain.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swPerDomainStart))
 	}()
 	logger := h.logger.WithTags(tags...)
 
@@ -1029,7 +1029,7 @@ func (h *apiHandler) StartWorkflowExecutionAsync(ctx context.Context, sp1 *types
 	sw := scope.StartTimer(metrics.CadenceLatencyPerTaskList)
 	defer func() {
 		sw.Stop()
-		scope.RecordHistogramDuration(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swPerTLStart))
+		scope.ExponentialHistogram(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swPerTLStart))
 	}()
 	scopePerDomain := h.metricsClient.Scope(metrics.FrontendStartWorkflowExecutionAsyncScope).Tagged(append(metrics.GetContextTags(ctx), metrics.DomainTag(sp1.GetDomain()))...)
 	scopePerDomain.IncCounter(metrics.CadenceRequests)
@@ -1037,7 +1037,7 @@ func (h *apiHandler) StartWorkflowExecutionAsync(ctx context.Context, sp1 *types
 	swPerDomain := scopePerDomain.StartTimer(metrics.CadenceLatency)
 	defer func() {
 		swPerDomain.Stop()
-		scopePerDomain.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swPerDomainStart))
+		scopePerDomain.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swPerDomainStart))
 	}()
 	logger := h.logger.WithTags(tags...)
 
@@ -1055,7 +1055,7 @@ func (h *apiHandler) TerminateWorkflowExecution(ctx context.Context, tp1 *types.
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	err = h.handler.TerminateWorkflowExecution(ctx, tp1)
@@ -1072,7 +1072,7 @@ func (h *apiHandler) UnpauseSchedule(ctx context.Context, up1 *types.UnpauseSche
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	up2, err = h.handler.UnpauseSchedule(ctx, up1)
@@ -1088,7 +1088,7 @@ func (h *apiHandler) UpdateDomain(ctx context.Context, up1 *types.UpdateDomainRe
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	up2, err = h.handler.UpdateDomain(ctx, up1)
@@ -1105,7 +1105,7 @@ func (h *apiHandler) UpdateSchedule(ctx context.Context, up1 *types.UpdateSchedu
 	scope.IncCounter(metrics.CadenceRequests)
 	swStart := time.Now()
 	sw := scope.StartTimer(metrics.CadenceLatency)
-	defer func() { sw.Stop(); scope.RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
+	defer func() { sw.Stop(); scope.ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(swStart)) }()
 	logger := h.logger.WithTags(tags...)
 
 	up2, err = h.handler.UpdateSchedule(ctx, up1)

--- a/service/history/engine/engineimpl/get_replication_messages.go
+++ b/service/history/engine/engineimpl/get_replication_messages.go
@@ -45,7 +45,7 @@ func (e *historyEngineImpl) GetReplicationMessages(
 	sw := e.metricsClient.StartTimer(scope, metrics.GetReplicationMessagesForShardLatency)
 	defer func() {
 		sw.Stop()
-		e.metricsClient.Scope(scope).RecordHistogramDuration(metrics.GetReplicationMessagesForShardLatencyHistogram, time.Since(replMsgStart))
+		e.metricsClient.Scope(scope).ExponentialHistogram(metrics.GetReplicationMessagesForShardLatencyHistogram, time.Since(replMsgStart))
 	}()
 
 	replicationMessages, err := e.replicationAckManager.GetTasks(
@@ -87,7 +87,7 @@ func (e *historyEngineImpl) GetDLQReplicationMessages(
 	sw := e.metricsClient.StartTimer(scope, metrics.GetDLQReplicationMessagesLatency)
 	defer func() {
 		sw.Stop()
-		e.metricsClient.Scope(scope).RecordHistogramDuration(metrics.GetDLQReplicationMessagesLatencyHistogram, time.Since(dlqStart))
+		e.metricsClient.Scope(scope).ExponentialHistogram(metrics.GetDLQReplicationMessagesLatencyHistogram, time.Since(dlqStart))
 	}()
 
 	tasks := make([]*types.ReplicationTask, 0, len(taskInfos))

--- a/service/history/engine/engineimpl/query_workflow.go
+++ b/service/history/engine/engineimpl/query_workflow.go
@@ -162,7 +162,7 @@ func (e *historyEngineImpl) QueryWorkflow(
 	sw := scope.StartTimer(metrics.DecisionTaskQueryLatency)
 	defer func() {
 		sw.Stop()
-		scope.RecordHistogramDuration(metrics.DecisionTaskQueryLatencyHistogram, time.Since(decisionQueryStart))
+		scope.ExponentialHistogram(metrics.DecisionTaskQueryLatencyHistogram, time.Since(decisionQueryStart))
 	}()
 	queryReg := mutableState.GetQueryRegistry()
 	if len(queryReg.GetBufferedIDs()) >= e.config.MaxBufferedQueryCount() {
@@ -227,7 +227,7 @@ func (e *historyEngineImpl) queryDirectlyThroughMatching(
 	sw := scope.StartTimer(metrics.DirectQueryDispatchLatency)
 	defer func() {
 		sw.Stop()
-		scope.RecordHistogramDuration(metrics.DirectQueryDispatchLatencyHistogram, time.Since(dispatchStart))
+		scope.ExponentialHistogram(metrics.DirectQueryDispatchLatencyHistogram, time.Since(dispatchStart))
 	}()
 
 	// Sticky task list is not very useful in the standby cluster because the decider cache is
@@ -256,7 +256,7 @@ func (e *historyEngineImpl) queryDirectlyThroughMatching(
 		stickyStopWatch := scope.StartTimer(metrics.DirectQueryDispatchStickyLatency)
 		matchingResp, err := e.rawMatchingClient.QueryWorkflow(stickyContext, stickyMatchingRequest)
 		stickyStopWatch.Stop()
-		scope.RecordHistogramDuration(metrics.DirectQueryDispatchStickyLatencyHistogram, time.Since(stickyStart))
+		scope.ExponentialHistogram(metrics.DirectQueryDispatchStickyLatencyHistogram, time.Since(stickyStart))
 		cancel()
 		if err == nil {
 			scope.IncCounter(metrics.DirectQueryDispatchStickySuccessCount)
@@ -298,7 +298,7 @@ func (e *historyEngineImpl) queryDirectlyThroughMatching(
 				Execution:  queryRequest.GetExecution(),
 			})
 			clearStickinessStopWatch.Stop()
-			scope.RecordHistogramDuration(metrics.DirectQueryDispatchClearStickinessLatencyHistogram, time.Since(clearStickinessStart))
+			scope.ExponentialHistogram(metrics.DirectQueryDispatchClearStickinessLatencyHistogram, time.Since(clearStickinessStart))
 			cancel()
 			if err != nil && err != workflow.ErrAlreadyCompleted && err != workflow.ErrNotExists {
 				return nil, err
@@ -335,7 +335,7 @@ func (e *historyEngineImpl) queryDirectlyThroughMatching(
 	nonStickyStopWatch := scope.StartTimer(metrics.DirectQueryDispatchNonStickyLatency)
 	matchingResp, err := e.matchingClient.QueryWorkflow(ctx, nonStickyMatchingRequest)
 	nonStickyStopWatch.Stop()
-	scope.RecordHistogramDuration(metrics.DirectQueryDispatchNonStickyLatencyHistogram, time.Since(nonStickyStart))
+	scope.ExponentialHistogram(metrics.DirectQueryDispatchNonStickyLatencyHistogram, time.Since(nonStickyStart))
 	if err != nil {
 		if strings.Contains(err.Error(), "unknown queryType") {
 			e.logger.Info("user calls for unsupported query type",

--- a/service/history/events/notifier.go
+++ b/service/history/events/notifier.go
@@ -201,7 +201,7 @@ func (notifier *notifierImpl) dispatchHistoryEventNotification(event *Notificati
 	timer := notifier.metrics.StartTimer(metrics.HistoryEventNotificationScope, metrics.HistoryEventNotificationFanoutLatency)
 	defer func() {
 		timer.Stop()
-		notifier.metrics.Scope(metrics.HistoryEventNotificationScope).RecordHistogramDuration(metrics.HistoryEventNotificationFanoutLatencyHistogram, time.Since(fanoutStart))
+		notifier.metrics.Scope(metrics.HistoryEventNotificationScope).ExponentialHistogram(metrics.HistoryEventNotificationFanoutLatencyHistogram, time.Since(fanoutStart))
 	}()
 	notifier.eventsPubsubs.GetAndDo(identifier, func(key interface{}, value interface{}) error { //nolint:errcheck
 		subscribers := value.(map[string]chan *Notification)
@@ -242,7 +242,7 @@ func (notifier *notifierImpl) dequeueHistoryEventNotifications() {
 			timeelapsed := time.Since(event.Timestamp)
 			notifier.metrics.RecordTimer(metrics.HistoryEventNotificationScope,
 				metrics.HistoryEventNotificationQueueingLatency, timeelapsed)
-			notifier.metrics.Scope(metrics.HistoryEventNotificationScope).RecordHistogramDuration(metrics.HistoryEventNotificationQueueingLatencyHistogram, timeelapsed)
+			notifier.metrics.Scope(metrics.HistoryEventNotificationScope).ExponentialHistogram(metrics.HistoryEventNotificationQueueingLatencyHistogram, timeelapsed)
 
 			notifier.dispatchHistoryEventNotification(event)
 		case <-notifier.closeChan:

--- a/service/history/execution/context.go
+++ b/service/history/execution/context.go
@@ -295,7 +295,7 @@ func (c *contextImpl) Unlock() {
 	}
 	elapsed := time.Since(c.lockTime)
 	c.metricsClient.RecordTimer(metrics.WorkflowContextScope, metrics.WorkflowContextLockLatency, elapsed)
-	c.metricsClient.Scope(metrics.WorkflowContextScope).RecordHistogramDuration(metrics.WorkflowContextLockLatencyHistogram, elapsed)
+	c.metricsClient.Scope(metrics.WorkflowContextScope).ExponentialHistogram(metrics.WorkflowContextLockLatencyHistogram, elapsed)
 	if elapsed > c.maxLockDuration {
 		c.maxLockDuration = elapsed
 		c.logger.Info("workflow context lock is released. this is logged only when it's longer than maxLockDuration", tag.WorkflowContextLockLatency(elapsed))

--- a/service/history/execution/workflow_repairer.go
+++ b/service/history/execution/workflow_repairer.go
@@ -186,7 +186,7 @@ func (r *workflowRepairerImpl) repairWorkflow(
 	}
 
 	defer func() {
-		taggedScope.RecordHistogramDuration(metrics.WorkflowRepairDuration, time.Since(startTime))
+		taggedScope.ExponentialHistogram(metrics.WorkflowRepairDuration, time.Since(startTime))
 
 		if retErr != nil {
 			isTimeout := errors.Is(retErr, context.DeadlineExceeded) || errors.Is(retErr, context.Canceled)

--- a/service/history/replication/task_executor.go
+++ b/service/history/replication/task_executor.go
@@ -135,7 +135,7 @@ func (e *taskExecutorImpl) handleActivityTask(
 	replicationStopWatch := e.metricsClient.StartTimer(metrics.SyncActivityTaskScope, metrics.CadenceLatency)
 	defer func() {
 		replicationStopWatch.Stop()
-		e.metricsClient.Scope(metrics.SyncActivityTaskScope).RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(replicationLatencyStart))
+		e.metricsClient.Scope(metrics.SyncActivityTaskScope).ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(replicationLatencyStart))
 	}()
 	request := &types.SyncActivityRequest{
 		DomainID:           attr.DomainID,
@@ -180,7 +180,7 @@ func (e *taskExecutorImpl) handleActivityTask(
 	stopwatch := e.metricsClient.StartTimer(metrics.HistoryRereplicationByActivityReplicationScope, metrics.CadenceClientLatency)
 	defer func() {
 		stopwatch.Stop()
-		e.metricsClient.Scope(metrics.HistoryRereplicationByActivityReplicationScope).RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(activityResendLatencyStart))
+		e.metricsClient.Scope(metrics.HistoryRereplicationByActivityReplicationScope).ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(activityResendLatencyStart))
 	}()
 
 	resendErr := e.historyResender.SendSingleWorkflowHistory(
@@ -247,7 +247,7 @@ func (e *taskExecutorImpl) handleHistoryReplicationTaskV2(
 	replicationStopWatch := e.metricsClient.StartTimer(metrics.HistoryReplicationV2TaskScope, metrics.CadenceLatency)
 	defer func() {
 		replicationStopWatch.Stop()
-		e.metricsClient.Scope(metrics.HistoryReplicationV2TaskScope).RecordHistogramDuration(metrics.CadenceLatencyHistogram, time.Since(replicationV2LatencyStart))
+		e.metricsClient.Scope(metrics.HistoryReplicationV2TaskScope).ExponentialHistogram(metrics.CadenceLatencyHistogram, time.Since(replicationV2LatencyStart))
 	}()
 	request := &types.ReplicateEventsV2Request{
 		DomainUUID: attr.DomainID,
@@ -285,7 +285,7 @@ func (e *taskExecutorImpl) handleHistoryReplicationTaskV2(
 	resendStopWatch := e.metricsClient.StartTimer(metrics.HistoryRereplicationByHistoryReplicationScope, metrics.CadenceClientLatency)
 	defer func() {
 		resendStopWatch.Stop()
-		e.metricsClient.Scope(metrics.HistoryRereplicationByHistoryReplicationScope).RecordHistogramDuration(metrics.CadenceClientLatencyHistogram, time.Since(historyResendLatencyStart))
+		e.metricsClient.Scope(metrics.HistoryRereplicationByHistoryReplicationScope).ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(historyResendLatencyStart))
 	}()
 
 	resendErr := e.historyResender.SendSingleWorkflowHistory(

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -577,10 +577,10 @@ func (s *contextImpl) DeleteFailoverLevel(category persistence.HistoryTaskCatego
 			switch category {
 			case persistence.HistoryTaskCategoryTransfer:
 				s.GetMetricsClient().RecordTimer(metrics.ShardInfoScope, metrics.ShardInfoTransferFailoverLatencyTimer, time.Since(level.StartTime))
-				s.GetMetricsClient().Scope(metrics.ShardInfoScope).RecordHistogramDuration(metrics.ShardInfoTransferFailoverLatencyHistogram, time.Since(level.StartTime))
+				s.GetMetricsClient().Scope(metrics.ShardInfoScope).ExponentialHistogram(metrics.ShardInfoTransferFailoverLatencyHistogram, time.Since(level.StartTime))
 			case persistence.HistoryTaskCategoryTimer:
 				s.GetMetricsClient().RecordTimer(metrics.ShardInfoScope, metrics.ShardInfoTimerFailoverLatencyTimer, time.Since(level.StartTime))
-				s.GetMetricsClient().Scope(metrics.ShardInfoScope).RecordHistogramDuration(metrics.ShardInfoTimerFailoverLatencyHistogram, time.Since(level.StartTime))
+				s.GetMetricsClient().Scope(metrics.ShardInfoScope).ExponentialHistogram(metrics.ShardInfoTimerFailoverLatencyHistogram, time.Since(level.StartTime))
 			}
 			return nil
 		}
@@ -1244,7 +1244,7 @@ func (s *contextImpl) emitShardInfoMetricsLogsLocked() {
 	metricsScope.IntExponentialHistogram(metrics.ShardInfoTransferDiffHistogram, int(diffTransferLevel))
 
 	metricsScope.RecordTimer(metrics.ShardInfoTimerDiffTimer, diffTimerLevel)
-	metricsScope.RecordHistogramDuration(metrics.ShardInfoTimerDiffHistogram, diffTimerLevel)
+	metricsScope.ExponentialHistogram(metrics.ShardInfoTimerDiffHistogram, diffTimerLevel)
 
 	metricsScope.RecordTimer(metrics.ShardInfoReplicationLagTimer, time.Duration(replicationLag))
 	metricsScope.IntExponentialHistogram(metrics.ShardInfoReplicationLagHistogram, int(replicationLag))
@@ -1253,7 +1253,7 @@ func (s *contextImpl) emitShardInfoMetricsLogsLocked() {
 	metricsScope.IntExponentialHistogram(metrics.ShardInfoTransferLagHistogram, int(transferLag))
 
 	metricsScope.RecordTimer(metrics.ShardInfoTimerLagTimer, timerLag)
-	metricsScope.RecordHistogramDuration(metrics.ShardInfoTimerLagHistogram, timerLag)
+	metricsScope.ExponentialHistogram(metrics.ShardInfoTimerLagHistogram, timerLag)
 
 	metricsScope.RecordTimer(metrics.ShardInfoTransferFailoverInProgressTimer, time.Duration(transferFailoverInProgress))
 	metricsScope.IntExponentialHistogram(metrics.ShardInfoTransferFailoverInProgressHistogram, transferFailoverInProgress)

--- a/service/history/shard/controller.go
+++ b/service/history/shard/controller.go
@@ -222,7 +222,7 @@ func (c *controller) GetEngineForShard(shardID int) (engine.Engine, error) {
 	sw := c.metricsScope.StartTimer(metrics.GetEngineForShardLatency)
 	defer func() {
 		sw.Stop()
-		c.metricsScope.RecordHistogramDuration(metrics.GetEngineForShardLatencyHistogram, time.Since(getEngineStart))
+		c.metricsScope.ExponentialHistogram(metrics.GetEngineForShardLatencyHistogram, time.Since(getEngineStart))
 	}()
 	item, err := c.getOrCreateHistoryShardItem(shardID)
 	if err != nil {
@@ -260,7 +260,7 @@ func (c *controller) removeEngineForShard(shardID int, shardItem *historyShardsI
 	sw := c.metricsScope.StartTimer(metrics.RemoveEngineForShardLatency)
 	defer func() {
 		sw.Stop()
-		c.metricsScope.RecordHistogramDuration(metrics.RemoveEngineForShardLatencyHistogram, time.Since(removeEngineStart))
+		c.metricsScope.ExponentialHistogram(metrics.RemoveEngineForShardLatencyHistogram, time.Since(removeEngineStart))
 	}()
 	c.logger.Info("removeEngineForShard called", tag.ShardID(shardID))
 	defer c.logger.Info("removeEngineForShard completed", tag.ShardID(shardID))
@@ -436,7 +436,7 @@ func (c *controller) acquireShards() {
 	sw := c.metricsScope.StartTimer(metrics.AcquireShardsLatency)
 	defer func() {
 		sw.Stop()
-		c.metricsScope.RecordHistogramDuration(metrics.AcquireShardsLatencyHistogram, time.Since(acquireStart))
+		c.metricsScope.ExponentialHistogram(metrics.AcquireShardsLatencyHistogram, time.Since(acquireStart))
 	}()
 
 	numShards := c.config.NumberOfShards
@@ -520,7 +520,7 @@ func (i *historyShardsItem) getOrCreateEngine(
 		if context.PreviousShardOwnerWasDifferent() {
 			acquisitionLatency := context.GetCurrentTime(i.GetClusterMetadata().GetCurrentClusterName()).Sub(context.GetLastUpdatedTime())
 			i.GetMetricsClient().RecordTimer(metrics.ShardInfoScope, metrics.ShardItemAcquisitionLatency, acquisitionLatency)
-			i.GetMetricsClient().Scope(metrics.ShardInfoScope).RecordHistogramDuration(metrics.ShardItemAcquisitionLatencyHistogram, acquisitionLatency)
+			i.GetMetricsClient().Scope(metrics.ShardInfoScope).ExponentialHistogram(metrics.ShardItemAcquisitionLatencyHistogram, acquisitionLatency)
 		}
 		i.engine = i.engineFactory.CreateEngine(context)
 		i.engine.Start()

--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -448,7 +448,7 @@ func (e *matchingEngineImpl) AddDecisionTask(
 	}
 	if syncMatched {
 		hCtx.scope.RecordTimer(metrics.SyncMatchLatencyPerTaskList, time.Since(startT))
-		hCtx.scope.RecordHistogramDuration(metrics.SyncMatchLatencyPerTaskListHistogram, time.Since(startT))
+		hCtx.scope.ExponentialHistogram(metrics.SyncMatchLatencyPerTaskListHistogram, time.Since(startT))
 	}
 	return &types.AddDecisionTaskResponse{
 		PartitionConfig: tlMgr.TaskListPartitionConfig(),
@@ -524,7 +524,7 @@ func (e *matchingEngineImpl) AddActivityTask(
 	}
 	if syncMatched {
 		hCtx.scope.RecordTimer(metrics.SyncMatchLatencyPerTaskList, time.Since(startT))
-		hCtx.scope.RecordHistogramDuration(metrics.SyncMatchLatencyPerTaskListHistogram, time.Since(startT))
+		hCtx.scope.ExponentialHistogram(metrics.SyncMatchLatencyPerTaskListHistogram, time.Since(startT))
 	}
 	return &types.AddActivityTaskResponse{
 		PartitionConfig: tlMgr.TaskListPartitionConfig(),
@@ -1245,7 +1245,7 @@ func (e *matchingEngineImpl) createPollForDecisionTaskResponse(
 		token, _ = e.tokenSerializer.Serialize(taskToken)
 		if task.ResponseC == nil {
 			scope.RecordTimer(metrics.AsyncMatchLatencyPerTaskList, time.Since(task.Event.CreatedTime))
-			scope.RecordHistogramDuration(metrics.AsyncMatchLatencyPerTaskListHistogram, time.Since(task.Event.CreatedTime))
+			scope.ExponentialHistogram(metrics.AsyncMatchLatencyPerTaskListHistogram, time.Since(task.Event.CreatedTime))
 		}
 	}
 
@@ -1279,7 +1279,7 @@ func (e *matchingEngineImpl) createPollForActivityTaskResponse(
 	}
 	if task.ResponseC == nil {
 		scope.RecordTimer(metrics.AsyncMatchLatencyPerTaskList, time.Since(task.Event.CreatedTime))
-		scope.RecordHistogramDuration(metrics.AsyncMatchLatencyPerTaskListHistogram, time.Since(task.Event.CreatedTime))
+		scope.ExponentialHistogram(metrics.AsyncMatchLatencyPerTaskListHistogram, time.Since(task.Event.CreatedTime))
 	}
 
 	response := &types.MatchingPollForActivityTaskResponse{}

--- a/service/matching/handler/handler.go
+++ b/service/matching/handler/handler.go
@@ -143,7 +143,7 @@ func (h *handlerImpl) AddActivityTask(
 	sw, swStart := hCtx.startProfiling(&h.startWG)
 	defer func() {
 		sw.Stop()
-		hCtx.scope.RecordHistogramDuration(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
+		hCtx.scope.ExponentialHistogram(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
 	}()
 
 	if request.GetForwardedFrom() != "" {
@@ -176,7 +176,7 @@ func (h *handlerImpl) AddDecisionTask(
 	sw, swStart := hCtx.startProfiling(&h.startWG)
 	defer func() {
 		sw.Stop()
-		hCtx.scope.RecordHistogramDuration(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
+		hCtx.scope.ExponentialHistogram(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
 	}()
 
 	if request.GetForwardedFrom() != "" {
@@ -209,7 +209,7 @@ func (h *handlerImpl) PollForActivityTask(
 	sw, swStart := hCtx.startProfiling(&h.startWG)
 	defer func() {
 		sw.Stop()
-		hCtx.scope.RecordHistogramDuration(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
+		hCtx.scope.ExponentialHistogram(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
 	}()
 
 	if request.GetForwardedFrom() != "" {
@@ -249,7 +249,7 @@ func (h *handlerImpl) PollForDecisionTask(
 	sw, swStart := hCtx.startProfiling(&h.startWG)
 	defer func() {
 		sw.Stop()
-		hCtx.scope.RecordHistogramDuration(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
+		hCtx.scope.ExponentialHistogram(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
 	}()
 
 	if request.GetForwardedFrom() != "" {
@@ -290,7 +290,7 @@ func (h *handlerImpl) QueryWorkflow(
 	sw, swStart := hCtx.startProfiling(&h.startWG)
 	defer func() {
 		sw.Stop()
-		hCtx.scope.RecordHistogramDuration(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
+		hCtx.scope.ExponentialHistogram(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
 	}()
 
 	if request.GetForwardedFrom() != "" {
@@ -323,7 +323,7 @@ func (h *handlerImpl) RespondQueryTaskCompleted(
 	sw, swStart := hCtx.startProfiling(&h.startWG)
 	defer func() {
 		sw.Stop()
-		hCtx.scope.RecordHistogramDuration(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
+		hCtx.scope.ExponentialHistogram(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
 	}()
 
 	// Count the request in the RPS, but we still accept it even if RPS is exceeded
@@ -349,7 +349,7 @@ func (h *handlerImpl) CancelOutstandingPoll(ctx context.Context,
 	sw, swStart := hCtx.startProfiling(&h.startWG)
 	defer func() {
 		sw.Stop()
-		hCtx.scope.RecordHistogramDuration(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
+		hCtx.scope.ExponentialHistogram(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
 	}()
 
 	// Count the request in the RPS, but we still accept it even if RPS is exceeded
@@ -379,7 +379,7 @@ func (h *handlerImpl) DescribeTaskList(
 	sw, swStart := hCtx.startProfiling(&h.startWG)
 	defer func() {
 		sw.Stop()
-		hCtx.scope.RecordHistogramDuration(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
+		hCtx.scope.ExponentialHistogram(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
 	}()
 
 	if ok := h.userRateLimiter.Allow(quotas.Info{Domain: domainName}); !ok {
@@ -409,7 +409,7 @@ func (h *handlerImpl) ListTaskListPartitions(
 	sw, swStart := hCtx.startProfiling(&h.startWG)
 	defer func() {
 		sw.Stop()
-		hCtx.scope.RecordHistogramDuration(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
+		hCtx.scope.ExponentialHistogram(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
 	}()
 
 	if ok := h.userRateLimiter.Allow(quotas.Info{Domain: request.GetDomain()}); !ok {
@@ -439,7 +439,7 @@ func (h *handlerImpl) GetTaskListsByDomain(
 	sw, swStart := hCtx.startProfiling(&h.startWG)
 	defer func() {
 		sw.Stop()
-		hCtx.scope.RecordHistogramDuration(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
+		hCtx.scope.ExponentialHistogram(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
 	}()
 
 	if ok := h.userRateLimiter.Allow(quotas.Info{Domain: request.GetDomain()}); !ok {
@@ -467,7 +467,7 @@ func (h *handlerImpl) UpdateTaskListPartitionConfig(
 	sw, swStart := hCtx.startProfiling(&h.startWG)
 	defer func() {
 		sw.Stop()
-		hCtx.scope.RecordHistogramDuration(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
+		hCtx.scope.ExponentialHistogram(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
 	}()
 
 	if ok := h.userRateLimiter.Allow(quotas.Info{Domain: domainName}); !ok {
@@ -495,7 +495,7 @@ func (h *handlerImpl) RefreshTaskListPartitionConfig(
 	sw, swStart := hCtx.startProfiling(&h.startWG)
 	defer func() {
 		sw.Stop()
-		hCtx.scope.RecordHistogramDuration(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
+		hCtx.scope.ExponentialHistogram(metrics.CadenceLatencyPerTaskListHistogram, time.Since(swStart))
 	}()
 
 	// Count the request in the RPS, but we still accept it even if RPS is exceeded

--- a/service/matching/tasklist/matcher.go
+++ b/service/matching/tasklist/matcher.go
@@ -455,7 +455,7 @@ func (tm *taskMatcherImpl) Poll(ctx context.Context, isolationGroup string) (*In
 	// try local match first without blocking until context timeout
 	if task, err = tm.pollNonBlocking(ctxWithCancelPropagation, isolatedTaskC, tm.taskC, tm.queryTaskC); err == nil {
 		tm.scope.RecordTimer(metrics.PollLocalMatchLatencyPerTaskList, time.Since(startT))
-		tm.scope.RecordHistogramDuration(metrics.PollLocalMatchLatencyPerTaskListHistogram, time.Since(startT))
+		tm.scope.ExponentialHistogram(metrics.PollLocalMatchLatencyPerTaskListHistogram, time.Since(startT))
 		return task, nil
 	}
 	// there is no local poller available to pickup this task. Now block waiting
@@ -484,7 +484,7 @@ func (tm *taskMatcherImpl) PollForQuery(ctx context.Context) (*InternalTask, err
 	// try local match first without blocking until context timeout
 	if task, err := tm.pollNonBlocking(ctx, nil, nil, tm.queryTaskC); err == nil {
 		tm.scope.RecordTimer(metrics.PollLocalMatchLatencyPerTaskList, time.Since(startT))
-		tm.scope.RecordHistogramDuration(metrics.PollLocalMatchLatencyPerTaskListHistogram, time.Since(startT))
+		tm.scope.ExponentialHistogram(metrics.PollLocalMatchLatencyPerTaskListHistogram, time.Since(startT))
 		return task, nil
 	}
 
@@ -517,7 +517,7 @@ func (tm *taskMatcherImpl) pollOrForward(
 			tm.scope.IncCounter(metrics.PollSuccessWithSyncPerTaskListCounter)
 		}
 		tm.scope.RecordTimer(metrics.PollLocalMatchLatencyPerTaskList, time.Since(startT))
-		tm.scope.RecordHistogramDuration(metrics.PollLocalMatchLatencyPerTaskListHistogram, time.Since(startT))
+		tm.scope.ExponentialHistogram(metrics.PollLocalMatchLatencyPerTaskListHistogram, time.Since(startT))
 		tm.scope.IncCounter(metrics.PollSuccessPerTaskListCounter)
 		event.Log(event.E{
 			TaskListName: tm.tasklist.GetName(),
@@ -538,7 +538,7 @@ func (tm *taskMatcherImpl) pollOrForward(
 			tm.scope.IncCounter(metrics.PollSuccessWithSyncPerTaskListCounter)
 		}
 		tm.scope.RecordTimer(metrics.PollLocalMatchLatencyPerTaskList, time.Since(startT))
-		tm.scope.RecordHistogramDuration(metrics.PollLocalMatchLatencyPerTaskListHistogram, time.Since(startT))
+		tm.scope.ExponentialHistogram(metrics.PollLocalMatchLatencyPerTaskListHistogram, time.Since(startT))
 		tm.scope.IncCounter(metrics.PollSuccessPerTaskListCounter)
 		event.Log(event.E{
 			TaskListName: tm.tasklist.GetName(),
@@ -580,7 +580,7 @@ func (tm *taskMatcherImpl) pollOrForward(
 		if task, err := tm.fwdr.ForwardPoll(ctx); err == nil {
 			token.release()
 			tm.scope.RecordTimer(metrics.PollForwardMatchLatencyPerTaskList, time.Since(startT))
-			tm.scope.RecordHistogramDuration(metrics.PollForwardMatchLatencyPerTaskListHistogram, time.Since(startT))
+			tm.scope.ExponentialHistogram(metrics.PollForwardMatchLatencyPerTaskListHistogram, time.Since(startT))
 			event.Log(event.E{
 				TaskListName: tm.tasklist.GetName(),
 				TaskListType: tm.tasklist.GetType(),
@@ -607,7 +607,7 @@ func (tm *taskMatcherImpl) poll(
 			tm.scope.IncCounter(metrics.PollSuccessWithSyncPerTaskListCounter)
 		}
 		tm.scope.RecordTimer(metrics.PollLocalMatchAfterForwardFailedLatencyPerTaskList, time.Since(startT))
-		tm.scope.RecordHistogramDuration(metrics.PollLocalMatchAfterForwardFailedLatencyPerTaskListHistogram, time.Since(startT))
+		tm.scope.ExponentialHistogram(metrics.PollLocalMatchAfterForwardFailedLatencyPerTaskListHistogram, time.Since(startT))
 		tm.scope.IncCounter(metrics.PollSuccessPerTaskListCounter)
 		event.Log(event.E{
 			TaskListName: tm.tasklist.GetName(),
@@ -628,7 +628,7 @@ func (tm *taskMatcherImpl) poll(
 			tm.scope.IncCounter(metrics.PollSuccessWithSyncPerTaskListCounter)
 		}
 		tm.scope.RecordTimer(metrics.PollLocalMatchAfterForwardFailedLatencyPerTaskList, time.Since(startT))
-		tm.scope.RecordHistogramDuration(metrics.PollLocalMatchAfterForwardFailedLatencyPerTaskListHistogram, time.Since(startT))
+		tm.scope.ExponentialHistogram(metrics.PollLocalMatchAfterForwardFailedLatencyPerTaskListHistogram, time.Since(startT))
 		tm.scope.IncCounter(metrics.PollSuccessPerTaskListCounter)
 		event.Log(event.E{
 			TaskListName: tm.tasklist.GetName(),

--- a/service/matching/tasklist/matcher_test.go
+++ b/service/matching/tasklist/matcher_test.go
@@ -506,6 +506,7 @@ func (t *MatcherTestSuite) TestMustOfferRemoteRateLimit() {
 	scope.On("IncCounter", metrics.AsyncMatchForwardTaskThrottleErrorPerTasklist)
 	scope.On("RecordTimer", mock.Anything, mock.Anything)
 	scope.On("IntExponentialHistogram", mock.Anything, mock.AnythingOfType("int")).Return().Maybe()
+	scope.On("ExponentialHistogram", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Maybe()
 	scope.On("RecordHistogramDuration", mock.Anything, mock.AnythingOfType("time.Duration")).Return().Maybe()
 	t.matcher.scope = &scope
 	completionFunc := func(*persistence.TaskInfo, error) {}

--- a/service/matching/tasklist/task_reader.go
+++ b/service/matching/tasklist/task_reader.go
@@ -483,7 +483,7 @@ func (tr *taskReader) dispatchSingleTaskFromBuffer(taskInfo *persistence.TaskInf
 	timerScope := tr.scope.StartTimer(metrics.AsyncMatchLatencyPerTaskList)
 	err := tr.dispatchTask(dispatchCtx, task)
 	timerScope.Stop()
-	tr.scope.RecordHistogramDuration(metrics.AsyncMatchLatencyPerTaskListHistogram, time.Since(asyncMatchStart))
+	tr.scope.ExponentialHistogram(metrics.AsyncMatchLatencyPerTaskListHistogram, time.Since(asyncMatchStart))
 	cancel()
 
 	if err == nil {

--- a/service/worker/diagnostics/workflow.go
+++ b/service/worker/diagnostics/workflow.go
@@ -114,7 +114,7 @@ func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflo
 	sw := scope.StartTimer(metrics.DiagnosticsWorkflowExecutionLatency)
 	defer func() {
 		sw.Stop()
-		scope.RecordHistogramDuration(metrics.DiagnosticsWorkflowExecutionLatencyHistogram, workflow.Now(ctx).Sub(diagStart))
+		scope.ExponentialHistogram(metrics.DiagnosticsWorkflowExecutionLatencyHistogram, workflow.Now(ctx).Sub(diagStart))
 	}()
 
 	var timeoutsResult *timeoutDiagnostics

--- a/service/worker/indexer/esProcessor.go
+++ b/service/worker/indexer/esProcessor.go
@@ -376,7 +376,7 @@ func (km *kafkaMessageWithMetrics) Ack() {
 	km.message.Ack() // nolint:errcheck
 	if km.swFromAddToAck != nil {
 		km.swFromAddToAck.Stop()
-		km.scope.RecordHistogramDuration(metrics.ESProcessorProcessMsgLatencyHistogram, time.Since(km.processStart))
+		km.scope.ExponentialHistogram(metrics.ESProcessorProcessMsgLatencyHistogram, time.Since(km.processStart))
 	}
 }
 
@@ -384,6 +384,6 @@ func (km *kafkaMessageWithMetrics) Nack() {
 	km.message.Nack() //nolint:errcheck
 	if km.swFromAddToAck != nil {
 		km.swFromAddToAck.Stop()
-		km.scope.RecordHistogramDuration(metrics.ESProcessorProcessMsgLatencyHistogram, time.Since(km.processStart))
+		km.scope.ExponentialHistogram(metrics.ESProcessorProcessMsgLatencyHistogram, time.Since(km.processStart))
 	}
 }

--- a/service/worker/indexer/esProcessor_test.go
+++ b/service/worker/indexer/esProcessor_test.go
@@ -199,7 +199,7 @@ func (s *esProcessorSuite) TestBulkAfterActionX() {
 	mapVal := newKafkaMessageWithMetrics(mockKafkaMsg, &testStopWatch, time.Now(), s.esProcessor.scope)
 	s.esProcessor.mapToKafkaMsg.Put(testKey, mapVal)
 	mockKafkaMsg.On("Ack").Return(nil).Once()
-	s.mockScope.On("RecordHistogramDuration", metrics.ESProcessorProcessMsgLatencyHistogram, mock.AnythingOfType("time.Duration")).Once()
+	s.mockScope.On("ExponentialHistogram", metrics.ESProcessorProcessMsgLatencyHistogram, mock.AnythingOfType("time.Duration")).Once()
 	s.esProcessor.bulkAfterAction(0, requests, response, nil)
 	mockKafkaMsg.AssertExpectations(s.T())
 }
@@ -237,7 +237,7 @@ func (s *esProcessorSuite) TestBulkAfterAction_Nack() {
 	s.esProcessor.mapToKafkaMsg.Put(testKey, mapVal)
 	mockKafkaMsg.On("Nack").Return(nil).Once()
 	mockKafkaMsg.On("Value").Return(payload).Once()
-	s.mockScope.On("RecordHistogramDuration", metrics.ESProcessorProcessMsgLatencyHistogram, mock.AnythingOfType("time.Duration")).Once()
+	s.mockScope.On("ExponentialHistogram", metrics.ESProcessorProcessMsgLatencyHistogram, mock.AnythingOfType("time.Duration")).Once()
 	// s.mockBulkProcessor.On("RetrieveKafkaKey", request, mock.Anything, mock.Anything).Return(testKey)
 	s.esProcessor.bulkAfterAction(0, requests, response, nil)
 	mockKafkaMsg.AssertExpectations(s.T())
@@ -277,7 +277,7 @@ func (s *esProcessorSuite) TestBulkAfterAction_Error() {
 	mockKafkaMsg.On("Nack").Return(nil).Once()
 	mockKafkaMsg.On("Value").Return(payload).Once()
 	s.mockScope.On("IncCounter", metrics.ESProcessorFailures).Once()
-	s.mockScope.On("RecordHistogramDuration", metrics.ESProcessorProcessMsgLatencyHistogram, mock.AnythingOfType("time.Duration")).Once()
+	s.mockScope.On("ExponentialHistogram", metrics.ESProcessorProcessMsgLatencyHistogram, mock.AnythingOfType("time.Duration")).Once()
 	s.esProcessor.bulkAfterAction(0, requests, response, &bulk.GenericError{Details: fmt.Errorf("some error")})
 }
 
@@ -316,7 +316,7 @@ func (s *esProcessorSuite) TestBulkAfterAction_Error_Nack() {
 	mockKafkaMsg.On("Ack").Return(nil).Once() // Expect Ack to be called
 	mockKafkaMsg.On("Value").Return(payload).Once()
 	s.mockScope.On("IncCounter", metrics.ESProcessorFailures).Once()
-	s.mockScope.On("RecordHistogramDuration", metrics.ESProcessorProcessMsgLatencyHistogram, mock.AnythingOfType("time.Duration")).Once()
+	s.mockScope.On("ExponentialHistogram", metrics.ESProcessorProcessMsgLatencyHistogram, mock.AnythingOfType("time.Duration")).Once()
 	s.esProcessor.bulkAfterAction(0, requests, response, &bulk.GenericError{Status: 404, Details: fmt.Errorf("some error")})
 }
 
@@ -333,7 +333,7 @@ func (s *esProcessorSuite) TestAckKafkaMsg() {
 	s.Equal(1, s.esProcessor.mapToKafkaMsg.Len())
 
 	mockKafkaMsg.On("Ack").Return(nil).Once()
-	s.mockScope.On("RecordHistogramDuration", metrics.ESProcessorProcessMsgLatencyHistogram, mock.AnythingOfType("time.Duration")).Once()
+	s.mockScope.On("ExponentialHistogram", metrics.ESProcessorProcessMsgLatencyHistogram, mock.AnythingOfType("time.Duration")).Once()
 	s.esProcessor.ackKafkaMsg(key)
 	mockKafkaMsg.AssertExpectations(s.T())
 	s.Equal(0, s.esProcessor.mapToKafkaMsg.Len())
@@ -352,7 +352,7 @@ func (s *esProcessorSuite) TestNackKafkaMsg() {
 	s.Equal(1, s.esProcessor.mapToKafkaMsg.Len())
 
 	mockKafkaMsg.On("Nack").Return(nil).Once()
-	s.mockScope.On("RecordHistogramDuration", metrics.ESProcessorProcessMsgLatencyHistogram, mock.AnythingOfType("time.Duration")).Once()
+	s.mockScope.On("ExponentialHistogram", metrics.ESProcessorProcessMsgLatencyHistogram, mock.AnythingOfType("time.Duration")).Once()
 	s.esProcessor.nackKafkaMsg(key)
 	mockKafkaMsg.AssertExpectations(s.T())
 	s.Equal(0, s.esProcessor.mapToKafkaMsg.Len())
@@ -536,7 +536,7 @@ func (s *esProcessorSuite) TestBulkAfterAction_Nack_Shadow_WithError() {
 	mockKafkaMsg.On("Nack").Return(nil).Once()
 	mockKafkaMsg.On("Value").Return(payload).Once()
 	s.mockScope.On("IncCounter", mock.AnythingOfType("metrics.MetricIdx")).Return()
-	s.mockScope.On("RecordHistogramDuration", metrics.ESProcessorProcessMsgLatencyHistogram, mock.AnythingOfType("time.Duration")).Once()
+	s.mockScope.On("ExponentialHistogram", metrics.ESProcessorProcessMsgLatencyHistogram, mock.AnythingOfType("time.Duration")).Once()
 	// Execute bulkAfterAction for primary processor with error
 	s.esProcessor.bulkAfterAction(0, requests, response, mockErr)
 }
@@ -577,7 +577,7 @@ func (s *esProcessorSuite) TestBulkAfterAction_Shadow_Fail_WithoutError() {
 	mockKafkaMsg.On("Nack").Return(nil).Once()
 	mockKafkaMsg.On("Value").Return(payload).Once()
 	s.mockScope.On("IncCounter", mock.AnythingOfType("int")).Return()
-	s.mockScope.On("RecordHistogramDuration", metrics.ESProcessorProcessMsgLatencyHistogram, mock.AnythingOfType("time.Duration")).Once()
+	s.mockScope.On("ExponentialHistogram", metrics.ESProcessorProcessMsgLatencyHistogram, mock.AnythingOfType("time.Duration")).Once()
 	// Execute bulkAfterAction for primary processor with error
 	s.esProcessor.bulkAfterAction(0, requests, response, nil)
 }

--- a/service/worker/indexer/indexer.go
+++ b/service/worker/indexer/indexer.go
@@ -199,7 +199,7 @@ func (i *Indexer) messageProcessLoop(workerWG *sync.WaitGroup) {
 		sw := i.scope.StartTimer(metrics.IndexProcessorProcessMsgLatency)
 		err := i.process(msg)
 		sw.Stop()
-		i.scope.RecordHistogramDuration(metrics.IndexProcessorProcessMsgLatencyHistogram, time.Since(indexProcessStart))
+		i.scope.ExponentialHistogram(metrics.IndexProcessorProcessMsgLatencyHistogram, time.Since(indexProcessStart))
 		if err != nil {
 			msg.Nack() //nolint:errcheck
 		}


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Use ExponentialHistogram when emit histogram metrics defined with exponential buckets 
ongoing timer→histogram migration (https://github.com/cadence-workflow/cadence/issues/7741)

**Why?**
Using RecordHistogramDuration with missing buckets can cause it to use default buckets which caps at 5s 

**How did you test it?**
go test ./common/metrics/... ./common/task/... ./service/history/execution/... ./service/history/shard/... ./service/history/workflowcache/...

**Potential risks**
Low. All changes are additive (dual-emit). New histogram definitions are validated at init() time.

**Release notes**
N/A — internal observability improvement, no behavior change.

**Documentation Changes**
This is batch 6 of the ongoing timer→histogram migration (https://github.com/cadence-workflow/cadence/issues/7741)
