### PR TITLE
fix(schedule): validate and forward SearchAttributes on UpdateSchedule

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -323,8 +323,8 @@ func (wh *WorkflowHandler) UpdateSchedule(
 	if scheduleID == "" {
 		return nil, &types.BadRequestError{Message: "ScheduleID is not set on request."}
 	}
-	if request.GetSpec() == nil && request.GetAction() == nil && request.GetPolicies() == nil {
-		return nil, &types.BadRequestError{Message: "At least one of Spec, Action, or Policies must be set on request."}
+	if request.GetSpec() == nil && request.GetAction() == nil && request.GetPolicies() == nil && request.GetSearchAttributes() == nil {
+		return nil, &types.BadRequestError{Message: "At least one of Spec, Action, Policies, or SearchAttributes must be set on request."}
 	}
 	if err := validateSchedulePolicies(request.GetPolicies()); err != nil {
 		return nil, err
@@ -335,11 +335,15 @@ func (wh *WorkflowHandler) UpdateSchedule(
 			return nil, err
 		}
 	}
+	if err := validateUserSearchAttributes(request.GetSearchAttributes()); err != nil {
+		return nil, err
+	}
 
 	signal := scheduler.UpdateSignal{
-		Spec:     request.GetSpec(),
-		Action:   request.GetAction(),
-		Policies: request.GetPolicies(),
+		Spec:             request.GetSpec(),
+		Action:           request.GetAction(),
+		Policies:         request.GetPolicies(),
+		SearchAttributes: request.GetSearchAttributes(),
 	}
 
 	if err := wh.signalScheduleWorkflow(ctx, domainName, scheduleID, scheduler.SignalNameUpdate, signal); err != nil {

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -779,6 +779,65 @@ func TestUpdateSchedule(t *testing.T) {
 			mockFn:  func(f *scheduleTestFixture) {},
 			wantErr: true,
 		},
+		"reserved SA key rejected": {
+			request: &types.UpdateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				SearchAttributes: &types.SearchAttributes{
+					IndexedFields: map[string][]byte{"CadenceScheduleState": []byte(`"active"`)},
+				},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"search attributes only update succeeds": {
+			request: &types.UpdateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				SearchAttributes: &types.SearchAttributes{
+					IndexedFields: map[string][]byte{"MyField": []byte(`"hello"`)},
+				},
+			},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.HistorySignalWorkflowExecutionRequest, _ ...yarpc.CallOption) error {
+						assert.Equal(t, scheduler.SignalNameUpdate, req.SignalRequest.SignalName)
+						var signal scheduler.UpdateSignal
+						require.NoError(t, json.Unmarshal(req.SignalRequest.Input, &signal))
+						assert.Nil(t, signal.Spec)
+						assert.Nil(t, signal.Action)
+						assert.Nil(t, signal.Policies)
+						require.NotNil(t, signal.SearchAttributes)
+						assert.Equal(t, []byte(`"hello"`), signal.SearchAttributes.IndexedFields["MyField"])
+						return nil
+					})
+			},
+			wantErr: false,
+		},
+		"search attributes forwarded with spec update": {
+			request: &types.UpdateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Spec:       &types.ScheduleSpec{CronExpression: "0 * * * *"},
+				SearchAttributes: &types.SearchAttributes{
+					IndexedFields: map[string][]byte{"MyField": []byte(`"hello"`)},
+				},
+			},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.HistorySignalWorkflowExecutionRequest, _ ...yarpc.CallOption) error {
+						var signal scheduler.UpdateSignal
+						require.NoError(t, json.Unmarshal(req.SignalRequest.Input, &signal))
+						assert.Equal(t, "0 * * * *", signal.Spec.CronExpression)
+						require.NotNil(t, signal.SearchAttributes)
+						assert.Equal(t, []byte(`"hello"`), signal.SearchAttributes.IndexedFields["MyField"])
+						return nil
+					})
+			},
+			wantErr: false,
+		},
 	}
 
 	for name, tt := range tests {

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -140,12 +140,13 @@ const (
 // SchedulerWorkflowInput is the input to the scheduler workflow.
 // It carries the schedule definition and any prior state (for ContinueAsNew).
 type SchedulerWorkflowInput struct {
-	Domain     string                 `json:"domain"`
-	ScheduleID string                 `json:"scheduleId"`
-	Spec       types.ScheduleSpec     `json:"spec"`
-	Action     types.ScheduleAction   `json:"action"`
-	Policies   types.SchedulePolicies `json:"policies"`
-	State      SchedulerWorkflowState `json:"state"`
+	Domain           string                  `json:"domain"`
+	ScheduleID       string                  `json:"scheduleId"`
+	Spec             types.ScheduleSpec      `json:"spec"`
+	Action           types.ScheduleAction    `json:"action"`
+	Policies         types.SchedulePolicies  `json:"policies"`
+	SearchAttributes *types.SearchAttributes `json:"searchAttributes,omitempty"`
+	State            SchedulerWorkflowState  `json:"state"`
 }
 
 // SchedulerWorkflowState is the mutable runtime state that survives ContinueAsNew.
@@ -220,9 +221,10 @@ type UnpauseSignal struct {
 
 // UpdateSignal is the payload sent with an update signal.
 type UpdateSignal struct {
-	Spec     *types.ScheduleSpec     `json:"spec,omitempty"`
-	Action   *types.ScheduleAction   `json:"action,omitempty"`
-	Policies *types.SchedulePolicies `json:"policies,omitempty"`
+	Spec             *types.ScheduleSpec     `json:"spec,omitempty"`
+	Action           *types.ScheduleAction   `json:"action,omitempty"`
+	Policies         *types.SchedulePolicies `json:"policies,omitempty"`
+	SearchAttributes *types.SearchAttributes `json:"searchAttributes,omitempty"`
 }
 
 // BackfillSignal is the payload sent with a backfill signal.

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -21,6 +21,7 @@
 package scheduler
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -359,6 +360,11 @@ func buildScheduleSearchAttributes(input *SchedulerWorkflowInput, state *Schedul
 	if sw := input.Action.StartWorkflow; sw != nil && sw.WorkflowType != nil && sw.WorkflowType.Name != "" {
 		sa[SearchAttrScheduleWorkflowType] = sw.WorkflowType.Name
 	}
+	if input.SearchAttributes != nil {
+		for k, v := range input.SearchAttributes.IndexedFields {
+			sa[k] = json.RawMessage(v)
+		}
+	}
 	return sa
 }
 
@@ -387,7 +393,7 @@ func handleUnpause(logger *zap.Logger, sig UnpauseSignal, state *SchedulerWorkfl
 }
 
 func handleUpdate(logger *zap.Logger, sig UpdateSignal, input *SchedulerWorkflowInput, state *SchedulerWorkflowState) bool {
-	if sig.Spec == nil && sig.Action == nil && sig.Policies == nil {
+	if sig.Spec == nil && sig.Action == nil && sig.Policies == nil && sig.SearchAttributes == nil {
 		logger.Info("ignoring empty update signal")
 		return false
 	}
@@ -440,6 +446,10 @@ func handleUpdate(logger *zap.Logger, sig UpdateSignal, input *SchedulerWorkflow
 				zap.Int("clearedCount", len(state.RunningWorkflows)))
 			state.RunningWorkflows = nil
 		}
+	}
+	if sig.SearchAttributes != nil {
+		input.SearchAttributes = sig.SearchAttributes
+		changed = true
 	}
 	if changed {
 		logger.Info("schedule updated")

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -23,6 +23,7 @@ package scheduler
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/robfig/cron/v3"
@@ -362,6 +363,9 @@ func buildScheduleSearchAttributes(input *SchedulerWorkflowInput, state *Schedul
 	}
 	if input.SearchAttributes != nil {
 		for k, v := range input.SearchAttributes.IndexedFields {
+			if strings.HasPrefix(k, "CadenceSchedule") {
+				continue
+			}
 			sa[k] = json.RawMessage(v)
 		}
 	}

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -21,6 +21,7 @@
 package scheduler
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -633,6 +634,18 @@ func TestHandleUpdate(t *testing.T) {
 			wantPol:     types.ScheduleOverlapPolicyConcurrent,
 			wantChanged: true,
 		},
+		{
+			name: "update search attributes only",
+			sig: UpdateSignal{
+				SearchAttributes: &types.SearchAttributes{
+					IndexedFields: map[string][]byte{"MyField": []byte(`"hello"`)},
+				},
+			},
+			wantCron:    "0 * * * *",
+			wantWF:      "old-workflow",
+			wantPol:     types.ScheduleOverlapPolicySkipNew,
+			wantChanged: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -644,6 +657,9 @@ func TestHandleUpdate(t *testing.T) {
 			assert.Equal(t, tt.wantCron, input.Spec.CronExpression)
 			assert.Equal(t, tt.wantWF, input.Action.StartWorkflow.WorkflowType.Name)
 			assert.Equal(t, tt.wantPol, input.Policies.OverlapPolicy)
+			if tt.sig.SearchAttributes != nil {
+				assert.Equal(t, tt.sig.SearchAttributes, input.SearchAttributes)
+			}
 		})
 	}
 
@@ -1146,6 +1162,29 @@ func TestBuildScheduleSearchAttributes(t *testing.T) {
 			want: map[string]interface{}{
 				SearchAttrScheduleState:        ScheduleStateActive,
 				SearchAttrScheduleWorkflowType: "wf",
+			},
+		},
+		{
+			name: "user search attributes are included in result",
+			input: &SchedulerWorkflowInput{
+				Spec: types.ScheduleSpec{CronExpression: "0 6 * * *"},
+				Action: types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType: &types.WorkflowType{Name: "my-workflow"},
+					},
+				},
+				SearchAttributes: &types.SearchAttributes{
+					IndexedFields: map[string][]byte{
+						"MyField": []byte(`"hello"`),
+					},
+				},
+			},
+			state: &SchedulerWorkflowState{Paused: false},
+			want: map[string]interface{}{
+				SearchAttrScheduleState:        ScheduleStateActive,
+				SearchAttrScheduleCron:         "0 6 * * *",
+				SearchAttrScheduleWorkflowType: "my-workflow",
+				"MyField":                      json.RawMessage(`"hello"`),
 			},
 		},
 	}

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1187,6 +1187,30 @@ func TestBuildScheduleSearchAttributes(t *testing.T) {
 				"MyField":                      json.RawMessage(`"hello"`),
 			},
 		},
+		{
+			name: "reserved CadenceSchedule keys in user SAs are silently skipped",
+			input: &SchedulerWorkflowInput{
+				Spec: types.ScheduleSpec{CronExpression: "0 6 * * *"},
+				Action: types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType: &types.WorkflowType{Name: "my-workflow"},
+					},
+				},
+				SearchAttributes: &types.SearchAttributes{
+					IndexedFields: map[string][]byte{
+						"CadenceScheduleState": []byte(`"injected"`),
+						"MyField":              []byte(`"hello"`),
+					},
+				},
+			},
+			state: &SchedulerWorkflowState{Paused: false},
+			want: map[string]interface{}{
+				SearchAttrScheduleState:        ScheduleStateActive,
+				SearchAttrScheduleCron:         "0 6 * * *",
+				SearchAttrScheduleWorkflowType: "my-workflow",
+				"MyField":                      json.RawMessage(`"hello"`),
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

- Added SearchAttributes field to UpdateSignal and SchedulerWorkflowInput in the scheduler package
- Updated handleUpdate to apply incoming SearchAttributes from the signal into workflow input
- Updated buildScheduleSearchAttributes to merge user-supplied SAs into the map passed to workflow.UpsertSearchAttributes on every execution (including after ContinueAsNew)
- Updated UpdateSchedule handler to validate user SAs (rejecting reserved CadenceSchedule* keys) and forward them in the update signal

**Why?**

- UpdateScheduleRequest has a SearchAttributes field that was silently dropped on the server — it was never validated or forwarded to the scheduler workflow. This meant users could not update the custom search attributes on an existing schedule, making them effectively immutable after creation.

**How did you test it?**

- Unit tests in TestHandleUpdate: new case verifying SA-only updates are applied to workflow input 
- Unit tests in TestBuildScheduleSearchAttributes: new case verifying user SAs are included in the returned map as json.RawMessage values
- Unit tests in TestUpdateSchedule: three new cases covering reserved-key rejection, SA-only update forwarding, and SA forwarding alongside a spec update
- make pr and make test pass cleanly

**Potential risks**

- Low. The change is additive — existing update requests without SearchAttributes are unaffected. The json.RawMessage wrapping is required to avoid double-encoding pre-serialized visibility index bytes; omitting it would corrupt SA values in the visibility layer, but this matches the existing pattern for how SA bytes flow through the system.

**Release notes**

-   UpdateSchedule now validates and applies SearchAttributes. Custom search attributes on a schedule can be updated after creation. Requests with CadenceSchedule* prefix keys in SearchAttributes are rejected with a BadRequestError.

**Documentation Changes**

