### PR TITLE
ci: add history simulation workflow

### DIFF
--- a/.github/workflows/history-simulation.yml
+++ b/.github/workflows/history-simulation.yml
@@ -17,6 +17,10 @@ jobs:
           - queuev2
           - queuev2_scheduled_cache_enabled
           - queuev2_split
+        include:
+          - scenario: queuev2_scheduled_cache_enabled
+            experimental: true
+    continue-on-error: ${{ matrix.experimental == true }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/history-simulation.yml
+++ b/.github/workflows/history-simulation.yml
@@ -1,0 +1,51 @@
+# This workflow runs history simulation scenarios via GithubActions matrix strategy.
+# Scenarios are defined in the `simulation/history/testdata/history_simulation_<scenario>.yaml` files.
+name: History Simulation
+on:
+  push:
+  pull_request:
+
+jobs:
+  history-simulation:
+    name: History Simulation (${{ matrix.scenario }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario:
+          - default
+          - queuev2
+          - queuev2_scheduled_cache_enabled
+          - queuev2_split
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.5'
+
+      - name: Run simulation
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 2
+          timeout_minutes: 20
+          command: |
+            ./simulation/history/run.sh --scenario ${{ matrix.scenario }}
+
+      - name: Upload test logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: history-${{ matrix.scenario }}-test.log
+          path: ./test.log
+
+      - name: Upload simulation output
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: history-${{ matrix.scenario }}-output
+          path: ./history-simulator-output/


### PR DESCRIPTION
**What changed?**

Added `.github/workflows/history-simulation.yml` to run history simulation scenarios in CI. Each of the 4 scenarios (`default`, `queuev2`, `queuev2_scheduled_cache_enabled`, `queuev2_split`) runs as an independent matrix job, mirroring the existing `replication-simulation.yml` pattern.

`queuev2_scheduled_cache_enabled` - experimental, so it is not required to pass CI.

**Why?**

History simulation tests existed locally but had no CI coverage. Without automated runs on every push/PR, regressions in history task scheduling and execution could go undetected. The replication simulation already runs this way; history simulation should follow the same model so both are consistently validated.

**How did you test it?**

CI will run all 4 scenarios on this PR. Each scenario can also be run locally:
```
./simulation/history/run.sh --scenario default
./simulation/history/run.sh --scenario queuev2
./simulation/history/run.sh --scenario queuev2_scheduled_cache_enabled
./simulation/history/run.sh --scenario queuev2_split
```

**Potential risks**

N/A — CI-only change, no production code modified.

**Release notes**

N/A

**Documentation Changes**

N/A