### PR TITLE
fix: emit IntExponentialHistogram bucket labels as numeric values

### DIFF
--- a/common/metrics/client.go
+++ b/common/metrics/client.go
@@ -142,14 +142,30 @@ func (m *ClientImpl) getBuckets(id MetricIdx) tally.Buckets {
 func getMetricDefs(serviceIdx ServiceIdx) map[MetricIdx]metricDefinition {
 	defs := make(map[MetricIdx]metricDefinition)
 	for idx, def := range MetricDefs[Common] {
-		defs[idx] = def
+		defs[idx] = withIntValueBuckets(def)
 	}
 
 	for idx, def := range MetricDefs[serviceIdx] {
-		defs[idx] = def
+		defs[idx] = withIntValueBuckets(def)
 	}
 
 	return defs
+}
+
+// withIntValueBuckets pre-computes intValueBuckets from intExponentialBuckets
+// so IntExponentialHistogram emits bucket labels as plain integers rather than
+// duration strings (which Grafana cannot parse as numeric).
+func withIntValueBuckets(def metricDefinition) metricDefinition {
+	if def.intExponentialBuckets == nil {
+		return def
+	}
+	src := def.intExponentialBuckets.buckets()
+	out := make(tally.ValueBuckets, len(src))
+	for i, v := range src {
+		out[i] = float64(v)
+	}
+	def.intValueBuckets = out
+	return def
 }
 
 func mergeMapToRight(src map[string]string, dest map[string]string) {

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -43,6 +43,12 @@ type (
 		buckets               tally.Buckets // buckets if we are emitting histograms
 		exponentialBuckets    histogrammy[SubsettableHistogram]
 		intExponentialBuckets histogrammy[IntSubsettableHistogram]
+		// intValueBuckets is populated at startup from intExponentialBuckets.buckets()
+		// converted to tally.ValueBuckets. This ensures bucket labels emitted to metrics
+		// backends render as plain integers ("1024") rather than duration strings
+		// ("1.024µs"), which Grafana cannot parse as numeric bucket boundaries.
+		// See IntExponentialHistogram for usage.
+		intValueBuckets tally.ValueBuckets
 	}
 
 	// scopeDefinition holds the tag definitions for a scope

--- a/common/metrics/scope.go
+++ b/common/metrics/scope.go
@@ -166,17 +166,18 @@ func (m *metricsScope) ExponentialHistogram(id MetricIdx, value time.Duration) {
 
 func (m *metricsScope) IntExponentialHistogram(id MetricIdx, value int) {
 	def := m.defs[id]
+	floatValue := float64(value)
 	if m.migrationConfig.Histogram.EmitHistogram(def.metricName.String()) {
-		m.scope.Tagged(def.intExponentialBuckets.tags()).Histogram(def.metricName.String(), def.intExponentialBuckets.buckets()).RecordDuration(time.Duration(value))
+		m.scope.Tagged(def.intExponentialBuckets.tags()).Histogram(def.metricName.String(), def.intValueBuckets).RecordValue(floatValue)
 	}
 	switch {
 	case !def.metricRollupName.Empty():
 		if m.migrationConfig.Histogram.EmitHistogram(def.metricRollupName.String()) {
-			m.rootScope.Tagged(def.intExponentialBuckets.tags()).Histogram(def.metricRollupName.String(), def.intExponentialBuckets.buckets()).RecordDuration(time.Duration(value))
+			m.rootScope.Tagged(def.intExponentialBuckets.tags()).Histogram(def.metricRollupName.String(), def.intValueBuckets).RecordValue(floatValue)
 		}
 	case m.isDomainTagged:
 		if m.migrationConfig.Histogram.EmitHistogram(def.metricName.String()) {
-			m.scope.Tagged(def.intExponentialBuckets.tags()).Tagged(map[string]string{domain: allValue}).Histogram(def.metricName.String(), def.intExponentialBuckets.buckets()).RecordDuration(time.Duration(value))
+			m.scope.Tagged(def.intExponentialBuckets.tags()).Tagged(map[string]string{domain: allValue}).Histogram(def.metricName.String(), def.intValueBuckets).RecordValue(floatValue)
 		}
 	}
 }

--- a/common/metrics/scope_test.go
+++ b/common/metrics/scope_test.go
@@ -388,6 +388,33 @@ func TestExponentialHistogramRollup(t *testing.T) {
 		"rollup IntExponentialHistogram metric should be emitted on rootScope")
 }
 
+func TestIntExponentialHistogramBucketLabelsAreNumeric(t *testing.T) {
+	// Regression test: IntExponentialHistogram used to call RecordDuration on
+	// tally.DurationBuckets, which produced bucket labels formatted as duration
+	// strings (e.g. "13µs") that Grafana could not parse as numeric bucket
+	// boundaries. The fix uses tally.ValueBuckets + RecordValue so labels render
+	// as plain numbers like "1024".
+	ts := tally.NewTestScope("", nil)
+	c := NewClient(ts, History, MigrationConfig{
+		Histogram: HistogramMigration{Default: "histogram"},
+	})
+
+	scope := c.Scope(HistoryDescribeQueueScope, DomainTag("test-domain"))
+	scope.IntExponentialHistogram(HistorySizeHistogram, 12345)
+
+	def := MetricDefs[Common][HistorySizeHistogram]
+	for _, h := range ts.Snapshot().Histograms() {
+		if h.Name() != def.metricName.String() {
+			continue
+		}
+		// ValueBuckets are emitted; DurationBuckets would be empty.
+		assert.NotEmpty(t, h.Values(), "histogram should record value buckets, not duration buckets")
+		assert.Empty(t, h.Durations(), "histogram should NOT record duration buckets")
+		return
+	}
+	t.Fatalf("histogram %q not found in snapshot", def.metricName.String())
+}
+
 func TestGaugeRollupUsesRootScope(t *testing.T) {
 	rootScope := tally.NewTestScope("", nil)
 	childScope := tally.NewTestScope("", nil)


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
IntExponentialHistogram was calling RecordDuration(time.Duration(value)) against tally.DurationBuckets, which caused tally to format bucket labels as duration strings ("8ns", "1.024µs"). These got sanitized by the metrics pipeline into invalid labels like 13_s, which Grafana cannot parse as numeric bucket boundaries.

Fix: Pre-compute a tally.ValueBuckets ([]float64) copy of each metric's integer buckets at startup and emit via RecordValue(float64(value)) instead. Bucket labels now render as plain numbers ("8", "1024").

ongoing timer→histogram migration (https://github.com/cadence-workflow/cadence/issues/7741)

**Why?**
Fix emitting IntExponentialHistogram bucket labels as numeric values 

**How did you test it?**
  go test ./common/metrics -run 'Test(IntExponentialHistogramBucketLabelsAreNumeric|ExponentialHistogramRollup|RecordHistogramDurationDomainTaggedDualEmit|HistogramSuffixes)'
go test ./common/metrics/... ./common/task/... ./service/history/execution/... ./service/history/shard/... ./service/history/workflowcache/...

**Potential risks**
Low. All changes are additive (dual-emit). New histogram definitions are validated at init() time.

**Release notes**
N/A — internal observability improvement, no behavior change.

**Documentation Changes**
Fix of the ongoing timer→histogram migration (https://github.com/cadence-workflow/cadence/issues/7741)