### PR TITLE
refactor(matching): migrate excludeShortLivedTaskListsFromShardManager to operational dynamic config

### DIFF
--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -237,7 +237,7 @@ func (s *server) startService() common.Daemon {
 		params.HashRings[s] = membership.NewHashring(s, peerProvider, clock.NewRealTimeSource(), params.Logger, params.MetricsClient.Scope(metrics.HashringScope))
 	}
 
-	wrappedRings := s.wrapHashRingsWithShardDistributor(params.HashRings, spectator, dc, params.PercentageOnboarded, params.Logger)
+	wrappedRings := s.wrapHashRingsWithShardDistributor(params.HashRings, spectator, operationalDC, params.PercentageOnboarded, params.Logger)
 
 	params.MembershipResolver, err = membership.NewResolver(
 		peerProvider,
@@ -344,14 +344,14 @@ func (s *server) startService() common.Daemon {
 func (*server) wrapHashRingsWithShardDistributor(
 	hashRings map[string]membership.SingleProvider,
 	spectator spectatorclient.Spectator,
-	dc *dynamicconfig.Collection,
+	operationalDC *dynamicconfig.Collection,
 	percentageOnboarded membership.PercentageOnboarded,
 	logger log.Logger,
 ) map[string]membership.SingleProvider {
 	if _, ok := hashRings[service.Matching]; ok {
 		hashRings[service.Matching] = membership.NewShardDistributorResolver(
 			spectator,
-			dc.GetBoolProperty(dynamicproperties.MatchingExcludeShortLivedTaskListsFromShardManager),
+			operationalDC.GetBoolProperty(dynamicproperties.MatchingExcludeShortLivedTaskListsFromShardManager),
 			percentageOnboarded,
 			hashRings[service.Matching],
 			logger,

--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -2373,6 +2373,7 @@ const (
 
 	// MatchingExcludeShortLivedTaskListsFromShardManager excludes short-lived task lists (e.g. bits task lists and sticky task lists)
 	// from using the shard manager to handle these shards. These short-lived task lists are assigned using hash_ring.
+	// Read from the primary database-backed operational dynamic config store.
 	// KeyName: matching.excludeShortLivedTaskListsFromShardManager
 	// Value type: Bool
 	// Default value: true

--- a/service/matching/config/config.go
+++ b/service/matching/config/config.go
@@ -181,7 +181,7 @@ type (
 )
 
 // NewConfig returns new service config with default values
-func NewConfig(dc *dynamicconfig.Collection, hostName string, rpcConfig config.RPC, getIsolationGroups func() []string) *Config {
+func NewConfig(dc *dynamicconfig.Collection, operationalDC *dynamicconfig.Collection, hostName string, rpcConfig config.RPC, getIsolationGroups func() []string) *Config {
 	return &Config{
 		PersistenceMaxQPS:                          dc.GetIntProperty(dynamicproperties.MatchingPersistenceMaxQPS),
 		PersistenceGlobalMaxQPS:                    dc.GetIntProperty(dynamicproperties.MatchingPersistenceGlobalMaxQPS),
@@ -244,7 +244,7 @@ func NewConfig(dc *dynamicconfig.Collection, hostName string, rpcConfig config.R
 		EnableStandbyTaskCompletion:                dc.GetBoolPropertyFilteredByTaskListInfo(dynamicproperties.MatchingEnableStandbyTaskCompletion),
 		EnableClientAutoConfig:                     dc.GetBoolPropertyFilteredByTaskListInfo(dynamicproperties.MatchingEnableClientAutoConfig),
 		EnableReturnAllTaskListKinds:               dc.GetBoolProperty(dynamicproperties.MatchingEnableReturnAllTaskListKinds),
-		ExcludeShortLivedTaskListsFromShardManager: dc.GetBoolProperty(dynamicproperties.MatchingExcludeShortLivedTaskListsFromShardManager),
+		ExcludeShortLivedTaskListsFromShardManager: operationalDC.GetBoolProperty(dynamicproperties.MatchingExcludeShortLivedTaskListsFromShardManager),
 		RecordTaskStartedTimeout:                   dc.GetDurationPropertyFilteredByDomain(dynamicproperties.MatchingRecordTaskStartedTimeout),
 		MinTaskListWritePartitions:                 dc.GetIntPropertyFilteredByTaskListInfo(dynamicproperties.MatchingTaskListMinimumWritePartitions),
 	}

--- a/service/matching/config/config_test.go
+++ b/service/matching/config/config_test.go
@@ -23,6 +23,7 @@
 package config
 
 import (
+	"maps"
 	"reflect"
 	"testing"
 	"time"
@@ -44,85 +45,98 @@ type configTestCase struct {
 func TestNewConfig(t *testing.T) {
 	hostname := "hostname"
 	fields := map[string]configTestCase{
-		"PersistenceMaxQPS":                          {dynamicproperties.MatchingPersistenceMaxQPS, 1},
-		"PersistenceGlobalMaxQPS":                    {dynamicproperties.MatchingPersistenceGlobalMaxQPS, 2},
-		"EnableSyncMatch":                            {dynamicproperties.MatchingEnableSyncMatch, true},
-		"UserRPS":                                    {dynamicproperties.MatchingUserRPS, 3},
-		"WorkerRPS":                                  {dynamicproperties.MatchingWorkerRPS, 4},
-		"DomainUserRPS":                              {dynamicproperties.MatchingDomainUserRPS, 5},
-		"DomainWorkerRPS":                            {dynamicproperties.MatchingDomainWorkerRPS, 6},
-		"RangeSize":                                  {nil, int64(100000)},
-		"ReadRangeSize":                              {dynamicproperties.MatchingReadRangeSize, 50000},
-		"GetTasksBatchSize":                          {dynamicproperties.MatchingGetTasksBatchSize, 7},
-		"UpdateAckInterval":                          {dynamicproperties.MatchingUpdateAckInterval, time.Duration(8)},
-		"IdleTasklistCheckInterval":                  {dynamicproperties.MatchingIdleTasklistCheckInterval, time.Duration(9)},
-		"MaxTasklistIdleTime":                        {dynamicproperties.MaxTasklistIdleTime, time.Duration(10)},
-		"LongPollExpirationInterval":                 {dynamicproperties.MatchingLongPollExpirationInterval, time.Duration(11)},
-		"MinTaskThrottlingBurstSize":                 {dynamicproperties.MatchingMinTaskThrottlingBurstSize, 12},
-		"MaxTaskDeleteBatchSize":                     {dynamicproperties.MatchingMaxTaskDeleteBatchSize, 13},
-		"OutstandingTaskAppendsThreshold":            {dynamicproperties.MatchingOutstandingTaskAppendsThreshold, 14},
-		"MaxTaskBatchSize":                           {dynamicproperties.MatchingMaxTaskBatchSize, 15},
-		"ThrottledLogRPS":                            {dynamicproperties.MatchingThrottledLogRPS, 16},
-		"NumTasklistWritePartitions":                 {dynamicproperties.MatchingNumTasklistWritePartitions, 17},
-		"NumTasklistReadPartitions":                  {dynamicproperties.MatchingNumTasklistReadPartitions, 18},
-		"ForwarderMaxOutstandingPolls":               {dynamicproperties.MatchingForwarderMaxOutstandingPolls, 19},
-		"ForwarderMaxOutstandingTasks":               {dynamicproperties.MatchingForwarderMaxOutstandingTasks, 20},
-		"ForwarderMaxRatePerSecond":                  {dynamicproperties.MatchingForwarderMaxRatePerSecond, 21},
-		"ForwarderMaxChildrenPerNode":                {dynamicproperties.MatchingForwarderMaxChildrenPerNode, 22},
-		"ShutdownDrainDuration":                      {dynamicproperties.MatchingShutdownDrainDuration, time.Duration(23)},
-		"EnableDebugMode":                            {dynamicproperties.EnableDebugMode, false},
-		"EnableTaskInfoLogByDomainID":                {dynamicproperties.MatchingEnableTaskInfoLogByDomainID, true},
-		"ActivityTaskSyncMatchWaitTime":              {dynamicproperties.MatchingActivityTaskSyncMatchWaitTime, time.Duration(24)},
-		"EnableTasklistIsolation":                    {dynamicproperties.EnableTasklistIsolation, false},
-		"AsyncTaskDispatchTimeout":                   {dynamicproperties.AsyncTaskDispatchTimeout, time.Duration(25)},
-		"LocalPollWaitTime":                          {dynamicproperties.LocalPollWaitTime, time.Duration(10)},
-		"LocalTaskWaitTime":                          {dynamicproperties.LocalTaskWaitTime, time.Duration(10)},
-		"HostName":                                   {nil, hostname},
-		"RPCConfig":                                  {nil, config.RPC{}},
-		"TaskDispatchRPS":                            {nil, 100000.0},
-		"TaskDispatchRPSTTL":                         {nil, time.Minute},
-		"MaxTimeBetweenTaskDeletes":                  {nil, time.Second},
-		"AllIsolationGroups":                         {nil, []string{"zone-1", "zone-2"}},
-		"EnableGetNumberOfPartitionsFromCache":       {dynamicproperties.MatchingEnableGetNumberOfPartitionsFromCache, false},
-		"EnablePartitionEmptyCheck":                  {dynamicproperties.MatchingEnablePartitionEmptyCheck, true},
-		"PartitionUpscaleRPS":                        {dynamicproperties.MatchingPartitionUpscaleRPS, 30},
-		"PartitionDownscaleFactor":                   {dynamicproperties.MatchingPartitionDownscaleFactor, 31.0},
-		"PartitionUpscaleSustainedDuration":          {dynamicproperties.MatchingPartitionUpscaleSustainedDuration, time.Duration(32)},
-		"PartitionDownscaleSustainedDuration":        {dynamicproperties.MatchingPartitionDownscaleSustainedDuration, time.Duration(33)},
-		"AdaptiveScalerUpdateInterval":               {dynamicproperties.MatchingAdaptiveScalerUpdateInterval, time.Duration(34)},
-		"EnableAdaptiveScaler":                       {dynamicproperties.MatchingEnableAdaptiveScaler, true},
-		"QPSTrackerInterval":                         {dynamicproperties.MatchingQPSTrackerInterval, 5 * time.Second},
-		"OverrideTaskListRPS":                        {dynamicproperties.MatchingOverrideTaskListRPS, 1500.0},
-		"EnableStandbyTaskCompletion":                {dynamicproperties.MatchingEnableStandbyTaskCompletion, false},
-		"EnableClientAutoConfig":                     {dynamicproperties.MatchingEnableClientAutoConfig, false},
-		"TaskIsolationDuration":                      {dynamicproperties.TaskIsolationDuration, time.Duration(35)},
-		"TaskIsolationPollerWindow":                  {dynamicproperties.TaskIsolationPollerWindow, time.Duration(36)},
-		"EnablePartitionIsolationGroupAssignment":    {dynamicproperties.EnablePartitionIsolationGroupAssignment, true},
-		"IsolationGroupUpscaleSustainedDuration":     {dynamicproperties.MatchingIsolationGroupUpscaleSustainedDuration, time.Duration(37)},
-		"IsolationGroupDownscaleSustainedDuration":   {dynamicproperties.MatchingIsolationGroupDownscaleSustainedDuration, time.Duration(38)},
-		"IsolationGroupHasPollersSustainedDuration":  {dynamicproperties.MatchingIsolationGroupHasPollersSustainedDuration, time.Duration(39)},
-		"IsolationGroupNoPollersSustainedDuration":   {dynamicproperties.MatchingIsolationGroupNoPollersSustainedDuration, time.Duration(40)},
-		"IsolationGroupsPerPartition":                {dynamicproperties.MatchingIsolationGroupsPerPartition, 41},
-		"EnableReturnAllTaskListKinds":               {dynamicproperties.MatchingEnableReturnAllTaskListKinds, true},
-		"AppendTaskTimeout":                          {dynamicproperties.AppendTaskTimeout, time.Duration(42)},
-		"ExcludeShortLivedTaskListsFromShardManager": {dynamicproperties.MatchingExcludeShortLivedTaskListsFromShardManager, false},
-		"RecordTaskStartedTimeout":                   {dynamicproperties.MatchingRecordTaskStartedTimeout, time.Duration(43)},
-		"MinTaskListWritePartitions":                 {dynamicproperties.MatchingTaskListMinimumWritePartitions, 1},
+		"PersistenceMaxQPS":                         {dynamicproperties.MatchingPersistenceMaxQPS, 1},
+		"PersistenceGlobalMaxQPS":                   {dynamicproperties.MatchingPersistenceGlobalMaxQPS, 2},
+		"EnableSyncMatch":                           {dynamicproperties.MatchingEnableSyncMatch, true},
+		"UserRPS":                                   {dynamicproperties.MatchingUserRPS, 3},
+		"WorkerRPS":                                 {dynamicproperties.MatchingWorkerRPS, 4},
+		"DomainUserRPS":                             {dynamicproperties.MatchingDomainUserRPS, 5},
+		"DomainWorkerRPS":                           {dynamicproperties.MatchingDomainWorkerRPS, 6},
+		"RangeSize":                                 {nil, int64(100000)},
+		"ReadRangeSize":                             {dynamicproperties.MatchingReadRangeSize, 50000},
+		"GetTasksBatchSize":                         {dynamicproperties.MatchingGetTasksBatchSize, 7},
+		"UpdateAckInterval":                         {dynamicproperties.MatchingUpdateAckInterval, time.Duration(8)},
+		"IdleTasklistCheckInterval":                 {dynamicproperties.MatchingIdleTasklistCheckInterval, time.Duration(9)},
+		"MaxTasklistIdleTime":                       {dynamicproperties.MaxTasklistIdleTime, time.Duration(10)},
+		"LongPollExpirationInterval":                {dynamicproperties.MatchingLongPollExpirationInterval, time.Duration(11)},
+		"MinTaskThrottlingBurstSize":                {dynamicproperties.MatchingMinTaskThrottlingBurstSize, 12},
+		"MaxTaskDeleteBatchSize":                    {dynamicproperties.MatchingMaxTaskDeleteBatchSize, 13},
+		"OutstandingTaskAppendsThreshold":           {dynamicproperties.MatchingOutstandingTaskAppendsThreshold, 14},
+		"MaxTaskBatchSize":                          {dynamicproperties.MatchingMaxTaskBatchSize, 15},
+		"ThrottledLogRPS":                           {dynamicproperties.MatchingThrottledLogRPS, 16},
+		"NumTasklistWritePartitions":                {dynamicproperties.MatchingNumTasklistWritePartitions, 17},
+		"NumTasklistReadPartitions":                 {dynamicproperties.MatchingNumTasklistReadPartitions, 18},
+		"ForwarderMaxOutstandingPolls":              {dynamicproperties.MatchingForwarderMaxOutstandingPolls, 19},
+		"ForwarderMaxOutstandingTasks":              {dynamicproperties.MatchingForwarderMaxOutstandingTasks, 20},
+		"ForwarderMaxRatePerSecond":                 {dynamicproperties.MatchingForwarderMaxRatePerSecond, 21},
+		"ForwarderMaxChildrenPerNode":               {dynamicproperties.MatchingForwarderMaxChildrenPerNode, 22},
+		"ShutdownDrainDuration":                     {dynamicproperties.MatchingShutdownDrainDuration, time.Duration(23)},
+		"EnableDebugMode":                           {dynamicproperties.EnableDebugMode, false},
+		"EnableTaskInfoLogByDomainID":               {dynamicproperties.MatchingEnableTaskInfoLogByDomainID, true},
+		"ActivityTaskSyncMatchWaitTime":             {dynamicproperties.MatchingActivityTaskSyncMatchWaitTime, time.Duration(24)},
+		"EnableTasklistIsolation":                   {dynamicproperties.EnableTasklistIsolation, false},
+		"AsyncTaskDispatchTimeout":                  {dynamicproperties.AsyncTaskDispatchTimeout, time.Duration(25)},
+		"LocalPollWaitTime":                         {dynamicproperties.LocalPollWaitTime, time.Duration(10)},
+		"LocalTaskWaitTime":                         {dynamicproperties.LocalTaskWaitTime, time.Duration(10)},
+		"HostName":                                  {nil, hostname},
+		"RPCConfig":                                 {nil, config.RPC{}},
+		"TaskDispatchRPS":                           {nil, 100000.0},
+		"TaskDispatchRPSTTL":                        {nil, time.Minute},
+		"MaxTimeBetweenTaskDeletes":                 {nil, time.Second},
+		"AllIsolationGroups":                        {nil, []string{"zone-1", "zone-2"}},
+		"EnableGetNumberOfPartitionsFromCache":      {dynamicproperties.MatchingEnableGetNumberOfPartitionsFromCache, false},
+		"EnablePartitionEmptyCheck":                 {dynamicproperties.MatchingEnablePartitionEmptyCheck, true},
+		"PartitionUpscaleRPS":                       {dynamicproperties.MatchingPartitionUpscaleRPS, 30},
+		"PartitionDownscaleFactor":                  {dynamicproperties.MatchingPartitionDownscaleFactor, 31.0},
+		"PartitionUpscaleSustainedDuration":         {dynamicproperties.MatchingPartitionUpscaleSustainedDuration, time.Duration(32)},
+		"PartitionDownscaleSustainedDuration":       {dynamicproperties.MatchingPartitionDownscaleSustainedDuration, time.Duration(33)},
+		"AdaptiveScalerUpdateInterval":              {dynamicproperties.MatchingAdaptiveScalerUpdateInterval, time.Duration(34)},
+		"EnableAdaptiveScaler":                      {dynamicproperties.MatchingEnableAdaptiveScaler, true},
+		"QPSTrackerInterval":                        {dynamicproperties.MatchingQPSTrackerInterval, 5 * time.Second},
+		"OverrideTaskListRPS":                       {dynamicproperties.MatchingOverrideTaskListRPS, 1500.0},
+		"EnableStandbyTaskCompletion":               {dynamicproperties.MatchingEnableStandbyTaskCompletion, false},
+		"EnableClientAutoConfig":                    {dynamicproperties.MatchingEnableClientAutoConfig, false},
+		"TaskIsolationDuration":                     {dynamicproperties.TaskIsolationDuration, time.Duration(35)},
+		"TaskIsolationPollerWindow":                 {dynamicproperties.TaskIsolationPollerWindow, time.Duration(36)},
+		"EnablePartitionIsolationGroupAssignment":   {dynamicproperties.EnablePartitionIsolationGroupAssignment, true},
+		"IsolationGroupUpscaleSustainedDuration":    {dynamicproperties.MatchingIsolationGroupUpscaleSustainedDuration, time.Duration(37)},
+		"IsolationGroupDownscaleSustainedDuration":  {dynamicproperties.MatchingIsolationGroupDownscaleSustainedDuration, time.Duration(38)},
+		"IsolationGroupHasPollersSustainedDuration": {dynamicproperties.MatchingIsolationGroupHasPollersSustainedDuration, time.Duration(39)},
+		"IsolationGroupNoPollersSustainedDuration":  {dynamicproperties.MatchingIsolationGroupNoPollersSustainedDuration, time.Duration(40)},
+		"IsolationGroupsPerPartition":               {dynamicproperties.MatchingIsolationGroupsPerPartition, 41},
+		"EnableReturnAllTaskListKinds":              {dynamicproperties.MatchingEnableReturnAllTaskListKinds, true},
+		"AppendTaskTimeout":                         {dynamicproperties.AppendTaskTimeout, time.Duration(42)},
+		"RecordTaskStartedTimeout":                  {dynamicproperties.MatchingRecordTaskStartedTimeout, time.Duration(43)},
+		"MinTaskListWritePartitions":                {dynamicproperties.MatchingTaskListMinimumWritePartitions, 1},
 	}
+	operationalConfigFields := map[string]configTestCase{
+		"ExcludeShortLivedTaskListsFromShardManager": {dynamicproperties.MatchingExcludeShortLivedTaskListsFromShardManager, false},
+	}
+	client := newTestClient(t, fields)
+	operationalClient := newTestClient(t, operationalConfigFields)
+
+	dc := dynamicconfig.NewCollection(client, testlogger.New(t))
+	operationalDC := dynamicconfig.NewCollection(operationalClient, testlogger.New(t))
+
+	config := NewConfig(dc, operationalDC, hostname, config.RPC{}, isolationGroupsHelper)
+
+	allFields := make(map[string]configTestCase)
+	maps.Copy(allFields, fields)
+	maps.Copy(allFields, operationalConfigFields)
+	assertFieldsMatch(t, *config, allFields)
+}
+
+func newTestClient(t *testing.T, fields map[string]configTestCase) dynamicconfig.Client {
+	t.Helper()
 	client := dynamicconfig.NewInMemoryClient()
 	for fieldName, expected := range fields {
 		if expected.key != nil {
-			err := client.UpdateValue(expected.key, expected.value)
-			if err != nil {
+			if err := client.UpdateValue(expected.key, expected.value); err != nil {
 				t.Errorf("Failed to update config for %s: %s", fieldName, err)
 			}
 		}
 	}
-	dc := dynamicconfig.NewCollection(client, testlogger.New(t))
-
-	config := NewConfig(dc, hostname, config.RPC{}, isolationGroupsHelper)
-
-	assertFieldsMatch(t, *config, fields)
+	return client
 }
 
 func assertFieldsMatch(t *testing.T, config interface{}, fields map[string]configTestCase) {
@@ -228,7 +242,7 @@ func TestGetTasksBatchSizeValidation(t *testing.T) {
 			assert.NoError(t, err)
 
 			dc := dynamicconfig.NewCollection(client, testlogger.New(t))
-			config := NewConfig(dc, "test-host", config.RPC{}, isolationGroupsHelper)
+			config := NewConfig(dc, dynamicconfig.NewNopCollection(), "test-host", config.RPC{}, isolationGroupsHelper)
 
 			// Test that GetTasksBatchSize returns the raw value (validation happens at usage site)
 			result := config.GetTasksBatchSize("test-domain", "test-tasklist", int(types.TaskListTypeDecision))

--- a/service/matching/handler/engine_integration_test.go
+++ b/service/matching/handler/engine_integration_test.go
@@ -1419,7 +1419,7 @@ func validateTimeRange(t time.Time, expectedDuration time.Duration) bool {
 }
 
 func defaultTestConfig() *config.Config {
-	config := config.NewConfig(dynamicconfig.NewNopCollection(), "some random hostname", commonConfig.RPC{}, getIsolationGroupsHelper)
+	config := config.NewConfig(dynamicconfig.NewNopCollection(), dynamicconfig.NewNopCollection(), "some random hostname", commonConfig.RPC{}, getIsolationGroupsHelper)
 	config.LongPollExpirationInterval = dynamicproperties.GetDurationPropertyFnFilteredByTaskListInfo(100 * time.Millisecond)
 	config.MaxTaskDeleteBatchSize = dynamicproperties.GetIntPropertyFilteredByTaskListInfo(1)
 	config.ReadRangeSize = dynamicproperties.GetIntPropertyFn(50000)

--- a/service/matching/handler/handler_test.go
+++ b/service/matching/handler/handler_test.go
@@ -115,7 +115,7 @@ func (s *handlerSuite) getHandler(config *config.Config) Handler {
 }
 
 func (s *handlerSuite) TestNewHandler() {
-	cfg := config.NewConfig(dynamicconfig.NewCollection(dynamicconfig.NewInMemoryClient(), s.mockResource.Logger), "matching-test", commonConfig.RPC{}, getIsolationGroupsHelper)
+	cfg := config.NewConfig(dynamicconfig.NewCollection(dynamicconfig.NewInMemoryClient(), s.mockResource.Logger), dynamicconfig.NewNopCollection(), "matching-test", commonConfig.RPC{}, getIsolationGroupsHelper)
 	handler := s.getHandler(cfg)
 	s.NotNil(handler)
 }
@@ -123,7 +123,7 @@ func (s *handlerSuite) TestNewHandler() {
 func (s *handlerSuite) TestStart() {
 	defer goleak.VerifyNone(s.T())
 
-	cfg := config.NewConfig(dynamicconfig.NewCollection(dynamicconfig.NewInMemoryClient(), s.mockResource.Logger), "matching-test", commonConfig.RPC{}, getIsolationGroupsHelper)
+	cfg := config.NewConfig(dynamicconfig.NewCollection(dynamicconfig.NewInMemoryClient(), s.mockResource.Logger), dynamicconfig.NewNopCollection(), "matching-test", commonConfig.RPC{}, getIsolationGroupsHelper)
 	handler := s.getHandler(cfg)
 
 	s.mockEngine.EXPECT().Start().Times(1)
@@ -134,7 +134,7 @@ func (s *handlerSuite) TestStart() {
 func (s *handlerSuite) TestStop() {
 	defer goleak.VerifyNone(s.T())
 
-	cfg := config.NewConfig(dynamicconfig.NewCollection(dynamicconfig.NewInMemoryClient(), s.mockResource.Logger), "matching-test", commonConfig.RPC{}, getIsolationGroupsHelper)
+	cfg := config.NewConfig(dynamicconfig.NewCollection(dynamicconfig.NewInMemoryClient(), s.mockResource.Logger), dynamicconfig.NewNopCollection(), "matching-test", commonConfig.RPC{}, getIsolationGroupsHelper)
 	handler := s.getHandler(cfg)
 
 	s.mockEngine.EXPECT().Start().Times(1)

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -61,6 +61,11 @@ func NewService(
 			params.Logger,
 			dynamicproperties.ClusterNameFilter(params.ClusterMetadata.GetCurrentClusterName()),
 		),
+		dynamicconfig.NewCollection(
+			params.OperationalConfigStore,
+			params.Logger,
+			dynamicproperties.ClusterNameFilter(params.ClusterMetadata.GetCurrentClusterName()),
+		),
 		params.HostName,
 		params.RPCConfig,
 		params.GetIsolationGroups,

--- a/service/matching/tasklist/adaptive_scaler_test.go
+++ b/service/matching/tasklist/adaptive_scaler_test.go
@@ -68,7 +68,7 @@ func setupMocksForAdaptiveScaler(t *testing.T, taskListID *Identifier) (*adaptiv
 	mockTimeSource := clock.NewMockedTimeSourceAt(time.Now())
 	mockMatchingClient := matching.NewMockClient(ctrl)
 	dynamicClient := dynamicconfig.NewInMemoryClient()
-	cfg := newTaskListConfig(taskListID, config.NewConfig(dynamicconfig.NewCollection(dynamicClient, logger), "test-host", commonConfig.RPC{}, func() []string { return nil }), "test-domain")
+	cfg := newTaskListConfig(taskListID, config.NewConfig(dynamicconfig.NewCollection(dynamicClient, logger), dynamicconfig.NewNopCollection(), "test-host", commonConfig.RPC{}, func() []string { return nil }), "test-domain")
 
 	deps := &mockAdaptiveScalerDeps{
 		id:                 taskListID,

--- a/service/matching/tasklist/isolation_balancer_test.go
+++ b/service/matching/tasklist/isolation_balancer_test.go
@@ -1313,7 +1313,7 @@ func isolationConfig(t *testing.T, dynamicClient dynamicconfig.Client, groupsPer
 	taskListID, err := NewIdentifier("test-domain-id", "test-task-list", 0)
 	require.NoError(t, err)
 	logger := testlogger.New(t)
-	cfg := newTaskListConfig(taskListID, config.NewConfig(dynamicconfig.NewCollection(dynamicClient, logger), "test-host", commonConfig.RPC{}, func() []string { return nil }), "test-domain")
+	cfg := newTaskListConfig(taskListID, config.NewConfig(dynamicconfig.NewCollection(dynamicClient, logger), dynamicconfig.NewNopCollection(), "test-host", commonConfig.RPC{}, func() []string { return nil }), "test-domain")
 	require.NoError(t, dynamicClient.UpdateValue(dynamicproperties.MatchingPartitionUpscaleRPS, 200))
 	require.NoError(t, dynamicClient.UpdateValue(dynamicproperties.MatchingPartitionDownscaleFactor, 0.75))
 	require.NoError(t, dynamicClient.UpdateValue(dynamicproperties.MatchingIsolationGroupsPerPartition, groupsPerPartition))

--- a/service/matching/tasklist/matcher_test.go
+++ b/service/matching/tasklist/matcher_test.go
@@ -73,7 +73,7 @@ func TestMatcherSuite(t *testing.T) {
 func (t *MatcherTestSuite) SetupTest() {
 	t.controller = gomock.NewController(t.T())
 	t.client = matching.NewMockClient(t.controller)
-	cfg := config.NewConfig(dynamicconfig.NewNopCollection(), "some random hostname", commonConfig.RPC{}, func() []string { return nil })
+	cfg := config.NewConfig(dynamicconfig.NewNopCollection(), dynamicconfig.NewNopCollection(), "some random hostname", commonConfig.RPC{}, func() []string { return nil })
 	cfg.TaskDispatchRPSTTL = 0
 	t.taskList = NewTestTaskListID(t.T(), uuid.New(), constants.ReservedTaskListPrefix+"tl0/1", persistence.TaskListTypeDecision)
 	tlCfg := newTaskListConfig(t.taskList, cfg, testDomainName)

--- a/service/matching/tasklist/task_list_manager_test.go
+++ b/service/matching/tasklist/task_list_manager_test.go
@@ -88,7 +88,7 @@ func setupMocksForTaskListManager(t *testing.T, taskListID *Identifier, taskList
 		dynamicClient:      dynamicClient,
 	}
 	deps.mockDomainCache.EXPECT().GetDomainName(gomock.Any()).Return("domainName", nil).Times(1)
-	config := config.NewConfig(dynamicconfig.NewCollection(dynamicClient, logger), "hostname", commonConfig.RPC{}, getIsolationgroupsHelper)
+	config := config.NewConfig(dynamicconfig.NewCollection(dynamicClient, logger), dynamicconfig.NewNopCollection(), "hostname", commonConfig.RPC{}, getIsolationgroupsHelper)
 	mockHistoryService := history.NewMockClient(ctrl)
 	mockRegistry := NewMockTaskListRegistry(ctrl)
 	mockRegistry.EXPECT().Unregister(gomock.Any()).AnyTimes()
@@ -114,7 +114,7 @@ func setupMocksForTaskListManager(t *testing.T, taskListID *Identifier, taskList
 }
 
 func defaultTestConfig() *config.Config {
-	config := config.NewConfig(dynamicconfig.NewNopCollection(), "some random hostname", commonConfig.RPC{}, getIsolationgroupsHelper)
+	config := config.NewConfig(dynamicconfig.NewNopCollection(), dynamicconfig.NewNopCollection(), "some random hostname", commonConfig.RPC{}, getIsolationgroupsHelper)
 	config.LongPollExpirationInterval = dynamicproperties.GetDurationPropertyFnFilteredByTaskListInfo(100 * time.Millisecond)
 	config.MaxTaskDeleteBatchSize = dynamicproperties.GetIntPropertyFilteredByTaskListInfo(1)
 	config.AllIsolationGroups = getIsolationgroupsHelper
@@ -497,7 +497,7 @@ func TestQueriesPerSecond(t *testing.T) {
 func TestCheckIdleTaskList(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	idleInterval := 100 * time.Millisecond
-	cfg := config.NewConfig(dynamicconfig.NewNopCollection(), "some random hostname", commonConfig.RPC{}, getIsolationgroupsHelper)
+	cfg := config.NewConfig(dynamicconfig.NewNopCollection(), dynamicconfig.NewNopCollection(), "some random hostname", commonConfig.RPC{}, getIsolationgroupsHelper)
 	cfg.IdleTasklistCheckInterval = dynamicproperties.GetDurationPropertyFnFilteredByTaskListInfo(idleInterval)
 
 	t.Run("Idle task-list", func(t *testing.T) {
@@ -591,7 +591,7 @@ func TestAddTaskStandby(t *testing.T) {
 	controller := gomock.NewController(t)
 	logger := testlogger.New(t)
 
-	cfg := config.NewConfig(dynamicconfig.NewNopCollection(), "some random hostname", commonConfig.RPC{}, getIsolationgroupsHelper)
+	cfg := config.NewConfig(dynamicconfig.NewNopCollection(), dynamicconfig.NewNopCollection(), "some random hostname", commonConfig.RPC{}, getIsolationgroupsHelper)
 	cfg.IdleTasklistCheckInterval = dynamicproperties.GetDurationPropertyFnFilteredByTaskListInfo(10 * time.Millisecond)
 
 	tlm := createTestTaskListManagerWithConfig(t, logger, controller, cfg, clock.NewMockedTimeSource())

--- a/service/matching/tasklist/task_reader_test.go
+++ b/service/matching/tasklist/task_reader_test.go
@@ -384,7 +384,7 @@ func TestTaskPump(t *testing.T) {
 }
 
 func defaultConfig() *config.Config {
-	config := config.NewConfig(dynamicconfig.NewNopCollection(), "some random hostname", commonConfig.RPC{}, func() []string {
+	config := config.NewConfig(dynamicconfig.NewNopCollection(), dynamicconfig.NewNopCollection(), "some random hostname", commonConfig.RPC{}, func() []string {
 		return defaultIsolationGroups
 	})
 	config.EnableTasklistIsolation = dynamicproperties.GetBoolPropertyFnFilteredByDomain(true)


### PR DESCRIPTION
**What changed?**

`matching.excludeShortLivedTaskListsFromShardManager` now reads from the primary database-backed operational dynamic config store instead of the generic dynamic config. Both read paths are migrated: the shard distributor resolver in `server.go` and the matching config in `config.go`.

**Why?**

Continuing the migration of shard-manager dynamic config properties to the operational store ([#6862](https://github.com/cadence-workflow/cadence/issues/6862)). This property is `true` in all environments, so a hard migration (no `ReadFromOperationalStore` toggle) is sufficient.

**How did you test it?**

Unit tests for matching config, handler, tasklist, and server packages all pass.

**Potential risks**

Low. The default value (`true`) matches what is deployed everywhere. If the operational store is unavailable, the `NopClient` fallback returns the same default.

**Release notes**

None.

**Documentation Changes**

None.