### PR TITLE
feat(scheduler): stamp CadenceScheduleBackfillID on backfill target runs

### DIFF
--- a/common/definition/indexedKeys.go
+++ b/common/definition/indexedKeys.go
@@ -52,6 +52,9 @@ const (
 	CadenceScheduleID         = "CadenceScheduleID"
 	CadenceScheduleTime       = "CadenceScheduleTime"
 	CadenceScheduleIsBackfill = "CadenceScheduleIsBackfill"
+	// CadenceScheduleBackfillID is set on target workflows started by a schedule
+	// backfill when the client supplied a non-empty BackfillID (keyword).
+	CadenceScheduleBackfillID = "CadenceScheduleBackfillID"
 
 	// Schedule search attributes set on the scheduler workflow itself (used by ListSchedules).
 	CadenceScheduleState        = "CadenceScheduleState"
@@ -99,6 +102,7 @@ func createDefaultIndexedKeys() map[string]interface{} {
 		CadenceScheduleState:        types.IndexedValueTypeKeyword,
 		CadenceScheduleCron:         types.IndexedValueTypeKeyword,
 		CadenceScheduleWorkflowType: types.IndexedValueTypeKeyword,
+		CadenceScheduleBackfillID:   types.IndexedValueTypeKeyword,
 	}
 	for k, v := range systemIndexedKeys {
 		defaultIndexedKeys[k] = v

--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -37,6 +37,7 @@ frontend.validSearchAttributes:
     CadenceScheduleState: 1
     CadenceScheduleCron: 1
     CadenceScheduleWorkflowType: 1
+    CadenceScheduleBackfillID: 1
     CloseStatus: 2
     CloseTime: 2
     CustomBoolField: 4

--- a/host/dynamicconfig.go
+++ b/host/dynamicconfig.go
@@ -29,7 +29,6 @@ import (
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/types"
-	"github.com/uber/cadence/service/worker/scheduler"
 )
 
 var (
@@ -55,24 +54,13 @@ var (
 	}
 )
 
-// validSearchAttributesWithSchedules returns the default indexed-keys map
-// extended with the scheduler-managed search attributes that the schedule
-// pipeline upserts.
-//
-// TODO: drop this once the scheduler search attributes are part of the
-// default indexed-keys set in common/definition. At that point the
-// staticOverrides entry for ValidSearchAttributes can go away entirely.
+// validSearchAttributesWithSchedules returns a copy of the default indexed-keys
+// map (including scheduler-managed keys on target and list workflows).
 func validSearchAttributesWithSchedules() map[string]interface{} {
-	out := make(map[string]interface{}, len(definition.GetDefaultIndexedKeys())+6)
+	out := make(map[string]interface{}, len(definition.GetDefaultIndexedKeys()))
 	for k, v := range definition.GetDefaultIndexedKeys() {
 		out[k] = v
 	}
-	out[scheduler.SearchAttrScheduleID] = types.IndexedValueTypeKeyword
-	out[scheduler.SearchAttrScheduleTime] = types.IndexedValueTypeDatetime
-	out[scheduler.SearchAttrIsBackfill] = types.IndexedValueTypeBool
-	out[scheduler.SearchAttrScheduleState] = types.IndexedValueTypeKeyword
-	out[scheduler.SearchAttrScheduleCron] = types.IndexedValueTypeKeyword
-	out[scheduler.SearchAttrScheduleWorkflowType] = types.IndexedValueTypeKeyword
 	return out
 }
 

--- a/service/worker/scheduler/activity.go
+++ b/service/worker/scheduler/activity.go
@@ -290,6 +290,11 @@ func buildSearchAttributes(req ProcessFireRequest) *types.SearchAttributes {
 	if v, err := json.Marshal(req.TriggerSource == TriggerSourceBackfill); err == nil {
 		fields[SearchAttrIsBackfill] = v
 	}
+	if req.TriggerSource == TriggerSourceBackfill && req.BackfillID != "" {
+		if v, err := json.Marshal(req.BackfillID); err == nil {
+			fields[SearchAttrBackfillID] = v
+		}
+	}
 
 	return &types.SearchAttributes{IndexedFields: fields}
 }

--- a/service/worker/scheduler/activity_test.go
+++ b/service/worker/scheduler/activity_test.go
@@ -647,6 +647,8 @@ func TestBuildSearchAttributes(t *testing.T) {
 		assert.False(t, isBackfill)
 
 		assert.Contains(t, sa.IndexedFields, SearchAttrScheduleTime)
+		_, hasBackfillID := sa.IndexedFields[SearchAttrBackfillID]
+		assert.False(t, hasBackfillID, "non-backfill runs should not set backfill id SA")
 	})
 
 	t.Run("backfill trigger sets isBackfill true", func(t *testing.T) {
@@ -660,6 +662,21 @@ func TestBuildSearchAttributes(t *testing.T) {
 		var isBackfill bool
 		require.NoError(t, json.Unmarshal(sa.IndexedFields[SearchAttrIsBackfill], &isBackfill))
 		assert.True(t, isBackfill)
+		_, hasBackfillID := sa.IndexedFields[SearchAttrBackfillID]
+		assert.False(t, hasBackfillID, "empty backfill id should omit SA")
+	})
+
+	t.Run("backfill trigger with id sets backfill id SA", func(t *testing.T) {
+		req := ProcessFireRequest{
+			ScheduleID:    "sched-1",
+			ScheduledTime: scheduledTime,
+			TriggerSource: TriggerSourceBackfill,
+			BackfillID:    "bf-123",
+		}
+		sa := buildSearchAttributes(req)
+		var got string
+		require.NoError(t, json.Unmarshal(sa.IndexedFields[SearchAttrBackfillID], &got))
+		assert.Equal(t, "bf-123", got)
 	})
 
 	t.Run("preserves user search attributes", func(t *testing.T) {

--- a/service/worker/scheduler/activity_test.go
+++ b/service/worker/scheduler/activity_test.go
@@ -188,6 +188,63 @@ func TestProcessScheduleFireActivity(t *testing.T) {
 			},
 		},
 		{
+			name: "backfill start stamps CadenceScheduleBackfillID on StartWorkflow",
+			req: func() ProcessFireRequest {
+				r := baseReq
+				r.TriggerSource = TriggerSourceBackfill
+				r.BackfillID = "bf-coverage"
+				return r
+			}(),
+			setupMock: func(m *frontend.MockClient) {
+				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, swReq *types.StartWorkflowExecutionRequest, _ ...interface{}) (*types.StartWorkflowExecutionResponse, error) {
+						require.NotNil(t, swReq.SearchAttributes)
+						require.Contains(t, swReq.SearchAttributes.IndexedFields, SearchAttrBackfillID)
+						var got string
+						require.NoError(t, json.Unmarshal(swReq.SearchAttributes.IndexedFields[SearchAttrBackfillID], &got))
+						assert.Equal(t, "bf-coverage", got)
+						var isBF bool
+						require.NoError(t, json.Unmarshal(swReq.SearchAttributes.IndexedFields[SearchAttrIsBackfill], &isBF))
+						assert.True(t, isBF)
+						return &types.StartWorkflowExecutionResponse{RunID: "run-bf"}, nil
+					})
+			},
+			wantResult: &ProcessFireResult{
+				TotalDelta:      1,
+				StartedWorkflow: &RunningWorkflowInfo{WorkflowID: expectedWfID, RunID: "run-bf"},
+			},
+		},
+		{
+			name: "BUFFER backfill start when previous closed stamps CadenceScheduleBackfillID",
+			req: func() ProcessFireRequest {
+				r := baseReq
+				r.OverlapPolicy = types.ScheduleOverlapPolicyBuffer
+				r.LastStartedWorkflow = &RunningWorkflowInfo{WorkflowID: "old-wf", RunID: "old-run"}
+				r.TriggerSource = TriggerSourceBackfill
+				r.BackfillID = "bf-buf-start"
+				return r
+			}(),
+			setupMock: func(m *frontend.MockClient) {
+				status := types.WorkflowExecutionCloseStatusCompleted
+				m.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{CloseStatus: &status},
+					}, nil)
+				m.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, swReq *types.StartWorkflowExecutionRequest, _ ...interface{}) (*types.StartWorkflowExecutionResponse, error) {
+						require.Contains(t, swReq.SearchAttributes.IndexedFields, SearchAttrBackfillID)
+						var got string
+						require.NoError(t, json.Unmarshal(swReq.SearchAttributes.IndexedFields[SearchAttrBackfillID], &got))
+						assert.Equal(t, "bf-buf-start", got)
+						return &types.StartWorkflowExecutionResponse{RunID: "run-buf"}, nil
+					})
+			},
+			wantResult: &ProcessFireResult{
+				TotalDelta:      1,
+				StartedWorkflow: &RunningWorkflowInfo{WorkflowID: expectedWfID, RunID: "run-buf"},
+			},
+		},
+		{
 			name: "SKIP_NEW skips when previous is running",
 			req: func() ProcessFireRequest {
 				r := baseReq

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -105,6 +105,7 @@ const (
 	SearchAttrScheduleID   = definition.CadenceScheduleID
 	SearchAttrScheduleTime = definition.CadenceScheduleTime
 	SearchAttrIsBackfill   = definition.CadenceScheduleIsBackfill
+	SearchAttrBackfillID   = definition.CadenceScheduleBackfillID
 
 	// Search attribute keys set on the scheduler workflow itself for ListSchedules.
 	// CadenceScheduleState is a Keyword SA holding the current lifecycle state
@@ -186,6 +187,8 @@ type BufferedFire struct {
 	ScheduledTime time.Time                   `json:"scheduledTime"`
 	TriggerSource TriggerSource               `json:"triggerSource"`
 	OverlapPolicy types.ScheduleOverlapPolicy `json:"overlapPolicy,omitempty"`
+	// BackfillID is set when TriggerSource is backfill so BUFFER drains stamp the same SA.
+	BackfillID string `json:"backfillId,omitempty"`
 }
 
 // RunningWorkflowInfo identifies a target workflow started by the scheduler,
@@ -290,6 +293,8 @@ type ProcessFireRequest struct {
 	// RunningWorkflows is the current in-flight set from workflow state; used
 	// only when OverlapPolicy==CONCURRENT and ConcurrencyLimit > 0.
 	RunningWorkflows []RunningWorkflowInfo `json:"runningWorkflows,omitempty"`
+	// BackfillID is non-empty only for fires driven by a schedule backfill (matches RPC BackfillID).
+	BackfillID string `json:"backfillId,omitempty"`
 }
 
 // ProcessFireResult is the output of processScheduleFireActivity. The workflow

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -181,7 +181,7 @@ func SchedulerWorkflow(ctx workflow.Context, input SchedulerWorkflowInput) error
 		}
 
 		if timerFired && !state.Paused {
-			processScheduleFire(ctx, logger, scope, &input, state, state.NextRunTime, TriggerSourceSchedule, input.Policies.OverlapPolicy)
+			processScheduleFire(ctx, logger, scope, &input, state, state.NextRunTime, TriggerSourceSchedule, input.Policies.OverlapPolicy, "")
 		}
 
 		if changed || state.Iterations >= maxIterationsBeforeContinueAsNew {
@@ -520,17 +520,17 @@ func effectiveFireOverlap(trigger TriggerSource, backfillOverlap, scheduleOverla
 // the live-fire activity call, the previous workflow could complete.
 // tryStartFire would then start the live fire ahead of older queued fires,
 // breaking FIFO.
-func processScheduleFire(ctx workflow.Context, logger *zap.Logger, scope tally.Scope, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource, overlapPolicy types.ScheduleOverlapPolicy) {
+func processScheduleFire(ctx workflow.Context, logger *zap.Logger, scope tally.Scope, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource, overlapPolicy types.ScheduleOverlapPolicy, backfillID string) {
 	if overlapPolicy == types.ScheduleOverlapPolicyBuffer && len(state.BufferedFires) > 0 {
 		// Skipping tryStartFire, so advance LastRunTime here.
 		if scheduledTime.After(state.LastRunTime) {
 			state.LastRunTime = scheduledTime
 		}
-		enqueueBufferedFire(logger, scope, input, state, scheduledTime, trigger, overlapPolicy)
+		enqueueBufferedFire(logger, scope, input, state, scheduledTime, trigger, overlapPolicy, backfillID)
 		return
 	}
-	if tryStartFire(ctx, logger, input, state, scheduledTime, trigger, overlapPolicy) == fireOutcomeBuffered {
-		enqueueBufferedFire(logger, scope, input, state, scheduledTime, trigger, overlapPolicy)
+	if tryStartFire(ctx, logger, input, state, scheduledTime, trigger, overlapPolicy, backfillID) == fireOutcomeBuffered {
+		enqueueBufferedFire(logger, scope, input, state, scheduledTime, trigger, overlapPolicy, backfillID)
 	}
 }
 
@@ -538,7 +538,7 @@ func processScheduleFire(ctx workflow.Context, logger *zap.Logger, scope tally.S
 // result to state, returning whether the fire was buffered. Shared by the
 // live-fire and drain-buffered-fire paths; the caller decides how to handle
 // a buffered outcome.
-func tryStartFire(ctx workflow.Context, logger *zap.Logger, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource, overlapPolicy types.ScheduleOverlapPolicy) fireOutcome {
+func tryStartFire(ctx workflow.Context, logger *zap.Logger, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource, overlapPolicy types.ScheduleOverlapPolicy, backfillID string) fireOutcome {
 	// LastRunTime moves forward only. Under BUFFER, an older queued fire can
 	// drain after a newer fire has already been processed.
 	if scheduledTime.After(state.LastRunTime) {
@@ -567,6 +567,7 @@ func tryStartFire(ctx workflow.Context, logger *zap.Logger, input *SchedulerWork
 		LastStartedWorkflow: state.LastStartedWorkflow,
 		ConcurrencyLimit:    input.Policies.ConcurrencyLimit,
 		RunningWorkflows:    state.RunningWorkflows,
+		BackfillID:          backfillID,
 	}
 
 	var result ProcessFireResult
@@ -609,7 +610,7 @@ func tryStartFire(ctx workflow.Context, logger *zap.Logger, input *SchedulerWork
 // user-configured buffer_limit and the MaxBufferedFiresSystemLimit ceiling.
 // Drops increment SkippedRuns and emit scheduler_buffer_overflow_count_per_domain
 // tagged with the binding limit (user_limit vs. system_limit).
-func enqueueBufferedFire(logger *zap.Logger, scope tally.Scope, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource, overlapPolicy types.ScheduleOverlapPolicy) {
+func enqueueBufferedFire(logger *zap.Logger, scope tally.Scope, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, scheduledTime time.Time, trigger TriggerSource, overlapPolicy types.ScheduleOverlapPolicy, backfillID string) {
 	effective, reason := effectiveBufferLimit(input.Policies.BufferLimit)
 	if len(state.BufferedFires) >= effective {
 		state.SkippedRuns++
@@ -629,6 +630,7 @@ func enqueueBufferedFire(logger *zap.Logger, scope tally.Scope, input *Scheduler
 		ScheduledTime: scheduledTime,
 		TriggerSource: trigger,
 		OverlapPolicy: overlapPolicy,
+		BackfillID:    backfillID,
 	})
 	logger.Info("schedule fire buffered",
 		zap.Time("scheduledTime", scheduledTime),
@@ -688,7 +690,7 @@ func drainBufferedFires(ctx workflow.Context, logger *zap.Logger, input *Schedul
 		if headOverlap == types.ScheduleOverlapPolicyInvalid {
 			headOverlap = input.Policies.OverlapPolicy
 		}
-		if tryStartFire(ctx, logger, input, state, head.ScheduledTime, head.TriggerSource, headOverlap) == fireOutcomeBuffered {
+		if tryStartFire(ctx, logger, input, state, head.ScheduledTime, head.TriggerSource, headOverlap, head.BackfillID) == fireOutcomeBuffered {
 			return false
 		}
 		state.BufferedFires = state.BufferedFires[1:]
@@ -848,7 +850,7 @@ func processMissedRunsAt(ctx workflow.Context, logger *zap.Logger, scope tally.S
 		if fired >= maxCatchUpFiresPerExecution {
 			break
 		}
-		processScheduleFire(ctx, logger, scope, input, state, t, TriggerSourceSchedule, input.Policies.OverlapPolicy)
+		processScheduleFire(ctx, logger, scope, input, state, t, TriggerSourceSchedule, input.Policies.OverlapPolicy, "")
 		fired++
 	}
 	unfired := int64(len(result.toFire) - fired)
@@ -912,7 +914,7 @@ func processBackfills(ctx workflow.Context, logger *zap.Logger, scope tally.Scop
 				return true
 			}
 			overlap := effectiveFireOverlap(TriggerSourceBackfill, bf.OverlapPolicy, input.Policies.OverlapPolicy)
-			processScheduleFire(ctx, logger, scope, input, state, t, TriggerSourceBackfill, overlap)
+			processScheduleFire(ctx, logger, scope, input, state, t, TriggerSourceBackfill, overlap, bf.BackfillID)
 			fired++
 		}
 

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1167,6 +1167,7 @@ func TestEnqueueBufferedFire(t *testing.T) {
 		initialSkipped     int64
 		enqueueTime        time.Time
 		trigger            TriggerSource
+		enqueueBackfillID  string
 		wantFires          []BufferedFire
 		wantSkippedRuns    int64
 		wantOverflowReason string
@@ -1245,6 +1246,17 @@ func TestEnqueueBufferedFire(t *testing.T) {
 				{ScheduledTime: t0, TriggerSource: TriggerSourceBackfill, OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
 			},
 		},
+		{
+			name:              "backfill id is preserved on buffered fire",
+			bufferLimit:       0,
+			initialFires:      nil,
+			enqueueTime:       t0,
+			trigger:           TriggerSourceBackfill,
+			enqueueBackfillID: "bf-abc",
+			wantFires: []BufferedFire{
+				{ScheduledTime: t0, TriggerSource: TriggerSourceBackfill, OverlapPolicy: types.ScheduleOverlapPolicyBuffer, BackfillID: "bf-abc"},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1257,7 +1269,7 @@ func TestEnqueueBufferedFire(t *testing.T) {
 				SkippedRuns:   tt.initialSkipped,
 			}
 			scope := tally.NewTestScope("", nil)
-			enqueueBufferedFire(testLogger, scope, input, state, tt.enqueueTime, tt.trigger, types.ScheduleOverlapPolicyBuffer)
+			enqueueBufferedFire(testLogger, scope, input, state, tt.enqueueTime, tt.trigger, types.ScheduleOverlapPolicyBuffer, tt.enqueueBackfillID)
 			assert.Equal(t, tt.wantFires, state.BufferedFires)
 			assert.Equal(t, tt.wantSkippedRuns, state.SkippedRuns)
 
@@ -1344,7 +1356,7 @@ func TestProcessScheduleFireBufferEnqueuesWhenQueueNonEmpty(t *testing.T) {
 	// nil ctx is safe because the BUFFER+non-empty-queue branch returns before
 	// touching workflow.ExecuteLocalActivity. If the fast path were ever
 	// removed, this call would panic — which is the property we want to lock in.
-	processScheduleFire(nil, testLogger, scope, input, state, liveFire, TriggerSourceSchedule, types.ScheduleOverlapPolicyBuffer)
+	processScheduleFire(nil, testLogger, scope, input, state, liveFire, TriggerSourceSchedule, types.ScheduleOverlapPolicyBuffer, "")
 
 	require.Len(t, state.BufferedFires, 2, "live fire should be enqueued at the tail")
 	assert.Equal(t, t0, state.BufferedFires[0].ScheduledTime, "older queued fire stays at head")

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1364,6 +1364,35 @@ func TestProcessScheduleFireBufferEnqueuesWhenQueueNonEmpty(t *testing.T) {
 	assert.Equal(t, liveFire, state.LastRunTime, "LastRunTime should still advance even on the fast path")
 }
 
+// TestProcessScheduleFireBufferPreservesBackfillID verifies the BUFFER fast path
+// passes BackfillID into the queued BufferedFire for backfill-driven fires.
+func TestProcessScheduleFireBufferPreservesBackfillID(t *testing.T) {
+	t0 := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	input := &SchedulerWorkflowInput{
+		Spec: types.ScheduleSpec{CronExpression: "* * * * *"},
+		Action: types.ScheduleAction{
+			StartWorkflow: &types.StartWorkflowAction{
+				WorkflowType: &types.WorkflowType{Name: "wf"},
+				TaskList:     &types.TaskList{Name: "tl"},
+			},
+		},
+		Policies: types.SchedulePolicies{OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
+	}
+	state := &SchedulerWorkflowState{
+		BufferedFires: []BufferedFire{
+			{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule, OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
+		},
+	}
+	scope := tally.NewTestScope("", nil)
+	liveFire := t0.Add(2 * time.Minute)
+
+	processScheduleFire(nil, testLogger, scope, input, state, liveFire, TriggerSourceBackfill, types.ScheduleOverlapPolicyBuffer, "bf-fast")
+
+	require.Len(t, state.BufferedFires, 2)
+	assert.Equal(t, "bf-fast", state.BufferedFires[1].BackfillID, "backfill id should be preserved on buffered fire")
+	assert.Equal(t, TriggerSourceBackfill, state.BufferedFires[1].TriggerSource)
+}
+
 // TestCatchUpWatermark verifies the catch-up watermark is the max of the
 // two relevant timestamps. LastProcessedTime advances only via catch-up;
 // LastRunTime advances on every fire (live or buffered). Picking only


### PR DESCRIPTION
**What changed?**
- Target workflows started by a schedule backfill can now get a `CadenceScheduleBackfillID` search attribute when the client sends a non-empty BackfillID on the backfill request.
- BackfillID is threaded from the pending backfill through processScheduleFire → ProcessFireRequest, including the BUFFER path so queued fires keep the same id when they eventually start.
- CadenceScheduleBackfillID is registered in definition.GetDefaultIndexedKeys()

**Why?**
CadenceScheduleIsBackfill + CadenceScheduleID is enough to ask “any backfill-origin runs for this schedule?”, but not “which batch?” when there are multiple backfills. Stamping the id on each run gives the UI (and audits) a stable way to group or filter executions by backfill.

**How did you test it?**
go test ./service/worker/scheduler/... 

**Potential risks**
N/A

**Release notes**
Schedules: Target workflow executions started by a backfill may include search attribute CadenceScheduleBackfillID when BackfillID is set on the backfill request. Operators should allowlist/index CadenceScheduleBackfillID (keyword) if they override valid search attributes.

**Documentation Changes**
N/A
