### PR TITLE
fix(schedule): make SchedulePolicies.{BufferLimit,ConcurrencyLimit} nullable end-to-end

### DIFF
--- a/common/types/mapper/proto/helpers.go
+++ b/common/types/mapper/proto/helpers.go
@@ -57,6 +57,20 @@ func toInt64Value(v *gogo.Int64Value) *int64 {
 	return common.Int64Ptr(v.Value)
 }
 
+func fromInt32Value(v *int32) *gogo.Int32Value {
+	if v == nil {
+		return nil
+	}
+	return &gogo.Int32Value{Value: *v}
+}
+
+func toInt32Value(v *gogo.Int32Value) *int32 {
+	if v == nil {
+		return nil
+	}
+	return common.Int32Ptr(v.Value)
+}
+
 func unixNanoToTime(t *int64) *gogo.Timestamp {
 	if t == nil {
 		return nil

--- a/common/types/mapper/proto/schedule.go
+++ b/common/types/mapper/proto/schedule.go
@@ -171,8 +171,8 @@ func FromSchedulePolicies(t *types.SchedulePolicies) *apiv1.SchedulePolicies {
 		CatchUpPolicy:    FromScheduleCatchUpPolicy(t.CatchUpPolicy),
 		CatchUpWindow:    durationToDurationProto(t.CatchUpWindow),
 		PauseOnFailure:   t.PauseOnFailure,
-		BufferLimit:      t.BufferLimit,
-		ConcurrencyLimit: t.ConcurrencyLimit,
+		BufferLimit:      fromInt32Value(t.BufferLimit),
+		ConcurrencyLimit: fromInt32Value(t.ConcurrencyLimit),
 	}
 }
 
@@ -185,8 +185,8 @@ func ToSchedulePolicies(t *apiv1.SchedulePolicies) *types.SchedulePolicies {
 		CatchUpPolicy:    ToScheduleCatchUpPolicy(t.CatchUpPolicy),
 		CatchUpWindow:    durationProtoToDuration(t.CatchUpWindow),
 		PauseOnFailure:   t.PauseOnFailure,
-		BufferLimit:      t.BufferLimit,
-		ConcurrencyLimit: t.ConcurrencyLimit,
+		BufferLimit:      toInt32Value(t.BufferLimit),
+		ConcurrencyLimit: toInt32Value(t.ConcurrencyLimit),
 	}
 }
 

--- a/common/types/mapper/proto/schedule_test.go
+++ b/common/types/mapper/proto/schedule_test.go
@@ -26,6 +26,7 @@ import (
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/common/types/mapper/testutils"
 	"github.com/uber/cadence/common/types/testdata"
@@ -50,7 +51,15 @@ func TestScheduleAction(t *testing.T) {
 }
 
 func TestSchedulePolicies(t *testing.T) {
-	for _, item := range []*types.SchedulePolicies{nil, {}, &testdata.SchedulePolicies} {
+	for _, item := range []*types.SchedulePolicies{
+		nil,
+		{},
+		// Pin *int32(0) (explicit "unlimited") round-trips distinctly from nil
+		// ("unset"), the whole point of the *int32 wrappers is keeping
+		// those two states distinguishable end-to-end.
+		{BufferLimit: common.Int32Ptr(0), ConcurrencyLimit: common.Int32Ptr(0)},
+		&testdata.SchedulePolicies,
+	} {
 		assert.Equal(t, item, ToSchedulePolicies(FromSchedulePolicies(item)))
 	}
 }

--- a/common/types/mapper/thrift/schedule.go
+++ b/common/types/mapper/thrift/schedule.go
@@ -139,8 +139,8 @@ func FromSchedulePolicies(t *types.SchedulePolicies) *shared.SchedulePolicies {
 		CatchUpPolicy:          FromScheduleCatchUpPolicy(t.CatchUpPolicy),
 		CatchUpWindowInSeconds: durationToSeconds(t.CatchUpWindow),
 		PauseOnFailure:         common.BoolPtr(t.PauseOnFailure),
-		BufferLimit:            common.Int32Ptr(t.BufferLimit),
-		ConcurrencyLimit:       common.Int32Ptr(t.ConcurrencyLimit),
+		BufferLimit:            t.BufferLimit,
+		ConcurrencyLimit:       t.ConcurrencyLimit,
 	}
 }
 
@@ -153,8 +153,8 @@ func ToSchedulePolicies(t *shared.SchedulePolicies) *types.SchedulePolicies {
 		CatchUpPolicy:    ToScheduleCatchUpPolicy(t.CatchUpPolicy),
 		CatchUpWindow:    secondsToDuration(t.CatchUpWindowInSeconds),
 		PauseOnFailure:   t.GetPauseOnFailure(),
-		BufferLimit:      t.GetBufferLimit(),
-		ConcurrencyLimit: t.GetConcurrencyLimit(),
+		BufferLimit:      t.BufferLimit,
+		ConcurrencyLimit: t.ConcurrencyLimit,
 	}
 }
 

--- a/common/types/mapper/thrift/schedule_test.go
+++ b/common/types/mapper/thrift/schedule_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/common/types/testdata"
 )
@@ -188,7 +189,15 @@ func TestScheduleActionConversion(t *testing.T) {
 }
 
 func TestSchedulePoliciesConversion(t *testing.T) {
-	for _, item := range []*types.SchedulePolicies{nil, {}, &testdata.SchedulePolicies} {
+	for _, item := range []*types.SchedulePolicies{
+		nil,
+		{},
+		// Pin *int32(0) (explicit "unlimited") round-trips distinctly from nil
+		// ("unset"), the whole point of the *int32 wrappers is keeping
+		// those two states distinguishable end-to-end.
+		{BufferLimit: common.Int32Ptr(0), ConcurrencyLimit: common.Int32Ptr(0)},
+		&testdata.SchedulePolicies,
+	} {
 		assert.Equal(t, item, ToSchedulePolicies(FromSchedulePolicies(item)))
 	}
 }

--- a/common/types/schedule.go
+++ b/common/types/schedule.go
@@ -243,15 +243,14 @@ func (v *ScheduleAction) GetStartWorkflow() *StartWorkflowAction {
 
 // SchedulePolicies configures schedule behavior.
 type SchedulePolicies struct {
-	OverlapPolicy    ScheduleOverlapPolicy `json:"overlapPolicy,omitempty"`
-	CatchUpPolicy    ScheduleCatchUpPolicy `json:"catchUpPolicy,omitempty"`
-	CatchUpWindow    time.Duration         `json:"catchUpWindow,omitempty"`
-	PauseOnFailure   bool                  `json:"pauseOnFailure,omitempty"`
+	OverlapPolicy  ScheduleOverlapPolicy `json:"overlapPolicy,omitempty"`
+	CatchUpPolicy  ScheduleCatchUpPolicy `json:"catchUpPolicy,omitempty"`
+	CatchUpWindow  time.Duration         `json:"catchUpWindow,omitempty"`
+	PauseOnFailure bool                  `json:"pauseOnFailure,omitempty"`
 	// BufferLimit and ConcurrencyLimit use *int32 to distinguish three states:
 	//   nil           -> "preserve existing" on Update, or "use server default" on Create
 	//   *int32(0)     -> explicitly unlimited
 	//   *int32(N>0)   -> capped at N
-	// See cadence-idl PR #268 for the matching wire-format change.
 	BufferLimit      *int32 `json:"bufferLimit,omitempty"`
 	ConcurrencyLimit *int32 `json:"concurrencyLimit,omitempty"`
 }

--- a/common/types/schedule.go
+++ b/common/types/schedule.go
@@ -247,8 +247,13 @@ type SchedulePolicies struct {
 	CatchUpPolicy    ScheduleCatchUpPolicy `json:"catchUpPolicy,omitempty"`
 	CatchUpWindow    time.Duration         `json:"catchUpWindow,omitempty"`
 	PauseOnFailure   bool                  `json:"pauseOnFailure,omitempty"`
-	BufferLimit      int32                 `json:"bufferLimit,omitempty"`
-	ConcurrencyLimit int32                 `json:"concurrencyLimit,omitempty"`
+	// BufferLimit and ConcurrencyLimit use *int32 to distinguish three states:
+	//   nil           -> "preserve existing" on Update, or "use server default" on Create
+	//   *int32(0)     -> explicitly unlimited
+	//   *int32(N>0)   -> capped at N
+	// See cadence-idl PR #268 for the matching wire-format change.
+	BufferLimit      *int32 `json:"bufferLimit,omitempty"`
+	ConcurrencyLimit *int32 `json:"concurrencyLimit,omitempty"`
 }
 
 func (v *SchedulePolicies) GetOverlapPolicy() (o ScheduleOverlapPolicy) {
@@ -279,18 +284,18 @@ func (v *SchedulePolicies) GetPauseOnFailure() (o bool) {
 	return
 }
 
-func (v *SchedulePolicies) GetBufferLimit() (o int32) {
+func (v *SchedulePolicies) GetBufferLimit() *int32 {
 	if v != nil {
 		return v.BufferLimit
 	}
-	return
+	return nil
 }
 
-func (v *SchedulePolicies) GetConcurrencyLimit() (o int32) {
+func (v *SchedulePolicies) GetConcurrencyLimit() *int32 {
 	if v != nil {
 		return v.ConcurrencyLimit
 	}
-	return
+	return nil
 }
 
 // SchedulePauseInfo captures the state of a paused schedule (response-only, server-populated).

--- a/common/types/testdata/schedule.go
+++ b/common/types/testdata/schedule.go
@@ -156,8 +156,8 @@ var (
 		CatchUpPolicy:    types.ScheduleCatchUpPolicyAll,
 		CatchUpWindow:    time.Hour,
 		PauseOnFailure:   true,
-		BufferLimit:      5,
-		ConcurrencyLimit: 2,
+		BufferLimit:      common.Int32Ptr(5),
+		ConcurrencyLimit: common.Int32Ptr(2),
 	}
 
 	SchedulePauseInfo = types.SchedulePauseInfo{

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/startreedata/pinot-client-go v0.2.0 // latest release supports pinot v0.12.0 which is also internal version
 	github.com/stretchr/testify v1.10.0
 	github.com/uber-go/tally v3.5.8+incompatible
-	github.com/uber/cadence-idl v0.0.0-20260518100102-6b2ed6e5dde0
+	github.com/uber/cadence-idl v0.0.0-20260528181009-11ac3616875d
 	github.com/uber/ringpop-go v0.10.0
 	github.com/uber/tchannel-go v1.34.4
 	github.com/urfave/cli/v2 v2.27.4

--- a/go.sum
+++ b/go.sum
@@ -511,8 +511,8 @@ github.com/uber-go/mapdecode v1.0.0/go.mod h1:b5nP15FwXTgpjTjeA9A2uTHXV5UJCl4arw
 github.com/uber-go/tally v3.3.12+incompatible/go.mod h1:YDTIBxdXyOU/sCWilKB4bgyufu1cEi0jdVnRdxvjnmU=
 github.com/uber-go/tally v3.5.8+incompatible h1:Z2vK6ib6G/r6bAGu7lAI/98cLPLUOtdHrY2bBikk4wg=
 github.com/uber-go/tally v3.5.8+incompatible/go.mod h1:YDTIBxdXyOU/sCWilKB4bgyufu1cEi0jdVnRdxvjnmU=
-github.com/uber/cadence-idl v0.0.0-20260518100102-6b2ed6e5dde0 h1:kdQYWHtPqvntrlsLxE6CFFGd7FJDtHBbePVcOa7t7aI=
-github.com/uber/cadence-idl v0.0.0-20260518100102-6b2ed6e5dde0/go.mod h1:ux5U12WfKGx6AFibwe52/OMp51fjUKSvosh0/eiSzps=
+github.com/uber/cadence-idl v0.0.0-20260528181009-11ac3616875d h1:hnL86N8Zxc7j5X5alWul59fplYcg7nJkK2/+f4dHNyA=
+github.com/uber/cadence-idl v0.0.0-20260528181009-11ac3616875d/go.mod h1:ux5U12WfKGx6AFibwe52/OMp51fjUKSvosh0/eiSzps=
 github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=

--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -82,14 +82,15 @@ func validateSchedulePolicies(policies *types.SchedulePolicies) error {
 func (wh *WorkflowHandler) warnIfBufferLimitExceedsSystemLimit(scheduleID, domainName string, policies *types.SchedulePolicies) {
 	if policies == nil ||
 		policies.OverlapPolicy != types.ScheduleOverlapPolicyBuffer ||
-		int(policies.BufferLimit) <= scheduler.MaxBufferedFiresSystemLimit {
+		policies.BufferLimit == nil ||
+		int(*policies.BufferLimit) <= scheduler.MaxBufferedFiresSystemLimit {
 		return
 	}
 	wh.GetLogger().Warn(
 		"buffer_limit exceeds scheduler system limit; drops will be attributed to system_limit",
 		tag.WorkflowDomainName(domainName),
 		tag.WorkflowID(scheduleWorkflowID(scheduleID)),
-		tag.Dynamic("bufferLimit", int(policies.BufferLimit)),
+		tag.Dynamic("bufferLimit", int(*policies.BufferLimit)),
 		tag.Dynamic("systemLimit", scheduler.MaxBufferedFiresSystemLimit),
 	)
 }

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -1240,10 +1240,9 @@ func TestValidateSchedulePolicies(t *testing.T) {
 	}
 }
 
-// TestWarnIfBufferLimitExceedsSystemLimit_NilSafe guards the B1 fix: callers
-// pass *types.SchedulePolicies and BufferLimit is *int32, so the helper must
-// not panic on nil policies or nil BufferLimit. It must also no-op when the
-// overlap policy isn't Buffer (limit has no effect there).
+// TestWarnIfBufferLimitExceedsSystemLimit_NilSafe verifies the helper does not
+// panic when policies or policies.BufferLimit is nil, and that it stays a no-op
+// when the overlap policy is not Buffer (BufferLimit has no effect there).
 func TestWarnIfBufferLimitExceedsSystemLimit_NilSafe(t *testing.T) {
 	f := newScheduleTestFixture(t)
 	defer f.finish()

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -35,6 +35,7 @@ import (
 	"go.uber.org/yarpc/yarpcerrors"
 
 	"github.com/uber/cadence/client/history"
+	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/client"
 	"github.com/uber/cadence/common/constants"
@@ -245,7 +246,7 @@ func TestCreateSchedule(t *testing.T) {
 				},
 				Policies: &types.SchedulePolicies{
 					OverlapPolicy: types.ScheduleOverlapPolicyBuffer,
-					BufferLimit:   int32(scheduler.MaxBufferedFiresSystemLimit * 2),
+					BufferLimit:   common.Int32Ptr(int32(scheduler.MaxBufferedFiresSystemLimit * 2)),
 				},
 			},
 			mockFn: func(f *scheduleTestFixture) {
@@ -1235,6 +1236,50 @@ func TestValidateSchedulePolicies(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+// TestWarnIfBufferLimitExceedsSystemLimit_NilSafe guards the B1 fix: callers
+// pass *types.SchedulePolicies and BufferLimit is *int32, so the helper must
+// not panic on nil policies or nil BufferLimit. It must also no-op when the
+// overlap policy isn't Buffer (limit has no effect there).
+func TestWarnIfBufferLimitExceedsSystemLimit_NilSafe(t *testing.T) {
+	f := newScheduleTestFixture(t)
+	defer f.finish()
+
+	cases := []struct {
+		name     string
+		policies *types.SchedulePolicies
+	}{
+		{name: "nil policies", policies: nil},
+		{
+			name: "Buffer policy with nil BufferLimit",
+			policies: &types.SchedulePolicies{
+				OverlapPolicy: types.ScheduleOverlapPolicyBuffer,
+				BufferLimit:   nil,
+			},
+		},
+		{
+			name: "non-Buffer policy with BufferLimit set",
+			policies: &types.SchedulePolicies{
+				OverlapPolicy: types.ScheduleOverlapPolicySkipNew,
+				BufferLimit:   common.Int32Ptr(int32(scheduler.MaxBufferedFiresSystemLimit * 2)),
+			},
+		},
+		{
+			name: "Buffer policy with BufferLimit under system limit",
+			policies: &types.SchedulePolicies{
+				OverlapPolicy: types.ScheduleOverlapPolicyBuffer,
+				BufferLimit:   common.Int32Ptr(1),
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				f.handler.warnIfBufferLimitExceedsSystemLimit("sched-1", "domain", tc.policies)
+			})
 		})
 	}
 }

--- a/service/worker/scheduler/activity.go
+++ b/service/worker/scheduler/activity.go
@@ -79,7 +79,7 @@ func processScheduleFireActivity(ctx context.Context, req ProcessFireRequest) (r
 	// completed entries, and enforce the cap. When under the cap, falls through
 	// to the shared start block; stillRunning is used there to build
 	// result.ActiveWorkflows. When at or over the cap, returns early with a skip.
-	isBoundedConcurrent := policy == types.ScheduleOverlapPolicyConcurrent && req.ConcurrencyLimit > 0
+	isBoundedConcurrent := policy == types.ScheduleOverlapPolicyConcurrent && req.ConcurrencyLimit != nil && *req.ConcurrencyLimit > 0
 	var stillRunning []RunningWorkflowInfo
 	if isBoundedConcurrent {
 		effectiveLimit := effectiveConcurrencyLimit(req.ConcurrencyLimit)

--- a/service/worker/scheduler/activity_test.go
+++ b/service/worker/scheduler/activity_test.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/uber/cadence/client/frontend"
+	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/types"
 )
@@ -445,7 +446,7 @@ func TestProcessScheduleFireActivity(t *testing.T) {
 			req: func() ProcessFireRequest {
 				r := baseReq
 				r.OverlapPolicy = types.ScheduleOverlapPolicyConcurrent
-				r.ConcurrencyLimit = 2
+				r.ConcurrencyLimit = common.Int32Ptr(2)
 				r.RunningWorkflows = []RunningWorkflowInfo{
 					{WorkflowID: "wf-1", RunID: "run-1"},
 					{WorkflowID: "wf-2", RunID: "run-2"},
@@ -471,7 +472,7 @@ func TestProcessScheduleFireActivity(t *testing.T) {
 			req: func() ProcessFireRequest {
 				r := baseReq
 				r.OverlapPolicy = types.ScheduleOverlapPolicyConcurrent
-				r.ConcurrencyLimit = 3
+				r.ConcurrencyLimit = common.Int32Ptr(3)
 				r.RunningWorkflows = []RunningWorkflowInfo{
 					{WorkflowID: "wf-1", RunID: "run-1"},
 					{WorkflowID: "wf-2", RunID: "run-2"},
@@ -501,7 +502,7 @@ func TestProcessScheduleFireActivity(t *testing.T) {
 			req: func() ProcessFireRequest {
 				r := baseReq
 				r.OverlapPolicy = types.ScheduleOverlapPolicyConcurrent
-				r.ConcurrencyLimit = 2
+				r.ConcurrencyLimit = common.Int32Ptr(2)
 				r.RunningWorkflows = []RunningWorkflowInfo{
 					{WorkflowID: "wf-1", RunID: "run-1"},
 					{WorkflowID: "wf-2", RunID: "run-2"},
@@ -538,7 +539,7 @@ func TestProcessScheduleFireActivity(t *testing.T) {
 			req: func() ProcessFireRequest {
 				r := baseReq
 				r.OverlapPolicy = types.ScheduleOverlapPolicyConcurrent
-				r.ConcurrencyLimit = 1
+				r.ConcurrencyLimit = common.Int32Ptr(1)
 				r.RunningWorkflows = []RunningWorkflowInfo{
 					{WorkflowID: "wf-1", RunID: "run-1"},
 				}
@@ -566,7 +567,7 @@ func TestProcessScheduleFireActivity(t *testing.T) {
 			req: func() ProcessFireRequest {
 				r := baseReq
 				r.OverlapPolicy = types.ScheduleOverlapPolicyConcurrent
-				r.ConcurrencyLimit = 2
+				r.ConcurrencyLimit = common.Int32Ptr(2)
 				r.RunningWorkflows = []RunningWorkflowInfo{
 					{WorkflowID: "wf-1", RunID: "run-1"},
 				}
@@ -583,7 +584,7 @@ func TestProcessScheduleFireActivity(t *testing.T) {
 			req: func() ProcessFireRequest {
 				r := baseReq
 				r.OverlapPolicy = types.ScheduleOverlapPolicyConcurrent
-				r.ConcurrencyLimit = 3
+				r.ConcurrencyLimit = common.Int32Ptr(3)
 				r.RunningWorkflows = []RunningWorkflowInfo{
 					{WorkflowID: "wf-1", RunID: "run-1"},
 				}
@@ -896,7 +897,7 @@ func TestProcessScheduleFireActivityMetrics(t *testing.T) {
 			req: func() ProcessFireRequest {
 				r := baseReq
 				r.OverlapPolicy = types.ScheduleOverlapPolicyConcurrent
-				r.ConcurrencyLimit = 2
+				r.ConcurrencyLimit = common.Int32Ptr(2)
 				r.RunningWorkflows = []RunningWorkflowInfo{
 					{WorkflowID: "wf-1", RunID: "run-1"},
 					{WorkflowID: "wf-2", RunID: "run-2"},
@@ -1092,14 +1093,16 @@ func TestProcessScheduleFireActivityLatency(t *testing.T) {
 func TestEffectiveConcurrencyLimit(t *testing.T) {
 	tests := []struct {
 		name      string
-		userLimit int32
+		userLimit *int32
 		want      int32
 	}{
-		{"below system limit returned as-is", 1, 1},
-		{"typical value returned as-is", 10, 10},
-		{"at system limit returned as-is", MaxConcurrencyLimitSystemLimit, MaxConcurrencyLimitSystemLimit},
-		{"one above system limit clamped", MaxConcurrencyLimitSystemLimit + 1, MaxConcurrencyLimitSystemLimit},
-		{"large value clamped to system limit", 10000, MaxConcurrencyLimitSystemLimit},
+		{"nil returns zero", nil, 0},
+		{"explicit zero returns zero", common.Int32Ptr(0), 0},
+		{"below system limit returned as-is", common.Int32Ptr(1), 1},
+		{"typical value returned as-is", common.Int32Ptr(10), 10},
+		{"at system limit returned as-is", common.Int32Ptr(MaxConcurrencyLimitSystemLimit), MaxConcurrencyLimitSystemLimit},
+		{"one above system limit clamped", common.Int32Ptr(MaxConcurrencyLimitSystemLimit + 1), MaxConcurrencyLimitSystemLimit},
+		{"large value clamped to system limit", common.Int32Ptr(10000), MaxConcurrencyLimitSystemLimit},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -288,8 +288,11 @@ type ProcessFireRequest struct {
 	TriggerSource       TriggerSource               `json:"triggerSource"`
 	OverlapPolicy       types.ScheduleOverlapPolicy `json:"overlapPolicy"`
 	LastStartedWorkflow *RunningWorkflowInfo        `json:"lastStartedWorkflow,omitempty"`
-	// ConcurrencyLimit mirrors SchedulePolicies.ConcurrencyLimit; 0 = unlimited.
-	ConcurrencyLimit int32 `json:"concurrencyLimit,omitempty"`
+	// ConcurrencyLimit mirrors SchedulePolicies.ConcurrencyLimit:
+	//   nil      = unset (use server default; effectively unlimited)
+	//   *int32(0) = explicitly unlimited
+	//   *int32(N) = capped at N concurrent runs
+	ConcurrencyLimit *int32 `json:"concurrencyLimit,omitempty"`
 	// RunningWorkflows is the current in-flight set from workflow state; used
 	// only when OverlapPolicy==CONCURRENT and ConcurrencyLimit > 0.
 	RunningWorkflows []RunningWorkflowInfo `json:"runningWorkflows,omitempty"`

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -22,6 +22,7 @@ package scheduler
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/robfig/cron/v3"
@@ -386,6 +387,15 @@ func handleUnpause(logger *zap.Logger, sig UnpauseSignal, state *SchedulerWorkfl
 	return true
 }
 
+// concurrencyLimitString renders a *int32 limit for log fields, printing "<nil>"
+// when unset so logs distinguish "no user limit" from "explicit 0 (unlimited)".
+func concurrencyLimitString(v *int32) string {
+	if v == nil {
+		return "<nil>"
+	}
+	return strconv.FormatInt(int64(*v), 10)
+}
+
 func handleUpdate(logger *zap.Logger, sig UpdateSignal, input *SchedulerWorkflowInput, state *SchedulerWorkflowState) bool {
 	if sig.Spec == nil && sig.Action == nil && sig.Policies == nil {
 		logger.Info("ignoring empty update signal")
@@ -430,13 +440,14 @@ func handleUpdate(logger *zap.Logger, sig UpdateSignal, input *SchedulerWorkflow
 		// list is meaningless under any other policy or when limit becomes 0.
 		newOverlap := input.Policies.OverlapPolicy
 		newLimit := input.Policies.ConcurrencyLimit
+		newLimitIsZero := newLimit != nil && *newLimit == 0
 		if previousOverlap == types.ScheduleOverlapPolicyConcurrent &&
-			(newOverlap != types.ScheduleOverlapPolicyConcurrent || newLimit == 0) &&
+			(newOverlap != types.ScheduleOverlapPolicyConcurrent || newLimitIsZero) &&
 			len(state.RunningWorkflows) > 0 {
 			logger.Warn("policy change cleared running workflows tracking",
 				zap.String("from", previousOverlap.String()),
 				zap.String("to", newOverlap.String()),
-				zap.Int32("newLimit", newLimit),
+				zap.String("newLimit", concurrencyLimitString(newLimit)),
 				zap.Int("clearedCount", len(state.RunningWorkflows)))
 			state.RunningWorkflows = nil
 		}
@@ -620,7 +631,7 @@ func enqueueBufferedFire(logger *zap.Logger, scope tally.Scope, input *Scheduler
 			zap.Time("scheduledTime", scheduledTime),
 			zap.String("reason", reason),
 			zap.Int("effectiveLimit", effective),
-			zap.Int32("userBufferLimit", input.Policies.BufferLimit),
+			zap.String("userBufferLimit", concurrencyLimitString(input.Policies.BufferLimit)),
 			zap.Int("systemLimit", MaxBufferedFiresSystemLimit),
 			zap.Int("bufferSize", len(state.BufferedFires)),
 		)
@@ -641,27 +652,31 @@ func enqueueBufferedFire(logger *zap.Logger, scope tally.Scope, input *Scheduler
 // effectiveBufferLimit returns the queue cap actually enforced for the BUFFER
 // overlap policy and the reason tag value to attribute drops at that cap.
 //
+//   - userLimit == nil (unset): returns the system limit, reason=system_limit.
 //   - userLimit == 0 (unlimited): returns the system limit, reason=system_limit.
-//   - 0 < userLimit <= system limit: returns userLimit, reason=user_limit.
-//   - userLimit > system limit: returns the system limit, reason=system_limit
+//   - 0 < *userLimit <= system limit: returns *userLimit, reason=user_limit.
+//   - *userLimit > system limit: returns the system limit, reason=system_limit
 //     (the user's limit cannot be honored without risking ContinueAsNew payload bloat).
-func effectiveBufferLimit(userLimit int32) (effective int, reason string) {
-	if userLimit <= 0 || int(userLimit) > MaxBufferedFiresSystemLimit {
+func effectiveBufferLimit(userLimit *int32) (effective int, reason string) {
+	if userLimit == nil || *userLimit <= 0 || int(*userLimit) > MaxBufferedFiresSystemLimit {
 		return MaxBufferedFiresSystemLimit, BufferOverflowReasonSystemLimit
 	}
-	return int(userLimit), BufferOverflowReasonUserLimit
+	return int(*userLimit), BufferOverflowReasonUserLimit
 }
 
 // effectiveConcurrencyLimit returns the concurrency cap enforced for the bounded
 // CONCURRENT overlap policy. Values above the system ceiling are silently clamped
 // so RunningWorkflows never grows large enough to bloat the ContinueAsNew payload
-// toward Cadence's BlobSizeLimitError (default 2MB). Only called when userLimit > 0
-// (i.e., isBoundedConcurrent is true).
-func effectiveConcurrencyLimit(userLimit int32) int32 {
-	if userLimit > MaxConcurrencyLimitSystemLimit {
+// toward Cadence's BlobSizeLimitError (default 2MB). Only called when userLimit is
+// non-nil and > 0 (i.e., isBoundedConcurrent is true).
+func effectiveConcurrencyLimit(userLimit *int32) int32 {
+	if userLimit == nil {
+		return 0
+	}
+	if *userLimit > MaxConcurrencyLimitSystemLimit {
 		return MaxConcurrencyLimitSystemLimit
 	}
-	return userLimit
+	return *userLimit
 }
 
 // drainBufferedFires executes queued fires in FIFO order, stopping as soon as

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -437,12 +437,13 @@ func handleUpdate(logger *zap.Logger, sig UpdateSignal, input *SchedulerWorkflow
 			state.BufferedFires = nil
 		}
 		// Drop running-workflow tracking when leaving bounded CONCURRENT: the
-		// list is meaningless under any other policy or when limit becomes 0.
+		// list is meaningless under any other policy or when the new limit is
+		// unbounded (nil = unset, *int32(0) = explicit unlimited).
 		newOverlap := input.Policies.OverlapPolicy
 		newLimit := input.Policies.ConcurrencyLimit
-		newLimitIsZero := newLimit != nil && *newLimit == 0
+		newLimitIsUnbounded := newLimit == nil || *newLimit == 0
 		if previousOverlap == types.ScheduleOverlapPolicyConcurrent &&
-			(newOverlap != types.ScheduleOverlapPolicyConcurrent || newLimitIsZero) &&
+			(newOverlap != types.ScheduleOverlapPolicyConcurrent || newLimitIsUnbounded) &&
 			len(state.RunningWorkflows) > 0 {
 			logger.Warn("policy change cleared running workflows tracking",
 				zap.String("from", previousOverlap.String()),

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -387,9 +387,9 @@ func handleUnpause(logger *zap.Logger, sig UnpauseSignal, state *SchedulerWorkfl
 	return true
 }
 
-// concurrencyLimitString renders a *int32 limit for log fields, printing "<nil>"
-// when unset so logs distinguish "no user limit" from "explicit 0 (unlimited)".
-func concurrencyLimitString(v *int32) string {
+// formatOptionalInt32 renders a *int32 for log fields, printing "<nil>" when
+// unset so logs distinguish "no user value" from "explicit 0".
+func formatOptionalInt32(v *int32) string {
 	if v == nil {
 		return "<nil>"
 	}
@@ -448,7 +448,7 @@ func handleUpdate(logger *zap.Logger, sig UpdateSignal, input *SchedulerWorkflow
 			logger.Warn("policy change cleared running workflows tracking",
 				zap.String("from", previousOverlap.String()),
 				zap.String("to", newOverlap.String()),
-				zap.String("newLimit", concurrencyLimitString(newLimit)),
+				zap.String("newLimit", formatOptionalInt32(newLimit)),
 				zap.Int("clearedCount", len(state.RunningWorkflows)))
 			state.RunningWorkflows = nil
 		}
@@ -632,7 +632,7 @@ func enqueueBufferedFire(logger *zap.Logger, scope tally.Scope, input *Scheduler
 			zap.Time("scheduledTime", scheduledTime),
 			zap.String("reason", reason),
 			zap.Int("effectiveLimit", effective),
-			zap.String("userBufferLimit", concurrencyLimitString(input.Policies.BufferLimit)),
+			zap.String("userBufferLimit", formatOptionalInt32(input.Policies.BufferLimit)),
 			zap.Int("systemLimit", MaxBufferedFiresSystemLimit),
 			zap.Int("bufferSize", len(state.BufferedFires)),
 		)

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -31,6 +31,7 @@ import (
 	"go.uber.org/cadence/workflow"
 	"go.uber.org/zap"
 
+	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/types"
 )
 
@@ -1162,7 +1163,7 @@ func TestEnqueueBufferedFire(t *testing.T) {
 	t0 := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 	tests := []struct {
 		name               string
-		bufferLimit        int32
+		bufferLimit        *int32
 		initialFires       []BufferedFire
 		initialSkipped     int64
 		enqueueTime        time.Time
@@ -1173,8 +1174,8 @@ func TestEnqueueBufferedFire(t *testing.T) {
 		wantOverflowReason string
 	}{
 		{
-			name:         "unlimited buffer accepts fire when bufferLimit=0",
-			bufferLimit:  0,
+			name:         "unlimited buffer accepts fire when bufferLimit=nil",
+			bufferLimit:  nil,
 			initialFires: []BufferedFire{{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule, OverlapPolicy: types.ScheduleOverlapPolicyBuffer}},
 			enqueueTime:  t0.Add(time.Minute),
 			trigger:      TriggerSourceSchedule,
@@ -1185,7 +1186,7 @@ func TestEnqueueBufferedFire(t *testing.T) {
 		},
 		{
 			name:        "enqueue below limit appends to tail",
-			bufferLimit: 3,
+			bufferLimit: common.Int32Ptr(3),
 			initialFires: []BufferedFire{
 				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule, OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
 				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule, OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
@@ -1200,7 +1201,7 @@ func TestEnqueueBufferedFire(t *testing.T) {
 		},
 		{
 			name:        "enqueue at user limit drops fire and emits user_limit metric",
-			bufferLimit: 2,
+			bufferLimit: common.Int32Ptr(2),
 			initialFires: []BufferedFire{
 				{ScheduledTime: t0, TriggerSource: TriggerSourceSchedule, OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
 				{ScheduledTime: t0.Add(time.Minute), TriggerSource: TriggerSourceSchedule, OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
@@ -1217,7 +1218,7 @@ func TestEnqueueBufferedFire(t *testing.T) {
 		},
 		{
 			name:               "enqueue at system limit with unlimited buffer_limit attributes to system_limit",
-			bufferLimit:        0,
+			bufferLimit:        nil,
 			initialFires:       largeBufferedFires(MaxBufferedFiresSystemLimit, t0),
 			initialSkipped:     0,
 			enqueueTime:        t0.Add(time.Hour),
@@ -1228,7 +1229,7 @@ func TestEnqueueBufferedFire(t *testing.T) {
 		},
 		{
 			name:               "enqueue at system limit when user buffer_limit exceeds it attributes to system_limit",
-			bufferLimit:        int32(MaxBufferedFiresSystemLimit * 2),
+			bufferLimit:        common.Int32Ptr(int32(MaxBufferedFiresSystemLimit * 2)),
 			initialFires:       largeBufferedFires(MaxBufferedFiresSystemLimit, t0),
 			enqueueTime:        t0.Add(time.Hour),
 			trigger:            TriggerSourceSchedule,
@@ -1238,7 +1239,7 @@ func TestEnqueueBufferedFire(t *testing.T) {
 		},
 		{
 			name:         "backfill trigger source is preserved",
-			bufferLimit:  0,
+			bufferLimit:  nil,
 			initialFires: nil,
 			enqueueTime:  t0,
 			trigger:      TriggerSourceBackfill,
@@ -1248,7 +1249,7 @@ func TestEnqueueBufferedFire(t *testing.T) {
 		},
 		{
 			name:              "backfill id is preserved on buffered fire",
-			bufferLimit:       0,
+			bufferLimit:       nil,
 			initialFires:      nil,
 			enqueueTime:       t0,
 			trigger:           TriggerSourceBackfill,
@@ -1468,37 +1469,43 @@ func TestDrainBufferedFiresRespectsCap(t *testing.T) {
 func TestEffectiveBufferLimit(t *testing.T) {
 	tests := []struct {
 		name       string
-		userLimit  int32
+		userLimit  *int32
 		wantLimit  int
 		wantReason string
 	}{
 		{
-			name:       "userLimit=0 (unlimited) yields system limit",
-			userLimit:  0,
+			name:       "nil userLimit yields system limit",
+			userLimit:  nil,
+			wantLimit:  MaxBufferedFiresSystemLimit,
+			wantReason: BufferOverflowReasonSystemLimit,
+		},
+		{
+			name:       "userLimit=0 (explicit unlimited) yields system limit",
+			userLimit:  common.Int32Ptr(0),
 			wantLimit:  MaxBufferedFiresSystemLimit,
 			wantReason: BufferOverflowReasonSystemLimit,
 		},
 		{
 			name:       "negative userLimit treated as unlimited yields system limit",
-			userLimit:  -1,
+			userLimit:  common.Int32Ptr(-1),
 			wantLimit:  MaxBufferedFiresSystemLimit,
 			wantReason: BufferOverflowReasonSystemLimit,
 		},
 		{
 			name:       "userLimit below system limit is honored",
-			userLimit:  100,
+			userLimit:  common.Int32Ptr(100),
 			wantLimit:  100,
 			wantReason: BufferOverflowReasonUserLimit,
 		},
 		{
 			name:       "userLimit equal to system limit is honored as user_limit",
-			userLimit:  int32(MaxBufferedFiresSystemLimit),
+			userLimit:  common.Int32Ptr(int32(MaxBufferedFiresSystemLimit)),
 			wantLimit:  MaxBufferedFiresSystemLimit,
 			wantReason: BufferOverflowReasonUserLimit,
 		},
 		{
 			name:       "userLimit above system limit is clamped to system limit",
-			userLimit:  int32(MaxBufferedFiresSystemLimit * 2),
+			userLimit:  common.Int32Ptr(int32(MaxBufferedFiresSystemLimit * 2)),
 			wantLimit:  MaxBufferedFiresSystemLimit,
 			wantReason: BufferOverflowReasonSystemLimit,
 		},
@@ -1521,45 +1528,45 @@ func TestHandleUpdate_RunningWorkflowsClearedOnOverlapPolicyChange(t *testing.T)
 	tests := []struct {
 		name              string
 		fromOverlap       types.ScheduleOverlapPolicy
-		fromLimit         int32
+		fromLimit         *int32
 		toOverlap         types.ScheduleOverlapPolicy
-		toLimit           int32
+		toLimit           *int32
 		initialRunningWFs []RunningWorkflowInfo
 		wantNil           bool
 	}{
 		{
 			name:              "CONCURRENT(limit=2) -> SKIP_NEW clears running workflows",
 			fromOverlap:       types.ScheduleOverlapPolicyConcurrent,
-			fromLimit:         2,
+			fromLimit:         common.Int32Ptr(2),
 			toOverlap:         types.ScheduleOverlapPolicySkipNew,
-			toLimit:           0,
+			toLimit:           common.Int32Ptr(0),
 			initialRunningWFs: runningWFs,
 			wantNil:           true,
 		},
 		{
 			name:              "CONCURRENT(limit=2) -> CONCURRENT(limit=0) clears running workflows",
 			fromOverlap:       types.ScheduleOverlapPolicyConcurrent,
-			fromLimit:         2,
+			fromLimit:         common.Int32Ptr(2),
 			toOverlap:         types.ScheduleOverlapPolicyConcurrent,
-			toLimit:           0,
+			toLimit:           common.Int32Ptr(0),
 			initialRunningWFs: runningWFs,
 			wantNil:           true,
 		},
 		{
 			name:              "CONCURRENT(limit=2) -> BUFFER clears running workflows",
 			fromOverlap:       types.ScheduleOverlapPolicyConcurrent,
-			fromLimit:         2,
+			fromLimit:         common.Int32Ptr(2),
 			toOverlap:         types.ScheduleOverlapPolicyBuffer,
-			toLimit:           0,
+			toLimit:           common.Int32Ptr(0),
 			initialRunningWFs: runningWFs,
 			wantNil:           true,
 		},
 		{
 			name:              "CONCURRENT(limit=5) -> CONCURRENT(limit=2) preserves running workflows",
 			fromOverlap:       types.ScheduleOverlapPolicyConcurrent,
-			fromLimit:         5,
+			fromLimit:         common.Int32Ptr(5),
 			toOverlap:         types.ScheduleOverlapPolicyConcurrent,
-			toLimit:           2,
+			toLimit:           common.Int32Ptr(2),
 			initialRunningWFs: runningWFs,
 			wantNil:           false,
 		},

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1553,6 +1553,15 @@ func TestHandleUpdate_RunningWorkflowsClearedOnOverlapPolicyChange(t *testing.T)
 			wantNil:           true,
 		},
 		{
+			name:              "CONCURRENT(limit=2) -> CONCURRENT(limit=nil) clears running workflows",
+			fromOverlap:       types.ScheduleOverlapPolicyConcurrent,
+			fromLimit:         common.Int32Ptr(2),
+			toOverlap:         types.ScheduleOverlapPolicyConcurrent,
+			toLimit:           nil,
+			initialRunningWFs: runningWFs,
+			wantNil:           true,
+		},
+		{
 			name:              "CONCURRENT(limit=2) -> BUFFER clears running workflows",
 			fromOverlap:       types.ScheduleOverlapPolicyConcurrent,
 			fromLimit:         common.Int32Ptr(2),

--- a/tools/cli/schedule_commands.go
+++ b/tools/cli/schedule_commands.go
@@ -88,7 +88,7 @@ func (sc *scheduleCLIImpl) CreateSchedule(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if policies != nil && policies.ConcurrencyLimit > 0 &&
+	if policies != nil && policies.ConcurrencyLimit != nil && *policies.ConcurrencyLimit > 0 &&
 		policies.OverlapPolicy != types.ScheduleOverlapPolicyConcurrent {
 		return commoncli.Problem("--concurrency_limit requires --overlap_policy concurrent", nil)
 	}
@@ -168,7 +168,7 @@ func (sc *scheduleCLIImpl) UpdateSchedule(c *cli.Context) error {
 	}
 	// Only reject explicit conflicts; standalone --concurrency_limit updates are
 	// valid when the schedule's existing server-side policy is already concurrent.
-	if policies != nil && policies.ConcurrencyLimit > 0 &&
+	if policies != nil && policies.ConcurrencyLimit != nil && *policies.ConcurrencyLimit > 0 &&
 		c.IsSet(FlagOverlapPolicy) && policies.OverlapPolicy != types.ScheduleOverlapPolicyConcurrent {
 		return commoncli.Problem("--concurrency_limit requires --overlap_policy concurrent", nil)
 	}
@@ -403,7 +403,7 @@ func buildPoliciesFromFlags(c *cli.Context) (*types.SchedulePolicies, error) {
 		if limit < 0 {
 			return nil, commoncli.Problem("--concurrency_limit must be >= 0", nil)
 		}
-		policies.ConcurrencyLimit = limit
+		policies.ConcurrencyLimit = &limit
 	}
 	return policies, nil
 }

--- a/tools/cli/schedule_commands_test.go
+++ b/tools/cli/schedule_commands_test.go
@@ -29,6 +29,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/uber/cadence/client/frontend"
+	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/types"
 )
 
@@ -116,7 +117,7 @@ func TestScheduleCLI_CreateSchedule_ConcurrencyLimit(t *testing.T) {
 				m.EXPECT().CreateSchedule(gomock.Any(), gomock.Any()).
 					DoAndReturn(func(_ interface{}, req *types.CreateScheduleRequest, _ ...interface{}) (*types.CreateScheduleResponse, error) {
 						assert.Equal(t, types.ScheduleOverlapPolicyConcurrent, req.Policies.OverlapPolicy)
-						assert.Equal(t, int32(3), req.Policies.ConcurrencyLimit)
+						assert.Equal(t, common.Int32Ptr(3), req.Policies.ConcurrencyLimit)
 						return &types.CreateScheduleResponse{ScheduleID: "my-sched"}, nil
 					})
 			},
@@ -256,7 +257,7 @@ func TestScheduleCLI_UpdateSchedule_ConcurrencyLimit(t *testing.T) {
 					DoAndReturn(func(_ interface{}, req *types.UpdateScheduleRequest, _ ...interface{}) (*types.UpdateScheduleResponse, error) {
 						assert.Nil(t, req.Spec)
 						assert.NotNil(t, req.Policies)
-						assert.Equal(t, int32(3), req.Policies.ConcurrencyLimit)
+						assert.Equal(t, common.Int32Ptr(3), req.Policies.ConcurrencyLimit)
 						return &types.UpdateScheduleResponse{}, nil
 					})
 			},
@@ -268,7 +269,7 @@ func TestScheduleCLI_UpdateSchedule_ConcurrencyLimit(t *testing.T) {
 				m.EXPECT().UpdateSchedule(gomock.Any(), gomock.Any()).
 					DoAndReturn(func(_ interface{}, req *types.UpdateScheduleRequest, _ ...interface{}) (*types.UpdateScheduleResponse, error) {
 						assert.NotNil(t, req.Policies)
-						assert.Equal(t, int32(0), req.Policies.ConcurrencyLimit)
+						assert.Equal(t, common.Int32Ptr(0), req.Policies.ConcurrencyLimit)
 						return &types.UpdateScheduleResponse{}, nil
 					})
 			},
@@ -280,7 +281,7 @@ func TestScheduleCLI_UpdateSchedule_ConcurrencyLimit(t *testing.T) {
 				m.EXPECT().UpdateSchedule(gomock.Any(), gomock.Any()).
 					DoAndReturn(func(_ interface{}, req *types.UpdateScheduleRequest, _ ...interface{}) (*types.UpdateScheduleResponse, error) {
 						assert.Equal(t, types.ScheduleOverlapPolicyConcurrent, req.Policies.OverlapPolicy)
-						assert.Equal(t, int32(5), req.Policies.ConcurrencyLimit)
+						assert.Equal(t, common.Int32Ptr(5), req.Policies.ConcurrencyLimit)
 						return &types.UpdateScheduleResponse{}, nil
 					})
 			},
@@ -593,14 +594,14 @@ func TestScheduleCLI_BuildPoliciesFromFlags(t *testing.T) {
 		{
 			name:       "only --concurrency_limit sets ConcurrencyLimit in result",
 			args:       []string{"--" + FlagConcurrencyLimit, "3"},
-			wantResult: &types.SchedulePolicies{ConcurrencyLimit: 3},
+			wantResult: &types.SchedulePolicies{ConcurrencyLimit: common.Int32Ptr(3)},
 		},
 		{
 			name: "--overlap_policy concurrent and --concurrency_limit both set in result",
 			args: []string{"--" + FlagOverlapPolicy, "concurrent", "--" + FlagConcurrencyLimit, "3"},
 			wantResult: &types.SchedulePolicies{
 				OverlapPolicy:    types.ScheduleOverlapPolicyConcurrent,
-				ConcurrencyLimit: 3,
+				ConcurrencyLimit: common.Int32Ptr(3),
 			},
 		},
 		{
@@ -608,7 +609,7 @@ func TestScheduleCLI_BuildPoliciesFromFlags(t *testing.T) {
 			args: []string{"--" + FlagOverlapPolicy, "skipnew", "--" + FlagConcurrencyLimit, "3"},
 			wantResult: &types.SchedulePolicies{
 				OverlapPolicy:    types.ScheduleOverlapPolicySkipNew,
-				ConcurrencyLimit: 3,
+				ConcurrencyLimit: common.Int32Ptr(3),
 			},
 		},
 		{


### PR DESCRIPTION

<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

- Bumps cadence-idl: https://github.com/cadence-workflow/cadence-idl/pull/268 which changes SchedulePolicies.{buffer_limit, concurrency_limit} on the proto wire from bare int32 to oogle.protobuf.Int32Value. Threads *int32 through the corresponding internal types, mappers, scheduler workflow/activity reads, frontend validation, and CLI:

  - common/types.SchedulePolicies.{BufferLimit, ConcurrencyLimit}: int32 → *int32 (Thrift wire was already optional i32, so the Thrift mapper is now pure pass-through; the proto mapper uses new
  fromInt32Value/toInt32Value helpers).
  - Scheduler workflow helpers effectiveBufferLimit / effectiveConcurrencyLimit and the bounded-concurrent gate in activity.go accept *int32 and are nil-safe.
  - Frontend warnIfBufferLimitExceedsSystemLimit no-ops on nil BufferLimit.
  - ProcessFireRequest.ConcurrencyLimit (signal payload) is *int32 and round-trips through JSON as null.
  - CLI builders pass &limit and use nil-safe comparisons.

- Three states are now distinguishable on the wire and in code:
   1. nil: preserve existing on Update 
   2. *int32(0): explicitly unlimited
   3. *int32(N): capped at N


**Why?**

- Proto3 bare scalars have no field presence, so the wire cannot represent "user didn't touch this field" vs "user explicitly set 0." That left the SDK and server with no way to express "leave this field alone" for BufferLimit/ConcurrencyLimit, and no way to distinguish "user wants unlimited (0)" from "user didn't set it." The mapper had to flatten nil↔0 on read and wrap 0→*int32(0) on write, losing information at both boundaries.

**How did you test it?**

- Updated table-driven tests in effectiveBufferLimit/effectiveConcurrencyLimit, handleUpdate, enqueueBufferedFire, frontend handler create/update, and CLI create/update to cover nil, *0, and *N cases.
- Added TestWarnIfBufferLimitExceedsSystemLimit_NilSafe covering nil policies, nil BufferLimit, non-Buffer policy with limit set, and under-limit cases.
- Manually verified Thrift round-trip (nil ↔ nil, *5 ↔ *5, *0 ↔ *0) and proto round-trip (nil ↔ nil, *5 ↔ Int32Value{5}, *0 ↔ Int32Value{0}) via existing mapper tests with updated testdata.

**Potential risks**

- Proto wire change 
- JSON in signal payloads — ProcessFireRequest.ConcurrencyLimit is *int32 in JSON. In-flight activity payloads serialized by an old server (bare int32 0) decode as *int32(0) on a new server, which now means "explicitly unlimited" instead of "unset." This is the intended new semantics, but operators with a hot scheduler workflow at upgrade time should be aware.

**Release notes**

- SchedulePolicies.BufferLimit and ConcurrencyLimit are now nullable (*int32). nil means "use server default" on Create or "preserve existing" on Update; *int32(0) means "explicitly unlimited." Callers that previously sent 0 to mean "unlimited" should switch to common.Int32Ptr(0) to preserve that intent.

**Documentation Changes**
N/A
