### PR TITLE
fix: Prevent failovers from converting a domain to active-active

### DIFF
--- a/common/domain/errors.go
+++ b/common/domain/errors.go
@@ -24,17 +24,18 @@ import "github.com/uber/cadence/common/types"
 
 var (
 	// err indicating that this cluster is not the primary, so cannot do domain registration or update
-	errNotPrimaryCluster                   = &types.BadRequestError{Message: "Cluster is not primary cluster, cannot do domain registration or domain update."}
-	errCannotRemoveClustersFromDomain      = &types.BadRequestError{Message: "Cannot remove existing replicated clusters from a domain."}
-	errActiveClusterNotInClusters          = &types.BadRequestError{Message: "Active cluster is not contained in all clusters."}
-	errCannotDoDomainFailoverAndUpdate     = &types.BadRequestError{Message: "Cannot set active cluster to current cluster when other parameters are set."}
-	errCannotDoGracefulFailoverFromCluster = &types.BadRequestError{Message: "Cannot start the graceful failover from a to-be-passive cluster."}
-	errGracefulFailoverInActiveCluster     = &types.BadRequestError{Message: "Cannot start the graceful failover from an active cluster to an active cluster."}
-	errOngoingGracefulFailover             = &types.BadRequestError{Message: "Cannot start concurrent graceful failover."}
-	errInvalidGracefulFailover             = &types.BadRequestError{Message: "Cannot start graceful failover without updating active cluster or in local domain."}
-	errInvalidFailoverNoChangeDetected     = &types.BadRequestError{Message: "a failover was requested, but there was no change detected, the configuration was not updated"}
-	errActiveClusterNameRequired           = &types.BadRequestError{Message: "ActiveClusterName is required for all global domains."}
-	errLocalDomainsCannotFailover          = &types.BadRequestError{Message: "Local domains cannot perform failovers or change replication configuration"}
+	errNotPrimaryCluster                      = &types.BadRequestError{Message: "Cluster is not primary cluster, cannot do domain registration or domain update."}
+	errCannotRemoveClustersFromDomain         = &types.BadRequestError{Message: "Cannot remove existing replicated clusters from a domain."}
+	errActiveClusterNotInClusters             = &types.BadRequestError{Message: "Active cluster is not contained in all clusters."}
+	errCannotDoDomainFailoverAndUpdate        = &types.BadRequestError{Message: "Cannot set active cluster to current cluster when other parameters are set."}
+	errCannotDoGracefulFailoverFromCluster    = &types.BadRequestError{Message: "Cannot start the graceful failover from a to-be-passive cluster."}
+	errGracefulFailoverInActiveCluster        = &types.BadRequestError{Message: "Cannot start the graceful failover from an active cluster to an active cluster."}
+	errOngoingGracefulFailover                = &types.BadRequestError{Message: "Cannot start concurrent graceful failover."}
+	errInvalidGracefulFailover                = &types.BadRequestError{Message: "Cannot start graceful failover without updating active cluster or in local domain."}
+	errInvalidFailoverNoChangeDetected        = &types.BadRequestError{Message: "a failover was requested, but there was no change detected, the configuration was not updated"}
+	errActiveClusterNameRequired              = &types.BadRequestError{Message: "ActiveClusterName is required for all global domains."}
+	errLocalDomainsCannotFailover             = &types.BadRequestError{Message: "Local domains cannot perform failovers or change replication configuration"}
+	errCannotPromoteToActiveActiveViaFailover = &types.BadRequestError{Message: "FailoverDomain cannot be used to promote a domain to active-active; use UpdateDomain to set cluster attributes"}
 
 	errInvalidRetentionPeriod = &types.BadRequestError{Message: "A valid retention period is not set on request."}
 	errInvalidArchivalConfig  = &types.BadRequestError{Message: "Invalid to enable archival without specifying a uri."}

--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -1780,7 +1780,7 @@ func (d *handlerImpl) validateDomainFailoverRequest(
 		return &types.BadRequestError{Message: "DomainName cannot be empty"}
 	}
 
-	if !currentDomainState.IsGlobalDomain {
+	if !currentDomainState.IsGlobalDomain || currentDomainState.ReplicationConfig == nil {
 		return errLocalDomainsCannotFailover
 	}
 

--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -1784,6 +1784,10 @@ func (d *handlerImpl) validateDomainFailoverRequest(
 		return errLocalDomainsCannotFailover
 	}
 
+	if request.ActiveClusters != nil && currentDomainState.ReplicationConfig.ActiveClusters == nil {
+		return errCannotPromoteToActiveActiveViaFailover
+	}
+
 	if request.ActiveClusters == nil && request.DomainActiveClusterName == nil {
 		return &types.BadRequestError{Message: "Domain's ActiveClusterName or ActiveClusters must be set to failover the domain"}
 	}

--- a/common/domain/handler_test.go
+++ b/common/domain/handler_test.go
@@ -3818,6 +3818,47 @@ func TestHandler_FailoverDomain(t *testing.T) {
 			err: errCannotPromoteToActiveActiveViaFailover,
 		},
 		{
+			name: "Error case - nil ReplicationConfig in domain response with ActiveClusters in request should be rejected",
+			setupMock: func(domainManager *persistence.MockDomainManager, updateRequest *types.FailoverDomainRequest, archivalMetadata *archiver.MockArchivalMetadata, timeSource clock.MockedTimeSource, domainReplicator *MockReplicator) {
+				domainResponse := &persistence.GetDomainResponse{
+					ReplicationConfig: nil, // malformed persistence response
+					Config: &persistence.DomainConfig{
+						Retention:                1,
+						EmitMetric:               true,
+						HistoryArchivalStatus:    types.ArchivalStatusDisabled,
+						VisibilityArchivalStatus: types.ArchivalStatusDisabled,
+						BadBinaries:              types.BadBinaries{Binaries: map[string]*types.BadBinaryInfo{}},
+						IsolationGroups:          types.IsolationGroupConfiguration{},
+						AsyncWorkflowConfig:      types.AsyncWorkflowConfiguration{Enabled: true},
+					},
+					Info: &persistence.DomainInfo{
+						Name:   constants.TestDomainName,
+						ID:     constants.TestDomainID,
+						Status: persistence.DomainStatusRegistered,
+					},
+					IsGlobalDomain:  true,
+					LastUpdatedTime: timeSource.Now().UnixNano(),
+					FailoverVersion: clusterAInitialFailoverVersion,
+				}
+				domainManager.EXPECT().GetMetadata(ctx).Return(&persistence.GetMetadataResponse{NotificationVersion: 15}, nil).Times(1)
+				domainManager.EXPECT().GetDomain(ctx, &persistence.GetDomainRequest{Name: updateRequest.GetDomainName()}).
+					Return(domainResponse, nil).Times(1)
+			},
+			request: &types.FailoverDomainRequest{
+				DomainName: constants.TestDomainName,
+				ActiveClusters: &types.ActiveClusters{
+					AttributeScopes: map[string]types.ClusterAttributeScope{
+						"region": {
+							ClusterAttributes: map[string]types.ActiveClusterInfo{
+								"us-east": {ActiveClusterName: clusterB},
+							},
+						},
+					},
+				},
+			},
+			err: errLocalDomainsCannotFailover,
+		},
+		{
 			name: "Success case - active-active domain with ActiveClusters in request should succeed",
 			setupMock: func(domainManager *persistence.MockDomainManager, updateRequest *types.FailoverDomainRequest, archivalMetadata *archiver.MockArchivalMetadata, timeSource clock.MockedTimeSource, domainReplicator *MockReplicator) {
 				domainResponse := &persistence.GetDomainResponse{

--- a/common/domain/handler_test.go
+++ b/common/domain/handler_test.go
@@ -3770,6 +3770,188 @@ func TestHandler_FailoverDomain(t *testing.T) {
 			},
 			err: errDomainUpdateTooFrequent,
 		},
+		{
+			name: "Error case - active-passive domain cannot be promoted to active-active via FailoverDomain",
+			setupMock: func(domainManager *persistence.MockDomainManager, updateRequest *types.FailoverDomainRequest, archivalMetadata *archiver.MockArchivalMetadata, timeSource clock.MockedTimeSource, domainReplicator *MockReplicator) {
+				domainResponse := &persistence.GetDomainResponse{
+					ReplicationConfig: &persistence.DomainReplicationConfig{
+						ActiveClusterName: clusterA,
+						Clusters: []*persistence.ClusterReplicationConfig{
+							{ClusterName: clusterA}, {ClusterName: clusterB}},
+						// ActiveClusters is nil — this is an active-passive domain
+					},
+					Config: &persistence.DomainConfig{
+						Retention:                1,
+						EmitMetric:               true,
+						HistoryArchivalStatus:    types.ArchivalStatusDisabled,
+						VisibilityArchivalStatus: types.ArchivalStatusDisabled,
+						BadBinaries:              types.BadBinaries{Binaries: map[string]*types.BadBinaryInfo{}},
+						IsolationGroups:          types.IsolationGroupConfiguration{},
+						AsyncWorkflowConfig:      types.AsyncWorkflowConfiguration{Enabled: true},
+					},
+					Info: &persistence.DomainInfo{
+						Name:   constants.TestDomainName,
+						ID:     constants.TestDomainID,
+						Status: persistence.DomainStatusRegistered,
+					},
+					IsGlobalDomain:  true,
+					LastUpdatedTime: timeSource.Now().UnixNano(),
+					FailoverVersion: clusterAInitialFailoverVersion,
+				}
+				domainManager.EXPECT().GetMetadata(ctx).Return(&persistence.GetMetadataResponse{NotificationVersion: 15}, nil).Times(1)
+				domainManager.EXPECT().GetDomain(ctx, &persistence.GetDomainRequest{Name: updateRequest.GetDomainName()}).
+					Return(domainResponse, nil).Times(1)
+				// UpdateDomain must NOT be called — guard should reject before reaching persistence
+			},
+			request: &types.FailoverDomainRequest{
+				DomainName: constants.TestDomainName,
+				ActiveClusters: &types.ActiveClusters{
+					AttributeScopes: map[string]types.ClusterAttributeScope{
+						"region": {
+							ClusterAttributes: map[string]types.ActiveClusterInfo{
+								"us-east": {ActiveClusterName: clusterB},
+							},
+						},
+					},
+				},
+			},
+			err: errCannotPromoteToActiveActiveViaFailover,
+		},
+		{
+			name: "Success case - active-active domain with ActiveClusters in request should succeed",
+			setupMock: func(domainManager *persistence.MockDomainManager, updateRequest *types.FailoverDomainRequest, archivalMetadata *archiver.MockArchivalMetadata, timeSource clock.MockedTimeSource, domainReplicator *MockReplicator) {
+				domainResponse := &persistence.GetDomainResponse{
+					ReplicationConfig: &persistence.DomainReplicationConfig{
+						ActiveClusterName: clusterA,
+						Clusters: []*persistence.ClusterReplicationConfig{
+							{ClusterName: clusterA}, {ClusterName: clusterB}},
+						ActiveClusters: &types.ActiveClusters{
+							AttributeScopes: map[string]types.ClusterAttributeScope{
+								"region": {
+									ClusterAttributes: map[string]types.ActiveClusterInfo{
+										"us-east": {ActiveClusterName: clusterA, FailoverVersion: clusterAInitialFailoverVersion},
+										"us-west": {ActiveClusterName: clusterB, FailoverVersion: clusterBInitialFailoverVersion},
+									},
+								},
+							},
+						},
+					},
+					Config: &persistence.DomainConfig{
+						Retention:                1,
+						EmitMetric:               true,
+						HistoryArchivalStatus:    types.ArchivalStatusDisabled,
+						VisibilityArchivalStatus: types.ArchivalStatusDisabled,
+						BadBinaries:              types.BadBinaries{Binaries: map[string]*types.BadBinaryInfo{}},
+						IsolationGroups:          types.IsolationGroupConfiguration{},
+						AsyncWorkflowConfig:      types.AsyncWorkflowConfiguration{Enabled: true},
+					},
+					Info: &persistence.DomainInfo{
+						Name:   constants.TestDomainName,
+						ID:     constants.TestDomainID,
+						Status: persistence.DomainStatusRegistered,
+					},
+					IsGlobalDomain:  true,
+					LastUpdatedTime: timeSource.Now().UnixNano(),
+					FailoverVersion: clusterAInitialFailoverVersion,
+				}
+				domainManager.EXPECT().GetMetadata(ctx).Return(&persistence.GetMetadataResponse{NotificationVersion: 15}, nil).Times(1)
+				domainManager.EXPECT().GetDomain(ctx, &persistence.GetDomainRequest{Name: updateRequest.GetDomainName()}).
+					Return(domainResponse, nil).Times(1)
+				timeSource.Advance(time.Hour)
+
+				expectedUpdateRequest := &persistence.UpdateDomainRequest{
+					Info: &persistence.DomainInfo{
+						Name:   constants.TestDomainName,
+						ID:     constants.TestDomainID,
+						Status: persistence.DomainStatusRegistered,
+					},
+					Config: domainResponse.Config,
+					ReplicationConfig: &persistence.DomainReplicationConfig{
+						ActiveClusterName: clusterA,
+						Clusters: []*persistence.ClusterReplicationConfig{
+							{ClusterName: clusterA}, {ClusterName: clusterB}},
+						ActiveClusters: &types.ActiveClusters{
+							AttributeScopes: map[string]types.ClusterAttributeScope{
+								"region": {
+									ClusterAttributes: map[string]types.ActiveClusterInfo{
+										// us-east failed over from clusterA to clusterB
+										"us-east": {ActiveClusterName: clusterB, FailoverVersion: clusterBInitialFailoverVersion},
+										"us-west": {ActiveClusterName: clusterB, FailoverVersion: clusterBInitialFailoverVersion},
+									},
+								},
+							},
+						},
+					},
+					PreviousFailoverVersion:     commonconstants.InitialPreviousFailoverVersion,
+					ConfigVersion:               1,                                    // incremented from 0
+					FailoverVersion:             clusterAInitialFailoverVersion + 100, // GetNextFailoverVersion("cluster-a", 2) = 101
+					LastUpdatedTime:             timeSource.Now().UnixNano(),
+					FailoverNotificationVersion: 15,
+					NotificationVersion:         15,
+				}
+				domainManager.EXPECT().UpdateDomain(ctx, expectedUpdateRequest).Return(nil).Times(1)
+				domainReplicator.EXPECT().
+					HandleTransmissionTask(
+						ctx,
+						types.DomainOperationUpdate,
+						expectedUpdateRequest.Info,
+						domainResponse.Config,
+						expectedUpdateRequest.ReplicationConfig,
+						int64(1), // ConfigVersion
+						clusterAInitialFailoverVersion+100,
+						commonconstants.InitialPreviousFailoverVersion,
+						true,
+					).Return(nil).Times(1)
+			},
+			request: &types.FailoverDomainRequest{
+				DomainName: constants.TestDomainName,
+				ActiveClusters: &types.ActiveClusters{
+					AttributeScopes: map[string]types.ClusterAttributeScope{
+						"region": {
+							ClusterAttributes: map[string]types.ActiveClusterInfo{
+								"us-east": {ActiveClusterName: clusterB},
+							},
+						},
+					},
+				},
+			},
+			response: func(timeSource clock.MockedTimeSource) *types.FailoverDomainResponse {
+				return &types.FailoverDomainResponse{
+					IsGlobalDomain:  true,
+					FailoverVersion: clusterAInitialFailoverVersion + 100,
+					DomainInfo: &types.DomainInfo{
+						Name:   constants.TestDomainName,
+						UUID:   constants.TestDomainID,
+						Status: common.Ptr(types.DomainStatusRegistered),
+					},
+					Configuration: &types.DomainConfiguration{
+						WorkflowExecutionRetentionPeriodInDays: 1,
+						EmitMetric:                             true,
+						HistoryArchivalStatus:                  common.Ptr(types.ArchivalStatusDisabled),
+						VisibilityArchivalStatus:               common.Ptr(types.ArchivalStatusDisabled),
+						BadBinaries:                            &types.BadBinaries{Binaries: map[string]*types.BadBinaryInfo{}},
+						IsolationGroups:                        &types.IsolationGroupConfiguration{},
+						AsyncWorkflowConfig:                    &types.AsyncWorkflowConfiguration{Enabled: true},
+					},
+					ReplicationConfiguration: &types.DomainReplicationConfiguration{
+						ActiveClusterName: clusterA,
+						Clusters: []*types.ClusterReplicationConfiguration{
+							{ClusterName: clusterA}, {ClusterName: clusterB},
+						},
+						ActiveClusters: &types.ActiveClusters{
+							AttributeScopes: map[string]types.ClusterAttributeScope{
+								"region": {
+									ClusterAttributes: map[string]types.ActiveClusterInfo{
+										"us-east": {ActiveClusterName: clusterB, FailoverVersion: clusterBInitialFailoverVersion},
+										"us-west": {ActiveClusterName: clusterB, FailoverVersion: clusterBInitialFailoverVersion},
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

Prevents a 'failover' command from also updating the cluster attributes of a domain if they do not exist. 

**Why?**

The supported method of converting a domain from global to global with active-active is via the UpdateDomain command. This prevents inadvertently changing a domain to active-active (a one way door) without explicitly upgrading it first (or creating it as active active initially). 

**How did you test it?**

Unit tests. 

**Potential risks**

None. 

**Release notes**

It is no longer possible to convert a domain from global to global active-active via the failover command. 

**Documentation Changes**

N/A