### PR TITLE
fix(frontend): auto-generate backfill ID when BackfillSchedule omits it

### DIFF
--- a/common/definition/indexedKeys.go
+++ b/common/definition/indexedKeys.go
@@ -53,7 +53,8 @@ const (
 	CadenceScheduleTime       = "CadenceScheduleTime"
 	CadenceScheduleIsBackfill = "CadenceScheduleIsBackfill"
 	// CadenceScheduleBackfillID is set on target workflows started by a schedule
-	// backfill when the client supplied a non-empty BackfillID (keyword).
+	// backfill, keyed by BackfillScheduleRequest.backfill_id (keyword). The frontend
+	// assigns a UUID when the client omits the id.
 	CadenceScheduleBackfillID = "CadenceScheduleBackfillID"
 
 	// Schedule search attributes set on the scheduler workflow itself (used by ListSchedules).

--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -527,13 +527,20 @@ func (wh *WorkflowHandler) BackfillSchedule(
 		StartTime:     request.GetStartTime(),
 		EndTime:       request.GetEndTime(),
 		OverlapPolicy: request.GetOverlapPolicy(),
-		BackfillID:    request.GetBackfillID(),
+		BackfillID:    resolveBackfillID(request.GetBackfillID()),
 	}
 
 	if err := wh.signalScheduleWorkflow(ctx, domainName, scheduleID, scheduler.SignalNameBackfill, signal); err != nil {
 		return nil, err
 	}
 	return &types.BackfillScheduleResponse{}, nil
+}
+
+func resolveBackfillID(clientID string) string {
+	if id := strings.TrimSpace(clientID); id != "" {
+		return id
+	}
+	return uuid.New().String()
 }
 
 func (wh *WorkflowHandler) ListSchedules(

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -933,6 +934,15 @@ func TestDeleteSchedule(t *testing.T) {
 	}
 }
 
+func TestResolveBackfillID(t *testing.T) {
+	assert.Equal(t, "bf-1", resolveBackfillID("bf-1"))
+	assert.Equal(t, "bf-1", resolveBackfillID("  bf-1  "))
+	_, err := uuid.Parse(resolveBackfillID(""))
+	require.NoError(t, err)
+	_, err = uuid.Parse(resolveBackfillID("  \t  "))
+	require.NoError(t, err)
+}
+
 func TestBackfillSchedule(t *testing.T) {
 	now := time.Now()
 	tests := map[string]struct {
@@ -991,6 +1001,47 @@ func TestBackfillSchedule(t *testing.T) {
 						require.NoError(t, json.Unmarshal(req.SignalRequest.Input, &signal))
 						assert.Equal(t, types.ScheduleOverlapPolicyConcurrent, signal.OverlapPolicy)
 						assert.Equal(t, "bf-1", signal.BackfillID)
+						return nil
+					})
+			},
+			wantErr: false,
+		},
+		"success without backfill id assigns uuid": {
+			request: &types.BackfillScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				StartTime:  now.Add(-time.Hour),
+				EndTime:    now,
+			},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.HistorySignalWorkflowExecutionRequest, _ ...yarpc.CallOption) error {
+						var signal scheduler.BackfillSignal
+						require.NoError(t, json.Unmarshal(req.SignalRequest.Input, &signal))
+						_, err := uuid.Parse(signal.BackfillID)
+						require.NoError(t, err, "expected server-generated UUID backfill id, got %q", signal.BackfillID)
+						return nil
+					})
+			},
+			wantErr: false,
+		},
+		"whitespace backfill id assigns uuid": {
+			request: &types.BackfillScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				StartTime:  now.Add(-time.Hour),
+				EndTime:    now,
+				BackfillID: "   ",
+			},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.HistorySignalWorkflowExecutionRequest, _ ...yarpc.CallOption) error {
+						var signal scheduler.BackfillSignal
+						require.NoError(t, json.Unmarshal(req.SignalRequest.Input, &signal))
+						_, err := uuid.Parse(signal.BackfillID)
+						require.NoError(t, err)
 						return nil
 					})
 			},


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
if empty/whitespace → uuid.New().String(). BackfillSchedule uses it on the backfill signal.

**Why?**
Every backfill should have a stable grouping key for CadenceScheduleBackfillID on target workflows (visibility/UI).
Previously, omitted backfill_id meant empty id → SA not stamped (activity.go only sets SA when BackfillID != "").
UI can still send its own UUID; API/CLI callers are covered without requiring client-side generation.

**How did you test it?**
`go test -count=1 -run 'TestResolveBackfillID|TestBackfillSchedule' ./service/frontend/api/...`

**Potential risks**
N/A

**Release notes**
N/A

**Documentation Changes**
N/A
