### PR TITLE
fix: escape Pinot string literals in PinotQueryFilter.addEqual

### DIFF
--- a/common/persistence/pinot/pinot_visibility_store.go
+++ b/common/persistence/pinot/pinot_visibility_store.go
@@ -720,14 +720,20 @@ func (f *PinotQueryFilter) checkFirstFilter() {
 
 func (f *PinotQueryFilter) addEqual(obj string, val interface{}) {
 	f.checkFirstFilter()
-	if _, ok := val.(string); ok {
-		val = fmt.Sprintf("'%s'", val)
+	if strVal, ok := val.(string); ok {
+		val = fmt.Sprintf("'%s'", escapePinotStringLiteral(strVal))
 	} else {
 		val = fmt.Sprintf("%v", val)
 	}
 
 	quotedVal := fmt.Sprintf("%s", val)
 	f.string += fmt.Sprintf("%s = %s\n", obj, quotedVal)
+}
+
+// escapePinotStringLiteral returns value with embedded single quotes doubled,
+// so the escaped value remains inside one Pinot string literal when wrapped.
+func escapePinotStringLiteral(value string) string {
+	return strings.ReplaceAll(value, "'", "''")
 }
 
 // addQuery adds a complete query into the filter

--- a/common/persistence/pinot/pinot_visibility_store_test.go
+++ b/common/persistence/pinot/pinot_visibility_store_test.go
@@ -1511,6 +1511,20 @@ LIMIT 0, 10
 	assert.NoError(t, err1)
 	assert.NoError(t, err2)
 	assert.NoError(t, err3)
+
+	request.WorkflowTypeName = "test-wf'type"
+	escapedResult, err := getListWorkflowExecutionsByTypeQuery(testTableName, request, true)
+	expectEscapedResult := fmt.Sprintf(`SELECT *
+FROM %s
+WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
+AND WorkflowType = 'test-wf''type'
+AND CloseTime BETWEEN 1547596871371 AND 2547596873371
+AND CloseStatus >= 0
+Order BY StartTime DESC
+LIMIT 0, 10
+`, testTableName)
+	assert.Equal(t, escapedResult, expectEscapedResult)
+	assert.NoError(t, err)
 }
 
 func TestGetListWorkflowExecutionsByWorkflowIDQuery(t *testing.T) {
@@ -1556,6 +1570,20 @@ LIMIT 0, 10
 	assert.NoError(t, err1)
 	assert.NoError(t, err2)
 	assert.NoError(t, err3)
+
+	request.WorkflowID = "test-w'id"
+	escapedResult, err := getListWorkflowExecutionsByWorkflowIDQuery(testTableName, request, true)
+	expectEscapedResult := fmt.Sprintf(`SELECT *
+FROM %s
+WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
+AND WorkflowID = 'test-w''id'
+AND CloseTime BETWEEN 1547596871371 AND 2547596873371
+AND CloseStatus >= 0
+Order BY StartTime DESC
+LIMIT 0, 10
+`, testTableName)
+	assert.Equal(t, escapedResult, expectEscapedResult)
+	assert.NoError(t, err)
 }
 
 func TestGetListWorkflowExecutionsByStatusQuery(t *testing.T) {


### PR DESCRIPTION
## Summary

`PinotQueryFilter.addEqual` wraps string values in single quotes via `fmt.Sprintf("'%s'", val)` without escaping embedded quotes. The legacy `ListOpenWorkflowExecutions` / `ListClosedWorkflowExecutions` filter paths reach this helper with request-controlled `ExecutionFilter.WorkflowID` and `TypeFilter.Name`, so a value containing `'` breaks out of its literal and alters the surrounding Pinot predicate.

This PR adds a small `escapePinotStringLiteral` helper that doubles single quotes (SQL-92 standard, Pinot-compatible) and routes string values through it. Two regression tests cover the workflow type and workflow ID paths.

## Why this matters

The newer query APIs (`CountWorkflowExecutions`, `ScanWorkflowExecutions`, `ListWorkflowExecutions`) already enforce a validated shape via `common/pinot/pinotQueryValidator.go` (`pinotQueryValidator_test.go` includes explicit rejection of multi-statement and `UNION`-style input). The legacy list filter paths bypass that validator and reach `addEqual` directly:

- `service/frontend/api/request_validator.go:196-224` and `request_validator.go:244-282` validate domain / time filter / cardinality / page size but do not validate or normalize `ExecutionFilter.WorkflowID` or `TypeFilter.Name`.
- `service/frontend/api/list_workflow_handlers.go:141-164` and `:272-296` copy those values into persistence-layer requests.
- `common/persistence/pinot/pinot_visibility_store.go:980-1048` builds the Pinot text query through `addEqual`.

`addEqual` was the right place to fix this — it's the central helper every legacy filter goes through. Aligning it with the newer-API validation pattern closes the gap without changing the API shape. Authenticated callers with `PermissionRead` on the visibility surface remain the only ones who can reach the path; the patch removes the predicate-shape break, not the auth boundary.

## Changes

- `addEqual` now passes string values through `escapePinotStringLiteral` before the `'%s'` wrap. Non-string values are unaffected; only the string branch changes.
- `escapePinotStringLiteral` is unexported and a one-liner over the existing `strings.ReplaceAll`. No new imports.
- `TestGetListWorkflowExecutionsByTypeQuery` and `TestGetListWorkflowExecutionsByWorkflowIDQuery` each gain a case with a single-quote in the filter value, asserting the generated query contains a doubled quote inside one literal rather than two adjacent literals.

## Testing

```
go test ./common/pinot ./common/persistence/pinot
ok  	github.com/uber/cadence/common/persistence/pinot
ok  	github.com/uber/cadence/common/pinot
```

`gofmt -l` and `go vet ./common/persistence/pinot` both clean on the changed files.
