### PR TITLE
feat: Add `--latest_time` support for `DecisionCompletedTime` reset type

### DIFF
--- a/tools/cli/defs.go
+++ b/tools/cli/defs.go
@@ -93,7 +93,7 @@ var resetTypesMap = map[string]string{
 	resetTypeLastDecisionCompleted:  "",
 	resetTypeLastContinuedAsNew:     "",
 	resetTypeBadBinary:              FlagResetBadBinaryChecksum,
-	resetTypeDecisionCompletedTime:  FlagEarliestTime,
+	resetTypeDecisionCompletedTime:  "",
 	resetTypeFirstDecisionScheduled: "",
 	resetTypeLastDecisionScheduled:  "",
 }

--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -233,11 +233,20 @@ func newWorkflowCommands() []*cli.Command {
 				&cli.StringFlag{
 					Name:    FlagEarliestTime,
 					Aliases: []string{"et"},
-					Usage: "EarliestTime of decision start time, required for resetType of DecisionCompletedTime." +
+					Usage: "EarliestTime of decision start time, one possible flag for resetType of DecisionCompletedTime. " +
 						"Supported formats are '2006-01-02T15:04:05+07:00', raw UnixNano and " +
 						"time range (N<duration>), where 0 < N < 1000000 and duration (full-notation/short-notation) can be second/s, " +
 						"minute/m, hour/h, day/d, week/w, month/M or year/y. For example, '15minute' or '15m' implies last 15 minutes, " +
-						"meaning that workflow will be reset to the first decision that completed in last 15 minutes.",
+						"meaning that workflow will be reset to the first decision that completed no earlier than 15 minutes ago.",
+				},
+				&cli.StringFlag{
+					Name:    FlagLatestTime,
+					Aliases: []string{"lt"},
+					Usage: "LatestTime of decision start time, one possible flag for resetType of DecisionCompletedTime. " +
+						"Supported formats are '2006-01-02T15:04:05+07:00', raw UnixNano and " +
+						"time range (N<duration>), where 0 < N < 1000000 and duration (full-notation/short-notation) can be second/s, " +
+						"minute/m, hour/h, day/d, week/w, month/M or year/y. For example, '15minute' or '15m' implies 15 minutes ago, " +
+						"meaning that workflow will be reset to the last decision that completed no later than 15 minutes ago.",
 				},
 				&cli.BoolFlag{
 					Name:  FlagSkipSignalReapply,
@@ -335,11 +344,20 @@ func newWorkflowCommands() []*cli.Command {
 				&cli.StringFlag{
 					Name:    FlagEarliestTime,
 					Aliases: []string{"et"},
-					Usage: "EarliestTime of decision start time, required for resetType of DecisionCompletedTime." +
+					Usage: "EarliestTime of decision start time, one possible flag for resetType of DecisionCompletedTime. " +
 						"Supported formats are '2006-01-02T15:04:05+07:00', raw UnixNano and " +
 						"time range (N<duration>), where 0 < N < 1000000 and duration (full-notation/short-notation) can be second/s, " +
 						"minute/m, hour/h, day/d, week/w, month/M or year/y. For example, '15minute' or '15m' implies last 15 minutes, " +
-						"meaning that workflow will be reset to the first decision that completed in last 15 minutes.",
+						"meaning that workflow will be reset to the first decision that completed no earlier than 15 minutes ago.",
+				},
+				&cli.StringFlag{
+					Name:    FlagLatestTime,
+					Aliases: []string{"lt"},
+					Usage: "LatestTime of decision start time, one possible flag for resetType of DecisionCompletedTime. " +
+						"Supported formats are '2006-01-02T15:04:05+07:00', raw UnixNano and " +
+						"time range (N<duration>), where 0 < N < 1000000 and duration (full-notation/short-notation) can be second/s, " +
+						"minute/m, hour/h, day/d, week/w, month/M or year/y. For example, '15minute' or '15m' implies 15 minutes ago, " +
+						"meaning that workflow will be reset to the last decision that completed no later than 15 minutes ago.",
 				},
 			},
 			Action: ResetInBatch,

--- a/tools/cli/workflow_commands.go
+++ b/tools/cli/workflow_commands.go
@@ -2359,13 +2359,30 @@ func getResetEventIDByType(
 			return
 		}
 	case resetTypeDecisionCompletedTime:
-		earliestTime, err := parseTime(c.String(FlagEarliestTime), 0)
-		if err != nil {
-			return "", 0, fmt.Errorf("Get reset event id by type failed: %w", err)
+		hasEarliest := c.IsSet(FlagEarliestTime)
+		hasLatest := c.IsSet(FlagLatestTime)
+		if hasEarliest == hasLatest {
+			return "", 0, fmt.Errorf("resetType %s requires exactly one of --%s or --%s",
+				resetTypeDecisionCompletedTime, FlagEarliestTime, FlagLatestTime)
 		}
-		decisionFinishID, err = getEarliestDecisionID(ctx, domain, wid, rid, earliestTime, frontendClient)
-		if err != nil {
-			return "", 0, fmt.Errorf("Get reset event id by type failed: %w", err)
+		if hasEarliest {
+			earliestTime, err := parseTime(c.String(FlagEarliestTime), 0)
+			if err != nil {
+				return "", 0, fmt.Errorf("Get reset event id by type failed: %w", err)
+			}
+			decisionFinishID, err = getEarliestDecisionID(ctx, domain, wid, rid, earliestTime, frontendClient)
+			if err != nil {
+				return "", 0, fmt.Errorf("Get reset event id by type failed: %w", err)
+			}
+		} else {
+			latestTime, err := parseTime(c.String(FlagLatestTime), 0)
+			if err != nil {
+				return "", 0, fmt.Errorf("Get reset event id by type failed: %w", err)
+			}
+			decisionFinishID, err = getLatestDecisionID(ctx, domain, wid, rid, latestTime, frontendClient)
+			if err != nil {
+				return "", 0, fmt.Errorf("Get reset event id by type failed: %w", err)
+			}
 		}
 	case resetTypeFirstDecisionScheduled:
 		decisionFinishID, err = getFirstDecisionTaskByType(ctx, domain, wid, rid, frontendClient, types.EventTypeDecisionTaskScheduled)
@@ -2723,6 +2740,49 @@ OuterLoop:
 			if e.GetEventType() == types.EventTypeDecisionTaskCompleted {
 				if e.GetTimestamp() >= earliestTime {
 					decisionFinishID = e.ID
+					break OuterLoop
+				}
+			}
+		}
+		if len(resp.NextPageToken) != 0 {
+			req.NextPageToken = resp.NextPageToken
+		} else {
+			break
+		}
+	}
+	if decisionFinishID == 0 {
+		return 0, printErrorAndReturn("Get DecisionFinishID failed", fmt.Errorf("no DecisionFinishID"))
+	}
+	return
+}
+
+func getLatestDecisionID(
+	ctx context.Context,
+	domain string, wid string,
+	rid string, latestTime int64,
+	frontendClient frontend.Client,
+) (decisionFinishID int64, err error) {
+	req := &types.GetWorkflowExecutionHistoryRequest{
+		Domain: domain,
+		Execution: &types.WorkflowExecution{
+			WorkflowID: wid,
+			RunID:      rid,
+		},
+		MaximumPageSize: 1000,
+		NextPageToken:   nil,
+	}
+
+OuterLoop:
+	for {
+		resp, err := frontendClient.GetWorkflowExecutionHistory(ctx, req)
+		if err != nil {
+			return 0, printErrorAndReturn("GetWorkflowExecutionHistory failed", err)
+		}
+		for _, e := range resp.GetHistory().GetEvents() {
+			if e.GetEventType() == types.EventTypeDecisionTaskCompleted {
+				if e.GetTimestamp() <= latestTime {
+					decisionFinishID = e.ID
+				} else {
 					break OuterLoop
 				}
 			}

--- a/tools/cli/workflow_commands_test.go
+++ b/tools/cli/workflow_commands_test.go
@@ -2068,31 +2068,116 @@ func Test_GetResetEventIDByType_BadBinary(t *testing.T) {
 }
 
 func Test_GetResetEventIDByType_DecisionCompletedTime(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	serverFrontendClient := frontend.NewMockClient(mockCtrl)
-	app := NewCliApp(&clientFactoryMock{
-		serverFrontendClient: serverFrontendClient,
-	})
-	set := flag.NewFlagSet("test", 0)
-	c := getMockContext(t, set, app)
-	serverFrontendClient.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), gomock.Any()).Return(&types.GetWorkflowExecutionHistoryResponse{
+	newContextWithFlags := func(app *cli.App, set func(fs *flag.FlagSet)) *cli.Context {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		fs.String(FlagDomain, "", "domain")
+		fs.String(FlagWorkflowID, "", "workflow_id")
+		fs.String(FlagRunID, "", "run_id")
+		fs.String(FlagReason, "", "reason")
+		fs.String(FlagResetType, "", "reset_type")
+		fs.String(FlagEarliestTime, "", "earliest_time")
+		fs.String(FlagLatestTime, "", "latest_time")
+		set(fs)
+		return cli.NewContext(app, fs, nil)
+	}
+
+	history := &types.GetWorkflowExecutionHistoryResponse{
 		History: &types.History{
 			Events: []*types.HistoryEvent{
-				{
-					ID: 15,
-				},
+				{ID: 1, EventType: types.EventTypeDecisionTaskCompleted.Ptr(), Timestamp: common.Int64Ptr(10)},
+				{ID: 3, EventType: types.EventTypeDecisionTaskCompleted.Ptr(), Timestamp: common.Int64Ptr(20)},
+				{ID: 5, EventType: types.EventTypeDecisionTaskCompleted.Ptr(), Timestamp: common.Int64Ptr(30)},
 			},
 		},
-	}, nil).Times(1)
-	_, decisionID, err := getResetEventIDByType(context.Background(), c, resetTypeDecisionCompletedTime, -1, "test-domain",
-		"test-workflow-id", "test-run-id", serverFrontendClient)
-	assert.Equal(t, int64(0), decisionID)
-	assert.ErrorContains(t, err, "no DecisionFinishID")
+	}
 
-	set.String(FlagEarliestTime, "20201025Test", "earliest_time")
-	_, _, err = getResetEventIDByType(context.Background(), c, resetTypeDecisionCompletedTime, -1, "test-domain",
-		"test-workflow-id", "test-run-id", serverFrontendClient)
-	assert.ErrorContains(t, err, "use UTC format")
+	tests := []struct {
+		name        string
+		setFlags    func(fs *flag.FlagSet)
+		mockHistory bool
+		wantErr     bool
+		errContains string
+		wantID      int64
+	}{
+		{
+			name: "latest_time picks last decision <= T",
+			setFlags: func(fs *flag.FlagSet) {
+				fs.Set(FlagResetType, resetTypeDecisionCompletedTime)
+				fs.Set(FlagLatestTime, "25")
+			},
+			mockHistory: true,
+			wantID:      3,
+		},
+		{
+			name: "invalid time value fails with a format error",
+			setFlags: func(fs *flag.FlagSet) {
+				fs.Set(FlagResetType, resetTypeDecisionCompletedTime)
+				fs.Set(FlagEarliestTime, "20201025Test")
+			},
+			wantErr:     true,
+			errContains: "use UTC format",
+		},
+		{
+			name: "earliest_time still picks first decision >= T",
+			setFlags: func(fs *flag.FlagSet) {
+				fs.Set(FlagResetType, resetTypeDecisionCompletedTime)
+				fs.Set(FlagEarliestTime, "15")
+			},
+			mockHistory: true,
+			wantID:      3,
+		},
+		{
+			name: "neither flag set is an error",
+			setFlags: func(fs *flag.FlagSet) {
+				fs.Set(FlagResetType, resetTypeDecisionCompletedTime)
+			},
+			wantErr: true,
+		},
+		{
+			name: "both flags set is an error",
+			setFlags: func(fs *flag.FlagSet) {
+				fs.Set(FlagResetType, resetTypeDecisionCompletedTime)
+				fs.Set(FlagEarliestTime, "15")
+				fs.Set(FlagLatestTime, "25")
+			},
+			wantErr: true,
+		},
+		{
+			name: "latest_time with no decision <= T is an error",
+			setFlags: func(fs *flag.FlagSet) {
+				fs.Set(FlagResetType, resetTypeDecisionCompletedTime)
+				fs.Set(FlagLatestTime, "5")
+			},
+			mockHistory: true,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			serverFrontendClient := frontend.NewMockClient(mockCtrl)
+			app := NewCliApp(&clientFactoryMock{serverFrontendClient: serverFrontendClient})
+			if tt.mockHistory {
+				serverFrontendClient.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), gomock.Any()).Return(history, nil).Times(1)
+			}
+			c := newContextWithFlags(app, tt.setFlags)
+
+			_, decisionFinishID, err := getResetEventIDByType(
+				context.Background(), c, resetTypeDecisionCompletedTime, 0,
+				"test-domain", "test-workflow-id", "test-run-id", serverFrontendClient)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errContains != "" {
+					assert.ErrorContains(t, err, tt.errContains)
+				}
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantID, decisionFinishID)
+		})
+	}
 }
 
 func Test_GetResetEventIDByType_FirstDecisionScheduled_LastDecisionScheduled(t *testing.T) {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Added `--latest_time` support for `DecisionCompletedTime` reset type in Cadence CLI command
- `cadence workflow reset --reset_type DecisionCompletedTime` now accepts either `--earliest_time T` or `--latest_time T` (last decision completed <= T)
- Added `getLatestDecisionID` helper in workflow_commands.go
- `resetTypesMap[DecisionCompletedTime]` changed from requiring `FlagEarliestTime` to `""` (flag validation moved into `getResetEventIDByType`)
- `getResetEventIDByType` enforces that exactly one of earliest_time/latest_time flags are passed in the command

Fixes: #8135 

**Why?**
When a system gets out of sync, operators need to reset every workflow in a domain back to a known-good point no-later-than a guaranteed sync time T

**How did you test it?**
Unit test: `go test -run 'Test_GetResetEventIDByType_DecisionCompletedTime' -v ./tools/cli/`


**Potential risks**
Reusing `DecisionCompletedTime` for two flags means the `resetTypesMap` entry is now empty, causing the flag requirement to be more opaque

**Release notes**
Add `--latest_time` support for `DecisionCompletedTime` reset type

**Documentation Changes**
N/A
