### PR TITLE
fix(schedule): tolerate ContinueAsNew race in DescribeSchedule

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -44,6 +44,13 @@ const (
 	schedulerWorkflowExecutionTimeout = 10 * 365 * 24 * time.Hour // ~10 years
 	schedulerWorkflowDecisionTimeout  = 10 * time.Second
 	defaultListSchedulesPageSize      = 10
+
+	// describeScheduleCANRetryAttempts and describeScheduleCANRetryInterval bound
+	// the wait for the ContinueAsNew resolver race in DescribeSchedule. The
+	// invalidation window is typically sub-second; ~1s total stays well within
+	// any reasonable client deadline.
+	describeScheduleCANRetryAttempts = 5
+	describeScheduleCANRetryInterval = 200 * time.Millisecond
 )
 
 func scheduleWorkflowID(scheduleID string) string {
@@ -208,19 +215,44 @@ func (wh *WorkflowHandler) DescribeSchedule(
 	}
 
 	wfID := scheduleWorkflowID(scheduleID)
-	// Reject the query if the scheduler workflow did not complete cleanly (e.g. FAILED,
-	// TERMINATED, TIMED_OUT). Without this, Cadence replays the closed workflow history
-	// and returns whatever state the query handler last saw — which is ACTIVE even for a
-	// scheduler that failed immediately (e.g. due to an invalid cron expression).
+	execution := &types.WorkflowExecution{WorkflowID: wfID}
+
+	domainID, err := wh.GetDomainCache().GetDomainID(domainName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Probe the scheduler workflow's current execution status before querying.
+	//
+	// Schedulers ContinueAsNew on every UpdateSchedule and periodically to bound
+	// history. During the executionCache invalidation window on the history host,
+	// getMutableState can briefly resolve wfID-without-runID to the just-closed
+	// old run and expose CloseStatus=CONTINUED_AS_NEW for an otherwise healthy
+	// schedule. The DWE probe — retried while the close status is CONTINUED_AS_NEW —
+	// distinguishes that transient race from a genuinely closed scheduler
+	// (FAILED, TERMINATED, TIMED_OUT, COMPLETED, CANCELED), which must not be
+	// reported as ACTIVE.
+	//
+	// QueryWorkflow keeps QueryRejectConditionNotCompletedCleanly as a safety net
+	// for the small window where the scheduler closes between the two RPCs.
+	info, err := wh.describeSchedulerExecution(ctx, domainID, domainName, scheduleID, execution)
+	if err != nil {
+		return nil, err
+	}
+	if info.CloseStatus != nil {
+		return nil, &types.InternalServiceError{
+			Message: fmt.Sprintf(
+				"schedule %q in domain %q is not operational: scheduler workflow ended with status %s",
+				scheduleID, domainName, info.CloseStatus.String(),
+			),
+		}
+	}
+
 	rejectCondition := types.QueryRejectConditionNotCompletedCleanly
 	queryResp, err := wh.QueryWorkflow(ctx, &types.QueryWorkflowRequest{
-		Domain: domainName,
-		Execution: &types.WorkflowExecution{
-			WorkflowID: wfID,
-		},
-		Query: &types.WorkflowQuery{
-			QueryType: scheduler.QueryTypeDescribe,
-		},
+		Domain:               domainName,
+		Execution:            execution,
+		Query:                &types.WorkflowQuery{QueryType: scheduler.QueryTypeDescribe},
 		QueryRejectCondition: &rejectCondition,
 	})
 	if err != nil {
@@ -688,4 +720,51 @@ func normalizeScheduleError(err error, scheduleID, domainName string) error {
 		}
 	}
 	return err
+}
+
+// describeSchedulerExecution returns the latest run's WorkflowExecutionInfo for
+// the scheduler workflow, retrying briefly while CloseStatus is CONTINUED_AS_NEW
+// to ride out the executionCache invalidation window after a ContinueAsNew
+// transition. If the close status is still CONTINUED_AS_NEW after the retry
+// budget the last response is returned; the caller treats that as "not
+// operational" so an operator can investigate a scheduler stuck mid-transition.
+//
+// Calls the history client directly so this internal probe does not emit
+// FrontendDescribeWorkflowExecution metrics.
+func (wh *WorkflowHandler) describeSchedulerExecution(
+	ctx context.Context,
+	domainID, domainName, scheduleID string,
+	execution *types.WorkflowExecution,
+) (*types.WorkflowExecutionInfo, error) {
+	req := &types.HistoryDescribeWorkflowExecutionRequest{
+		DomainUUID: domainID,
+		Request: &types.DescribeWorkflowExecutionRequest{
+			Domain:    domainName,
+			Execution: execution,
+		},
+	}
+	var lastInfo *types.WorkflowExecutionInfo
+	for attempt := 0; attempt < describeScheduleCANRetryAttempts; attempt++ {
+		resp, err := wh.GetHistoryClient().DescribeWorkflowExecution(ctx, req)
+		if err != nil {
+			return nil, normalizeScheduleError(err, scheduleID, domainName)
+		}
+		info := resp.GetWorkflowExecutionInfo()
+		if info == nil {
+			return nil, &types.InternalServiceError{Message: "nil workflow execution info from scheduler workflow"}
+		}
+		lastInfo = info
+		if info.CloseStatus == nil || *info.CloseStatus != types.WorkflowExecutionCloseStatusContinuedAsNew {
+			return info, nil
+		}
+		if attempt == describeScheduleCANRetryAttempts-1 {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(describeScheduleCANRetryInterval):
+		}
+	}
+	return lastInfo, nil
 }

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -351,6 +351,10 @@ func TestDescribeSchedule(t *testing.T) {
 			request: validRequest,
 			mockFn: func(f *scheduleTestFixture) {
 				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+					}, nil)
 				f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
 					Return(nil, errors.New("query failed"))
 			},
@@ -360,18 +364,120 @@ func TestDescribeSchedule(t *testing.T) {
 			request: validRequest,
 			mockFn: func(f *scheduleTestFixture) {
 				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
-				f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
 					Return(nil, &types.EntityNotExistsError{Message: "workflow not found"})
 			},
 			wantErr: true,
+			checkErr: func(t *testing.T, err error) {
+				var notFound *types.EntityNotExistsError
+				assert.ErrorAs(t, err, &notFound)
+				assert.Contains(t, notFound.Message, "schedule")
+			},
 		},
-		// Regression: a scheduler workflow that ended FAILED (e.g. invalid cron) must not
-		// surface as ACTIVE. The handler sets QueryRejectConditionNotCompletedCleanly so
-		// Cadence rejects the query for any non-clean close status.
-		"scheduler workflow failed - query rejected": {
+		"describe workflow error": {
 			request: validRequest,
 			mockFn: func(f *scheduleTestFixture) {
 				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("describe failed"))
+			},
+			wantErr: true,
+		},
+		// A scheduler workflow that ended FAILED (for example, an invalid cron) must not
+		// surface as ACTIVE. The DWE probe sees a non-nil CloseStatus and refuses to
+		// serve the schedule.
+		"scheduler workflow failed - closed": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				closeStatus := types.WorkflowExecutionCloseStatusFailed
+				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{CloseStatus: &closeStatus},
+					}, nil)
+			},
+			wantErr: true,
+			checkErr: func(t *testing.T, err error) {
+				var internalErr *types.InternalServiceError
+				assert.ErrorAs(t, err, &internalErr)
+				assert.Contains(t, internalErr.Message, "FAILED")
+			},
+		},
+		"scheduler workflow terminated - closed": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				closeStatus := types.WorkflowExecutionCloseStatusTerminated
+				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{CloseStatus: &closeStatus},
+					}, nil)
+			},
+			wantErr: true,
+			checkErr: func(t *testing.T, err error) {
+				var internalErr *types.InternalServiceError
+				assert.ErrorAs(t, err, &internalErr)
+				assert.Contains(t, internalErr.Message, "TERMINATED")
+			},
+		},
+		// Schedulers ContinueAsNew on every UpdateSchedule and periodically to bound
+		// history. While the executionCache is invalidating, wfID-without-runID can
+		// briefly resolve to the just-closed old run; the helper retries until the
+		// new (running) run is visible.
+		"scheduler mid-ContinueAsNew - DescribeWorkflowExecution retried until running": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				canStatus := types.WorkflowExecutionCloseStatusContinuedAsNew
+				gomock.InOrder(
+					f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+						Return(&types.DescribeWorkflowExecutionResponse{
+							WorkflowExecutionInfo: &types.WorkflowExecutionInfo{CloseStatus: &canStatus},
+						}, nil),
+					f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+						Return(&types.DescribeWorkflowExecutionResponse{
+							WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+						}, nil),
+				)
+				f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+					Return(&types.HistoryQueryWorkflowResponse{
+						Response: &types.QueryWorkflowResponse{QueryResult: descBytes},
+					}, nil)
+			},
+			wantErr: false,
+		},
+		// If the close status stays CONTINUED_AS_NEW past the retry budget, the
+		// scheduler is likely stuck mid-transition; surface that as not operational
+		// so an operator can investigate.
+		"scheduler mid-ContinueAsNew - retry budget exhausted": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				canStatus := types.WorkflowExecutionCloseStatusContinuedAsNew
+				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{CloseStatus: &canStatus},
+					}, nil).
+					Times(describeScheduleCANRetryAttempts)
+			},
+			wantErr: true,
+			checkErr: func(t *testing.T, err error) {
+				var internalErr *types.InternalServiceError
+				assert.ErrorAs(t, err, &internalErr)
+				assert.Contains(t, internalErr.Message, "CONTINUED_AS_NEW")
+			},
+		},
+		// If the scheduler closes between the DWE probe and the QueryWorkflow call,
+		// the reject condition on the query stops the history layer from replaying
+		// closed history and reporting stale ACTIVE state.
+		"scheduler closes between DWE and Query - reject condition catches it": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+					}, nil)
 				closeStatus := types.WorkflowExecutionCloseStatusFailed
 				f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
 					Return(&types.HistoryQueryWorkflowResponse{
@@ -387,35 +493,23 @@ func TestDescribeSchedule(t *testing.T) {
 				assert.Contains(t, internalErr.Message, "FAILED")
 			},
 		},
-		"scheduler workflow terminated - query rejected": {
-			request: validRequest,
-			mockFn: func(f *scheduleTestFixture) {
-				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
-				closeStatus := types.WorkflowExecutionCloseStatusTerminated
-				f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
-					Return(&types.HistoryQueryWorkflowResponse{
-						Response: &types.QueryWorkflowResponse{
-							QueryRejected: &types.QueryRejected{CloseStatus: &closeStatus},
-						},
-					}, nil)
-			},
-			wantErr: true,
-			checkErr: func(t *testing.T, err error) {
-				var internalErr *types.InternalServiceError
-				assert.ErrorAs(t, err, &internalErr)
-				assert.Contains(t, internalErr.Message, "TERMINATED")
-			},
-		},
 		"success": {
 			request: validRequest,
 			mockFn: func(f *scheduleTestFixture) {
 				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.HistoryDescribeWorkflowExecutionRequest, _ ...yarpc.CallOption) (*types.DescribeWorkflowExecutionResponse, error) {
+						assert.Equal(t, testDomainID, req.DomainUUID)
+						assert.Equal(t, "cadence-scheduler:my-schedule", req.Request.Execution.WorkflowID)
+						return &types.DescribeWorkflowExecutionResponse{
+							WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+						}, nil
+					})
 				f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
 					DoAndReturn(func(_ context.Context, req *types.HistoryQueryWorkflowRequest, _ ...yarpc.CallOption) (*types.HistoryQueryWorkflowResponse, error) {
 						assert.Equal(t, testDomainID, req.DomainUUID)
 						assert.Equal(t, "cadence-scheduler:my-schedule", req.Request.Execution.WorkflowID)
 						assert.Equal(t, scheduler.QueryTypeDescribe, req.Request.Query.QueryType)
-						// Verify the reject condition is set so closed/failed workflows are detected.
 						require.NotNil(t, req.Request.QueryRejectCondition)
 						assert.Equal(t, types.QueryRejectConditionNotCompletedCleanly, *req.Request.QueryRejectCondition)
 
@@ -1025,7 +1119,7 @@ func TestNormalizeScheduleError(t *testing.T) {
 		defer f.finish()
 
 		f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
-		f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+		f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
 			Return(nil, &types.EntityNotExistsError{Message: "workflow cadence-scheduler:s1 not found"})
 
 		_, err := f.handler.DescribeSchedule(context.Background(), &types.DescribeScheduleRequest{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- `DescribeSchedule` now probes the scheduler workflow's current execution status via `DescribeWorkflowExecution` before issuing the query.
- The probe retries briefly while the latest run's `CloseStatus` is `CONTINUED_AS_NEW`, so the executionCache has time to resolve `wfID`-without-`runID` to the new running run.
- `QueryWorkflow` keeps `QueryRejectConditionNotCompletedCleanly` as a safety net for the small window where the scheduler closes between the two RPCs.
- The probe goes through the history client directly so it does not emit `FrontendDescribeWorkflowExecution` metrics for an internal lookup.

<!-- Tell your future self why have you made these changes -->
**Why?**
After #8065 added `QueryRejectConditionNotCompletedCleanly` to catch scheduler workflows that ended in a non-clean status (FAILED / TERMINATED / TIMED_OUT), `DescribeSchedule` started rejecting healthy schedules whose scheduler workflow had just ContinueAsNew'd. Schedulers ContinueAsNew on every `UpdateSchedule` and periodically to bound history, so the regression hit any update-then-describe pattern.


**How did you test it?**
```
go build ./...                                       # clean
go test ./service/frontend/api/... -count=1       
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- The CONTINUED_AS_NEW retry budget is bounded (5 attempts × 200ms = ~1s max). Worst case for a scheduler genuinely stuck mid-ContinueAsNew, callers see a ~1s wait followed by an `InternalServiceError` — the same surface as today, just with extra time before the error.
- The probe uses the history client directly (skipping the public `wh.DescribeWorkflowExecution`), so frontend `DescribeWorkflowExecution`-scoped metrics are unchanged.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A

**Documentation Changes**
N/A