### PR TITLE
fix(gitar): gitar rule for headers

### DIFF
--- a/.gitar/rules/pr-description-quality.md
+++ b/.gitar/rules/pr-description-quality.md
@@ -68,11 +68,11 @@ From https://cbea.ms/git-commit/#why-not-how:
 - ❌ "Note:" paragraphs or explanatory text outside recommendations
 - ❌ Grouping recommendations by type
 
-## Section Names (Use EXACT Brackets)
+## Section Names (Use EXACT values from list)
 
-- **[What changed?]**
-- **[Why?]**
-- **[How did you test it?]**
-- **[Potential risks]**
-- **[Release notes]**
-- **[Documentation Changes]**
+- **What changed?**
+- **Why?**
+- **How did you test it?**
+- **Potential risks**
+- **Release notes**
+- **Documentation Changes**


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Updated gitar rule for headers, removing brackets.

**Why?**
Gitar was attempting to match the brackets and it was causing any PR description using the template to fail, because it does not contain brackets.

**How did you test it?**
Testing it in this PR. Using the same template with the update rule to see if gitar flags an issue with the template. This is the only way to test it.

**Potential risks**
N/A

**Release notes**
N/A

**Documentation Changes**
N/A
