### PR TITLE
fix(metrics): normalize cache metric labels for Prometheus

### DIFF
--- a/client/matching/partition_config_provider.go
+++ b/client/matching/partition_config_provider.go
@@ -105,7 +105,7 @@ func NewPartitionConfigProvider(
 			Pin:             false,
 			MaxCount:        3000,
 			ActivelyEvict:   false,
-			MetricsScope:    metricsClient.Scope(metrics.PartitionConfigProviderScope),
+			MetricsScope:    metricsClient.Scope(metrics.PartitionConfigProviderScope).Tagged(metrics.NonShardTag()),
 			Logger:          logger,
 		}),
 	}

--- a/client/matching/rr_loadbalancer.go
+++ b/client/matching/rr_loadbalancer.go
@@ -57,7 +57,7 @@ func NewRoundRobinLoadBalancer(
 			Pin:             false,
 			MaxCount:        3000,
 			ActivelyEvict:   false,
-			MetricsScope:    provider.GetMetricsClient().Scope(metrics.LoadBalancerScope),
+			MetricsScope:    provider.GetMetricsClient().Scope(metrics.LoadBalancerScope).Tagged(metrics.NonShardTag()),
 			Logger:          provider.GetLogger(),
 		}),
 		writeCache: cache.New(&cache.Options{
@@ -66,7 +66,7 @@ func NewRoundRobinLoadBalancer(
 			Pin:             false,
 			MaxCount:        3000,
 			ActivelyEvict:   false,
-			MetricsScope:    provider.GetMetricsClient().Scope(metrics.LoadBalancerScope),
+			MetricsScope:    provider.GetMetricsClient().Scope(metrics.LoadBalancerScope).Tagged(metrics.NonShardTag()),
 			Logger:          provider.GetLogger(),
 		}),
 		pickPartitionFn: pickPartition,

--- a/client/matching/weighted_loadbalancer.go
+++ b/client/matching/weighted_loadbalancer.go
@@ -160,7 +160,7 @@ func NewWeightedLoadBalancer(
 			Pin:             false,
 			MaxCount:        3000,
 			ActivelyEvict:   false,
-			MetricsScope:    provider.GetMetricsClient().Scope(metrics.LoadBalancerScope),
+			MetricsScope:    provider.GetMetricsClient().Scope(metrics.LoadBalancerScope).Tagged(metrics.NonShardTag()),
 			Logger:          logger,
 		}),
 		logger: logger,

--- a/common/activecluster/manager.go
+++ b/common/activecluster/manager.go
@@ -82,7 +82,7 @@ func NewManager(
 			MaxCount:      workflowPolicyCacheMaxCount,
 			ActivelyEvict: true,
 			Pin:           false,
-			MetricsScope:  metricsCl.Scope(metrics.ActiveClusterManagerWorkflowCacheScope),
+			MetricsScope:  metricsCl.Scope(metrics.ActiveClusterManagerWorkflowCacheScope).Tagged(metrics.NonShardTag()),
 			Logger:        logger,
 		}),
 	}

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -184,11 +184,12 @@ func New(opts *Options) Cache {
 
 	if cache.metricsScope == nil {
 		cache.metricsScope = metrics.NoopScope
+	} else {
+		cache.metricsScope = cache.metricsScope.Tagged(
+			metrics.CacheTypeTag(metrics.LRUCacheTypeTagValue),
+			metrics.SourceClusterTag(metrics.SourceClusterNoneTagValue),
+		)
 	}
-	cache.metricsScope = cache.metricsScope.Tagged(
-		metrics.CacheTypeTag(metrics.LRUCacheTypeTagValue),
-		metrics.SourceClusterTag(metrics.SourceClusterNoneTagValue),
-	)
 
 	if opts.IsSizeBased == nil {
 		cache.isSizeBased = dynamicproperties.GetBoolPropertyFn(false)

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -185,6 +185,10 @@ func New(opts *Options) Cache {
 	if cache.metricsScope == nil {
 		cache.metricsScope = metrics.NoopScope
 	}
+	cache.metricsScope = cache.metricsScope.Tagged(
+		metrics.CacheTypeTag(metrics.LRUCacheTypeTagValue),
+		metrics.SourceClusterTag(metrics.SourceClusterNoneTagValue),
+	)
 
 	if opts.IsSizeBased == nil {
 		cache.isSizeBased = dynamicproperties.GetBoolPropertyFn(false)

--- a/common/cache/metrics_test.go
+++ b/common/cache/metrics_test.go
@@ -96,7 +96,7 @@ func emitLRUCacheMetrics(t *testing.T, metricScope metrics.Scope) {
 func emitMutableStateCacheMetrics(client metrics.Client) {
 	scope := metrics.WithCacheScopeLabels(
 		client.Scope(metrics.HistoryCacheGetOrCreateScope),
-		1,
+		metrics.ShardIDTag(1),
 		metrics.SourceClusterNoneTagValue,
 		metrics.MutableStateCacheTypeTagValue,
 	)
@@ -109,7 +109,7 @@ func emitMutableStateCacheMetrics(client metrics.Client) {
 func emitEventsCacheMetrics(client metrics.Client) {
 	scope := metrics.WithCacheScopeLabels(
 		client.Scope(metrics.EventsCacheGetEventScope),
-		1,
+		metrics.ShardIDTag(1),
 		metrics.SourceClusterNoneTagValue,
 		metrics.EventsCacheTypeTagValue,
 	)

--- a/common/cache/metrics_test.go
+++ b/common/cache/metrics_test.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cache
+
+import (
+	"testing"
+	"time"
+
+	p8s "github.com/m3db/prometheus_client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	tallyp8s "github.com/uber-go/tally/prometheus"
+
+	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
+)
+
+func TestCacheMetricsLabelConsistency(t *testing.T) {
+	var registrationErrors []error
+	promCfg := &tallyp8s.Configuration{
+		OnError:   "none",
+		TimerType: "histogram",
+	}
+	reporter, err := promCfg.NewReporter(tallyp8s.ConfigurationOptions{
+		Registry: p8s.NewRegistry(),
+		OnError: func(err error) {
+			registrationErrors = append(registrationErrors, err)
+		},
+	})
+	require.NoError(t, err)
+
+	rootScope, closer := tally.NewRootScope(tally.ScopeOptions{
+		Tags: map[string]string{
+			metrics.CadenceServiceTagName: "history",
+		},
+		CachedReporter: reporter,
+		Separator:      tallyp8s.DefaultSeparator,
+	}, time.Second)
+	defer closer.Close()
+
+	historyMetrics := metrics.NewClient(rootScope, metrics.History, metrics.MigrationConfig{})
+	lruCacheScopes := []metrics.Scope{
+		historyMetrics.Scope(metrics.HistoryExecutionCacheScope).Tagged(metrics.ShardIDTag(1)),
+		historyMetrics.Scope(metrics.HistoryWorkflowCacheScope).Tagged(metrics.NonShardTag()),
+		historyMetrics.Scope(metrics.EventsCacheGetEventScope).Tagged(metrics.ShardIDTag(7)),
+		historyMetrics.Scope(metrics.ActiveClusterManagerWorkflowCacheScope).Tagged(metrics.NonShardTag()),
+		historyMetrics.Scope(metrics.LoadBalancerScope).Tagged(metrics.NonShardTag()),
+		historyMetrics.Scope(metrics.PartitionConfigProviderScope).Tagged(metrics.NonShardTag()),
+		historyMetrics.Scope(metrics.PersistenceGetShardScope).Tagged(metrics.NonShardTag()),
+	}
+	for _, scope := range lruCacheScopes {
+		emitLRUCacheMetrics(t, scope)
+	}
+	emitMutableStateCacheMetrics(historyMetrics)
+	emitEventsCacheMetrics(historyMetrics)
+	emitReplicationCacheMetrics(historyMetrics)
+
+	require.Empty(t, registrationErrors, "Prometheus registration errors must not be emitted")
+}
+
+func emitLRUCacheMetrics(t *testing.T, metricScope metrics.Scope) {
+	t.Helper()
+
+	lruCache := New(&Options{
+		MaxCount:     1,
+		MetricsScope: metricScope,
+		Logger:       log.NewNoop(),
+		IsSizeBased:  dynamicproperties.GetBoolPropertyFn(false),
+	})
+
+	require.Nil(t, lruCache.Get("missing"))
+	lruCache.Put("first", "value")
+	require.Equal(t, "value", lruCache.Get("first"))
+	lruCache.Put("second", "value")
+}
+
+func emitMutableStateCacheMetrics(client metrics.Client) {
+	scope := client.Scope(
+		metrics.HistoryCacheGetOrCreateScope,
+		metrics.SourceClusterTag(metrics.SourceClusterNoneTagValue),
+		metrics.ShardIDTag(1),
+	)
+
+	scope.IncCounter(metrics.CacheRequests)
+	scope.IncCounter(metrics.CacheMissCounter)
+	scope.RecordTimer(metrics.CacheLatency, time.Millisecond)
+}
+
+func emitEventsCacheMetrics(client metrics.Client) {
+	scope := client.Scope(
+		metrics.EventsCacheGetEventScope,
+		metrics.SourceClusterTag(metrics.SourceClusterNoneTagValue),
+		metrics.ShardIDTag(1),
+	)
+
+	scope.IncCounter(metrics.CacheRequests)
+	scope.IncCounter(metrics.CacheMissCounter)
+	scope.RecordTimer(metrics.CacheLatency, time.Millisecond)
+}
+
+func emitReplicationCacheMetrics(client metrics.Client) {
+	scope := client.Scope(
+		metrics.ReplicatorCacheManagerScope,
+		metrics.CacheTypeTag(metrics.ReplicationCacheTypeTagValue),
+		metrics.SourceClusterTag("active"),
+		metrics.ShardIDTag(1),
+	)
+
+	scope.IncCounter(metrics.CacheRequests)
+	scope.IncCounter(metrics.CacheHitCounter)
+	scope.IncCounter(metrics.CacheMissCounter)
+	scope.IncCounter(metrics.CacheFullCounter)
+	scope.RecordTimer(metrics.CacheLatency, time.Millisecond)
+	scope.ExponentialHistogram(metrics.ExponentialCacheLatency, time.Millisecond)
+	scope.RecordTimer(metrics.CacheSize, time.Duration(1))
+	scope.RecordHistogramValue(metrics.CacheSizeHistogram, 1)
+	scope.UpdateGauge(metrics.CacheSizeGauge, 1)
+}

--- a/common/cache/metrics_test.go
+++ b/common/cache/metrics_test.go
@@ -94,10 +94,11 @@ func emitLRUCacheMetrics(t *testing.T, metricScope metrics.Scope) {
 }
 
 func emitMutableStateCacheMetrics(client metrics.Client) {
-	scope := client.Scope(
-		metrics.HistoryCacheGetOrCreateScope,
-		metrics.SourceClusterTag(metrics.SourceClusterNoneTagValue),
-		metrics.ShardIDTag(1),
+	scope := metrics.WithCacheScopeLabels(
+		client.Scope(metrics.HistoryCacheGetOrCreateScope),
+		1,
+		metrics.SourceClusterNoneTagValue,
+		metrics.MutableStateCacheTypeTagValue,
 	)
 
 	scope.IncCounter(metrics.CacheRequests)
@@ -106,10 +107,11 @@ func emitMutableStateCacheMetrics(client metrics.Client) {
 }
 
 func emitEventsCacheMetrics(client metrics.Client) {
-	scope := client.Scope(
-		metrics.EventsCacheGetEventScope,
-		metrics.SourceClusterTag(metrics.SourceClusterNoneTagValue),
-		metrics.ShardIDTag(1),
+	scope := metrics.WithCacheScopeLabels(
+		client.Scope(metrics.EventsCacheGetEventScope),
+		1,
+		metrics.SourceClusterNoneTagValue,
+		metrics.EventsCacheTypeTagValue,
 	)
 
 	scope.IncCounter(metrics.CacheRequests)

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -119,6 +119,9 @@ const (
 
 	MutableStateCacheTypeTagValue = "mutablestate"
 	EventsCacheTypeTagValue       = "events"
+	LRUCacheTypeTagValue          = "lru"
+	ReplicationCacheTypeTagValue  = "replication"
+	SourceClusterNoneTagValue     = "none"
 )
 
 // Common service base metrics

--- a/common/metrics/defs_test.go
+++ b/common/metrics/defs_test.go
@@ -177,9 +177,7 @@ func TestMetricsAreUnique(t *testing.T) {
 				name := met.metricName.String()
 				if seen[name] {
 					switch name {
-					case "cache_full", "cache_hit", "cache_miss":
-						continue // normalized cache metric families intentionally keep shared names.
-					case "cadence_requests_per_tl", "cross_cluster_fetch_errors":
+					case "cache_full", "cache_miss", "cache_hit", "cadence_requests_per_tl", "cross_cluster_fetch_errors":
 						continue // known dup.  worth changing as some cause problems.
 					}
 					t.Errorf("duplicate metric name %q", name)

--- a/common/metrics/defs_test.go
+++ b/common/metrics/defs_test.go
@@ -177,7 +177,7 @@ func TestMetricsAreUnique(t *testing.T) {
 				name := met.metricName.String()
 				if seen[name] {
 					switch name {
-					case "cache_full", "cache_miss", "cache_hit", "cadence_requests_per_tl", "cross_cluster_fetch_errors":
+					case "cadence_requests_per_tl", "cross_cluster_fetch_errors":
 						continue // known dup.  worth changing as some cause problems.
 					}
 					t.Errorf("duplicate metric name %q", name)

--- a/common/metrics/defs_test.go
+++ b/common/metrics/defs_test.go
@@ -177,6 +177,8 @@ func TestMetricsAreUnique(t *testing.T) {
 				name := met.metricName.String()
 				if seen[name] {
 					switch name {
+					case "cache_full", "cache_hit", "cache_miss":
+						continue // normalized cache metric families intentionally keep shared names.
 					case "cadence_requests_per_tl", "cross_cluster_fetch_errors":
 						continue // known dup.  worth changing as some cause problems.
 					}

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -134,11 +134,11 @@ func CacheTypeTag(value string) Tag {
 }
 
 // WithCacheScopeLabels returns a scope tagged with the cache metric labels required for consistent Prometheus registration.
-func WithCacheScopeLabels(scope Scope, shardIDVal int, sourceClusterVal string, cacheTypeVal string) Scope {
+func WithCacheScopeLabels(scope Scope, shardTag Tag, sourceClusterVal string, cacheTypeVal string) Scope {
 	return scope.Tagged(
 		CacheTypeTag(cacheTypeVal),
 		SourceClusterTag(sourceClusterVal),
-		ShardIDTag(shardIDVal),
+		shardTag,
 	)
 }
 

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -123,6 +123,25 @@ func ShardIDTag(shardIDVal int) Tag {
 	return metricWithUnknown(shardID, strconv.Itoa(shardIDVal))
 }
 
+// NonShardTag is used for metrics that need a stable shard_id label but are not scoped to a real shard.
+func NonShardTag() Tag {
+	return ShardIDTag(-1)
+}
+
+// CacheTypeTag returns a tag for cache metric category.
+func CacheTypeTag(value string) Tag {
+	return metricWithUnknown(CacheTypeTagName, value)
+}
+
+// WithCacheScopeLabels returns a scope tagged with the cache metric labels required for consistent Prometheus registration.
+func WithCacheScopeLabels(scope Scope, shardIDVal int, sourceClusterVal string, cacheTypeVal string) Scope {
+	return scope.Tagged(
+		CacheTypeTag(cacheTypeVal),
+		SourceClusterTag(sourceClusterVal),
+		ShardIDTag(shardIDVal),
+	)
+}
+
 // DomainTag returns a new domain tag. For timers, this also ensures that we
 // dual emit the metric with the all tag. If a blank domain is provided then
 // this converts that to an unknown domain.

--- a/service/frontend/api/producer_manager.go
+++ b/service/frontend/api/producer_manager.go
@@ -70,7 +70,7 @@ func NewProducerManager(
 			InitialCapacity: 5,
 			MaxCount:        100,
 			Pin:             true,
-			MetricsScope:    metricsClient.Scope(metrics.PersistenceGetShardScope), // was metrics.Frontend, using incorrect int
+			MetricsScope:    metricsClient.Scope(metrics.PersistenceGetShardScope).Tagged(metrics.NonShardTag()), // was metrics.Frontend, using incorrect int
 			Logger:          logger,
 		}),
 	}

--- a/service/history/events/cache.go
+++ b/service/history/events/cache.go
@@ -66,7 +66,7 @@ type (
 		disabled       bool
 		logger         log.Logger
 		metricsClient  metrics.Client
-		shardID        *int
+		shardID        int
 	}
 
 	eventKey struct {
@@ -152,9 +152,11 @@ func newCacheWithOption(
 	opts.TTL = ttl
 	opts.MaxCount = maxCount
 	opts.MetricsScope = metricsClient.Scope(metrics.EventsCacheGetEventScope)
+	cacheShardID := -1
 	if shardID != nil {
-		opts.MetricsScope = opts.MetricsScope.Tagged(metrics.ShardIDTag(*shardID))
+		cacheShardID = *shardID
 	}
+	opts.MetricsScope = opts.MetricsScope.Tagged(metrics.ShardIDTag(cacheShardID))
 
 	opts.MaxSize = maxSize
 	opts.Logger = logger.WithTags(tag.ComponentEventsCache)
@@ -167,8 +169,17 @@ func newCacheWithOption(
 		disabled:       disabled,
 		logger:         logger.WithTags(tag.ComponentEventsCache),
 		metricsClient:  metricsClient,
-		shardID:        shardID,
+		shardID:        cacheShardID,
 	}
+}
+
+func (e *cacheImpl) cacheMetricsScope(scope metrics.ScopeIdx) metrics.Scope {
+	return metrics.WithCacheScopeLabels(
+		e.metricsClient.Scope(scope),
+		e.shardID,
+		metrics.SourceClusterNoneTagValue,
+		metrics.EventsCacheTypeTagValue,
+	)
 }
 
 func newEventKey(
@@ -195,8 +206,9 @@ func (e *cacheImpl) GetEvent(
 	eventID int64,
 	branchToken []byte,
 ) (*types.HistoryEvent, error) {
-	e.metricsClient.IncCounter(metrics.EventsCacheGetEventScope, metrics.CacheRequests)
-	sw := e.metricsClient.StartTimer(metrics.EventsCacheGetEventScope, metrics.CacheLatency)
+	metricsScope := e.cacheMetricsScope(metrics.EventsCacheGetEventScope)
+	metricsScope.IncCounter(metrics.CacheRequests)
+	sw := metricsScope.StartTimer(metrics.CacheLatency)
 	defer sw.Stop()
 
 	key := newEventKey(domainID, workflowID, runID, eventID)
@@ -208,11 +220,11 @@ func (e *cacheImpl) GetEvent(
 		}
 	}
 
-	e.metricsClient.IncCounter(metrics.EventsCacheGetEventScope, metrics.CacheMissCounter)
+	metricsScope.IncCounter(metrics.CacheMissCounter)
 	event, err := e.getHistoryEventFromStore(ctx, firstEventID, eventID, branchToken, shardID, domainID)
 
 	if err != nil {
-		e.metricsClient.IncCounter(metrics.EventsCacheGetEventScope, metrics.CacheFailures)
+		metricsScope.IncCounter(metrics.CacheFailures)
 		logTags := []tag.Tag{
 			tag.ShardID(shardID),
 			tag.Error(err),
@@ -235,8 +247,9 @@ func (e *cacheImpl) PutEvent(
 	eventID int64,
 	event *types.HistoryEvent,
 ) {
-	e.metricsClient.IncCounter(metrics.EventsCachePutEventScope, metrics.CacheRequests)
-	sw := e.metricsClient.StartTimer(metrics.EventsCachePutEventScope, metrics.CacheLatency)
+	metricsScope := e.cacheMetricsScope(metrics.EventsCachePutEventScope)
+	metricsScope.IncCounter(metrics.CacheRequests)
+	sw := metricsScope.StartTimer(metrics.CacheLatency)
 	defer sw.Stop()
 
 	key := newEventKey(domainID, workflowID, runID, eventID)
@@ -251,8 +264,9 @@ func (e *cacheImpl) getHistoryEventFromStore(
 	shardID int,
 	domainID string,
 ) (*types.HistoryEvent, error) {
-	e.metricsClient.IncCounter(metrics.EventsCacheGetFromStoreScope, metrics.CacheRequests)
-	sw := e.metricsClient.StartTimer(metrics.EventsCacheGetFromStoreScope, metrics.CacheLatency)
+	metricsScope := e.cacheMetricsScope(metrics.EventsCacheGetFromStoreScope)
+	metricsScope.IncCounter(metrics.CacheRequests)
+	sw := metricsScope.StartTimer(metrics.CacheLatency)
 	defer sw.Stop()
 
 	var historyEvents []*types.HistoryEvent
@@ -271,7 +285,7 @@ func (e *cacheImpl) getHistoryEventFromStore(
 	})
 
 	if err != nil {
-		e.metricsClient.IncCounter(metrics.EventsCacheGetFromStoreScope, metrics.CacheFailures)
+		metricsScope.IncCounter(metrics.CacheFailures)
 		return nil, err
 	}
 

--- a/service/history/events/cache.go
+++ b/service/history/events/cache.go
@@ -66,7 +66,7 @@ type (
 		disabled       bool
 		logger         log.Logger
 		metricsClient  metrics.Client
-		shardID        int
+		shardID        *int
 	}
 
 	eventKey struct {
@@ -152,11 +152,11 @@ func newCacheWithOption(
 	opts.TTL = ttl
 	opts.MaxCount = maxCount
 	opts.MetricsScope = metricsClient.Scope(metrics.EventsCacheGetEventScope)
-	cacheShardID := -1
 	if shardID != nil {
-		cacheShardID = *shardID
+		opts.MetricsScope = opts.MetricsScope.Tagged(metrics.ShardIDTag(*shardID))
+	} else {
+		opts.MetricsScope = opts.MetricsScope.Tagged(metrics.NonShardTag())
 	}
-	opts.MetricsScope = opts.MetricsScope.Tagged(metrics.ShardIDTag(cacheShardID))
 
 	opts.MaxSize = maxSize
 	opts.Logger = logger.WithTags(tag.ComponentEventsCache)
@@ -169,14 +169,19 @@ func newCacheWithOption(
 		disabled:       disabled,
 		logger:         logger.WithTags(tag.ComponentEventsCache),
 		metricsClient:  metricsClient,
-		shardID:        cacheShardID,
+		shardID:        shardID,
 	}
 }
 
 func (e *cacheImpl) cacheMetricsScope(scope metrics.ScopeIdx) metrics.Scope {
+	shardTag := metrics.NonShardTag()
+	if e.shardID != nil {
+		shardTag = metrics.ShardIDTag(*e.shardID)
+	}
+
 	return metrics.WithCacheScopeLabels(
 		e.metricsClient.Scope(scope),
-		e.shardID,
+		shardTag,
 		metrics.SourceClusterNoneTagValue,
 		metrics.EventsCacheTypeTagValue,
 	)

--- a/service/history/execution/cache.go
+++ b/service/history/execution/cache.go
@@ -134,7 +134,7 @@ func NewCache(shard shard.Context) Cache {
 func (c *cacheImpl) cacheMetricsScope(scope metrics.ScopeIdx) metrics.Scope {
 	return metrics.WithCacheScopeLabels(
 		c.metricsClient.Scope(scope),
-		c.shard.GetShardID(),
+		metrics.ShardIDTag(c.shard.GetShardID()),
 		metrics.SourceClusterNoneTagValue,
 		metrics.MutableStateCacheTypeTagValue,
 	)

--- a/service/history/execution/cache.go
+++ b/service/history/execution/cache.go
@@ -131,6 +131,15 @@ func NewCache(shard shard.Context) Cache {
 	}
 }
 
+func (c *cacheImpl) cacheMetricsScope(scope metrics.ScopeIdx) metrics.Scope {
+	return metrics.WithCacheScopeLabels(
+		c.metricsClient.Scope(scope),
+		c.shard.GetShardID(),
+		metrics.SourceClusterNoneTagValue,
+		metrics.MutableStateCacheTypeTagValue,
+	)
+}
+
 // GetOrCreateCurrentWorkflowExecution gets or creates workflow execution context for the current run
 func (c *cacheImpl) GetOrCreateCurrentWorkflowExecution(
 	ctx context.Context,
@@ -139,8 +148,9 @@ func (c *cacheImpl) GetOrCreateCurrentWorkflowExecution(
 ) (Context, ReleaseFunc, error) {
 
 	scope := metrics.HistoryCacheGetOrCreateCurrentScope
-	c.metricsClient.IncCounter(scope, metrics.CacheRequests)
-	sw := c.metricsClient.StartTimer(scope, metrics.CacheLatency)
+	metricsScope := c.cacheMetricsScope(scope)
+	metricsScope.IncCounter(metrics.CacheRequests)
+	sw := metricsScope.StartTimer(metrics.CacheLatency)
 	defer sw.Stop()
 
 	// using empty run ID as current workflow run ID
@@ -168,12 +178,13 @@ func (c *cacheImpl) GetAndCreateWorkflowExecution(
 ) (Context, Context, ReleaseFunc, bool, error) {
 
 	scope := metrics.HistoryCacheGetAndCreateScope
-	c.metricsClient.IncCounter(scope, metrics.CacheRequests)
-	sw := c.metricsClient.StartTimer(scope, metrics.CacheLatency)
+	metricsScope := c.cacheMetricsScope(scope)
+	metricsScope.IncCounter(metrics.CacheRequests)
+	sw := metricsScope.StartTimer(metrics.CacheLatency)
 	defer sw.Stop()
 
 	if err := c.validateWorkflowExecutionInfo(ctx, domainID, &execution); err != nil {
-		c.metricsClient.IncCounter(scope, metrics.CacheFailures)
+		metricsScope.IncCounter(metrics.CacheFailures)
 		return nil, nil, nil, false, err
 	}
 
@@ -187,13 +198,13 @@ func (c *cacheImpl) GetAndCreateWorkflowExecution(
 		if err := contextFromCache.Lock(ctx); err != nil {
 			// ctx is done before lock can be acquired
 			c.Release(key)
-			c.metricsClient.IncCounter(metrics.HistoryCacheGetAndCreateScope, metrics.CacheFailures)
+			metricsScope.IncCounter(metrics.CacheFailures)
 			c.metricsClient.IncCounter(metrics.HistoryCacheGetAndCreateScope, metrics.AcquireLockFailedCounter)
 			return nil, nil, nil, false, err
 		}
 		releaseFunc = c.makeReleaseFunc(key, contextFromCache, false)
 	} else {
-		c.metricsClient.IncCounter(metrics.HistoryCacheGetAndCreateScope, metrics.CacheMissCounter)
+		metricsScope.IncCounter(metrics.CacheMissCounter)
 	}
 
 	// Note, the one loaded from DB is not put into cache and don't affect any behavior
@@ -232,12 +243,13 @@ func (c *cacheImpl) GetOrCreateWorkflowExecution(
 ) (Context, ReleaseFunc, error) {
 
 	scope := metrics.HistoryCacheGetOrCreateScope
-	c.metricsClient.IncCounter(scope, metrics.CacheRequests)
-	sw := c.metricsClient.StartTimer(scope, metrics.CacheLatency)
+	metricsScope := c.cacheMetricsScope(scope)
+	metricsScope.IncCounter(metrics.CacheRequests)
+	sw := metricsScope.StartTimer(metrics.CacheLatency)
 	defer sw.Stop()
 
 	if err := c.validateWorkflowExecutionInfo(ctx, domainID, &execution); err != nil {
-		c.metricsClient.IncCounter(scope, metrics.CacheFailures)
+		metricsScope.IncCounter(metrics.CacheFailures)
 		return nil, nil, err
 	}
 
@@ -266,12 +278,13 @@ func (c *cacheImpl) getOrCreateWorkflowExecutionInternal(
 	key := definition.NewWorkflowIdentifier(domainID, execution.GetWorkflowID(), execution.GetRunID())
 	workflowCtx, cacheHit := c.Get(key).(Context)
 	if !cacheHit {
-		c.metricsClient.IncCounter(scope, metrics.CacheMissCounter)
+		metricsScope := c.cacheMetricsScope(scope)
+		metricsScope.IncCounter(metrics.CacheMissCounter)
 		// Let's create the workflow execution workflowCtx
 		workflowCtx = NewContext(domainID, execution, c.shard, c.executionManager, c.logger)
 		elem, err := c.PutIfNotExist(key, workflowCtx)
 		if err != nil {
-			c.metricsClient.IncCounter(scope, metrics.CacheFailures)
+			metricsScope.IncCounter(metrics.CacheFailures)
 			return nil, nil, err
 		}
 		workflowCtx = elem.(Context)
@@ -284,7 +297,7 @@ func (c *cacheImpl) getOrCreateWorkflowExecutionInternal(
 	if err := workflowCtx.Lock(ctx); err != nil {
 		// ctx is done before lock can be acquired
 		c.Release(key)
-		c.metricsClient.IncCounter(scope, metrics.CacheFailures)
+		c.cacheMetricsScope(scope).IncCounter(metrics.CacheFailures)
 		c.metricsClient.IncCounter(scope, metrics.AcquireLockFailedCounter)
 		return nil, nil, err
 	}
@@ -357,8 +370,9 @@ func (c *cacheImpl) getCurrentExecutionWithRetry(
 	request *persistence.GetCurrentExecutionRequest,
 ) (*persistence.GetCurrentExecutionResponse, error) {
 
-	c.metricsClient.IncCounter(metrics.HistoryCacheGetCurrentExecutionScope, metrics.CacheRequests)
-	sw := c.metricsClient.StartTimer(metrics.HistoryCacheGetCurrentExecutionScope, metrics.CacheLatency)
+	metricsScope := c.cacheMetricsScope(metrics.HistoryCacheGetCurrentExecutionScope)
+	metricsScope.IncCounter(metrics.CacheRequests)
+	sw := metricsScope.StartTimer(metrics.CacheLatency)
 	defer sw.Stop()
 
 	var response *persistence.GetCurrentExecutionResponse
@@ -375,7 +389,7 @@ func (c *cacheImpl) getCurrentExecutionWithRetry(
 	)
 	err := throttleRetry.Do(ctx, op)
 	if err != nil {
-		c.metricsClient.IncCounter(metrics.HistoryCacheGetCurrentExecutionScope, metrics.CacheFailures)
+		metricsScope.IncCounter(metrics.CacheFailures)
 		return nil, err
 	}
 

--- a/service/history/replication/task_store.go
+++ b/service/history/replication/task_store.go
@@ -59,8 +59,9 @@ type TaskStore struct {
 	throttleRetry *backoff.ThrottleRetry
 	timeSource    clock.TimeSource
 
-	scope  metrics.Scope
-	logger log.Logger
+	scope   metrics.Scope
+	logger  log.Logger
+	shardID int
 
 	lastLogTime time.Time
 }
@@ -107,9 +108,19 @@ func NewTaskStore(
 		),
 		scope:       metricsClient.Scope(metrics.ReplicatorCacheManagerScope),
 		logger:      logger.WithTags(tag.ComponentReplicationCacheManager),
+		shardID:     shardID,
 		rateLimiter: quotas.NewDynamicRateLimiter(config.ReplicationTaskGenerationQPS.AsFloat64()),
 		timeSource:  timeSource,
 	}
+}
+
+func (m *TaskStore) cacheMetricsScope(cluster string) metrics.Scope {
+	return metrics.WithCacheScopeLabels(
+		m.scope,
+		m.shardID,
+		cluster,
+		metrics.ReplicationCacheTypeTagValue,
+	)
 }
 
 // Get will return a hydrated replication message for a given cluster based on raw task info.
@@ -133,7 +144,7 @@ func (m *TaskStore) Get(ctx context.Context, cluster string, info persistence.Ta
 		return nil, nil
 	}
 
-	scope := m.scope.Tagged(metrics.SourceClusterTag(cluster))
+	scope := m.cacheMetricsScope(cluster)
 
 	scope.IncCounter(metrics.CacheRequests)
 	// Keep timer (backwards compatible), dual-emit exponential histogram for migration.
@@ -151,7 +162,7 @@ func (m *TaskStore) Get(ctx context.Context, cluster string, info persistence.Ta
 		return task, nil
 	}
 
-	m.scope.IncCounter(metrics.CacheMissCounter)
+	scope.IncCounter(metrics.CacheMissCounter)
 
 	// Rate limit to not kill the database
 	m.rateLimiter.Wait(ctx)
@@ -165,7 +176,7 @@ func (m *TaskStore) Get(ctx context.Context, cluster string, info persistence.Ta
 	err = m.throttleRetry.Do(ctx, op)
 
 	if err != nil {
-		m.scope.IncCounter(metrics.CacheFailures)
+		scope.IncCounter(metrics.CacheFailures)
 		return nil, err
 	}
 
@@ -195,7 +206,7 @@ func (m *TaskStore) Put(task *types.ReplicationTask) {
 			continue
 		}
 
-		scope := m.scope.Tagged(metrics.SourceClusterTag(targetCluster))
+		scope := m.cacheMetricsScope(targetCluster)
 
 		err = cacheByCluster.Put(task, task.ByteSize())
 		switch {
@@ -230,7 +241,7 @@ func (m *TaskStore) Ack(cluster string, lastTaskID int64) error {
 
 	_, _ = cache.Ack(lastTaskID)
 
-	scope := m.scope.Tagged(metrics.SourceClusterTag(cluster))
+	scope := m.cacheMetricsScope(cluster)
 	count := cache.Count()
 	scope.RecordTimer(metrics.CacheSize, time.Duration(count))
 	scope.RecordHistogramValue(metrics.CacheSizeHistogram, float64(count))

--- a/service/history/replication/task_store.go
+++ b/service/history/replication/task_store.go
@@ -117,7 +117,7 @@ func NewTaskStore(
 func (m *TaskStore) cacheMetricsScope(cluster string) metrics.Scope {
 	return metrics.WithCacheScopeLabels(
 		m.scope,
-		m.shardID,
+		metrics.ShardIDTag(m.shardID),
 		cluster,
 		metrics.ReplicationCacheTypeTagValue,
 	)

--- a/service/history/workflowcache/cache.go
+++ b/service/history/workflowcache/cache.go
@@ -90,7 +90,7 @@ func New(params Params) WFCache {
 			Pin:           false,
 			MaxCount:      params.MaxCount,
 			ActivelyEvict: true,
-			MetricsScope:  params.MetricsClient.Scope(metrics.HistoryWorkflowCacheScope),
+			MetricsScope:  params.MetricsClient.Scope(metrics.HistoryWorkflowCacheScope).Tagged(metrics.NonShardTag()),
 			Logger:        params.Logger,
 		}),
 		externalLimiterFactory: params.ExternalLimiterFactory,


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
  Normalized label sets for shared cache metrics emitted through Prometheus.

  - Added normalized cache labels for LRU, history execution/events cache, and replication cache metrics.
  - Added `cache_type`, `source_cluster`, and `shard_id` consistently where shared `cache_*` metric names are emitted.
  - Added helpers for cache metric labeling: `WithCacheScopeLabels`, `NonShardTag`, and `SourceClusterNoneTagValue`.
  - Added a Prometheus regression test covering representative cache metric emitters.

**Why?**
https://github.com/cadence-workflow/cadence/issues/7844
Prometheus requires each metric family to use a stable set of label keys. Several cache paths emitted the same metric names, such as `cache_hit`, `cache_miss`, `cache_full`, and `cache_latency`, with different label sets. That can cause Prometheus registration errors and dropped cache metrics. This keeps the existing `cache_*` metric names and fixes the label-set inconsistency directly.

**How did you test it?**
  - `go test ./common/cache -run TestCacheMetricsLabelConsistency`
- `go test ./common/cache ./common/metrics ./service/history/replication ./service/history/execution ./service/history/events ./client/matching ./common/activecluster ./service/history/workflowcache ./service/frontend/api `
  - Verified the regression test fails against `origin/master` with Prometheus label registration errors.

**Potential risks**
This changes the Prometheus label schema for affected cache metrics. Existing dashboards or alerts may need to include or ignore the new labels, especially `cache_type`, `source_cluster`, and `shard_id`.

**Release notes**
Cache metrics emitted with shared `cache_*` names now use consistent Prometheus labels to avoid registration conflicts and dropped metrics.

**Documentation Changes**

