### PR TITLE
feat(history): notify queue processors before shard lock release

### DIFF
--- a/service/history/common/errors.go
+++ b/service/history/common/errors.go
@@ -1,7 +1,5 @@
-// The MIT License (MIT)
-
-// Copyright (c) 2017-2020 Uber Technologies Inc.
-
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
@@ -9,8 +7,8 @@
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
 //
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -23,25 +21,26 @@
 package common
 
 import (
-	"time"
-
 	"github.com/uber/cadence/common/persistence"
-	"github.com/uber/cadence/service/history/events"
+	"github.com/uber/cadence/common/types"
 )
 
-type (
-	// NotifyTaskInfo defines the info of task notification
-	NotifyTaskInfo struct {
-		ExecutionInfo    *persistence.WorkflowExecutionInfo
-		Tasks            []persistence.Task
-		VersionHistories *persistence.VersionHistories
-		Activities       map[int64]*persistence.ActivityInfo
-		History          events.PersistedBlobs
-		PersistenceError bool
-
-		// TODO: remove this when queuev1 is replaced by queuev2
-		// ClusterCurrentTimes is not nil for timer tasks
-		// It contains current times per cluster of all tasks in this notification
-		ClusterCurrentTimes map[string]time.Time
+// IsOperationPossiblySuccessfulError returns true for errors where a persistence
+// write may have succeeded despite the error being returned (e.g. timeout, unknown
+// network error). Returns false for errors that definitively indicate the write
+// did not occur.
+func IsOperationPossiblySuccessfulError(err error) bool {
+	switch err.(type) {
+	case nil,
+		*types.WorkflowExecutionAlreadyStartedError,
+		*persistence.WorkflowExecutionAlreadyStartedError,
+		*persistence.CurrentWorkflowConditionFailedError,
+		*persistence.ConditionFailedError,
+		*types.ServiceBusyError,
+		*types.LimitExceededError,
+		*persistence.ShardOwnershipLostError:
+		return false
+	default:
+		return true
 	}
-)
+}

--- a/service/history/common/errors_test.go
+++ b/service/history/common/errors_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/types"
+)
+
+func TestIsOperationPossiblySuccessfulError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"WorkflowExecutionAlreadyStartedError (types)", &types.WorkflowExecutionAlreadyStartedError{}, false},
+		{"WorkflowExecutionAlreadyStartedError (persistence)", &persistence.WorkflowExecutionAlreadyStartedError{}, false},
+		{"CurrentWorkflowConditionFailedError", &persistence.CurrentWorkflowConditionFailedError{}, false},
+		{"ConditionFailedError", &persistence.ConditionFailedError{}, false},
+		{"ServiceBusyError", &types.ServiceBusyError{}, false},
+		{"LimitExceededError", &types.LimitExceededError{}, false},
+		{"ShardOwnershipLostError", &persistence.ShardOwnershipLostError{}, false},
+		{"TimeoutError", &persistence.TimeoutError{}, true},
+		{"context.DeadlineExceeded", context.DeadlineExceeded, true},
+		{"generic error", assert.AnError, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsOperationPossiblySuccessfulError(tc.err))
+		})
+	}
+}

--- a/service/history/decision/handler_test.go
+++ b/service/history/decision/handler_test.go
@@ -295,8 +295,6 @@ func TestHandleDecisionTaskFailed(t *testing.T) {
 				engine := engine.NewMockEngine(ctrl)
 				h.shard.(*shard.MockContext).EXPECT().GetEngine().Times(3).Return(engine)
 				engine.EXPECT().NotifyNewHistoryEvent(gomock.Any())
-				engine.EXPECT().NotifyNewTransferTasks(gomock.Any())
-				engine.EXPECT().NotifyNewTimerTasks(gomock.Any())
 				engine.EXPECT().NotifyNewReplicationTasks(gomock.Any())
 			},
 			expectErr: false,
@@ -482,8 +480,6 @@ func TestHandleDecisionTaskStarted(t *testing.T) {
 				engine := engine.NewMockEngine(ctrl)
 				h.shard.(*shard.MockContext).EXPECT().GetEngine().Times(3).Return(engine)
 				engine.EXPECT().NotifyNewHistoryEvent(gomock.Any())
-				engine.EXPECT().NotifyNewTransferTasks(gomock.Any())
-				engine.EXPECT().NotifyNewTimerTasks(gomock.Any())
 				engine.EXPECT().NotifyNewReplicationTasks(gomock.Any())
 			},
 			expectErr: nil,
@@ -628,8 +624,6 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetEngine().Return(engine).Times(3)
 				engine.EXPECT().NotifyNewHistoryEvent(events.NewNotification(constants.TestDomainID, &types.WorkflowExecution{WorkflowID: constants.TestWorkflowID, RunID: constants.TestRunID},
 					0, 5, 0, 1, 0, nil))
-				engine.EXPECT().NotifyNewTransferTasks(gomock.Any())
-				engine.EXPECT().NotifyNewTimerTasks(gomock.Any())
 				engine.EXPECT().NotifyNewReplicationTasks(gomock.Any())
 
 				decisionHandler.domainCache.(*cache.MockDomainCache).EXPECT().GetDomain(constants.TestDomainName).Times(1).Return(constants.TestLocalDomainEntry, nil)
@@ -756,8 +750,6 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetEngine().Return(engine).Times(3)
 				engine.EXPECT().NotifyNewHistoryEvent(events.NewNotification(constants.TestDomainID, &types.WorkflowExecution{WorkflowID: constants.TestWorkflowID, RunID: constants.TestRunID},
 					0, 1, 0, 1, 0, nil))
-				engine.EXPECT().NotifyNewTransferTasks(gomock.Any())
-				engine.EXPECT().NotifyNewTimerTasks(gomock.Any())
 				engine.EXPECT().NotifyNewReplicationTasks(gomock.Any())
 			},
 			mutableState: &persistence.WorkflowMutableState{
@@ -956,8 +948,6 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 				decisionHandler.shard.(*shard.MockContext).EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error updating workflow execution"))
 				engine := engine.NewMockEngine(ctrl)
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetEngine().Return(engine).Times(2)
-				engine.EXPECT().NotifyNewTransferTasks(gomock.Any())
-				engine.EXPECT().NotifyNewTimerTasks(gomock.Any())
 				engine.EXPECT().NotifyNewReplicationTasks(gomock.Any())
 
 			},
@@ -1136,8 +1126,6 @@ func TestHandleDecisionTaskCompleted(t *testing.T) {
 				decisionHandler.shard.(*shard.MockContext).EXPECT().GetEngine().Return(engine).Times(3)
 				engine.EXPECT().NotifyNewHistoryEvent(events.NewNotification(constants.TestDomainID, &types.WorkflowExecution{WorkflowID: constants.TestWorkflowID, RunID: constants.TestRunID},
 					0, 3, 0, 1, 0, nil))
-				engine.EXPECT().NotifyNewTransferTasks(gomock.Any())
-				engine.EXPECT().NotifyNewTimerTasks(gomock.Any())
 				engine.EXPECT().NotifyNewReplicationTasks(gomock.Any())
 			},
 			assertResponseBody: func(t *testing.T, resp *types.HistoryRespondDecisionTaskCompletedResponse) {

--- a/service/history/execution/context.go
+++ b/service/history/execution/context.go
@@ -989,16 +989,9 @@ func notifyTasks(
 	history events.PersistedBlobs,
 	persistenceError bool,
 ) {
-	transferTaskInfo := &hcommon.NotifyTaskInfo{
-		ExecutionInfo:    executionInfo,
-		Tasks:            tasksByCategory[persistence.HistoryTaskCategoryTransfer],
-		PersistenceError: persistenceError,
-	}
-	timerTaskInfo := &hcommon.NotifyTaskInfo{
-		ExecutionInfo:    executionInfo,
-		Tasks:            tasksByCategory[persistence.HistoryTaskCategoryTimer],
-		PersistenceError: persistenceError,
-	}
+	// Transfer and timer tasks are notified inside the shard lock by the shard context.
+	// Only replication tasks remain here since they require persisted event blobs from
+	// the history layer, which are not available inside the shard context.
 	replicationTaskInfo := &hcommon.NotifyTaskInfo{
 		ExecutionInfo:    executionInfo,
 		Tasks:            tasksByCategory[persistence.HistoryTaskCategoryReplication],
@@ -1008,9 +1001,6 @@ func notifyTasks(
 		PersistenceError: persistenceError,
 	}
 
-	// TODO: unify these methods
-	engine.NotifyNewTransferTasks(transferTaskInfo)
-	engine.NotifyNewTimerTasks(timerTaskInfo)
 	engine.NotifyNewReplicationTasks(replicationTaskInfo)
 }
 
@@ -1489,22 +1479,10 @@ func (c *contextImpl) ByteSize() uint64 {
 }
 
 func isOperationPossiblySuccessfulError(err error) bool {
-	switch err.(type) {
-	case nil:
+	if IsConflictError(err) {
 		return false
-	case *types.WorkflowExecutionAlreadyStartedError,
-		*persistence.WorkflowExecutionAlreadyStartedError,
-		*persistence.CurrentWorkflowConditionFailedError,
-		*persistence.ConditionFailedError,
-		*types.ServiceBusyError,
-		*types.LimitExceededError,
-		*persistence.ShardOwnershipLostError:
-		return false
-	case *persistence.TimeoutError:
-		return true
-	default:
-		return !IsConflictError(err)
 	}
+	return hcommon.IsOperationPossiblySuccessfulError(err)
 }
 
 func validateWorkflowRequestsAndMode(requests []*persistence.WorkflowRequest, mode persistence.CreateWorkflowRequestMode) error {

--- a/service/history/execution/context_test.go
+++ b/service/history/execution/context_test.go
@@ -264,32 +264,6 @@ func TestNotifyTasksFromWorkflowSnapshot(t *testing.T) {
 			},
 			persistenceError: true,
 			mockSetup: func(mockEngine *engine.MockEngine) {
-				mockEngine.EXPECT().NotifyNewTransferTasks(&hcommon.NotifyTaskInfo{
-					ExecutionInfo: &persistence.WorkflowExecutionInfo{
-						DomainID:   "test-domain-id",
-						WorkflowID: "test-workflow-id",
-						RunID:      "test-run-id",
-					},
-					Tasks: []persistence.Task{
-						&persistence.ActivityTask{
-							TaskList: "test-tl",
-						},
-					},
-					PersistenceError: true,
-				})
-				mockEngine.EXPECT().NotifyNewTimerTasks(&hcommon.NotifyTaskInfo{
-					ExecutionInfo: &persistence.WorkflowExecutionInfo{
-						DomainID:   "test-domain-id",
-						WorkflowID: "test-workflow-id",
-						RunID:      "test-run-id",
-					},
-					Tasks: []persistence.Task{
-						&persistence.ActivityTimeoutTask{
-							Attempt: 10,
-						},
-					},
-					PersistenceError: true,
-				})
 				mockEngine.EXPECT().NotifyNewReplicationTasks(&hcommon.NotifyTaskInfo{
 					ExecutionInfo: &persistence.WorkflowExecutionInfo{
 						DomainID:   "test-domain-id",
@@ -394,32 +368,6 @@ func TestNotifyTasksFromWorkflowMutation(t *testing.T) {
 			},
 			persistenceError: true,
 			mockSetup: func(mockEngine *engine.MockEngine) {
-				mockEngine.EXPECT().NotifyNewTransferTasks(&hcommon.NotifyTaskInfo{
-					ExecutionInfo: &persistence.WorkflowExecutionInfo{
-						DomainID:   "test-domain-id",
-						WorkflowID: "test-workflow-id",
-						RunID:      "test-run-id",
-					},
-					Tasks: []persistence.Task{
-						&persistence.ActivityTask{
-							TaskList: "test-tl",
-						},
-					},
-					PersistenceError: true,
-				})
-				mockEngine.EXPECT().NotifyNewTimerTasks(&hcommon.NotifyTaskInfo{
-					ExecutionInfo: &persistence.WorkflowExecutionInfo{
-						DomainID:   "test-domain-id",
-						WorkflowID: "test-workflow-id",
-						RunID:      "test-run-id",
-					},
-					Tasks: []persistence.Task{
-						&persistence.ActivityTimeoutTask{
-							Attempt: 10,
-						},
-					},
-					PersistenceError: true,
-				})
 				mockEngine.EXPECT().NotifyNewReplicationTasks(&hcommon.NotifyTaskInfo{
 					ExecutionInfo: &persistence.WorkflowExecutionInfo{
 						DomainID:   "test-domain-id",

--- a/service/history/queue/timer_queue_processor.go
+++ b/service/history/queue/timer_queue_processor.go
@@ -254,7 +254,7 @@ func (t *timerQueueProcessor) NotifyNewTask(clusterName string, info *hcommon.No
 		panic(fmt.Sprintf("Cannot find standby timer gate for %s.", clusterName))
 	}
 
-	curTime := t.shard.GetCurrentTime(clusterName)
+	curTime := info.ClusterCurrentTimes[clusterName]
 	standbyQueueTimerGate.SetCurrentTime(curTime)
 	t.logger.Debug("Current time for standby queue timergate is updated", tag.ClusterName(clusterName), tag.Timestamp(curTime))
 	standbyQueueProcessor.notifyNewTimers(info.Tasks)

--- a/service/history/queue/timer_queue_processor_test.go
+++ b/service/history/queue/timer_queue_processor_test.go
@@ -1,0 +1,234 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package queue
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/reconciliation/invariant"
+	hcommon "github.com/uber/cadence/service/history/common"
+	"github.com/uber/cadence/service/history/config"
+	"github.com/uber/cadence/service/history/constants"
+	"github.com/uber/cadence/service/history/execution"
+	"github.com/uber/cadence/service/history/shard"
+	"github.com/uber/cadence/service/history/task"
+	"github.com/uber/cadence/service/worker/archiver"
+)
+
+func setupTimerQueueProcessor(t *testing.T) (*gomock.Controller, *timerQueueProcessor) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+
+	mockShard := shard.NewTestContext(
+		t,
+		ctrl,
+		&persistence.ShardInfo{
+			ShardID: 10,
+			RangeID: 1,
+		},
+		config.NewForTest(),
+	)
+
+	return ctrl, NewTimerQueueProcessor(
+		mockShard,
+		task.NewMockProcessor(ctrl),
+		execution.NewCache(mockShard),
+		archiver.NewMockClient(ctrl),
+		invariant.NewMockInvariant(ctrl),
+	).(*timerQueueProcessor)
+}
+
+func TestTimerQueueProcessor_NotifyNewTask(t *testing.T) {
+	const standbyCluster = "standby"
+	activeCluster := constants.TestClusterMetadata.GetCurrentClusterName()
+
+	// A timer task with a non-zero visibility timestamp.
+	timerTask := &persistence.UserTimerTask{
+		TaskData: persistence.TaskData{
+			VisibilityTimestamp: time.Now().Add(time.Second),
+		},
+	}
+
+	tests := map[string]struct {
+		clusterName       string
+		tasks             []persistence.Task
+		preFetched        map[string]time.Time // nil means field is nil, not empty map
+		checkNotification func(t *testing.T, processor *timerQueueProcessor)
+		shouldPanic       bool
+	}{
+		"no tasks - no notification": {
+			clusterName: activeCluster,
+			tasks:       []persistence.Task{},
+			preFetched:  nil,
+			checkNotification: func(t *testing.T, processor *timerQueueProcessor) {
+				select {
+				case <-processor.activeQueueProcessor.newTimerCh:
+					t.Fatal("expected no notification on active queue processor but got one")
+				default:
+					// expected: channel empty
+				}
+			},
+		},
+		"active cluster - notifyNewTimer fires": {
+			clusterName: activeCluster,
+			tasks:       []persistence.Task{timerTask},
+			preFetched:  nil,
+			checkNotification: func(t *testing.T, processor *timerQueueProcessor) {
+				select {
+				case <-processor.activeQueueProcessor.newTimerCh:
+					// expected
+				case <-time.After(100 * time.Millisecond):
+					t.Fatal("timed out waiting for active queue processor notification")
+				}
+			},
+		},
+		"standby cluster without pre-fetched times": {
+			clusterName: standbyCluster,
+			tasks:       []persistence.Task{timerTask},
+			preFetched:  nil, // nil → calls shard.GetCurrentTime
+			checkNotification: func(t *testing.T, processor *timerQueueProcessor) {
+				select {
+				case <-processor.standbyQueueProcessors[standbyCluster].newTimerCh:
+					// expected
+				case <-time.After(100 * time.Millisecond):
+					t.Fatal("timed out waiting for standby queue processor notification")
+				}
+			},
+		},
+		"standby cluster with pre-fetched times - map hit": {
+			clusterName: standbyCluster,
+			tasks:       []persistence.Task{timerTask},
+			preFetched:  map[string]time.Time{standbyCluster: time.Now()},
+			checkNotification: func(t *testing.T, processor *timerQueueProcessor) {
+				select {
+				case <-processor.standbyQueueProcessors[standbyCluster].newTimerCh:
+					// expected
+				case <-time.After(100 * time.Millisecond):
+					t.Fatal("timed out waiting for standby queue processor notification (pre-fetched map hit)")
+				}
+			},
+		},
+		"standby cluster with pre-fetched times - map miss": {
+			clusterName: standbyCluster,
+			tasks:       []persistence.Task{timerTask},
+			// Non-nil map but does not contain standbyCluster → zero value → fallback to time.Now()
+			preFetched: map[string]time.Time{},
+			checkNotification: func(t *testing.T, processor *timerQueueProcessor) {
+				select {
+				case <-processor.standbyQueueProcessors[standbyCluster].newTimerCh:
+					// expected: fallback to time.Now() still triggers notification
+				case <-time.After(100 * time.Millisecond):
+					t.Fatal("timed out waiting for standby queue processor notification (pre-fetched map miss)")
+				}
+			},
+		},
+		"unknown cluster - panics": {
+			clusterName:       "unknown-cluster",
+			tasks:             []persistence.Task{timerTask},
+			preFetched:        nil,
+			shouldPanic:       true,
+			checkNotification: func(t *testing.T, processor *timerQueueProcessor) {},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl, processor := setupTimerQueueProcessor(t)
+			defer ctrl.Finish()
+
+			info := &hcommon.NotifyTaskInfo{
+				ExecutionInfo: &persistence.WorkflowExecutionInfo{
+					DomainID:   constants.TestDomainID,
+					WorkflowID: constants.TestWorkflowID,
+					RunID:      constants.TestRunID,
+				},
+				Tasks:               tc.tasks,
+				ClusterCurrentTimes: tc.preFetched,
+			}
+
+			if tc.shouldPanic {
+				assert.Panics(t, func() {
+					processor.NotifyNewTask(tc.clusterName, info)
+				})
+				return
+			}
+
+			processor.NotifyNewTask(tc.clusterName, info)
+			tc.checkNotification(t, processor)
+		})
+	}
+}
+
+func TestTimerQueueProcessor_NotifyNewTask_PreFetchedTimePropagation(t *testing.T) {
+	// Verify that when a pre-fetched time is provided, the standby timer gate's
+	// SetCurrentTime is called with that value.
+	//
+	// Observable side-effect: if we first arm the gate with a fireTime in the past
+	// (via Update), and then call NotifyNewTask with a pre-fetched time that is >=
+	// fireTime, SetCurrentTime will fire the gate's Chan. This proves SetCurrentTime
+	// was called with the pre-fetched time rather than the shard's current time.
+	const standbyCluster = "standby"
+
+	ctrl, processor := setupTimerQueueProcessor(t)
+	defer ctrl.Finish()
+
+	fireTime := time.Now().Add(-10 * time.Second)      // 10 seconds ago
+	preFetchedTime := time.Now().Add(-5 * time.Second) // 5 seconds ago (> fireTime)
+
+	// Arm the standby gate with a fireTime in the past.
+	gate := processor.standbyQueueTimerGates[standbyCluster]
+	gate.Update(fireTime)
+
+	timerTask := &persistence.UserTimerTask{
+		TaskData: persistence.TaskData{
+			VisibilityTimestamp: time.Now().Add(time.Second),
+		},
+	}
+
+	info := &hcommon.NotifyTaskInfo{
+		ExecutionInfo: &persistence.WorkflowExecutionInfo{
+			DomainID:   constants.TestDomainID,
+			WorkflowID: constants.TestWorkflowID,
+			RunID:      constants.TestRunID,
+		},
+		Tasks: []persistence.Task{timerTask},
+		ClusterCurrentTimes: map[string]time.Time{
+			standbyCluster: preFetchedTime,
+		},
+	}
+
+	processor.NotifyNewTask(standbyCluster, info)
+
+	// SetCurrentTime(preFetchedTime) fires the gate because preFetchedTime >= fireTime.
+	select {
+	case <-gate.Chan():
+		// expected: gate fired because pre-fetched time was applied
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("standby timer gate did not fire; pre-fetched time was not propagated to SetCurrentTime")
+	}
+}

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -643,7 +643,6 @@ func (s *contextImpl) CreateWorkflowExecution(
 	}
 
 	domainID := request.NewWorkflowSnapshot.ExecutionInfo.DomainID
-	workflowID := request.NewWorkflowSnapshot.ExecutionInfo.WorkflowID
 
 	// do not try to get domain cache within shard lock
 	domainEntry, err := s.GetDomainCache().GetDomainByID(domainID)
@@ -653,6 +652,18 @@ func (s *contextImpl) CreateWorkflowExecution(
 
 	s.Lock()
 	defer s.Unlock()
+
+	resp, err := s.createWorkflowExecutionLocked(ctx, request, domainEntry)
+	s.notifyTasksFromCreateWorkflowExecution(request, err)
+	return resp, err
+}
+
+func (s *contextImpl) createWorkflowExecutionLocked(
+	ctx context.Context,
+	request *persistence.CreateWorkflowExecutionRequest,
+	domainEntry *cache.DomainCacheEntry,
+) (*persistence.CreateWorkflowExecutionResponse, error) {
+	workflowID := request.NewWorkflowSnapshot.ExecutionInfo.WorkflowID
 
 	immediateTaskMaxReadLevel := int64(0)
 	if err := s.allocateTaskIDsLocked(
@@ -738,7 +749,6 @@ func (s *contextImpl) UpdateWorkflowExecution(
 	}
 
 	domainID := request.UpdateWorkflowMutation.ExecutionInfo.DomainID
-	workflowID := request.UpdateWorkflowMutation.ExecutionInfo.WorkflowID
 
 	// do not try to get domain cache within shard lock
 	domainEntry, err := s.GetDomainCache().GetDomainByID(domainID)
@@ -749,6 +759,18 @@ func (s *contextImpl) UpdateWorkflowExecution(
 
 	s.Lock()
 	defer s.Unlock()
+
+	resp, err := s.updateWorkflowExecutionLocked(ctx, request, domainEntry)
+	s.notifyTasksFromUpdateWorkflowExecution(request, err)
+	return resp, err
+}
+
+func (s *contextImpl) updateWorkflowExecutionLocked(
+	ctx context.Context,
+	request *persistence.UpdateWorkflowExecutionRequest,
+	domainEntry *cache.DomainCacheEntry,
+) (*persistence.UpdateWorkflowExecutionResponse, error) {
+	workflowID := request.UpdateWorkflowMutation.ExecutionInfo.WorkflowID
 
 	immediateTaskMaxReadLevel := int64(0)
 	if err := s.allocateTaskIDsLocked(
@@ -839,7 +861,6 @@ func (s *contextImpl) ConflictResolveWorkflowExecution(
 	}
 
 	domainID := request.ResetWorkflowSnapshot.ExecutionInfo.DomainID
-	workflowID := request.ResetWorkflowSnapshot.ExecutionInfo.WorkflowID
 
 	// do not try to get domain cache within shard lock
 	domainEntry, err := s.GetDomainCache().GetDomainByID(domainID)
@@ -851,6 +872,18 @@ func (s *contextImpl) ConflictResolveWorkflowExecution(
 
 	s.Lock()
 	defer s.Unlock()
+
+	resp, err := s.conflictResolveWorkflowExecutionLocked(ctx, request, domainEntry)
+	s.notifyTasksFromConflictResolveWorkflowExecution(request, err)
+	return resp, err
+}
+
+func (s *contextImpl) conflictResolveWorkflowExecutionLocked(
+	ctx context.Context,
+	request *persistence.ConflictResolveWorkflowExecutionRequest,
+	domainEntry *cache.DomainCacheEntry,
+) (*persistence.ConflictResolveWorkflowExecutionResponse, error) {
+	workflowID := request.ResetWorkflowSnapshot.ExecutionInfo.WorkflowID
 
 	immediateTaskMaxReadLevel := int64(0)
 	if request.CurrentWorkflowMutation != nil {
@@ -1422,6 +1455,11 @@ func (s *contextImpl) SetCurrentTime(cluster string, currentTime time.Time) {
 func (s *contextImpl) GetCurrentTime(cluster string) time.Time {
 	s.RLock()
 	defer s.RUnlock()
+	return s.getCurrentTimeLocked(cluster)
+}
+
+// getCurrentTimeLocked returns the current time for a cluster without acquiring the shard lock.
+func (s *contextImpl) getCurrentTimeLocked(cluster string) time.Time {
 	if cluster != s.GetClusterMetadata().GetCurrentClusterName() {
 		return s.remoteClusterCurrentTime[cluster]
 	}
@@ -1763,4 +1801,21 @@ func (s *contextImpl) logConflictResolveWorkflowExecutionEvents(request *persist
 	simulation.LogEvents(events...)
 	events = s.getEventsFromWorkflowSnapshot(request.NewWorkflowSnapshot)
 	simulation.LogEvents(events...)
+}
+
+// fetchClusterCurrentTimesLocked returns current times for all standby clusters referenced by timerTasks.
+// Caller must hold s.Lock() or s.RLock().
+func (s *contextImpl) fetchClusterCurrentTimesLocked(timerTasks []persistence.Task) map[string]time.Time {
+	currentCluster := s.GetClusterMetadata().GetCurrentClusterName()
+	clusterTimes := make(map[string]time.Time)
+	for _, task := range timerTasks {
+		clusterName, err := s.GetClusterMetadata().ClusterNameForFailoverVersion(task.GetVersion())
+		if err != nil || clusterName == currentCluster {
+			continue
+		}
+		if _, exists := clusterTimes[clusterName]; !exists {
+			clusterTimes[clusterName] = s.getCurrentTimeLocked(clusterName)
+		}
+	}
+	return clusterTimes
 }

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -518,10 +518,11 @@ func (s *contextTestSuite) TestReplicateFailoverMarkers() {
 func (s *contextTestSuite) TestCreateWorkflowExecution() {
 	cases := []struct {
 		name            string
-		err             error
+		request         *persistence.CreateWorkflowExecutionRequest
 		domainLookupErr error
+		err             error
 		response        *persistence.CreateWorkflowExecutionResponse
-		setup           func()
+		setupMocks      func()
 		asserts         func(*persistence.CreateWorkflowExecutionResponse, error)
 	}{
 		{
@@ -551,7 +552,7 @@ func (s *contextTestSuite) TestCreateWorkflowExecution() {
 		{
 			name: "Other error - update shard succeed",
 			err:  assert.AnError,
-			setup: func() {
+			setupMocks: func() {
 				s.mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(nil)
 			},
 			asserts: func(resp *persistence.CreateWorkflowExecutionResponse, err error) {
@@ -562,7 +563,7 @@ func (s *contextTestSuite) TestCreateWorkflowExecution() {
 		{
 			name: "Other error - update shard failed",
 			err:  assert.AnError,
-			setup: func() {
+			setupMocks: func() {
 				s.mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(assert.AnError)
 			},
 			asserts: func(resp *persistence.CreateWorkflowExecutionResponse, err error) {
@@ -577,6 +578,64 @@ func (s *contextTestSuite) TestCreateWorkflowExecution() {
 				s.ErrorIs(err, assert.AnError)
 			},
 		},
+		{
+			name: "Success with transfer tasks - notify called",
+			request: &persistence.CreateWorkflowExecutionRequest{
+				DomainName: testDomain,
+				NewWorkflowSnapshot: persistence.WorkflowSnapshot{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						DomainID:   testDomainID,
+						WorkflowID: testWorkflowID,
+					},
+					TasksByCategory: map[persistence.HistoryTaskCategory][]persistence.Task{
+						persistence.HistoryTaskCategoryTransfer: {
+							&persistence.DecisionTask{
+								WorkflowIdentifier: persistence.WorkflowIdentifier{
+									DomainID:   testDomainID,
+									WorkflowID: testWorkflowID,
+								},
+							},
+						},
+					},
+				},
+			},
+			response: &persistence.CreateWorkflowExecutionResponse{},
+			setupMocks: func() {
+				mockEngine := engine.NewMockEngine(s.controller)
+				s.context.SetEngine(mockEngine)
+				mockEngine.EXPECT().NotifyNewTransferTasks(gomock.Any()).Times(1)
+			},
+			asserts: func(response *persistence.CreateWorkflowExecutionResponse, err error) {
+				s.NoError(err)
+				s.NotNil(response)
+			},
+		},
+		{
+			name: "Definitive error - notify suppressed",
+			request: &persistence.CreateWorkflowExecutionRequest{
+				DomainName: testDomain,
+				NewWorkflowSnapshot: persistence.WorkflowSnapshot{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						DomainID:   testDomainID,
+						WorkflowID: testWorkflowID,
+					},
+					TasksByCategory: map[persistence.HistoryTaskCategory][]persistence.Task{
+						persistence.HistoryTaskCategoryTransfer: {
+							&persistence.DecisionTask{},
+						},
+					},
+				},
+			},
+			err: &persistence.WorkflowExecutionAlreadyStartedError{},
+			setupMocks: func() {
+				mockEngine := engine.NewMockEngine(s.controller)
+				s.context.SetEngine(mockEngine)
+				// No EXPECT() for notify — if notify fires, gomock will fail the test
+			},
+			asserts: func(resp *persistence.CreateWorkflowExecutionResponse, err error) {
+				s.ErrorAs(err, new(*persistence.WorkflowExecutionAlreadyStartedError))
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -584,14 +643,17 @@ func (s *contextTestSuite) TestCreateWorkflowExecution() {
 			// Need setup the suite manually, since we are in a subtest
 			s.SetupTest()
 			ctx := context.Background()
-			request := &persistence.CreateWorkflowExecutionRequest{
-				DomainName: testDomain,
-				NewWorkflowSnapshot: persistence.WorkflowSnapshot{
-					ExecutionInfo: &persistence.WorkflowExecutionInfo{
-						DomainID:   testDomainID,
-						WorkflowID: testWorkflowID,
+			request := tc.request
+			if request == nil {
+				request = &persistence.CreateWorkflowExecutionRequest{
+					DomainName: testDomain,
+					NewWorkflowSnapshot: persistence.WorkflowSnapshot{
+						ExecutionInfo: &persistence.WorkflowExecutionInfo{
+							DomainID:   testDomainID,
+							WorkflowID: testWorkflowID,
+						},
 					},
-				},
+				}
 			}
 
 			domainCacheEntry := cache.NewLocalDomainCacheEntryForTest(
@@ -600,8 +662,8 @@ func (s *contextTestSuite) TestCreateWorkflowExecution() {
 				testCluster,
 			)
 			s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntry, tc.domainLookupErr)
-			if tc.setup != nil {
-				tc.setup()
+			if tc.setupMocks != nil {
+				tc.setupMocks()
 			}
 
 			s.mockResource.ExecutionMgr.On("CreateWorkflowExecution", ctx, mock.Anything).Once().Return(tc.response, tc.err)
@@ -615,10 +677,11 @@ func (s *contextTestSuite) TestCreateWorkflowExecution() {
 func (s *contextTestSuite) TestUpdateWorkflowExecution() {
 	cases := []struct {
 		name            string
-		err             error
+		request         *persistence.UpdateWorkflowExecutionRequest
 		domainLookupErr error
+		err             error
 		response        *persistence.UpdateWorkflowExecutionResponse
-		setup           func()
+		setupMocks      func()
 		asserts         func(*persistence.UpdateWorkflowExecutionResponse, error)
 	}{
 		{
@@ -648,7 +711,7 @@ func (s *contextTestSuite) TestUpdateWorkflowExecution() {
 		{
 			name: "Other error - update shard succeed",
 			err:  assert.AnError,
-			setup: func() {
+			setupMocks: func() {
 				s.mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(nil)
 			},
 			asserts: func(resp *persistence.UpdateWorkflowExecutionResponse, err error) {
@@ -659,7 +722,7 @@ func (s *contextTestSuite) TestUpdateWorkflowExecution() {
 		{
 			name: "Other error - update shard failed",
 			err:  assert.AnError,
-			setup: func() {
+			setupMocks: func() {
 				s.mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(assert.AnError)
 			},
 			asserts: func(resp *persistence.UpdateWorkflowExecutionResponse, err error) {
@@ -674,14 +737,9 @@ func (s *contextTestSuite) TestUpdateWorkflowExecution() {
 				s.ErrorIs(err, assert.AnError)
 			},
 		},
-	}
-
-	for _, tc := range cases {
-		s.Run(tc.name, func() {
-			// Need setup the suite manually, since we are in a subtest
-			s.SetupTest()
-			ctx := context.Background()
-			request := &persistence.UpdateWorkflowExecutionRequest{
+		{
+			name: "Success with timer tasks - notify called",
+			request: &persistence.UpdateWorkflowExecutionRequest{
 				RangeID: 123,
 				Mode:    persistence.UpdateWorkflowModeUpdateCurrent,
 				UpdateWorkflowMutation: persistence.WorkflowMutation{
@@ -689,9 +747,114 @@ func (s *contextTestSuite) TestUpdateWorkflowExecution() {
 						DomainID:   testDomainID,
 						WorkflowID: testWorkflowID,
 					},
+					TasksByCategory: map[persistence.HistoryTaskCategory][]persistence.Task{
+						persistence.HistoryTaskCategoryTimer: {
+							&persistence.DecisionTimeoutTask{
+								WorkflowIdentifier: persistence.WorkflowIdentifier{
+									DomainID:   testDomainID,
+									WorkflowID: testWorkflowID,
+								},
+							},
+						},
+					},
 				},
 				NewWorkflowSnapshot: &persistence.WorkflowSnapshot{},
 				DomainName:          testDomain,
+			},
+			response: &persistence.UpdateWorkflowExecutionResponse{},
+			setupMocks: func() {
+				mockEngine := engine.NewMockEngine(s.controller)
+				s.context.SetEngine(mockEngine)
+				mockEngine.EXPECT().NotifyNewTimerTasks(gomock.Any()).Times(1)
+			},
+			asserts: func(response *persistence.UpdateWorkflowExecutionResponse, err error) {
+				s.NoError(err)
+				s.NotNil(response)
+			},
+		},
+		{
+			name: "Ambiguous error with tasks - notify called with persistenceError=true",
+			request: &persistence.UpdateWorkflowExecutionRequest{
+				RangeID: 123,
+				Mode:    persistence.UpdateWorkflowModeUpdateCurrent,
+				UpdateWorkflowMutation: persistence.WorkflowMutation{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						DomainID:   testDomainID,
+						WorkflowID: testWorkflowID,
+					},
+					TasksByCategory: map[persistence.HistoryTaskCategory][]persistence.Task{
+						persistence.HistoryTaskCategoryTransfer: {
+							&persistence.DecisionTask{},
+						},
+					},
+				},
+				NewWorkflowSnapshot: &persistence.WorkflowSnapshot{},
+				DomainName:          testDomain,
+			},
+			err: assert.AnError,
+			setupMocks: func() {
+				s.mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(nil)
+				mockEngine := engine.NewMockEngine(s.controller)
+				s.context.SetEngine(mockEngine)
+				mockEngine.EXPECT().NotifyNewTransferTasks(gomock.Any()).Times(1)
+			},
+			asserts: func(resp *persistence.UpdateWorkflowExecutionResponse, err error) {
+				s.Equal(assert.AnError, err)
+			},
+		},
+		{
+			// Covers the nil-snapshot guard in notifyTasksFromSnapshot: NewWorkflowSnapshot
+			// is a pointer that may legitimately be nil on an update.
+			name: "Success with timer task and nil new snapshot",
+			request: &persistence.UpdateWorkflowExecutionRequest{
+				RangeID: 123,
+				Mode:    persistence.UpdateWorkflowModeUpdateCurrent,
+				UpdateWorkflowMutation: persistence.WorkflowMutation{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						DomainID:   testDomainID,
+						WorkflowID: testWorkflowID,
+					},
+					TasksByCategory: map[persistence.HistoryTaskCategory][]persistence.Task{
+						persistence.HistoryTaskCategoryTimer: {
+							&persistence.DecisionTimeoutTask{},
+						},
+					},
+				},
+				NewWorkflowSnapshot: nil,
+				DomainName:          testDomain,
+			},
+			response: &persistence.UpdateWorkflowExecutionResponse{},
+			setupMocks: func() {
+				mockEngine := engine.NewMockEngine(s.controller)
+				s.context.SetEngine(mockEngine)
+				mockEngine.EXPECT().NotifyNewTimerTasks(gomock.Any()).Times(1)
+			},
+			asserts: func(response *persistence.UpdateWorkflowExecutionResponse, err error) {
+				s.NoError(err)
+				s.NotNil(response)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			// Need setup the suite manually, since we are in a subtest
+			s.SetupTest()
+			ctx := context.Background()
+			request := tc.request
+			if request == nil {
+				request = &persistence.UpdateWorkflowExecutionRequest{
+					RangeID: 123,
+					Mode:    persistence.UpdateWorkflowModeUpdateCurrent,
+					UpdateWorkflowMutation: persistence.WorkflowMutation{
+						ExecutionInfo: &persistence.WorkflowExecutionInfo{
+							DomainID:   testDomainID,
+							WorkflowID: testWorkflowID,
+						},
+					},
+					NewWorkflowSnapshot: &persistence.WorkflowSnapshot{},
+					DomainName:          testDomain,
+				}
 			}
 
 			domainCacheEntry := cache.NewLocalDomainCacheEntryForTest(
@@ -700,8 +863,8 @@ func (s *contextTestSuite) TestUpdateWorkflowExecution() {
 				testCluster,
 			)
 			s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntry, tc.domainLookupErr)
-			if tc.setup != nil {
-				tc.setup()
+			if tc.setupMocks != nil {
+				tc.setupMocks()
 			}
 
 			s.mockResource.ExecutionMgr.On("UpdateWorkflowExecution", ctx, mock.Anything).Once().Return(tc.response, tc.err)
@@ -715,10 +878,11 @@ func (s *contextTestSuite) TestUpdateWorkflowExecution() {
 func (s *contextTestSuite) TestConflictResolveWorkflowExecution() {
 	cases := []struct {
 		name            string
-		err             error
+		request         *persistence.ConflictResolveWorkflowExecutionRequest
 		domainLookupErr error
+		err             error
 		response        *persistence.ConflictResolveWorkflowExecutionResponse
-		setup           func()
+		setupMocks      func()
 		asserts         func(*persistence.ConflictResolveWorkflowExecutionResponse, error)
 	}{
 		{
@@ -748,7 +912,7 @@ func (s *contextTestSuite) TestConflictResolveWorkflowExecution() {
 		{
 			name: "Other error - update shard succeed",
 			err:  assert.AnError,
-			setup: func() {
+			setupMocks: func() {
 				s.mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(nil)
 			},
 			asserts: func(resp *persistence.ConflictResolveWorkflowExecutionResponse, err error) {
@@ -759,7 +923,7 @@ func (s *contextTestSuite) TestConflictResolveWorkflowExecution() {
 		{
 			name: "Other error - update shard failed",
 			err:  assert.AnError,
-			setup: func() {
+			setupMocks: func() {
 				s.mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(assert.AnError)
 			},
 			asserts: func(resp *persistence.ConflictResolveWorkflowExecutionResponse, err error) {
@@ -774,6 +938,71 @@ func (s *contextTestSuite) TestConflictResolveWorkflowExecution() {
 				s.ErrorIs(err, assert.AnError)
 			},
 		},
+		{
+			name: "Success with tasks in reset snapshot - notify called",
+			request: &persistence.ConflictResolveWorkflowExecutionRequest{
+				ResetWorkflowSnapshot: persistence.WorkflowSnapshot{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						DomainID:   testDomainID,
+						WorkflowID: testWorkflowID,
+					},
+					TasksByCategory: map[persistence.HistoryTaskCategory][]persistence.Task{
+						persistence.HistoryTaskCategoryTransfer: {
+							&persistence.DecisionTask{
+								WorkflowIdentifier: persistence.WorkflowIdentifier{
+									DomainID:   testDomainID,
+									WorkflowID: testWorkflowID,
+								},
+							},
+						},
+					},
+				},
+				NewWorkflowSnapshot:     &persistence.WorkflowSnapshot{},
+				CurrentWorkflowMutation: &persistence.WorkflowMutation{},
+				DomainName:              testDomain,
+			},
+			response: &persistence.ConflictResolveWorkflowExecutionResponse{},
+			setupMocks: func() {
+				mockEngine := engine.NewMockEngine(s.controller)
+				s.context.SetEngine(mockEngine)
+				mockEngine.EXPECT().NotifyNewTransferTasks(gomock.Any()).Times(1)
+			},
+			asserts: func(response *persistence.ConflictResolveWorkflowExecutionResponse, err error) {
+				s.NoError(err)
+				s.NotNil(response)
+			},
+		},
+		{
+			// Covers the nil-mutation guard in notifyTasksFromMutation: CurrentWorkflowMutation
+			// is a pointer that may legitimately be nil on a conflict-resolve.
+			name: "Success with transfer task in reset snapshot and nil current mutation",
+			request: &persistence.ConflictResolveWorkflowExecutionRequest{
+				ResetWorkflowSnapshot: persistence.WorkflowSnapshot{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						DomainID:   testDomainID,
+						WorkflowID: testWorkflowID,
+					},
+					TasksByCategory: map[persistence.HistoryTaskCategory][]persistence.Task{
+						persistence.HistoryTaskCategoryTransfer: {
+							&persistence.DecisionTask{},
+						},
+					},
+				},
+				NewWorkflowSnapshot:     &persistence.WorkflowSnapshot{},
+				CurrentWorkflowMutation: nil,
+				DomainName:              testDomain,
+			},
+			response: &persistence.ConflictResolveWorkflowExecutionResponse{},
+			setupMocks: func() {
+				mockEngine := engine.NewMockEngine(s.controller)
+				s.context.SetEngine(mockEngine)
+				mockEngine.EXPECT().NotifyNewTransferTasks(gomock.Any()).Times(1)
+			},
+			asserts: func(response *persistence.ConflictResolveWorkflowExecutionResponse, err error) {
+				s.NoError(err)
+				s.NotNil(response)
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -781,16 +1010,19 @@ func (s *contextTestSuite) TestConflictResolveWorkflowExecution() {
 			// Need setup the suite manually, since we are in a subtest
 			s.SetupTest()
 			ctx := context.Background()
-			request := &persistence.ConflictResolveWorkflowExecutionRequest{
-				ResetWorkflowSnapshot: persistence.WorkflowSnapshot{
-					ExecutionInfo: &persistence.WorkflowExecutionInfo{
-						DomainID:   testDomainID,
-						WorkflowID: testWorkflowID,
+			request := tc.request
+			if request == nil {
+				request = &persistence.ConflictResolveWorkflowExecutionRequest{
+					ResetWorkflowSnapshot: persistence.WorkflowSnapshot{
+						ExecutionInfo: &persistence.WorkflowExecutionInfo{
+							DomainID:   testDomainID,
+							WorkflowID: testWorkflowID,
+						},
 					},
-				},
-				NewWorkflowSnapshot:     &persistence.WorkflowSnapshot{},
-				CurrentWorkflowMutation: &persistence.WorkflowMutation{},
-				DomainName:              testDomain,
+					NewWorkflowSnapshot:     &persistence.WorkflowSnapshot{},
+					CurrentWorkflowMutation: &persistence.WorkflowMutation{},
+					DomainName:              testDomain,
+				}
 			}
 
 			domainCacheEntry := cache.NewLocalDomainCacheEntryForTest(
@@ -799,8 +1031,8 @@ func (s *contextTestSuite) TestConflictResolveWorkflowExecution() {
 				testCluster,
 			)
 			s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntry, tc.domainLookupErr)
-			if tc.setup != nil {
-				tc.setup()
+			if tc.setupMocks != nil {
+				tc.setupMocks()
 			}
 
 			s.mockResource.ExecutionMgr.On("ConflictResolveWorkflowExecution", ctx, mock.Anything).Once().Return(tc.response, tc.err)
@@ -1618,4 +1850,99 @@ func (s *contextTestSuite) TestAllocateTimerIDsLocked_WhenMultipleTasksProvidedA
 	s.NotEqual(originalTaskID2, task2.GetTaskID(), "Task 2 ID should have been updated")
 	s.True(task1.GetTaskID() > 0, "Task 1 ID should be positive")
 	s.True(task2.GetTaskID() > 0, "Task 2 ID should be positive")
+}
+
+func TestPrefetchClusterTimesLocked(t *testing.T) {
+	// cluster.TestCurrentClusterInitialFailoverVersion = 0 → "active" (current cluster, skipped)
+	// cluster.TestAlternativeClusterInitialFailoverVersion = 1 → "standby" (remote cluster, included)
+
+	tests := map[string]struct {
+		tasks        []persistence.Task
+		remoteTime   map[string]time.Time
+		expectedKeys []string
+	}{
+		"no tasks - empty map returned": {
+			tasks:        []persistence.Task{},
+			expectedKeys: nil,
+		},
+		"active cluster task - skipped": {
+			tasks: []persistence.Task{
+				// Version 0 maps to current cluster → skipped
+				&persistence.DecisionTimeoutTask{TaskData: persistence.TaskData{Version: cluster.TestCurrentClusterInitialFailoverVersion}},
+			},
+			expectedKeys: nil,
+		},
+		"unknown failover version - skipped silently": {
+			tasks: []persistence.Task{
+				&persistence.DecisionTimeoutTask{TaskData: persistence.TaskData{Version: 9999}},
+			},
+			expectedKeys: nil,
+		},
+		"standby cluster task - included": {
+			tasks: []persistence.Task{
+				// Version 1 maps to standby cluster
+				&persistence.DecisionTimeoutTask{TaskData: persistence.TaskData{Version: cluster.TestAlternativeClusterInitialFailoverVersion}},
+			},
+			remoteTime: map[string]time.Time{
+				cluster.TestAlternativeClusterName: time.Now(),
+			},
+			expectedKeys: []string{cluster.TestAlternativeClusterName},
+		},
+		"duplicate standby cluster tasks - returned once": {
+			tasks: []persistence.Task{
+				&persistence.DecisionTimeoutTask{TaskData: persistence.TaskData{Version: cluster.TestAlternativeClusterInitialFailoverVersion}},
+				&persistence.DecisionTimeoutTask{TaskData: persistence.TaskData{Version: cluster.TestAlternativeClusterInitialFailoverVersion}},
+			},
+			remoteTime: map[string]time.Time{
+				cluster.TestAlternativeClusterName: time.Now(),
+			},
+			expectedKeys: []string{cluster.TestAlternativeClusterName},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			ctx := NewTestContext(
+				t,
+				ctrl,
+				&persistence.ShardInfo{ShardID: 1, RangeID: 1},
+				config.NewForTest(),
+			)
+			if tc.remoteTime != nil {
+				ctx.contextImpl.remoteClusterCurrentTime = tc.remoteTime
+			}
+
+			result := ctx.contextImpl.fetchClusterCurrentTimesLocked(tc.tasks)
+
+			if len(tc.expectedKeys) == 0 {
+				assert.Empty(t, result)
+			} else {
+				for _, key := range tc.expectedKeys {
+					assert.Contains(t, result, key)
+				}
+				assert.Len(t, result, len(tc.expectedKeys))
+			}
+		})
+	}
+}
+
+func TestGetCurrentTimeLocked(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := NewTestContext(t, ctrl, &persistence.ShardInfo{ShardID: 1, RangeID: 1}, config.NewForTest())
+	currentCluster := ctx.GetClusterMetadata().GetCurrentClusterName()
+
+	// current cluster → returns timeSource.Now()
+	result := ctx.contextImpl.getCurrentTimeLocked(currentCluster)
+	assert.False(t, result.IsZero())
+
+	// remote cluster → returns remoteClusterCurrentTime entry
+	remoteTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	ctx.contextImpl.remoteClusterCurrentTime["standby"] = remoteTime
+	result = ctx.contextImpl.getCurrentTimeLocked("standby")
+	assert.Equal(t, remoteTime, result)
 }

--- a/service/history/shard/notify_task.go
+++ b/service/history/shard/notify_task.go
@@ -44,7 +44,7 @@ func isOperationPossiblySuccessfulError(err error) bool {
 // isNotifyTaskNeeded determines whether task notification should be sent based on the error returned from a persistence operation.
 // Returns isNotify=true when the persistence write may have landed (success or ambiguous error), false for definitive failures.
 // Returns persistenceError=true when the write outcome is uncertain (ambiguous error), so processors can handle duplicates.
-func isNotifyTaskNeeded(err error) (isNotify, persistenceError bool) {
+func isNotifyTaskNeeded(err error) (notify, persistenceError bool) {
 	if err == nil {
 		return true, false
 	}
@@ -60,7 +60,7 @@ func (s *contextImpl) notifyTasksFromCreateWorkflowExecution(
 	request *persistence.CreateWorkflowExecutionRequest,
 	err error,
 ) {
-	if isNotify, persistenceError := isNotifyTaskNeeded(err); isNotify {
+	if notify, persistenceError := isNotifyTaskNeeded(err); notify {
 		s.notifyTasksFromSnapshot(&request.NewWorkflowSnapshot, persistenceError)
 	}
 }
@@ -71,7 +71,7 @@ func (s *contextImpl) notifyTasksFromUpdateWorkflowExecution(
 	request *persistence.UpdateWorkflowExecutionRequest,
 	err error,
 ) {
-	if isNotify, persistenceError := isNotifyTaskNeeded(err); isNotify {
+	if notify, persistenceError := isNotifyTaskNeeded(err); notify {
 		s.notifyTasksFromMutation(&request.UpdateWorkflowMutation, persistenceError)
 		s.notifyTasksFromSnapshot(request.NewWorkflowSnapshot, persistenceError)
 	}
@@ -83,7 +83,7 @@ func (s *contextImpl) notifyTasksFromConflictResolveWorkflowExecution(
 	request *persistence.ConflictResolveWorkflowExecutionRequest,
 	err error,
 ) {
-	if isNotify, persistenceError := isNotifyTaskNeeded(err); isNotify {
+	if notify, persistenceError := isNotifyTaskNeeded(err); notify {
 		s.notifyTasksFromSnapshot(&request.ResetWorkflowSnapshot, persistenceError)
 		s.notifyTasksFromSnapshot(request.NewWorkflowSnapshot, persistenceError)
 		s.notifyTasksFromMutation(request.CurrentWorkflowMutation, persistenceError)

--- a/service/history/shard/notify_task.go
+++ b/service/history/shard/notify_task.go
@@ -1,0 +1,135 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package shard
+
+import (
+	"github.com/uber/cadence/common/persistence"
+	hcommon "github.com/uber/cadence/service/history/common"
+)
+
+// isOperationPossiblySuccessfulError returns true for errors where a persistence write
+// may have succeeded despite the error being returned (e.g. timeout, unknown network error).
+// Returns false for errors that definitively indicate the write did not occur.
+//
+// DuplicateRequestError returns false here because a duplicate write means no new tasks
+// were created, so no notification is needed. This differs from the execution layer where
+// the write "possibly succeeded" from the caller's perspective.
+func isOperationPossiblySuccessfulError(err error) bool {
+	if _, ok := err.(*persistence.DuplicateRequestError); ok {
+		return false
+	}
+	return hcommon.IsOperationPossiblySuccessfulError(err)
+}
+
+// isNotifyTaskNeeded determines whether task notification should be sent based on the error returned from a persistence operation.
+// Returns isNotify=true when the persistence write may have landed (success or ambiguous error), false for definitive failures.
+// Returns persistenceError=true when the write outcome is uncertain (ambiguous error), so processors can handle duplicates.
+func isNotifyTaskNeeded(err error) (isNotify, persistenceError bool) {
+	if err == nil {
+		return true, false
+	}
+	if isOperationPossiblySuccessfulError(err) {
+		return true, true
+	}
+	return false, false
+}
+
+// notifyTasksFromCreateWorkflowExecution sends task notifications for a CreateWorkflowExecution operation.
+// Must be called while holding s.Lock().
+func (s *contextImpl) notifyTasksFromCreateWorkflowExecution(
+	request *persistence.CreateWorkflowExecutionRequest,
+	err error,
+) {
+	if isNotify, persistenceError := isNotifyTaskNeeded(err); isNotify {
+		s.notifyTasksFromSnapshot(&request.NewWorkflowSnapshot, persistenceError)
+	}
+}
+
+// notifyTasksFromUpdateWorkflowExecution sends task notifications for an UpdateWorkflowExecution operation.
+// Must be called while holding s.Lock().
+func (s *contextImpl) notifyTasksFromUpdateWorkflowExecution(
+	request *persistence.UpdateWorkflowExecutionRequest,
+	err error,
+) {
+	if isNotify, persistenceError := isNotifyTaskNeeded(err); isNotify {
+		s.notifyTasksFromMutation(&request.UpdateWorkflowMutation, persistenceError)
+		s.notifyTasksFromSnapshot(request.NewWorkflowSnapshot, persistenceError)
+	}
+}
+
+// notifyTasksFromConflictResolveWorkflowExecution sends task notifications for a ConflictResolveWorkflowExecution operation.
+// Must be called while holding s.Lock().
+func (s *contextImpl) notifyTasksFromConflictResolveWorkflowExecution(
+	request *persistence.ConflictResolveWorkflowExecutionRequest,
+	err error,
+) {
+	if isNotify, persistenceError := isNotifyTaskNeeded(err); isNotify {
+		s.notifyTasksFromSnapshot(&request.ResetWorkflowSnapshot, persistenceError)
+		s.notifyTasksFromSnapshot(request.NewWorkflowSnapshot, persistenceError)
+		s.notifyTasksFromMutation(request.CurrentWorkflowMutation, persistenceError)
+	}
+}
+
+// notifyTasks notifies the transfer and timer queue processors of new tasks.
+// Must be called while holding s.Lock().
+func (s *contextImpl) notifyTasks(
+	executionInfo *persistence.WorkflowExecutionInfo,
+	tasksByCategory map[persistence.HistoryTaskCategory][]persistence.Task,
+	persistenceError bool,
+) {
+
+	if transferTasks := tasksByCategory[persistence.HistoryTaskCategoryTransfer]; len(transferTasks) > 0 {
+		s.GetEngine().NotifyNewTransferTasks(&hcommon.NotifyTaskInfo{
+			ExecutionInfo:    executionInfo,
+			Tasks:            transferTasks,
+			PersistenceError: persistenceError,
+		})
+	}
+
+	if timerTasks := tasksByCategory[persistence.HistoryTaskCategoryTimer]; len(timerTasks) > 0 {
+		s.GetEngine().NotifyNewTimerTasks(&hcommon.NotifyTaskInfo{
+			ExecutionInfo:       executionInfo,
+			Tasks:               timerTasks,
+			PersistenceError:    persistenceError,
+			ClusterCurrentTimes: s.fetchClusterCurrentTimesLocked(timerTasks),
+		})
+	}
+}
+
+// notifyTasksFromSnapshot notifies queue processors of tasks from a workflow snapshot.
+// Must be called while holding s.Lock().
+func (s *contextImpl) notifyTasksFromSnapshot(snapshot *persistence.WorkflowSnapshot, persistenceError bool) {
+	if snapshot == nil {
+		return
+	}
+	s.notifyTasks(snapshot.ExecutionInfo, snapshot.TasksByCategory, persistenceError)
+}
+
+// notifyTasksFromMutation notifies queue processors of tasks from a workflow mutation.
+// Must be called while holding s.Lock().
+func (s *contextImpl) notifyTasksFromMutation(mutation *persistence.WorkflowMutation, persistenceError bool) {
+	if mutation == nil {
+		return
+	}
+	s.notifyTasks(mutation.ExecutionInfo, mutation.TasksByCategory, persistenceError)
+}

--- a/service/history/shard/notify_task_test.go
+++ b/service/history/shard/notify_task_test.go
@@ -1,0 +1,61 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package shard
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/types"
+)
+
+func TestIsOperationPossiblySuccessfulError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"WorkflowExecutionAlreadyStartedError (types)", &types.WorkflowExecutionAlreadyStartedError{}, false},
+		{"WorkflowExecutionAlreadyStartedError (persistence)", &persistence.WorkflowExecutionAlreadyStartedError{}, false},
+		{"CurrentWorkflowConditionFailedError", &persistence.CurrentWorkflowConditionFailedError{}, false},
+		{"ConditionFailedError", &persistence.ConditionFailedError{}, false},
+		{"ServiceBusyError", &types.ServiceBusyError{}, false},
+		{"LimitExceededError", &types.LimitExceededError{}, false},
+		{"ShardOwnershipLostError", &persistence.ShardOwnershipLostError{}, false},
+		// DuplicateRequestError is explicitly false in the shard layer (unlike the execution layer
+		// where it falls through to the common base and returns true).
+		{"DuplicateRequestError", &persistence.DuplicateRequestError{}, false},
+		{"TimeoutError", &persistence.TimeoutError{}, true},
+		{"context.DeadlineExceeded", context.DeadlineExceeded, true},
+		{"generic error", assert.AnError, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isOperationPossiblySuccessfulError(tc.err))
+		})
+	}
+}


### PR DESCRIPTION
**What changed?**

Transfer and timer task processors are now notified while the shard write lock is still held, eliminating the window between `updateMaxReadLevelLocked` and processor wake-up. Three `shardContext` methods (`CreateWorkflowExecution`, `UpdateWorkflowExecution`, `ConflictResolveWorkflowExecution`) are each split into a public + locked variant. The public method acquires the lock, calls the locked variant, then calls a per-operation notify helper — all inside `s.Lock()` / `defer s.Unlock()`.

Key components:
- `service/history/shard/notify_task.go` — shard-layer task notification helpers:
  - `isOperationPossiblySuccessfulError` (delegates to `service/history/common/errors.go`; treats `DuplicateRequestError` as definitive unlike the execution layer)
  - `isNotifyTaskNeeded` — returns `(isNotify, persistenceError)`: `true,false` on success; `true,true` on ambiguous error; `false,false` on definitive failure
  - `notifyTasksFromCreateWorkflowExecution`, `notifyTasksFromUpdateWorkflowExecution`, `notifyTasksFromConflictResolveWorkflowExecution` — per-operation notify helpers
  - `notifyTasks`, `notifyTasksFromSnapshot`, `notifyTasksFromMutation` — core notification helpers
- `createWorkflowExecutionLocked`, `updateWorkflowExecutionLocked`, `conflictResolveWorkflowExecutionLocked` — locked variants of the three shard context methods
- `fetchClusterCurrentTimesLocked`, `getCurrentTimeLocked` — pre-fetch cluster times while holding the shard write lock
- `ClusterCurrentTimes map[string]time.Time` added to `NotifyTaskInfo` to fix standby timer deadlock (calling `GetCurrentTime` while holding the shard write lock would re-enter the same `sync.RWMutex`)
- Replication tasks remain notified from the execution layer (circular import prevents placing `events.PersistedBlobs` in persistence request structs)

**Why?**

Previously, queue processor notification happened in the execution layer after `shardContext.Create/UpdateWorkflowExecution` returned — meaning after the shard write lock was already released. This created a window where `immediateTaskMaxReadLevel` was updated and the lock was gone, but the processor hadn't been woken yet. Any goroutine that acquired the lock in that window could advance the read level further without the processor being aware of the original task.

Moving notification to inside the lock ensures the processor is always woken before any other goroutine can observe the updated read level.

Relates to #7953.

**How did you test it?**

```bash
go test -race ./service/history/shard/...
go test -race ./service/history/execution/...
go test -race ./service/history/queue/...
go test -race ./service/history/queuev2/...
go test -race ./service/history/decision/...
go test -race ./service/history/engine/engineimpl/...
# full suite:
go test ./service/history/...
```

All pass.

**Potential risks**

- Core task processing path touched. The notify helpers add a small amount of work inside the shard lock (non-blocking channel sends, timer gate updates). These were already safe to call under lock per safety analysis (no shard re-entry, all channel sends have `default` clauses).
- Standby timer deadlock fix: `timerQueueProcessor.NotifyNewTask` for non-current clusters previously called `t.shard.GetCurrentTime()` (acquires `s.RLock()`). Now uses `ClusterCurrentTimes` when set by a caller holding `s.Lock()`. Fallback to `time.Now()` if a cluster is unexpectedly absent from the map (should not occur in normal operation).
- Retried transient errors: each retry attempt fires one notification. For `TimeoutError` (the canonical "possibly successful" case) this is identical to previous behavior since timeouts are not retried. For retried transient errors, extra notifications are idempotent for transfer/timer and benign for replication (processor skips missing task IDs).

**Release notes**

N/A — internal optimization to reduce queue processor wake-up latency.

**Documentation Changes**

N/A