### PR TITLE
chore(failover): refactor handleGracefulFailover method

### DIFF
--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -540,21 +540,18 @@ func (d *handlerImpl) handleFailoverRequest(ctx context.Context,
 	// if the failover 'graceful' - as indicated as having a FailoverTimeoutInSeconds,
 	// then we set some additional parameters for the graceful failover
 	if updateRequest.FailoverTimeoutInSeconds != nil {
-		gracefulFailoverEndTime, previousFailoverVersion, err := d.handleGracefulFailover(
-			updateRequest,
+		if err := d.validateGracefulFailover(
 			intendedDomainState.ReplicationConfig,
 			currentActiveCluster,
 			currentState.FailoverEndTime,
-			currentState.FailoverVersion,
 			activeClusterChanged,
 			isGlobalDomain,
-		)
-		if err != nil {
+		); err != nil {
 			return nil, err
 		}
 		failoverType = constants.FailoverTypeGrace
-		intendedDomainState.FailoverEndTime = gracefulFailoverEndTime
-		intendedDomainState.PreviousFailoverVersion = previousFailoverVersion
+		intendedDomainState.FailoverEndTime = d.computeGracefulFailoverEndTime(updateRequest.GetFailoverTimeoutInSeconds())
+		intendedDomainState.PreviousFailoverVersion = currentState.FailoverVersion
 	}
 
 	// replication config is a subset of config,
@@ -1713,34 +1710,31 @@ func (d *handlerImpl) updateReplicationConfig(
 	return config, replicationConfigChanged, activeClusterChanged, nil
 }
 
-func (d *handlerImpl) handleGracefulFailover(
-	updateRequest *types.UpdateDomainRequest,
+func (d *handlerImpl) validateGracefulFailover(
 	replicationConfig *persistence.DomainReplicationConfig,
 	currentActiveCluster string,
 	gracefulFailoverEndTime *int64,
-	failoverVersion int64,
 	activeClusterChanged bool,
 	isGlobalDomain bool,
-) (*int64, int64, error) {
-	// must update active cluster on a global domain
+) error {
 	if !activeClusterChanged || !isGlobalDomain || replicationConfig.IsActiveActive() {
-		return nil, 0, errInvalidGracefulFailover
+		return errInvalidGracefulFailover
 	}
-	// must start with the passive -> active cluster
 	if replicationConfig.ActiveClusterName != d.clusterMetadata.GetCurrentClusterName() {
-		return nil, 0, errCannotDoGracefulFailoverFromCluster
+		return errCannotDoGracefulFailoverFromCluster
 	}
 	if replicationConfig.ActiveClusterName == currentActiveCluster {
-		return nil, 0, errGracefulFailoverInActiveCluster
+		return errGracefulFailoverInActiveCluster
 	}
-	// cannot have concurrent failover
 	if gracefulFailoverEndTime != nil {
-		return nil, 0, errOngoingGracefulFailover
+		return errOngoingGracefulFailover
 	}
-	endTime := d.timeSource.Now().Add(time.Duration(updateRequest.GetFailoverTimeoutInSeconds()) * time.Second).UnixNano()
-	previousFailoverVersion := failoverVersion
+	return nil
+}
 
-	return &endTime, previousFailoverVersion, nil
+func (d *handlerImpl) computeGracefulFailoverEndTime(failoverTimeoutInSeconds int32) *int64 {
+	endTime := d.timeSource.Now().Add(time.Duration(failoverTimeoutInSeconds) * time.Second).UnixNano()
+	return &endTime
 }
 
 func (d *handlerImpl) validateGlobalDomainReplicationConfigForUpdateDomain(

--- a/common/domain/handler_test.go
+++ b/common/domain/handler_test.go
@@ -2289,7 +2289,7 @@ func TestHandler_UpdateDomain(t *testing.T) {
 			},
 		},
 		{
-			name: "Error case - handleGracefulFailover error in the case of a global domain - it should return an error to the user",
+			name: "Error case - validateGracefulFailover error in the case of a global domain - it should return an error to the user",
 			setupMock: func(domainManager *persistence.MockDomainManager, updateRequest *types.UpdateDomainRequest, archivalMetadata *archiver.MockArchivalMetadata, _ clock.MockedTimeSource, _ *MockReplicator) {
 				domainManager.EXPECT().GetMetadata(ctx).Return(&persistence.GetMetadataResponse{}, nil).Times(1)
 				domainManager.EXPECT().GetDomain(ctx, &persistence.GetDomainRequest{Name: updateRequest.GetName()}).
@@ -3310,19 +3310,15 @@ func TestUpdateReplicationConfig(t *testing.T) {
 	}
 }
 
-func TestHandleGracefulFailover(t *testing.T) {
-	failoverTimeoutInSeconds := int32(1)
-	failoverVersion := int64(3)
-
+func TestValidateGracefulFailover(t *testing.T) {
 	testCases := []struct {
-		name                           string
-		replicationConfig              *persistence.DomainReplicationConfig
-		currentActiveCluster           string
-		gracefulFailoverEndTime        *int64
-		activeClusterChange            bool
-		isGlobalDomain                 bool
-		updatedGracefulFailoverEndTime func(now time.Time) *int64
-		err                            error
+		name                    string
+		replicationConfig       *persistence.DomainReplicationConfig
+		currentActiveCluster    string
+		gracefulFailoverEndTime *int64
+		activeClusterChange     bool
+		isGlobalDomain          bool
+		err                     error
 	}{
 		{
 			name: "Success case",
@@ -3333,9 +3329,6 @@ func TestHandleGracefulFailover(t *testing.T) {
 			currentActiveCluster: cluster.TestAlternativeClusterName,
 			activeClusterChange:  true,
 			isGlobalDomain:       true,
-			updatedGracefulFailoverEndTime: func(now time.Time) *int64 {
-				return common.Ptr(now.Add(time.Duration(failoverTimeoutInSeconds) * time.Second).UnixNano())
-			},
 		},
 		{
 			name:                "Error case - activeClusterChange is false",
@@ -3391,21 +3384,12 @@ func TestHandleGracefulFailover(t *testing.T) {
 			mockDomainMgr := persistence.NewMockDomainManager(controller)
 			mockReplicator := NewMockReplicator(controller)
 
-			handler := newTestHandler(t, controller, mockDomainMgr, true, mockReplicator)
+			handler := newTestHandler(t, controller, mockDomainMgr, true, mockReplicator).(*handlerImpl)
 
-			now := handler.(*handlerImpl).timeSource.Now()
-
-			request := &types.UpdateDomainRequest{
-				FailoverTimeoutInSeconds: common.Int32Ptr(failoverTimeoutInSeconds),
-			}
-
-			gracefulFailoverEndTime, previousFailoverVersion, err := (*handlerImpl).handleGracefulFailover(
-				handler.(*handlerImpl),
-				request,
+			err := handler.validateGracefulFailover(
 				tc.replicationConfig,
 				tc.currentActiveCluster,
 				tc.gracefulFailoverEndTime,
-				failoverVersion,
 				tc.activeClusterChange,
 				tc.isGlobalDomain,
 			)
@@ -3415,8 +3399,6 @@ func TestHandleGracefulFailover(t *testing.T) {
 				assert.Equal(t, tc.err, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tc.updatedGracefulFailoverEndTime(now), gracefulFailoverEndTime)
-				assert.Equal(t, failoverVersion, previousFailoverVersion)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Refactored handleGracefulFailover. Extracted validateGracefulFailover from it and added computeGracefulFailoverEndTime to compute graceful failover end time.

**Why?**
The initial method was doing multiple things and had pass through variables. Extracted methods to make it easier to understand.

**How did you test it?**
go test -race ./common/domain/

**Potential risks**
No potential risks, the behavior is the same.

**Release notes**
N/A

**Documentation Changes**
N/A
