### PR TITLE
fix(schedule): forward SearchAttributes into SchedulerWorkflowInput on CreateSchedule

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -152,10 +152,11 @@ func (wh *WorkflowHandler) CreateSchedule(
 	}
 
 	workflowInput := scheduler.SchedulerWorkflowInput{
-		Domain:     domainName,
-		ScheduleID: scheduleID,
-		Spec:       *request.GetSpec(),
-		Action:     *request.GetAction(),
+		Domain:           domainName,
+		ScheduleID:       scheduleID,
+		Spec:             *request.GetSpec(),
+		Action:           *request.GetAction(),
+		SearchAttributes: request.GetSearchAttributes(),
 	}
 	if request.GetPolicies() != nil {
 		workflowInput.Policies = *request.GetPolicies()

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -280,6 +280,34 @@ func TestCreateSchedule(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		"search attributes forwarded into workflow input": {
+			request: &types.CreateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "my-schedule",
+				Spec:       &types.ScheduleSpec{CronExpression: "*/5 * * * *"},
+				Action: &types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType: &types.WorkflowType{Name: "my-workflow"},
+						TaskList:     &types.TaskList{Name: "my-tasklist"},
+					},
+				},
+				SearchAttributes: &types.SearchAttributes{
+					IndexedFields: map[string][]byte{"CustomStringField": []byte(`"hello"`)},
+				},
+			},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.HistoryStartWorkflowExecutionRequest, _ ...yarpc.CallOption) (*types.StartWorkflowExecutionResponse, error) {
+						var input scheduler.SchedulerWorkflowInput
+						require.NoError(t, json.Unmarshal(req.StartRequest.Input, &input))
+						require.NotNil(t, input.SearchAttributes)
+						assert.Equal(t, []byte(`"hello"`), input.SearchAttributes.IndexedFields["CustomStringField"])
+						return &types.StartWorkflowExecutionResponse{RunID: "test-run-id"}, nil
+					})
+			},
+			wantErr: false,
+		},
 	}
 
 	for name, tt := range tests {


### PR DESCRIPTION
## Summary
Intent:
- Fix a bug where custom SearchAttributes passed to CreateSchedule were lost after the scheduler workflow's first ContinueAsNew
- SearchAttributes were previously passed only to StartWorkflowExecution (setting them on the initial execution) but were never stored in SchedulerWorkflowInput, so buildScheduleSearchAttributes couldn't re-upsert them after ContinueAsNew

Changes:
- Populate SearchAttributes into SchedulerWorkflowInput when building it in CreateSchedule, so it survives ContinueAsNew via buildScheduleSearchAttributes
- Added test case verifying SearchAttributes are present in the serialized workflow input

## Test Plan
go test -count=1 -run 'TestCreateSchedule' ./service/frontend/api/

## Revert Plan
Revert this PR via `git revert <commit_sha>`.


