### PR TITLE
fix(frontend): enforce ListDomains authorization

### DIFF
--- a/service/frontend/templates/accesscontrolled.tmpl
+++ b/service/frontend/templates/accesscontrolled.tmpl
@@ -93,6 +93,9 @@ func (a *{{$decorator}}) {{$method.Declaration}} {
 	a.handler.{{$method.Call}}
 }
 {{- else}}
+	{{- if and (eq $interfaceType "api.Handler") (eq $method.Name "ListDomains")}}
+	return a.listAuthorizedDomains(ctx, {{(index $method.Params 1).Name}})
+	{{- else}}
 	{{- if or (eq $interfaceType "admin.Handler") (hasKey $permissionMap $method.Name) }}
 	{{- if and (eq $interfaceType "api.Handler") (ge (len $method.Params) 2)}}
 	{{- if has $method.Name $nonDomainAuthAPIs}}
@@ -149,6 +152,7 @@ func (a *{{$decorator}}) {{$method.Declaration}} {
 	}
 	{{- end}}
 	return a.handler.{{$method.Call}}
+	{{- end}}
 }
 {{- end}}
 {{end}}

--- a/service/frontend/wrappers/accesscontrolled/access_controlled.go
+++ b/service/frontend/wrappers/accesscontrolled/access_controlled.go
@@ -66,6 +66,43 @@ func (a *apiHandler) isAuthorized(
 	return isAuth, nil
 }
 
+func (a *apiHandler) listAuthorizedDomains(
+	ctx context.Context,
+	listRequest *types.ListDomainsRequest,
+) (*types.ListDomainsResponse, error) {
+	response, err := a.handler.ListDomains(ctx, listRequest)
+	if err != nil || response == nil {
+		return response, err
+	}
+	if len(response.GetDomains()) == 0 {
+		return response, nil
+	}
+
+	scope := a.GetMetricsClient().Scope(metrics.FrontendListDomainsScope)
+	authorizedDomains := make([]*types.DescribeDomainResponse, 0, len(response.GetDomains()))
+	for _, domain := range response.GetDomains() {
+		attr := &authorization.Attributes{
+			APIName:     "ListDomains",
+			Permission:  authorization.PermissionRead,
+			RequestBody: authorization.NewFilteredRequestBody(listRequest),
+			DomainName:  domain.GetDomainInfo().GetName(),
+		}
+		isAuthorized, err := a.isAuthorized(ctx, attr, scope)
+		if err != nil {
+			return nil, err
+		}
+		if isAuthorized {
+			authorizedDomains = append(authorizedDomains, domain)
+		}
+	}
+
+	if len(authorizedDomains) == 0 {
+		return nil, errUnauthorized
+	}
+	response.Domains = authorizedDomains
+	return response, nil
+}
+
 // getMetricsScopeWithDomain return metrics scope with domain tag
 func (a *apiHandler) getMetricsScopeWithDomain(
 	scope metrics.ScopeIdx,

--- a/service/frontend/wrappers/accesscontrolled/access_controlled.go
+++ b/service/frontend/wrappers/accesscontrolled/access_controlled.go
@@ -96,9 +96,6 @@ func (a *apiHandler) listAuthorizedDomains(
 		}
 	}
 
-	if len(authorizedDomains) == 0 {
-		return nil, errUnauthorized
-	}
 	response.Domains = authorizedDomains
 	return response, nil
 }

--- a/service/frontend/wrappers/accesscontrolled/access_controlled_test.go
+++ b/service/frontend/wrappers/accesscontrolled/access_controlled_test.go
@@ -34,8 +34,10 @@ import (
 	"github.com/uber/cadence/common/authorization"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/metrics/mocks"
+	"github.com/uber/cadence/common/resource"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/frontend/admin"
+	"github.com/uber/cadence/service/frontend/api"
 )
 
 func TestIsAuthorized(t *testing.T) {
@@ -148,4 +150,122 @@ func TestDescribeCluster(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestListDomainsFiltersUnauthorizedDomains(t *testing.T) {
+	controller := gomock.NewController(t)
+
+	mockAuthorizer := authorization.NewMockAuthorizer(controller)
+	mockAPIHandler := api.NewMockHandler(controller)
+	mockResource := resource.NewMockResource(controller)
+	mockResource.EXPECT().GetMetricsClient().Return(metrics.NewNoopMetricsClient()).AnyTimes()
+
+	request := &types.ListDomainsRequest{PageSize: 10}
+	response := &types.ListDomainsResponse{
+		Domains: []*types.DescribeDomainResponse{
+			listDomainsTestResponse("allowed-domain"),
+			listDomainsTestResponse("denied-domain"),
+		},
+		NextPageToken: []byte("next-page"),
+	}
+	mockAPIHandler.EXPECT().ListDomains(gomock.Any(), request).Return(response, nil)
+	mockAuthorizer.EXPECT().
+		Authorize(gomock.Any(), listDomainsAuthAttr("allowed-domain")).
+		Return(authorization.Result{Decision: authorization.DecisionAllow}, nil)
+	mockAuthorizer.EXPECT().
+		Authorize(gomock.Any(), listDomainsAuthAttr("denied-domain")).
+		Return(authorization.Result{Decision: authorization.DecisionDeny}, nil)
+
+	handler := &apiHandler{
+		handler:    mockAPIHandler,
+		authorizer: mockAuthorizer,
+		Resource:   mockResource,
+	}
+	result, err := handler.ListDomains(context.Background(), request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("next-page"), result.NextPageToken)
+	assert.Len(t, result.Domains, 1)
+	assert.Equal(t, "allowed-domain", result.Domains[0].GetDomainInfo().GetName())
+}
+
+func TestListDomainsReturnsUnauthorizedWhenNoDomainsAreAuthorized(t *testing.T) {
+	controller := gomock.NewController(t)
+
+	mockAuthorizer := authorization.NewMockAuthorizer(controller)
+	mockAPIHandler := api.NewMockHandler(controller)
+	mockResource := resource.NewMockResource(controller)
+	mockResource.EXPECT().GetMetricsClient().Return(metrics.NewNoopMetricsClient()).AnyTimes()
+
+	request := &types.ListDomainsRequest{PageSize: 10}
+	response := &types.ListDomainsResponse{
+		Domains: []*types.DescribeDomainResponse{
+			listDomainsTestResponse("denied-domain"),
+		},
+	}
+	mockAPIHandler.EXPECT().ListDomains(gomock.Any(), request).Return(response, nil)
+	mockAuthorizer.EXPECT().
+		Authorize(gomock.Any(), listDomainsAuthAttr("denied-domain")).
+		Return(authorization.Result{Decision: authorization.DecisionDeny}, nil)
+
+	handler := &apiHandler{
+		handler:    mockAPIHandler,
+		authorizer: mockAuthorizer,
+		Resource:   mockResource,
+	}
+	result, err := handler.ListDomains(context.Background(), request)
+
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, errUnauthorized)
+}
+
+func TestListDomainsAllowsAllDomainsForAdminAuthorizer(t *testing.T) {
+	controller := gomock.NewController(t)
+
+	mockAuthorizer := authorization.NewMockAuthorizer(controller)
+	mockAPIHandler := api.NewMockHandler(controller)
+	mockResource := resource.NewMockResource(controller)
+	mockResource.EXPECT().GetMetricsClient().Return(metrics.NewNoopMetricsClient()).AnyTimes()
+
+	request := &types.ListDomainsRequest{PageSize: 10}
+	response := &types.ListDomainsResponse{
+		Domains: []*types.DescribeDomainResponse{
+			listDomainsTestResponse("first-domain"),
+			listDomainsTestResponse("second-domain"),
+		},
+	}
+	mockAPIHandler.EXPECT().ListDomains(gomock.Any(), request).Return(response, nil)
+	mockAuthorizer.EXPECT().
+		Authorize(gomock.Any(), listDomainsAuthAttr("first-domain")).
+		Return(authorization.Result{Decision: authorization.DecisionAllow}, nil)
+	mockAuthorizer.EXPECT().
+		Authorize(gomock.Any(), listDomainsAuthAttr("second-domain")).
+		Return(authorization.Result{Decision: authorization.DecisionAllow}, nil)
+
+	handler := &apiHandler{
+		handler:    mockAPIHandler,
+		authorizer: mockAuthorizer,
+		Resource:   mockResource,
+	}
+	result, err := handler.ListDomains(context.Background(), request)
+
+	assert.NoError(t, err)
+	assert.Len(t, result.Domains, 2)
+	assert.Equal(t, "first-domain", result.Domains[0].GetDomainInfo().GetName())
+	assert.Equal(t, "second-domain", result.Domains[1].GetDomainInfo().GetName())
+}
+
+func listDomainsTestResponse(name string) *types.DescribeDomainResponse {
+	return &types.DescribeDomainResponse{
+		DomainInfo: &types.DomainInfo{Name: name},
+	}
+}
+
+func listDomainsAuthAttr(domain string) gomock.Matcher {
+	return gomock.Cond(func(attr *authorization.Attributes) bool {
+		return attr.APIName == "ListDomains" &&
+			attr.Permission == authorization.PermissionRead &&
+			attr.DomainName == domain &&
+			attr.RequestBody != nil
+	})
 }

--- a/service/frontend/wrappers/accesscontrolled/access_controlled_test.go
+++ b/service/frontend/wrappers/accesscontrolled/access_controlled_test.go
@@ -189,7 +189,7 @@ func TestListDomainsFiltersUnauthorizedDomains(t *testing.T) {
 	assert.Equal(t, "allowed-domain", result.Domains[0].GetDomainInfo().GetName())
 }
 
-func TestListDomainsReturnsUnauthorizedWhenNoDomainsAreAuthorized(t *testing.T) {
+func TestListDomainsReturnsEmptyWhenNoDomainsAreAuthorized(t *testing.T) {
 	controller := gomock.NewController(t)
 
 	mockAuthorizer := authorization.NewMockAuthorizer(controller)
@@ -215,11 +215,103 @@ func TestListDomainsReturnsUnauthorizedWhenNoDomainsAreAuthorized(t *testing.T) 
 	}
 	result, err := handler.ListDomains(context.Background(), request)
 
-	assert.Nil(t, result)
-	assert.ErrorIs(t, err, errUnauthorized)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Empty(t, result.Domains)
 }
 
-func TestListDomainsAllowsAllDomainsForAdminAuthorizer(t *testing.T) {
+func TestListDomainsReturnsEmptyPageWithNextPageTokenWhenNoDomainsAreAuthorized(t *testing.T) {
+	controller := gomock.NewController(t)
+
+	mockAuthorizer := authorization.NewMockAuthorizer(controller)
+	mockAPIHandler := api.NewMockHandler(controller)
+	mockResource := resource.NewMockResource(controller)
+	mockResource.EXPECT().GetMetricsClient().Return(metrics.NewNoopMetricsClient()).AnyTimes()
+
+	request := &types.ListDomainsRequest{PageSize: 10}
+	response := &types.ListDomainsResponse{
+		Domains: []*types.DescribeDomainResponse{
+			listDomainsTestResponse("denied-domain"),
+		},
+		NextPageToken: []byte("next-page"),
+	}
+	mockAPIHandler.EXPECT().ListDomains(gomock.Any(), request).Return(response, nil)
+	mockAuthorizer.EXPECT().
+		Authorize(gomock.Any(), listDomainsAuthAttr("denied-domain")).
+		Return(authorization.Result{Decision: authorization.DecisionDeny}, nil)
+
+	handler := &apiHandler{
+		handler:    mockAPIHandler,
+		authorizer: mockAuthorizer,
+		Resource:   mockResource,
+	}
+	result, err := handler.ListDomains(context.Background(), request)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, []byte("next-page"), result.NextPageToken)
+	assert.Empty(t, result.Domains)
+}
+
+func TestListDomainsPropagatesHandlerError(t *testing.T) {
+	controller := gomock.NewController(t)
+
+	mockAuthorizer := authorization.NewMockAuthorizer(controller)
+	mockAPIHandler := api.NewMockHandler(controller)
+	listDomainsErr := errors.New("list domains failed")
+
+	request := &types.ListDomainsRequest{PageSize: 10}
+	mockAPIHandler.EXPECT().ListDomains(gomock.Any(), request).Return(nil, listDomainsErr)
+
+	handler := &apiHandler{
+		handler:    mockAPIHandler,
+		authorizer: mockAuthorizer,
+	}
+	result, err := handler.ListDomains(context.Background(), request)
+
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, listDomainsErr)
+}
+
+func TestListDomainsPropagatesAuthorizerError(t *testing.T) {
+	controller := gomock.NewController(t)
+
+	mockAuthorizer := authorization.NewMockAuthorizer(controller)
+	mockAPIHandler := api.NewMockHandler(controller)
+	mockResource := resource.NewMockResource(controller)
+	mockResource.EXPECT().GetMetricsClient().Return(metrics.NewNoopMetricsClient()).AnyTimes()
+
+	request := &types.ListDomainsRequest{PageSize: 10}
+	response := &types.ListDomainsResponse{
+		Domains: []*types.DescribeDomainResponse{
+			listDomainsTestResponse("allowed-domain"),
+			listDomainsTestResponse("error-domain"),
+			listDomainsTestResponse("unchecked-domain"),
+		},
+	}
+	authorizerErr := errors.New("authorizer failed")
+	mockAPIHandler.EXPECT().ListDomains(gomock.Any(), request).Return(response, nil)
+	gomock.InOrder(
+		mockAuthorizer.EXPECT().
+			Authorize(gomock.Any(), listDomainsAuthAttr("allowed-domain")).
+			Return(authorization.Result{Decision: authorization.DecisionAllow}, nil),
+		mockAuthorizer.EXPECT().
+			Authorize(gomock.Any(), listDomainsAuthAttr("error-domain")).
+			Return(authorization.Result{}, authorizerErr),
+	)
+
+	handler := &apiHandler{
+		handler:    mockAPIHandler,
+		authorizer: mockAuthorizer,
+		Resource:   mockResource,
+	}
+	result, err := handler.ListDomains(context.Background(), request)
+
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, authorizerErr)
+}
+
+func TestListDomainsReturnsAllWhenAllAuthorized(t *testing.T) {
 	controller := gomock.NewController(t)
 
 	mockAuthorizer := authorization.NewMockAuthorizer(controller)

--- a/service/frontend/wrappers/accesscontrolled/api_generated.go
+++ b/service/frontend/wrappers/accesscontrolled/api_generated.go
@@ -324,7 +324,7 @@ func (a *apiHandler) ListClosedWorkflowExecutions(ctx context.Context, lp1 *type
 }
 
 func (a *apiHandler) ListDomains(ctx context.Context, lp1 *types.ListDomainsRequest) (lp2 *types.ListDomainsResponse, err error) {
-	return a.handler.ListDomains(ctx, lp1)
+	return a.listAuthorizedDomains(ctx, lp1)
 }
 
 func (a *apiHandler) ListFailoverHistory(ctx context.Context, lp1 *types.ListFailoverHistoryRequest) (lp2 *types.ListFailoverHistoryResponse, err error) {


### PR DESCRIPTION
**What changed?**

Added access-control handling for `ListDomains` so the frontend wrapper authorizes each returned domain with read permission before returning it to the caller. Regenerated the access-controlled API wrapper from the template. Fixes #7823.

**Why?**

`ListDomains` previously bypassed backend authorization entirely, which allowed callers to enumerate domain metadata even when OAuth authorization was enabled. Filtering the returned domains through the existing authorizer keeps behavior aligned with `DescribeDomain`: admins can see every domain, while non-admin callers only see domains whose READ_GROUPS/WRITE_GROUPS metadata allows them.

**How did you test it?**

- `go test ./service/frontend/wrappers/accesscontrolled -run 'Test(IsAuthorized|DescribeCluster|ListDomains)' -count=1`
- `go test ./service/frontend/wrappers/accesscontrolled -count=1`
- `go test ./service/frontend/wrappers/... -count=1`
- `git diff --check`
- `make pr GEN_DIR=service/frontend/api`

**Potential risks**

Domain filtering happens after the persistence page is read, so a response can contain fewer domains than the requested page size when some domains are not authorized. If no domain in a non-empty page is authorized, the wrapper returns `AccessDeniedError`.

**Release notes**

`ListDomains` now enforces backend authorization and filters returned domains by read access. Fixes #7823.

**Documentation Changes**

N/A.