### PR TITLE
build: Update docker image to support custom config file

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -37,6 +37,7 @@ We also provide several other compose files for different features/modes:
 * docker-compose-postgres.yml uses PostgreSQL as persistence storage
 * docker-compose-statsd.yaml runs with Statsd+Graphite
 * docker-compose-multiclusters.yaml runs with 2 cadence clusters
+* docker-compose-custom-config.yml uses a custom configuration file instead of the template
 
 For example:
 ```
@@ -44,6 +45,36 @@ docker compose -f docker-compose-mysql.yml up
 ```
 
 Also feel free to make your own to combine the above features.
+
+Using a custom configuration file
+-----------------------
+By default, the Cadence server uses `config_template.yaml` which is processed by `dockerize` to substitute environment variables. If you need more control over the configuration, you can provide a fully custom config file.
+
+To use a custom configuration:
+
+1. Create your custom config file based on `config_template.yaml` or `config/server/custom-config.yaml` (example provided)
+2. Mount it into the container
+3. Set the `CADENCE_CONFIG_FILE` environment variable to point to your custom config
+
+Example using docker-compose:
+```yaml
+services:
+  cadence:
+    image: ubercadence/server:master-auto-setup
+    environment:
+      - "CADENCE_CONFIG_FILE=/etc/cadence/config/custom.yaml"
+    volumes:
+      - ./config/server/custom-config.yaml:/etc/cadence/config/custom.yaml:ro
+```
+
+Or with docker run:
+```bash
+docker run -v $(pwd)/config/server/custom-config.yaml:/etc/cadence/config/custom.yaml \
+  -e CADENCE_CONFIG_FILE=/etc/cadence/config/custom.yaml \
+  ubercadence/server:master-auto-setup
+```
+
+See `docker-compose-custom-config.yml` and `config/server/custom-config.yaml` for a complete example.
 
 Run canary and bench(load test)
 -----------------------

--- a/docker/config/server/custom-config.yaml
+++ b/docker/config/server/custom-config.yaml
@@ -1,0 +1,140 @@
+# Example custom Cadence configuration file
+# This demonstrates a manually constructed config without template variables
+# You can customize this for your specific deployment needs
+
+log:
+  stdout: true
+  level: debug
+
+persistence:
+  numHistoryShards: 4
+  defaultStore: default
+  visibilityStore: visibility
+  datastores:
+    default:
+      nosql:
+        pluginName: "cassandra"
+        hosts: "cassandra"
+        keyspace: "cadence"
+        user: "cassandra"
+        password: "cassandra"
+        protoVersion: 4
+    visibility:
+      nosql:
+        pluginName: "cassandra"
+        hosts: "cassandra"
+        keyspace: "cadence_visibility"
+        user: "cassandra"
+        password: "cassandra"
+        protoVersion: 4
+
+ringpop:
+  name: cadence
+  broadcastAddress: ""
+  bootstrapMode: hosts
+  bootstrapHosts:
+    - "${HOST_IP}:${FRONTEND_PORT:7933}"
+    - "${HOST_IP}:${HISTORY_PORT:7934}"
+    - "${HOST_IP}:${MATCHING_PORT:7935}"
+    - "${HOST_IP}:${WORKER_PORT:7939}"
+  maxJoinDuration: 30s
+
+services:
+  frontend:
+    rpc:
+      port: "${FRONTEND_PORT:7933}"
+      grpcPort: "${GRPC_FRONTEND_PORT:7833}"
+      bindOnIP: "${BIND_ON_IP:0.0.0.0}"
+    metrics:
+      prometheus:
+        timerType: "histogram"
+        listenAddress: "${PROMETHEUS_ENDPOINT_0:0.0.0.0:8000}"
+    pprof:
+      port: "${FRONTEND_PPROF_PORT:7936}"
+      host: "${BIND_ON_IP:0.0.0.0}"
+
+  matching:
+    rpc:
+      port: "${MATCHING_PORT:7935}"
+      grpcPort: "${GRPC_MATCHING_PORT:7835}"
+      bindOnIP: "${BIND_ON_IP:0.0.0.0}"
+    metrics:
+      prometheus:
+        timerType: "histogram"
+        listenAddress: "${PROMETHEUS_ENDPOINT_1:0.0.0.0:8001}"
+
+  history:
+    rpc:
+      port: "${HISTORY_PORT:7934}"
+      grpcPort: "${GRPC_HISTORY_PORT:7834}"
+      bindOnIP: "${BIND_ON_IP:0.0.0.0}"
+    metrics:
+      prometheus:
+        timerType: "histogram"
+        listenAddress: "${PROMETHEUS_ENDPOINT_2:0.0.0.0:8002}"
+
+  worker:
+    rpc:
+      port: "${WORKER_PORT:7939}"
+      bindOnIP: "${BIND_ON_IP:0.0.0.0}"
+    metrics:
+      prometheus:
+        timerType: "histogram"
+        listenAddress: "${PROMETHEUS_ENDPOINT_3:0.0.0.0:8003}"
+
+clusterGroupMetadata:
+  clusterRedirectionPolicy:
+    policy: "all-domain-apis-forwarding"
+  failoverVersionIncrement: 10
+  primaryClusterName: "cluster0"
+  currentClusterName: "cluster0"
+  clusterGroup:
+    cluster0:
+      enabled: true
+      initialFailoverVersion: 0
+      rpcName: "cadence-frontend"
+      rpcAddress: "cadence:7833"
+      rpcTransport: "grpc"
+      authorizationProvider:
+        enable: "${ENABLE_OAUTH:false}"
+        type: "OAuthAuthorization"
+        privateKey: "${OAUTH_PRIVATE_KEY:}"
+
+archival:
+  history:
+    status: "disabled"
+    enableRead: false
+  visibility:
+    status: "disabled"
+    enableRead: false
+
+domainDefaults:
+  archival:
+    history:
+      status: "disabled"
+      URI: ""
+    visibility:
+      status: "disabled"
+      URI: ""
+
+publicClient:
+  hostPort: "cadence:7833"
+
+dynamicconfig:
+  client: filebased
+  filebased:
+    filepath: "/etc/cadence/config/dynamicconfig/development.yaml"
+    pollInterval: "60s"
+
+authorization:
+  oauthAuthorizer:
+    enable: false
+    maxJwtTTL: 86400
+
+shard-distributor-matching:
+  namespaces:
+    - namespace: "cadence-matching"
+      heartbeat_interval: "1s"
+      migration_mode: "local_pass"
+      ttl_shard: "5m"
+      ttl_report: "1m"

--- a/docker/docker-compose-custom-config.yml
+++ b/docker/docker-compose-custom-config.yml
@@ -1,0 +1,88 @@
+# Example docker-compose configuration demonstrating how to use a custom config file
+# instead of the default config_template.yaml
+#
+# Usage:
+#   1. Create your custom config file based on config/server/custom-config.yaml (example provided)
+#   2. Mount it into the container at /etc/cadence/config/custom.yaml
+#   3. Set CADENCE_CONFIG_FILE environment variable to point to your custom config
+#
+# To run:
+#   docker-compose -f docker-compose-custom-config.yml up
+
+services:
+  cassandra:
+    image: cassandra:4.1.1
+    ports:
+      - "9042:9042"
+    environment:
+      - "MAX_HEAP_SIZE=256M"
+      - "HEAP_NEWSIZE=128M"
+    healthcheck:
+      test: ["CMD", "cqlsh", "-u cassandra", "-p cassandra" ,"-e describe keyspaces"]
+      interval: 15s
+      timeout: 30s
+      retries: 10
+
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus:/etc/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    ports:
+      - '9090:9090'
+
+  node-exporter:
+    image: prom/node-exporter
+    ports:
+      - '9100:9100'
+
+  cadence:
+    image: ubercadence/server:master-auto-setup
+    ports:
+     - "8000:8000"
+     - "8001:8001"
+     - "8002:8002"
+     - "8003:8003"
+     - "7933:7933"
+     - "7934:7934"
+     - "7935:7935"
+     - "7939:7939"
+     - "7833:7833"
+     - "7936:7936"
+    environment:
+      # Set this to use a custom config file instead of config_template.yaml
+      # The config file supports environment variables
+      - "CADENCE_CONFIG_FILE=/etc/cadence/config/custom.yaml"
+      - "CASSANDRA_SEEDS=cassandra" # still needed by start.sh script
+    volumes:
+      # Mount your custom config file here
+      # Example uses the provided custom-config.yaml from config/server/
+      - ./config/server/custom-config.yaml:/etc/cadence/config/custom.yaml:ro
+      # Optionally mount custom dynamic config
+      # - ./config/dynamicconfig/development.yaml:/etc/cadence/config/dynamicconfig/development.yaml:ro
+    depends_on:
+      cassandra:
+        condition: service_healthy
+      prometheus:
+        condition: service_started
+
+  cadence-web:
+    image: ubercadence/web:latest
+    environment:
+      - "CADENCE_GRPC_PEERS=cadence:7833"
+      - "CADENCE_HISTORY_PAGE_V2_ENABLED=OPT_OUT"
+    ports:
+      - "8088:8088"
+    depends_on:
+      - cadence
+
+  grafana:
+    image: grafana/grafana
+    volumes:
+      - ./grafana:/etc/grafana
+    user: "1000"
+    depends_on:
+      - prometheus
+    ports:
+      - '3000:3000'

--- a/docker/start-cadence.sh
+++ b/docker/start-cadence.sh
@@ -2,9 +2,17 @@
 
 set -ex
 
-CONFIG_TEMPLATE_PATH="${CONFIG_TEMPLATE_PATH:-/etc/cadence/config/config_template.yaml}"
+# If CADENCE_CONFIG_FILE is set, copy it to docker.yaml and use the config directory
+# Otherwise, use the template to generate docker.yaml
+if [ -n "$CADENCE_CONFIG_FILE" ]; then
+    echo "Using custom config file: $CADENCE_CONFIG_FILE"
+    # Copy custom config to docker.yaml so cadence-server can find it
+    cp "$CADENCE_CONFIG_FILE" /etc/cadence/config/docker.yaml
+else
+    echo "Generating config from template"
+    CONFIG_TEMPLATE_PATH="${CONFIG_TEMPLATE_PATH:-/etc/cadence/config/config_template.yaml}"
+    dockerize -template "$CONFIG_TEMPLATE_PATH:/etc/cadence/config/docker.yaml"
+fi
 
-dockerize -template $CONFIG_TEMPLATE_PATH:/etc/cadence/config/docker.yaml
-
-exec cadence-server --root $CADENCE_HOME --env docker start --services=$SERVICES
+exec cadence-server --root "$CADENCE_HOME" --env docker --config config start --services="$SERVICES"
 


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
This change adds support for using custom configuration files with Cadence Docker containers as an alternative to the template-based configuration system.

**Why?**
1. **More control**: Users can provide exact configuration without learning template syntax
2. **Easier debugging**: Static config files are easier to understand than templated ones
3. **Complex configurations**: Some advanced configurations are easier to express directly
4. **Backward compatible**: Existing setups continue to work without changes
5. **Flexible**: Can mix environment variables for some settings and custom config for others

**How did you test it?**
The change is backward compatible. To test:

1. **Existing setup should still work**:
   ```bash
   docker compose up
   ```

2. **Custom config should work**:
   ```bash
   docker compose -f docker-compose-custom-config.yml up
   ```

Both approaches should successfully start Cadence with appropriate configuration.

**Potential risks**


**Release notes**


**Documentation Changes**

