### PR TITLE
fix(queuev2): add pendingInjectBuffer to cachedQueueReader

### DIFF
--- a/common/persistence/tasks.go
+++ b/common/persistence/tasks.go
@@ -375,6 +375,8 @@ func (a HistoryTaskKey) Less(b HistoryTaskKey) bool { return a.Compare(b) < 0 }
 // Greater reports whether a sorts after b.
 func (a HistoryTaskKey) Greater(b HistoryTaskKey) bool { return a.Compare(b) > 0 }
 
+func (a HistoryTaskKey) GreaterOrEqual(b HistoryTaskKey) bool { return a.Compare(b) >= 0 }
+
 // Equal reports whether a and b are identical.
 func (a HistoryTaskKey) Equal(b HistoryTaskKey) bool { return a.Compare(b) == 0 }
 

--- a/common/persistence/tasks_test.go
+++ b/common/persistence/tasks_test.go
@@ -681,3 +681,66 @@ func TestIsTaskCorruptedWithAllTaskTypes(t *testing.T) {
 		}
 	})
 }
+
+func TestHistoryTaskKeyGreaterOrEqual(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name string
+		a, b HistoryTaskKey
+		want bool
+	}{
+		{
+			name: "equal keys",
+			a:    NewHistoryTaskKey(now, 1),
+			b:    NewHistoryTaskKey(now, 1),
+			want: true,
+		},
+		{
+			name: "higher taskID is greater or equal",
+			a:    NewHistoryTaskKey(now, 2),
+			b:    NewHistoryTaskKey(now, 1),
+			want: true,
+		},
+		{
+			name: "later time is greater or equal regardless of taskID",
+			a:    NewHistoryTaskKey(now.Add(time.Second), 0),
+			b:    NewHistoryTaskKey(now, 2),
+			want: true,
+		},
+		{
+			name: "smaller key is not greater or equal",
+			a:    NewHistoryTaskKey(now, 1),
+			b:    NewHistoryTaskKey(now, 2),
+			want: false,
+		},
+		{
+			name: "earlier time is not greater or equal",
+			a:    NewHistoryTaskKey(now, 2),
+			b:    NewHistoryTaskKey(now.Add(time.Second), 0),
+			want: false,
+		},
+		{
+			name: "minimum sentinel equals itself",
+			a:    MinimumHistoryTaskKey,
+			b:    MinimumHistoryTaskKey,
+			want: true,
+		},
+		{
+			name: "maximum is greater or equal than minimum",
+			a:    MaximumHistoryTaskKey,
+			b:    MinimumHistoryTaskKey,
+			want: true,
+		},
+		{
+			name: "minimum is not greater or equal than maximum",
+			a:    MinimumHistoryTaskKey,
+			b:    MaximumHistoryTaskKey,
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.a.GreaterOrEqual(tc.b))
+		})
+	}
+}

--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -111,16 +111,21 @@ type cachedQueueReader struct {
 	// Always update via updateExclusiveUpperBound to keep the prefetch loop in sync.
 	exclusiveUpperBound persistence.HistoryTaskKey
 
-	// prefetchTargetUpper is the exclusive upper key the current in-flight prefetch
+	// prefetchTargetUpper is the new exclusive upper key the current in-flight prefetch
 	// is aiming to reach. Set under mu before the DB call; cleared to
-	// MinimumHistoryTaskKey after the call completes.
-	// MinimumHistoryTaskKey means no prefetch is in-flight.
+	// MinimumHistoryTaskKey after the call completes
 	prefetchTargetUpper persistence.HistoryTaskKey
 
-	// pendingInjectBuffer accumulates tasks arriving via Inject while a prefetch
-	// DB call is in-flight and whose key falls in [exclusiveUpperBound, prefetchTargetUpper).
-	// Drained into the in-memory queue after the prefetch completes.
-	// Guarded by mu.
+	// pendingInjectBuffer holds tasks that arrive via Inject while a prefetch is in-flight
+	// with keys in [exclusiveUpperBound, prefetchTargetUpper).
+	//
+	// Without this buffer, a task saved to DB during a prefetch may be missed: its key is
+	// beyond the current exclusiveUpperBound, so it is not injected into the cache, and the
+	// prefetch may not see it due to a race between reading from DB and the task being saved.
+	// When the prefetch completes, it advances exclusiveUpperBound past the task's key,
+	// leaving the task permanently dropped from the cache.
+	//
+	// These tasks are drained into the cache after the prefetch extends the window.
 	pendingInjectBuffer []persistence.Task
 
 	ctx    context.Context
@@ -406,14 +411,16 @@ func (q *cachedQueueReader) isTaskCovered(key persistence.HistoryTaskKey) bool {
 	return !key.Less(q.inclusiveLowerBound) && key.Less(q.exclusiveUpperBound)
 }
 
-// isToBufferTask reports whether t should be placed in pendingInjectBuffer so it can
-// be drained once the in-flight prefetch extends the window to cover it.
+// isToBufferTask reports whether the given task key should be placed in pendingInjectBuffer
+// and within [exclusiveUpperBound, prefetchTargetUpper) and if a prefetch is in-flight
 // Caller must hold q.mu (read or write).
-func (q *cachedQueueReader) isToBufferTask(t persistence.Task) bool {
-	key := t.GetTaskKey()
-	return !q.prefetchTargetUpper.Equal(persistence.MinimumHistoryTaskKey) &&
-		!key.Less(q.inclusiveLowerBound) &&
-		key.Less(q.prefetchTargetUpper)
+func (q *cachedQueueReader) isToBufferTask(key persistence.HistoryTaskKey) bool {
+	// there is no in-flight prefetch, so no tasks should be buffered.
+	if q.prefetchTargetUpper.Equal(persistence.MinimumHistoryTaskKey) {
+		return false
+	}
+
+	return key.GreaterOrEqual(q.exclusiveUpperBound) && key.Less(q.prefetchTargetUpper)
 }
 
 // putTasks adds tasks to the cache and enforces the size cap.
@@ -561,7 +568,7 @@ func (q *cachedQueueReader) Inject(tasks []persistence.Task) {
 			covered = append(covered, t)
 			continue
 		}
-		if q.isToBufferTask(t) {
+		if q.isToBufferTask(t.GetTaskKey()) {
 			q.pendingInjectBuffer = append(q.pendingInjectBuffer, t)
 			continue
 		}

--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -111,6 +111,18 @@ type cachedQueueReader struct {
 	// Always update via updateExclusiveUpperBound to keep the prefetch loop in sync.
 	exclusiveUpperBound persistence.HistoryTaskKey
 
+	// prefetchTargetUpper is the exclusive upper key the current in-flight prefetch
+	// is aiming to reach. Set under mu before the DB call; cleared to
+	// MinimumHistoryTaskKey after the call completes.
+	// MinimumHistoryTaskKey means no prefetch is in-flight.
+	prefetchTargetUpper persistence.HistoryTaskKey
+
+	// pendingInjectBuffer accumulates tasks arriving via Inject while a prefetch
+	// DB call is in-flight and whose key falls in [exclusiveUpperBound, prefetchTargetUpper).
+	// Drained into the in-memory queue after the prefetch completes.
+	// Guarded by mu.
+	pendingInjectBuffer []persistence.Task
+
 	ctx    context.Context
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
@@ -270,6 +282,8 @@ func (q *cachedQueueReader) Clear() {
 	)
 
 	q.queue.Clear()
+	q.pendingInjectBuffer = q.pendingInjectBuffer[:0]
+	q.prefetchTargetUpper = persistence.MinimumHistoryTaskKey
 	q.updateInclusiveLowerBound(persistence.MinimumHistoryTaskKey)
 	q.updateExclusiveUpperBound(persistence.MinimumHistoryTaskKey)
 }
@@ -311,6 +325,12 @@ func (q *cachedQueueReader) prefetch() error {
 	// and to the configured page size (to bound each round-trip).
 	pageSize := min(availableCacheSize, q.options.PrefetchPageSize())
 
+	// Record the prefetch's target window so Inject can buffer tasks that arrive
+	// while the DB call is in-flight. Cleared inside the write lock after the call.
+	q.mu.Lock()
+	q.prefetchTargetUpper = exclusiveMaxTaskKey
+	q.mu.Unlock()
+
 	resp, err := q.base.GetTask(q.ctx, &GetTaskRequest{
 		Progress: &GetTaskProgress{
 			Range: Range{
@@ -323,13 +343,18 @@ func (q *cachedQueueReader) prefetch() error {
 		Predicate: NewUniversalPredicate(),
 		PageSize:  pageSize,
 	})
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	// Always clear the in-flight target and drain the buffer, even on error,
+	// so that buffered tasks are not permanently lost.
+	defer q.insertBufferedTasks()
+	q.prefetchTargetUpper = persistence.MinimumHistoryTaskKey
+
 	if err != nil {
 		q.logger.Error("prefetch failed", tag.Error(err))
 		return fmt.Errorf("prefetch failed: %w", err)
 	}
-
-	q.mu.Lock()
-	defer q.mu.Unlock()
 
 	// Upper bound changed while we held the lock (e.g. a concurrent Inject
 	// triggered RTrimBySize, shrinking the window). The fetched tasks start at
@@ -381,6 +406,16 @@ func (q *cachedQueueReader) isTaskCovered(key persistence.HistoryTaskKey) bool {
 	return !key.Less(q.inclusiveLowerBound) && key.Less(q.exclusiveUpperBound)
 }
 
+// isToBufferTask reports whether t should be placed in pendingInjectBuffer so it can
+// be drained once the in-flight prefetch extends the window to cover it.
+// Caller must hold q.mu (read or write).
+func (q *cachedQueueReader) isToBufferTask(t persistence.Task) bool {
+	key := t.GetTaskKey()
+	return !q.prefetchTargetUpper.Equal(persistence.MinimumHistoryTaskKey) &&
+		!key.Less(q.inclusiveLowerBound) &&
+		key.Less(q.prefetchTargetUpper)
+}
+
 // putTasks adds tasks to the cache and enforces the size cap.
 // Returns true if RTrimBySize fired and updated exclusiveUpperBound,
 // meaning the caller must not re-advance the bound.
@@ -407,6 +442,22 @@ func (q *cachedQueueReader) putTasks(tasks []persistence.Task) bool {
 	q.updateExclusiveUpperBound(newUpper)
 
 	return true
+}
+
+// insertBufferedTasks drains pendingInjectBuffer into the cache for tasks now
+// covered by the updated exclusiveUpperBound. Must be called under q.mu (write lock).
+func (q *cachedQueueReader) insertBufferedTasks() {
+	if len(q.pendingInjectBuffer) == 0 {
+		return
+	}
+	var covered []persistence.Task
+	for _, t := range q.pendingInjectBuffer {
+		if q.isTaskCovered(t.GetTaskKey()) {
+			covered = append(covered, t)
+		}
+	}
+	q.pendingInjectBuffer = q.pendingInjectBuffer[:0]
+	q.putTasks(covered)
 }
 
 // updateExclusiveUpperBound sets the upper bound and trigger prefetch if needed.
@@ -487,9 +538,11 @@ func (q *cachedQueueReader) UpdateReadLevel(readLevel persistence.HistoryTaskKey
 	q.advanceInclusiveLowerBound(readLevel)
 }
 
-// Inject adds tasks within [inclusiveLowerBound, exclusiveUpperBound) to the
-// in-memory queue. Tasks outside the window are skipped; the prefetch loop
-// loads them as the window advances. No-op when the cache is off.
+// Inject adds tasks that have just been persisted into the in-memory cache.
+// Tasks within the current cache window are inserted immediately. Tasks that
+// fall in [exclusiveUpperBound, prefetchTargetUpper) while a prefetch is
+// in-flight are buffered and drained once the prefetch completes. All other
+// tasks are dropped. No-op when the cache is off.
 func (q *cachedQueueReader) Inject(tasks []persistence.Task) {
 	if q.isDisabled() {
 		return
@@ -500,10 +553,18 @@ func (q *cachedQueueReader) Inject(tasks []persistence.Task) {
 
 	var covered []persistence.Task
 	for _, t := range tasks {
-		if t.GetTaskID() == 0 || !q.isTaskCovered(t.GetTaskKey()) {
+		if t.GetTaskID() == 0 {
+			// no tasks with taskID == 0 are expected
 			continue
 		}
-		covered = append(covered, t)
+		if q.isTaskCovered(t.GetTaskKey()) {
+			covered = append(covered, t)
+			continue
+		}
+		if q.isToBufferTask(t) {
+			q.pendingInjectBuffer = append(q.pendingInjectBuffer, t)
+			continue
+		}
 	}
 
 	q.putTasks(covered)

--- a/service/history/queuev2/queue_reader_cached_test.go
+++ b/service/history/queuev2/queue_reader_cached_test.go
@@ -1195,3 +1195,113 @@ func TestCachedQueueReader_IsRangeCovered(t *testing.T) {
 		})
 	}
 }
+
+func TestCachedQueueReader_IsTaskCovered(t *testing.T) {
+	now := time.Now()
+	lower := newTimeKey(now)
+	upper := newTimeKey(now.Add(time.Hour))
+
+	tests := []struct {
+		name string
+		key  persistence.HistoryTaskKey
+		want bool
+	}{
+		{
+			name: "key before lower bound",
+			key:  newTimeKey(now.Add(-time.Minute)),
+			want: false,
+		},
+		{
+			name: "key at lower bound (inclusive)",
+			key:  lower,
+			want: true,
+		},
+		{
+			name: "key inside window",
+			key:  newTimeKey(now.Add(30 * time.Minute)),
+			want: true,
+		},
+		{
+			name: "key at upper bound (exclusive)",
+			key:  upper,
+			want: false,
+		},
+		{
+			name: "key beyond upper bound",
+			key:  newTimeKey(now.Add(2 * time.Hour)),
+			want: false,
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	r, _ := setupMocksForCachedQueueReader(t, ctrl)
+	setBounds(r, lower, upper)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, r.isTaskCovered(tc.key))
+		})
+	}
+}
+
+func TestCachedQueueReader_IsToBufferTask(t *testing.T) {
+	now := time.Now()
+	lower := newTimeKey(now)
+	upper := newTimeKey(now.Add(time.Hour))
+	prefetchTarget := newTimeKey(now.Add(2 * time.Hour))
+
+	tests := []struct {
+		name                string
+		prefetchTargetUpper persistence.HistoryTaskKey
+		key                 persistence.HistoryTaskKey
+		want                bool
+	}{
+		{
+			name:                "no prefetch in-flight (prefetchTargetUpper is minimum)",
+			prefetchTargetUpper: persistence.MinimumHistoryTaskKey,
+			key:                 newTimeKey(now.Add(90 * time.Minute)),
+			want:                false,
+		},
+		{
+			name:                "key inside covered window (below upper bound)",
+			prefetchTargetUpper: prefetchTarget,
+			key:                 newTimeKey(now.Add(30 * time.Minute)),
+			want:                false,
+		},
+		{
+			name:                "key at upper bound (start of buffer window, inclusive)",
+			prefetchTargetUpper: prefetchTarget,
+			key:                 upper,
+			want:                true,
+		},
+		{
+			name:                "key inside buffer window",
+			prefetchTargetUpper: prefetchTarget,
+			key:                 newTimeKey(now.Add(90 * time.Minute)),
+			want:                true,
+		},
+		{
+			name:                "key at prefetch target (exclusive)",
+			prefetchTargetUpper: prefetchTarget,
+			key:                 prefetchTarget,
+			want:                false,
+		},
+		{
+			name:                "key beyond prefetch target",
+			prefetchTargetUpper: prefetchTarget,
+			key:                 newTimeKey(now.Add(3 * time.Hour)),
+			want:                false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			r, _ := setupMocksForCachedQueueReader(t, ctrl)
+			setBounds(r, lower, upper)
+			r.prefetchTargetUpper = tc.prefetchTargetUpper
+
+			assert.Equal(t, tc.want, r.isToBufferTask(tc.key))
+		})
+	}
+}

--- a/service/history/queuev2/queue_reader_cached_test.go
+++ b/service/history/queuev2/queue_reader_cached_test.go
@@ -218,18 +218,23 @@ func TestCachedQueueReader_Inject(t *testing.T) {
 	now := time.Now()
 	lower := newTimeKey(now)
 	upper := newTimeKey(now.Add(time.Hour))
+	prefetchTarget := newTimeKey(now.Add(2 * time.Hour))
 	inside := newTask(1, now.Add(30*time.Minute))
 	before := newTask(2, now.Add(-time.Minute))
 	atUpper := newTask(3, upper.GetScheduledTime())
+	inBuffer := newTask(4, now.Add(90*time.Minute))  // in [upper, prefetchTarget)
+	beyondTarget := newTask(5, now.Add(3*time.Hour)) // beyond prefetchTarget
 	zeroID := newTask(0, now.Add(30*time.Minute))
 	trimKey := inside.GetTaskKey().Next()
 
 	tests := []struct {
-		name         string
-		tasks        []persistence.Task
-		optsOverride func(*cachedQueueReaderOptions)
-		setupMocks   func(queue *MockInMemQueue)
-		wantUpper    persistence.HistoryTaskKey
+		name               string
+		tasks              []persistence.Task
+		initPrefetchTarget persistence.HistoryTaskKey
+		optsOverride       func(*cachedQueueReaderOptions)
+		setupMocks         func(queue *MockInMemQueue)
+		wantUpper          persistence.HistoryTaskKey
+		wantBufferLen      int
 	}{
 		{
 			name:  "disabled skips all",
@@ -293,6 +298,30 @@ func TestCachedQueueReader_Inject(t *testing.T) {
 			},
 			wantUpper: trimKey,
 		},
+		{
+			name:               "task in [upper, prefetchTarget) buffered when prefetch in-flight",
+			tasks:              []persistence.Task{inBuffer},
+			initPrefetchTarget: prefetchTarget,
+			setupMocks:         func(*MockInMemQueue) {},
+			wantUpper:          upper,
+			wantBufferLen:      1,
+		},
+		{
+			name:               "task beyond prefetchTarget dropped even when prefetch in-flight",
+			tasks:              []persistence.Task{beyondTarget},
+			initPrefetchTarget: prefetchTarget,
+			setupMocks:         func(*MockInMemQueue) {},
+			wantUpper:          upper,
+			wantBufferLen:      0,
+		},
+		{
+			name:               "task with ID=0 not buffered even when prefetch in-flight",
+			tasks:              []persistence.Task{zeroID},
+			initPrefetchTarget: prefetchTarget,
+			setupMocks:         func(*MockInMemQueue) {},
+			wantUpper:          upper,
+			wantBufferLen:      0,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -300,14 +329,21 @@ func TestCachedQueueReader_Inject(t *testing.T) {
 			r, deps := setupMocksForCachedQueueReader(t, ctrl, tc.optsOverride)
 			queue := deps.mockQueue
 			setBounds(r, lower, upper)
+			if !tc.initPrefetchTarget.Equal(persistence.MinimumHistoryTaskKey) {
+				r.mu.Lock()
+				r.prefetchTargetUpper = tc.initPrefetchTarget
+				r.mu.Unlock()
+			}
 			tc.setupMocks(queue)
 
 			r.Inject(tc.tasks)
 
 			r.mu.RLock()
-			got := r.exclusiveUpperBound
+			gotUpper := r.exclusiveUpperBound
+			gotBufferLen := len(r.pendingInjectBuffer)
 			r.mu.RUnlock()
-			assert.True(t, got.Equal(tc.wantUpper), "upper: got %v want %v", got, tc.wantUpper)
+			assert.True(t, gotUpper.Equal(tc.wantUpper), "upper: got %v want %v", gotUpper, tc.wantUpper)
+			assert.Equal(t, tc.wantBufferLen, gotBufferLen, "buffer length")
 		})
 	}
 }
@@ -318,6 +354,10 @@ func TestCachedQueueReader_Clear(t *testing.T) {
 	r, deps := setupMocksForCachedQueueReader(t, ctrl)
 	queue := deps.mockQueue
 	setBounds(r, newTimeKey(now), newTimeKey(now.Add(time.Hour)))
+	r.mu.Lock()
+	r.prefetchTargetUpper = newTimeKey(now.Add(2 * time.Hour))
+	r.pendingInjectBuffer = []persistence.Task{newTask(1, now.Add(90*time.Minute))}
+	r.mu.Unlock()
 
 	queue.EXPECT().Len().Return(0).AnyTimes()
 	queue.EXPECT().Clear()
@@ -331,6 +371,75 @@ func TestCachedQueueReader_Clear(t *testing.T) {
 		"upper: got %v want Minimum", r.exclusiveUpperBound)
 	assert.True(t, r.inclusiveLowerBound.Equal(persistence.MinimumHistoryTaskKey),
 		"lower: got %v want Minimum", r.inclusiveLowerBound)
+	assert.True(t, r.prefetchTargetUpper.Equal(persistence.MinimumHistoryTaskKey),
+		"prefetchTargetUpper: got %v want Minimum", r.prefetchTargetUpper)
+	assert.Empty(t, r.pendingInjectBuffer, "pendingInjectBuffer should be empty after Clear")
+}
+
+func TestCachedQueueReader_InsertBufferedTasks(t *testing.T) {
+	now := time.Now()
+	lower := newTimeKey(now)
+	upper := newTimeKey(now.Add(time.Hour))
+
+	tIn := newTask(1, now.Add(30*time.Minute))  // within [lower, upper)
+	tOut := newTask(2, now.Add(90*time.Minute)) // beyond upper
+
+	tests := []struct {
+		name       string
+		initBuffer []persistence.Task
+		setupMocks func(queue *MockInMemQueue)
+	}{
+		{
+			name:       "empty buffer: no-op",
+			initBuffer: nil,
+			setupMocks: func(*MockInMemQueue) {},
+		},
+		{
+			name:       "covered task drained into cache",
+			initBuffer: []persistence.Task{tIn},
+			setupMocks: func(queue *MockInMemQueue) {
+				queue.EXPECT().Len().Return(0).AnyTimes()
+				queue.EXPECT().PutTasks([]persistence.Task{tIn})
+				queue.EXPECT().RTrimBySize(100).Return(persistence.MinimumHistoryTaskKey, false)
+			},
+		},
+		{
+			name:       "uncovered task dropped, buffer cleared",
+			initBuffer: []persistence.Task{tOut},
+			setupMocks: func(*MockInMemQueue) {},
+		},
+		{
+			name:       "mixed: covered drained, uncovered dropped",
+			initBuffer: []persistence.Task{tIn, tOut},
+			setupMocks: func(queue *MockInMemQueue) {
+				queue.EXPECT().Len().Return(0).AnyTimes()
+				queue.EXPECT().PutTasks([]persistence.Task{tIn})
+				queue.EXPECT().RTrimBySize(100).Return(persistence.MinimumHistoryTaskKey, false)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			r, deps := setupMocksForCachedQueueReader(t, ctrl)
+			queue := deps.mockQueue
+			setBounds(r, lower, upper)
+
+			r.mu.Lock()
+			r.pendingInjectBuffer = append(r.pendingInjectBuffer, tc.initBuffer...)
+			r.mu.Unlock()
+
+			tc.setupMocks(queue)
+
+			r.mu.Lock()
+			r.insertBufferedTasks()
+			gotBuffer := r.pendingInjectBuffer
+			r.mu.Unlock()
+
+			assert.Empty(t, gotBuffer, "pendingInjectBuffer after drain")
+		})
+	}
 }
 
 func TestCachedQueueReader_GetTask(t *testing.T) {
@@ -763,6 +872,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 		optsOverride func(*cachedQueueReaderOptions)
 		initLower    persistence.HistoryTaskKey
 		initUpper    persistence.HistoryTaskKey
+		initBuffer   []persistence.Task
 		setupMocks   func(base *MockQueueReader, queue *MockInMemQueue, r *cachedQueueReader)
 		wantErr      bool
 		wantLower    persistence.HistoryTaskKey
@@ -906,6 +1016,31 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 			wantLower: someLower,
 			wantUpper: differentUpper,
 		},
+		{
+			// A task buffered in pendingInjectBuffer (arrived while prefetch was in-flight)
+			// must be drained into the cache once the prefetch completes and the upper
+			// bound advances to cover it.
+			name:      "buffered task drained into cache after prefetch completes",
+			initLower: someLower,
+			initUpper: someUpper,
+			initBuffer: []persistence.Task{
+				// scheduled at someUpper+1min; will fall within [someUpper, maxKey) after prefetch
+				newTask(99, someUpper.GetScheduledTime().Add(time.Minute)),
+			},
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedQueueReader) {
+				tBuf := newTask(99, someUpper.GetScheduledTime().Add(time.Minute))
+				queue.EXPECT().Len().Return(0).AnyTimes()
+				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).Return(&GetTaskResponse{
+					Tasks:    nil,
+					Progress: &GetTaskProgress{NextTaskKey: maxKey},
+				}, nil)
+				// insertBufferedTasks drains tBuf after upper advances to maxKey.
+				queue.EXPECT().PutTasks([]persistence.Task{tBuf})
+				queue.EXPECT().RTrimBySize(maxSize).Return(persistence.MinimumHistoryTaskKey, false)
+			},
+			wantLower: someLower,
+			wantUpper: maxKey,
+		},
 	}
 
 	for _, tc := range tests {
@@ -920,6 +1055,11 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 			clk.Advance(now.Sub(clk.Now())) // sync mock clock to the fixed reference time
 
 			setBounds(r, tc.initLower, tc.initUpper)
+			if len(tc.initBuffer) > 0 {
+				r.mu.Lock()
+				r.pendingInjectBuffer = append(r.pendingInjectBuffer, tc.initBuffer...)
+				r.mu.Unlock()
+			}
 			tc.setupMocks(base, queue, r)
 
 			err := r.prefetch()


### PR DESCRIPTION
**What changed?**

Added `pendingInjectBuffer` and `prefetchTargetUpper` fields to `cachedQueueReader` in `service/history/queuev2/queue_reader_cached.go`. While a prefetch DB call is in-flight, tasks arriving via `Inject` whose key falls in `[exclusiveUpperBound, prefetchTargetUpper)` are buffered rather than dropped. `insertBufferedTasks` drains the buffer into the cache once the prefetch completes and the upper bound advances to cover them.

**Why?**

There was a race where a task persisted concurrently with an in-flight prefetch could be permanently missed: the prefetch DB query ran before the task was written, the upper bound advanced past the task's `scheduledTime`, and a subsequent `GetTask` served from cache (believing coverage was complete) without ever seeing the task.

Previously, `Inject` dropped any task outside `[inclusiveLowerBound, exclusiveUpperBound)`. Tasks arriving during a prefetch in the window `[exclusiveUpperBound, prefetchTargetUpper)` — i.e., the range the in-flight DB call is about to cover — would be silently dropped and never retrieved, causing task loss.

The fix: record `prefetchTargetUpper` before each DB call. `Inject` now buffers tasks in that in-flight window. `insertBufferedTasks` is deferred under the post-DB write lock so it runs after the upper bound advances, correctly inserting buffered tasks into the cache. On error the buffer is also drained (tasks remain uncovered and will be re-fetched).

Relates to #7953.

**How did you test it?**

Unit tests covering the new behavior:

```bash
# All existing tests pass
go test -race ./service/history/queuev2/... -run TestCachedQueueReader

# New/updated test cases specifically for the buffer logic
go test -race ./service/history/queuev2/... -run TestCachedQueueReader_Inject
go test -race ./service/history/queuev2/... -run TestCachedQueueReader_InsertBufferedTasks
go test -race ./service/history/queuev2/... -run TestCachedQueueReader_Clear
go test -race ./service/history/queuev2/... -run TestCachedQueueReader_Prefetch/buffered_task_drained_into_cache_after_prefetch_completes
```

History Simulation was run multiple times:
```bash
for i in {1..10}; do ./simulation/history/run.sh --scenario queuev2_scheduled_cache_enabled; done
```

**Potential risks**

- Modifies core task cache logic in `cachedQueueReader`
- The buffer is cleared on `Clear()`, so no stale tasks persist across resets.
- No schema or IDL changes. No feature flags.

**Release notes**

N/A — internal cache correctness fix for queuev2's `cachedQueueReader`. No user-facing behavior change; prevents silent task loss under concurrent prefetch + persist.

**Documentation Changes**

N/A