### PR TITLE
feat(queuev2): wire CachedQueueReader to timer queue factory

### DIFF
--- a/service/history/queuev2/queue_scheduled.go
+++ b/service/history/queuev2/queue_scheduled.go
@@ -56,7 +56,7 @@ type (
 	}
 )
 
-func NewScheduledQueue(
+func newScheduledQueue(
 	shard shard.Context,
 	category persistence.HistoryTaskCategory,
 	taskProcessor task.Processor,
@@ -66,7 +66,7 @@ func NewScheduledQueue(
 	metricsScope metrics.Scope,
 	queueReader QueueReader,
 	options *Options,
-) Queue {
+) *scheduledQueue {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &scheduledQueue{
 		base: newQueueBase(
@@ -86,6 +86,21 @@ func NewScheduledQueue(
 		cancel:     cancel,
 		status:     common.DaemonStatusInitialized,
 	}
+}
+
+func NewScheduledQueue(
+	shard shard.Context,
+	category persistence.HistoryTaskCategory,
+	taskProcessor task.Processor,
+	taskExecutor task.Executor,
+	logger log.Logger,
+	metricsClient metrics.Client,
+	metricsScope metrics.Scope,
+	queueReader QueueReader,
+	options *Options,
+) Queue {
+	return newScheduledQueue(shard, category, taskProcessor, taskExecutor,
+		logger, metricsClient, metricsScope, queueReader, options)
 }
 
 func (q *scheduledQueue) Start() {

--- a/service/history/queuev2/timer_queue_factory.go
+++ b/service/history/queuev2/timer_queue_factory.go
@@ -132,40 +132,53 @@ func (f *timerQueueFactory) createQueuev2(
 		logger,
 	)
 	config := shard.GetConfig()
+	metricsScope := shard.GetMetricsClient().Scope(metrics.TimerQueueProcessorV2Scope).Tagged(metrics.ShardIDTag(shard.GetShardID()))
+	options := &Options{
+		PageSize:                             config.TimerTaskBatchSize,
+		DeleteBatchSize:                      config.TimerTaskDeleteBatchSize,
+		MaxPollRPS:                           config.TimerProcessorMaxPollRPS,
+		MaxPollInterval:                      config.TimerProcessorMaxPollInterval,
+		MaxPollIntervalJitterCoefficient:     config.TimerProcessorMaxPollIntervalJitterCoefficient,
+		UpdateAckInterval:                    config.TimerProcessorUpdateAckInterval,
+		UpdateAckIntervalJitterCoefficient:   config.TimerProcessorUpdateAckIntervalJitterCoefficient,
+		MaxPendingTasksCount:                 config.QueueMaxPendingTaskCount,
+		PollBackoffInterval:                  config.QueueProcessorPollBackoffInterval,
+		PollBackoffIntervalJitterCoefficient: config.QueueProcessorPollBackoffIntervalJitterCoefficient,
+		VirtualSliceForceAppendInterval:      config.VirtualSliceForceAppendInterval,
+		MaxStartJitterInterval:               dynamicproperties.GetDurationPropertyFn(0),
+		RedispatchInterval:                   config.ActiveTaskRedispatchInterval,
+		CriticalPendingTaskCount:             config.QueueCriticalPendingTaskCount,
+		EnablePendingTaskCountAlert:          func() bool { return config.EnableTimerQueueV2PendingTaskCountAlert(shard.GetShardID()) },
+		MaxVirtualQueueCount:                 config.QueueMaxVirtualQueueCount,
+	}
 
-	queueReader := NewQueueReader(
+	var cachedReader CachedQueueReader
+	reader := NewQueueReader(
 		shard,
 		persistence.HistoryTaskCategoryTimer,
-		config.TimerProcessorMaxPollInterval,
-		config.TimerProcessorMaxPollIntervalJitterCoefficient,
+		options.MaxPollInterval,
+		options.MaxPollIntervalJitterCoefficient,
 	)
+	if config.TimerProcessorEnableCachedScheduledQueue() {
+		cachedReader = newCachedQueueReader(reader, newInMemQueue(), shard, metricsScope)
+		reader = cachedReader
+	}
 
-	return NewScheduledQueue(
+	base := newScheduledQueue(
 		shard,
 		persistence.HistoryTaskCategoryTimer,
 		f.taskProcessor,
 		executorWrapper,
 		logger,
 		shard.GetMetricsClient(),
-		shard.GetMetricsClient().Scope(metrics.TimerQueueProcessorV2Scope).Tagged(metrics.ShardIDTag(shard.GetShardID())),
-		queueReader,
-		&Options{
-			PageSize:                             config.TimerTaskBatchSize,
-			DeleteBatchSize:                      config.TimerTaskDeleteBatchSize,
-			MaxPollRPS:                           config.TimerProcessorMaxPollRPS,
-			MaxPollInterval:                      config.TimerProcessorMaxPollInterval,
-			MaxPollIntervalJitterCoefficient:     config.TimerProcessorMaxPollIntervalJitterCoefficient,
-			UpdateAckInterval:                    config.TimerProcessorUpdateAckInterval,
-			UpdateAckIntervalJitterCoefficient:   config.TimerProcessorUpdateAckIntervalJitterCoefficient,
-			MaxPendingTasksCount:                 config.QueueMaxPendingTaskCount,
-			PollBackoffInterval:                  config.QueueProcessorPollBackoffInterval,
-			PollBackoffIntervalJitterCoefficient: config.QueueProcessorPollBackoffIntervalJitterCoefficient,
-			VirtualSliceForceAppendInterval:      config.VirtualSliceForceAppendInterval,
-			MaxStartJitterInterval:               dynamicproperties.GetDurationPropertyFn(0),
-			RedispatchInterval:                   config.ActiveTaskRedispatchInterval,
-			CriticalPendingTaskCount:             config.QueueCriticalPendingTaskCount,
-			EnablePendingTaskCountAlert:          func() bool { return config.EnableTimerQueueV2PendingTaskCountAlert(shard.GetShardID()) },
-			MaxVirtualQueueCount:                 config.QueueMaxVirtualQueueCount,
-		},
+		metricsScope,
+		reader,
+		options,
 	)
+
+	if cachedReader != nil {
+		return newCachedScheduledQueue(base, cachedReader)
+	}
+
+	return base
 }

--- a/service/history/queuev2/timer_queue_factory_test.go
+++ b/service/history/queuev2/timer_queue_factory_test.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
 
+	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/reconciliation/invariant"
 	"github.com/uber/cadence/service/history/config"
@@ -67,4 +68,53 @@ func TestTimerQueueFactory_IsQueueV2Enabled(t *testing.T) {
 	// by default, queue v2 is disabled
 	enabled := factory.isQueueV2Enabled(mockShard)
 	assert.False(t, enabled)
+}
+
+func TestTimerQueueFactory_CreateQueueV2_Cached(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	ctrl := gomock.NewController(t)
+
+	cfg := config.NewForTest()
+	cfg.TimerProcessorEnableCachedScheduledQueue = dynamicproperties.GetBoolPropertyFn(true)
+
+	mockShard := shard.NewTestContext(
+		t, ctrl, &persistence.ShardInfo{
+			ShardID:          10,
+			RangeID:          1,
+			TransferAckLevel: 0,
+		}, cfg)
+
+	factory := &timerQueueFactory{
+		taskProcessor:  task.NewMockProcessor(ctrl),
+		archivalClient: archiver.NewMockClient(ctrl),
+	}
+
+	processor := factory.createQueuev2(mockShard, execution.NewMockCache(ctrl), invariant.NewMockInvariant(ctrl))
+
+	assert.NotNil(t, processor)
+	_, ok := processor.(*cachedScheduledQueue)
+	assert.True(t, ok, "expected *cachedScheduledQueue when TimerProcessorEnableCachedScheduledQueue=true")
+}
+
+func TestTimerQueueFactory_CreateQueuev2_DisabledByDefault(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	ctrl := gomock.NewController(t)
+
+	mockShard := shard.NewTestContext(
+		t, ctrl, &persistence.ShardInfo{
+			ShardID:          10,
+			RangeID:          1,
+			TransferAckLevel: 0,
+		}, config.NewForTest())
+
+	factory := &timerQueueFactory{
+		taskProcessor:  task.NewMockProcessor(ctrl),
+		archivalClient: archiver.NewMockClient(ctrl),
+	}
+
+	processor := factory.createQueuev2(mockShard, execution.NewMockCache(ctrl), invariant.NewMockInvariant(ctrl))
+
+	assert.NotNil(t, processor)
+	_, ok := processor.(*scheduledQueue)
+	assert.True(t, ok, "expected plain *scheduledQueue when TimerProcessorEnableCachedScheduledQueue=false (default)")
 }


### PR DESCRIPTION
**What changed?**

Wires `CachedQueueReader` into the timer queue factory behind the `TimerProcessorEnableCachedScheduledQueue` dynamic config flag (default: `false`). Part of https://github.com/cadence-workflow/cadence/issues/7953.

**Why?**

Еhe `CachedQueueReader` and `CachedScheduledQueue` types existed but were never instantiated — the timer factory always used the plain `QueueReader` directly. This change completes the wiring so the cache can actually be enabled via dynamic config. The flag defaults to `false` so there is no behavior change until explicitly enabled.

**Dependencies**
   * https://github.com/cadence-workflow/cadence/pull/8109

**How did you test it?**

```
go test -race -run "TestTimerQueueFactory|TestCachedScheduledQueue" ./service/history/queuev2/...
```

- `TestTimerQueueFactory_CreateQueueV2_Cached` — verifies `*cachedScheduledQueue` is returned when `TimerProcessorEnableCachedScheduledQueue=true`.
- `TestTimerQueueFactory_CreateQueuev2_DisabledByDefault` — verifies plain `*scheduledQueue` is returned by default (flag off).
- All existing `TestCachedScheduledQueue_*` tests continue to pass.

**Potential risks**

Disabled by default (`TimerProcessorEnableCachedScheduledQueue=false`). No behavior change until the flag is explicitly enabled. When enabled, a restart is needed. 

**Release notes**

N/A — feature is disabled by default and requires explicit operator opt-in.

**Documentation Changes**

N/A