### PR TITLE
fix(failover): wire Reason in failover request

### DIFF
--- a/common/types/mapper/proto/api.go
+++ b/common/types/mapper/proto/api.go
@@ -4533,6 +4533,7 @@ func FromFailoverDomainRequest(t *types.FailoverDomainRequest) *apiv1.FailoverDo
 		DomainName:              t.DomainName,
 		DomainActiveClusterName: t.GetDomainActiveClusterName(),
 		ActiveClusters:          FromActiveClusters(t.ActiveClusters),
+		Reason:                  t.GetReason(),
 	}
 }
 
@@ -4544,10 +4545,15 @@ func ToFailoverDomainRequest(t *apiv1.FailoverDomainRequest) *types.FailoverDoma
 	if t.DomainActiveClusterName != "" {
 		domainActiveClusterName = common.StringPtr(t.DomainActiveClusterName)
 	}
+	var reason *string
+	if t.Reason != "" {
+		reason = common.StringPtr(t.Reason)
+	}
 	return &types.FailoverDomainRequest{
 		DomainName:              t.DomainName,
 		DomainActiveClusterName: domainActiveClusterName,
 		ActiveClusters:          ToActiveClusters(t.ActiveClusters),
+		Reason:                  reason,
 	}
 }
 

--- a/common/types/mapper/proto/api_test.go
+++ b/common/types/mapper/proto/api_test.go
@@ -2073,8 +2073,8 @@ func TestDeprecateDomainRequestFuzz(t *testing.T) {
 }
 
 func TestFailoverDomainRequestFuzz(t *testing.T) {
-	// [BUG] Non-symmetric mapping: An empty string DomainActiveClusterName becomes nil, but the return trip translates it back to nil
-	// [Missing] Reason is not yet implemented in the mapper
+	// [BUG] Non-symmetric mapping: proto3 cannot distinguish unset from an empty string, so
+	// a *string(ptr("")) input round-trips to nil. Applies to both DomainActiveClusterName and Reason.
 	testutils.RunMapperFuzzTest(t, FromFailoverDomainRequest, ToFailoverDomainRequest,
 		testutils.WithCustomFuncs(
 			FailoverTypeFuzzer,

--- a/common/types/mapper/thrift/shared.go
+++ b/common/types/mapper/thrift/shared.go
@@ -1623,6 +1623,7 @@ func FromFailoverDomainRequest(t *types.FailoverDomainRequest) *shared.FailoverD
 		DomainName:              &t.DomainName,
 		DomainActiveClusterName: t.DomainActiveClusterName,
 		ActiveClusters:          FromActiveClusters(t.ActiveClusters),
+		Reason:                  t.Reason,
 	}
 }
 
@@ -1635,6 +1636,7 @@ func ToFailoverDomainRequest(t *shared.FailoverDomainRequest) *types.FailoverDom
 		DomainName:              t.GetDomainName(),
 		DomainActiveClusterName: t.DomainActiveClusterName,
 		ActiveClusters:          ToActiveClusters(t.ActiveClusters),
+		Reason:                  t.Reason,
 	}
 }
 

--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -1821,6 +1821,14 @@ func (v *FailoverDomainRequest) GetDomain() (o string) {
 	return
 }
 
+// GetReason is an internal getter
+func (v *FailoverDomainRequest) GetReason() (o string) {
+	if v != nil && v.Reason != nil {
+		return *v.Reason
+	}
+	return
+}
+
 // FailoverDomainResponse is an internal type (TBD...)
 type FailoverDomainResponse struct {
 	DomainInfo               *DomainInfo                     `json:"domainInfo,omitempty"`

--- a/common/types/testdata/service_frontend.go
+++ b/common/types/testdata/service_frontend.go
@@ -86,12 +86,14 @@ var (
 		DomainName:              DomainName,
 		DomainActiveClusterName: common.StringPtr(ClusterName1),
 		ActiveClusters:          &ActiveClusters,
+		Reason:                  common.StringPtr(Reason),
 	}
 	FailoverDomainRequest_OnlyActiveClusters = types.FailoverDomainRequest{
 		DomainName: DomainName,
 		// Explicitly set to nil to test ActiveActive failovers
 		DomainActiveClusterName: nil,
 		ActiveClusters:          &ActiveClusters,
+		Reason:                  common.StringPtr(Reason),
 	}
 	ActiveClusters = types.ActiveClusters{
 		AttributeScopes: map[string]types.ClusterAttributeScope{


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Wired Reason in DomainFailoverRequest in thrift and proto.

**Why?**
This wiring was missed when Reason was added to the DomainFailoverRequest

**How did you test it?**
go test -race -run 'TestFailoverDomainRequest' ./common/types/mapper/proto/... ./common/types/mapper/thrift/...

**Potential risks**
No risk, fixing existing silent drop issue.

**Release notes**
N/A

**Documentation Changes**
N/A
