### PR TITLE
fix(schedule): retry QueryWorkflow when scheduler run is not yet queryable

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -46,9 +46,10 @@ const (
 	defaultListSchedulesPageSize      = 10
 
 	// describeScheduleCANRetryAttempts and describeScheduleCANRetryInterval bound
-	// the wait for the ContinueAsNew resolver race in DescribeSchedule. The
-	// invalidation window is typically sub-second; ~1s total stays well within
-	// any reasonable client deadline.
+	// the wait for transient scheduler states in DescribeSchedule: the
+	// ContinueAsNew executionCache invalidation window, and the brief period after
+	// a new run starts before its first decision task is processed. Both resolve
+	// within milliseconds; ~1s total stays well within any reasonable client deadline.
 	describeScheduleCANRetryAttempts = 5
 	describeScheduleCANRetryInterval = 200 * time.Millisecond
 )
@@ -248,15 +249,9 @@ func (wh *WorkflowHandler) DescribeSchedule(
 		}
 	}
 
-	rejectCondition := types.QueryRejectConditionNotCompletedCleanly
-	queryResp, err := wh.QueryWorkflow(ctx, &types.QueryWorkflowRequest{
-		Domain:               domainName,
-		Execution:            execution,
-		Query:                &types.WorkflowQuery{QueryType: scheduler.QueryTypeDescribe},
-		QueryRejectCondition: &rejectCondition,
-	})
+	queryResp, err := wh.querySchedulerWorkflow(ctx, domainName, scheduleID, execution)
 	if err != nil {
-		return nil, normalizeScheduleError(err, scheduleID, domainName)
+		return nil, err
 	}
 
 	if queryResp == nil {
@@ -767,4 +762,42 @@ func (wh *WorkflowHandler) describeSchedulerExecution(
 		}
 	}
 	return lastInfo, nil
+}
+
+// querySchedulerWorkflow issues a QueryWorkflow call for the scheduler's
+// describe query, retrying briefly if the workflow has not yet processed its
+// first decision task. That transient state occurs right after CreateSchedule
+// or immediately after a ContinueAsNew run starts.
+func (wh *WorkflowHandler) querySchedulerWorkflow(
+	ctx context.Context,
+	domainName, scheduleID string,
+	execution *types.WorkflowExecution,
+) (*types.QueryWorkflowResponse, error) {
+	rejectCondition := types.QueryRejectConditionNotCompletedCleanly
+	req := &types.QueryWorkflowRequest{
+		Domain:               domainName,
+		Execution:            execution,
+		Query:                &types.WorkflowQuery{QueryType: scheduler.QueryTypeDescribe},
+		QueryRejectCondition: &rejectCondition,
+	}
+	var lastErr error
+	for attempt := 0; attempt < describeScheduleCANRetryAttempts; attempt++ {
+		resp, err := wh.QueryWorkflow(ctx, req)
+		if err == nil {
+			return resp, nil
+		}
+		var qfe *types.QueryFailedError
+		if !errors.As(err, &qfe) || !strings.Contains(qfe.Message, "decision task") {
+			return nil, normalizeScheduleError(err, scheduleID, domainName)
+		}
+		lastErr = err
+		if attempt < describeScheduleCANRetryAttempts-1 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(describeScheduleCANRetryInterval):
+			}
+		}
+	}
+	return nil, normalizeScheduleError(lastErr, scheduleID, domainName)
 }

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -467,6 +467,49 @@ func TestDescribeSchedule(t *testing.T) {
 				assert.Contains(t, internalErr.Message, "CONTINUED_AS_NEW")
 			},
 		},
+		// A freshly started scheduler run has not yet processed its first decision
+		// task and cannot be queried. querySchedulerWorkflow retries until the run
+		// is ready; here it succeeds on the second attempt.
+		"scheduler not yet queryable - retried until ready": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+					}, nil)
+				gomock.InOrder(
+					f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+						Return(nil, &types.QueryFailedError{Message: "workflow must handle at least one decision task before it can be queried"}),
+					f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+						Return(&types.HistoryQueryWorkflowResponse{
+							Response: &types.QueryWorkflowResponse{QueryResult: descBytes},
+						}, nil),
+				)
+			},
+			wantErr: false,
+		},
+		// If the workflow remains unqueryable past the retry budget, the last error
+		// is returned so the caller can surface it without masking the root cause.
+		"scheduler not yet queryable - retry budget exhausted": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+					}, nil)
+				f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+					Return(nil, &types.QueryFailedError{Message: "workflow must handle at least one decision task before it can be queried"}).
+					Times(describeScheduleCANRetryAttempts)
+			},
+			wantErr: true,
+			checkErr: func(t *testing.T, err error) {
+				var qfe *types.QueryFailedError
+				assert.ErrorAs(t, err, &qfe)
+				assert.Contains(t, qfe.Message, "decision task")
+			},
+		},
 		// If the scheduler closes between the DWE probe and the QueryWorkflow call,
 		// the reject condition on the query stops the history layer from replaying
 		// closed history and reporting stale ACTIVE state.


### PR DESCRIPTION
## What changed?
- Extracted the `QueryWorkflow` call in `DescribeSchedule` into a `querySchedulerWorkflow` helper. The helper retries briefly when the query fails with "workflow must handle at least one decision task before it can be queried"
- Updated the `describeScheduleCANRetryAttempts`/`Interval` constants comment to mention both use cases
- Added two unit test cases covering the retry-until-ready and retry-budget-exhausted paths

## Why?
After `CreateSchedule`, the scheduler workflow starts a new run that must process its first decision task before it can serve queries. Similarly, after `UpdateSchedule` (which triggers `ContinueAsNew`), once the new run starts it goes through the same startup window. In both cases, `QueryWorkflow` transiently fails with the "decision task" error until the run is ready.

This is a companion to #8123, which addressed the `CONTINUED_AS_NEW` executionCache race. Both are transient scheduler startup states that resolve within milliseconds; reusing the same retry budget (~1s total) covers both.

Without this fix, `DescribeSchedule` fails for callers that invoke it immediately after `CreateSchedule` or `UpdateSchedule`.

## How did you test it?
- All `TestDescribeSchedule` unit tests pass including the two new cases
- `go test ./service/frontend/api/... -count=1` — ok (12s)

## Potential risks
The retry adds at most `describeScheduleCANRetryAttempts × describeScheduleCANRetryInterval` (~1s) of latency if the scheduler run genuinely cannot process decision tasks, an infrastructure problem rather than a normal transient state. In that case the last error is returned unchanged.

## Release notes
N/A