### PR TITLE
ci(queuev2): add optional integration test with cached queue reader

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -164,6 +164,37 @@ jobs:
           name: go-cassandra-running-history-queue-v2-alert-integration-coverage
           path: .build/coverage/*.out
 
+  golang-integration-test-with-cassandra-running-history-queue-v2-cached-reader:
+    name: Golang integration test with running history queue v2 with cached reader
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.5'
+
+      - name: Run integration profile for cassandra running history queue v2 with cached reader
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 2
+          timeout_minutes: 30
+          command: |
+            docker compose -f docker/github_actions/docker-compose.yml run integration-test-cassandra-queue-v2-cached-reader bash -c "make .just-build && make cover_integration_profile"
+
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-cassandra-running-history-queue-v2-cached-reader-integration-coverage
+          path: .build/coverage/*.out
+
 
   golang-integration-test-with-cassandra-and-elasticsearch-v7:
     name: Golang integration test with cassandra and elasticsearch v7

--- a/docker/github_actions/docker-compose.yml
+++ b/docker/github_actions/docker-compose.yml
@@ -185,6 +185,32 @@ services:
         aliases:
           - integration-test
 
+  integration-test-cassandra-queue-v2-cached-reader:
+    build:
+      context: ../../
+      dockerfile: ./docker/github_actions/Dockerfile${DOCKERFILE_SUFFIX}
+    environment:
+      - "CASSANDRA=1"
+      - "CASSANDRA_SEEDS=cassandra"
+      - "ES_SEEDS=elasticsearch"
+      - "KAFKA_SEEDS=kafka"
+      - "TEST_TAG=esintegration"
+      - "ENABLE_QUEUE_V2=true"
+      - "ENABLE_QUEUE_V2_CACHED_QUEUE_READER=true"
+    depends_on:
+      cassandra:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_started
+      kafka:
+        condition: service_started
+    volumes:
+      - ../../:/cadence
+    networks:
+      services-network:
+        aliases:
+          - integration-test
+
   integration-test-mysql:
     build:
       context: ../../

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -55,6 +55,8 @@ func TestIntegrationSuite(t *testing.T) {
 		configPath = "testdata/integration_queuev2_cluster.yaml"
 		if os.Getenv("ENABLE_QUEUE_V2_ALERT") == "true" {
 			configPath = "testdata/integration_queuev2_with_alert_cluster.yaml"
+		} else if os.Getenv("ENABLE_QUEUE_V2_CACHED_QUEUE_READER") == "true" {
+			configPath = "testdata/integration_queuev2_cached_reader_cluster.yaml"
 		}
 	}
 	clusterConfig, err := GetTestClusterConfig(configPath)

--- a/host/testdata/dynamicconfig/integration_queuev2_cached_reader_test.yaml
+++ b/host/testdata/dynamicconfig/integration_queuev2_cached_reader_test.yaml
@@ -1,0 +1,15 @@
+history.enableTimerQueueV2:
+- value: true
+  constraints: {}
+history.enableTransferQueueV2:
+- value: true
+  constraints: {}
+frontend.warmupDuration:
+- value: "1s"
+  constraints: {}
+history.timerProcessorEnableCachedScheduledQueue:
+- value: true
+  constraints: {}
+history.timerProcessorCachedQueueReaderMode:
+- value: "enabled"
+  constraints: {}

--- a/host/testdata/integration_queuev2_cached_reader_cluster.yaml
+++ b/host/testdata/integration_queuev2_cached_reader_cluster.yaml
@@ -1,0 +1,16 @@
+enablearchival: true
+clusterno: 0
+messagingclientconfig:
+  usemock: true
+historyconfig:
+  numhistoryshards: 4
+  numhistoryhosts: 1
+matchingconfig:
+  nummatchinghosts: 1
+workerconfig:
+  enablearchiver: true
+  enablereplicator: true
+  enableindexer: false
+dynamicclientconfig:
+  filepath: "testdata/dynamicconfig/integration_queuev2_cached_reader_test.yaml"
+  pollInterval: "10s"


### PR DESCRIPTION
**What changed?**

Added a new optional CI job (`golang-integration-test-with-cassandra-running-history-queue-v2-cached-reader`) that runs the full queue-v2 integration suite with `CachedQueueReader` enabled (`timerProcessorEnableCachedScheduledQueue=true`, mode `"enabled"`). Relates to #7953.

**Why?**

`CachedQueueReader` was added in #8109 and wired to the timer queue factory in #8129, but has no integration-level coverage. Previously only unit tests exercised it. Running the full cassandra integration suite with the cache active will surface correctness issues under realistic conditions. The job is marked `continue-on-error: true` so failures don't block PRs while the feature matures.

**How did you test it?**

```
make pr    # tidy → go-generate → fmt → lint — passed, no file changes
make build # compile-check all packages and test files — passed
```

The new CI job can be verified by checking the Actions tab for the `Golang integration test with running history queue v2 with cached reader` job.

**Potential risks**

N/A — only CI config, Docker Compose service definition, and test cluster config files changed. No production code modified.

**Release notes**

N/A — internal CI change.

**Documentation Changes**

N/A