### PR TITLE
Make event deduplication exhaustive

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2753,7 +2753,7 @@ const (
 	DecisionRetriesExceededCounter
 	StaleMutableStateCounter
 	DataInconsistentCounter
-	DuplicateActivityTaskEventCounter
+	DuplicateBufferedEventCounter
 	TimerResurrectionCounter
 	TimerProcessingDeletionTimerNoopDueToMutableStateNotLoading
 	TimerProcessingDeletionTimerNoopDueToWFRunning
@@ -3771,7 +3771,7 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 		DecisionRetriesExceededCounter:                                {metricName: "decision_retries_exceeded", metricType: Counter},
 		StaleMutableStateCounter:                                      {metricName: "stale_mutable_state", metricType: Counter},
 		DataInconsistentCounter:                                       {metricName: "data_inconsistent", metricType: Counter},
-		DuplicateActivityTaskEventCounter:                             {metricName: "duplicate_activity_task_event", metricType: Counter},
+		DuplicateBufferedEventCounter:                                 {metricName: "duplicate_buffered_event", metricType: Counter},
 		TimerResurrectionCounter:                                      {metricName: "timer_resurrection", metricType: Counter},
 		TimerProcessingDeletionTimerNoopDueToMutableStateNotLoading:   {metricName: "timer_processing_skipping_deletion_due_to_missing_mutable_state", metricType: Counter},
 		TimerProcessingDeletionTimerNoopDueToWFRunning:                {metricName: "timer_processing_skipping_deletion_due_to_running", metricType: Counter},

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -2263,7 +2263,7 @@ func (e *mutableStateBuilder) reorderAndFilterDuplicateEvents(events []*types.Hi
 		startedEventID   int64
 	}
 
-	activityTaskUniqueEvents := make(map[eventUniquenessParams]struct{})
+	bufferedUniqueEvents := make(map[eventUniquenessParams]struct{})
 
 	checkEventUniqueness := func(event *types.HistoryEvent) bool {
 		var uniqueEventParams eventUniquenessParams
@@ -2340,11 +2340,48 @@ func (e *mutableStateBuilder) reorderAndFilterDuplicateEvents(events []*types.Hi
 				scheduledEventID: scheduledEventID,
 				startedEventID:   event.ChildWorkflowExecutionCanceledEventAttributes.StartedEventID,
 			}
+		case types.EventTypeChildWorkflowExecutionTerminated:
+			scheduledEventID = event.ChildWorkflowExecutionTerminatedEventAttributes.GetInitiatedEventID()
+			uniqueEventParams = eventUniquenessParams{
+				eventType:        event.GetEventType(),
+				scheduledEventID: scheduledEventID,
+				startedEventID:   event.ChildWorkflowExecutionTerminatedEventAttributes.StartedEventID,
+			}
+		case types.EventTypeStartChildWorkflowExecutionFailed:
+			scheduledEventID = event.StartChildWorkflowExecutionFailedEventAttributes.GetInitiatedEventID()
+			uniqueEventParams = eventUniquenessParams{
+				eventType:        event.GetEventType(),
+				scheduledEventID: scheduledEventID,
+			}
+		case types.EventTypeExternalWorkflowExecutionCancelRequested:
+			scheduledEventID = event.ExternalWorkflowExecutionCancelRequestedEventAttributes.GetInitiatedEventID()
+			uniqueEventParams = eventUniquenessParams{
+				eventType:        event.GetEventType(),
+				scheduledEventID: scheduledEventID,
+			}
+		case types.EventTypeRequestCancelExternalWorkflowExecutionFailed:
+			scheduledEventID = event.RequestCancelExternalWorkflowExecutionFailedEventAttributes.GetInitiatedEventID()
+			uniqueEventParams = eventUniquenessParams{
+				eventType:        event.GetEventType(),
+				scheduledEventID: scheduledEventID,
+			}
+		case types.EventTypeExternalWorkflowExecutionSignaled:
+			scheduledEventID = event.ExternalWorkflowExecutionSignaledEventAttributes.GetInitiatedEventID()
+			uniqueEventParams = eventUniquenessParams{
+				eventType:        event.GetEventType(),
+				scheduledEventID: scheduledEventID,
+			}
+		case types.EventTypeSignalExternalWorkflowExecutionFailed:
+			scheduledEventID = event.SignalExternalWorkflowExecutionFailedEventAttributes.GetInitiatedEventID()
+			uniqueEventParams = eventUniquenessParams{
+				eventType:        event.GetEventType(),
+				scheduledEventID: scheduledEventID,
+			}
 		default:
 			return true
 		}
 
-		if _, ok := activityTaskUniqueEvents[uniqueEventParams]; ok {
+		if _, ok := bufferedUniqueEvents[uniqueEventParams]; ok {
 			e.logger.Error("Duplicate event found",
 				tag.WorkflowDomainName(e.GetDomainEntry().GetInfo().Name),
 				tag.WorkflowID(e.GetExecutionInfo().WorkflowID),
@@ -2354,10 +2391,10 @@ func (e *mutableStateBuilder) reorderAndFilterDuplicateEvents(events []*types.Hi
 				tag.Dynamic("duplication-source", source),
 			)
 
-			e.metricsClient.IncCounter(metrics.HistoryFlushBufferedEventsScope, metrics.DuplicateActivityTaskEventCounter)
+			e.metricsClient.IncCounter(metrics.HistoryFlushBufferedEventsScope, metrics.DuplicateBufferedEventCounter)
 			return false
 		}
-		activityTaskUniqueEvents[uniqueEventParams] = struct{}{}
+		bufferedUniqueEvents[uniqueEventParams] = struct{}{}
 		return true
 	}
 

--- a/service/history/execution/mutable_state_builder_test.go
+++ b/service/history/execution/mutable_state_builder_test.go
@@ -3846,6 +3846,116 @@ func Test__reorderAndFilterDuplicateEvents(t *testing.T) {
 			},
 		},
 		{
+			name: "child workflow terminated event duplicated",
+			buildEvents: func(msb *mutableStateBuilder) ([]*types.HistoryEvent, []*types.HistoryEvent) {
+				event1 := msb.CreateNewHistoryEvent(types.EventTypeChildWorkflowExecutionTerminated)
+				event1.ChildWorkflowExecutionTerminatedEventAttributes = &types.ChildWorkflowExecutionTerminatedEventAttributes{
+					InitiatedEventID: 1,
+					StartedEventID:   2,
+				}
+				event2 := msb.CreateNewHistoryEvent(types.EventTypeChildWorkflowExecutionTerminated)
+				event2.ChildWorkflowExecutionTerminatedEventAttributes = &types.ChildWorkflowExecutionTerminatedEventAttributes{
+					InitiatedEventID: 1,
+					StartedEventID:   2,
+				}
+
+				return []*types.HistoryEvent{event1, event2}, []*types.HistoryEvent{event1}
+			},
+			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
+				assert.Equal(t, 1, logs.FilterMessage("Duplicate event found").Len())
+			},
+		},
+		{
+			name: "start child workflow execution failed event duplicated",
+			buildEvents: func(msb *mutableStateBuilder) ([]*types.HistoryEvent, []*types.HistoryEvent) {
+				event1 := msb.CreateNewHistoryEvent(types.EventTypeStartChildWorkflowExecutionFailed)
+				event1.StartChildWorkflowExecutionFailedEventAttributes = &types.StartChildWorkflowExecutionFailedEventAttributes{
+					InitiatedEventID: 1,
+				}
+				event2 := msb.CreateNewHistoryEvent(types.EventTypeStartChildWorkflowExecutionFailed)
+				event2.StartChildWorkflowExecutionFailedEventAttributes = &types.StartChildWorkflowExecutionFailedEventAttributes{
+					InitiatedEventID: 1,
+				}
+
+				return []*types.HistoryEvent{event1, event2}, []*types.HistoryEvent{event1}
+			},
+			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
+				assert.Equal(t, 1, logs.FilterMessage("Duplicate event found").Len())
+			},
+		},
+		{
+			name: "external workflow execution cancel requested event duplicated",
+			buildEvents: func(msb *mutableStateBuilder) ([]*types.HistoryEvent, []*types.HistoryEvent) {
+				event1 := msb.CreateNewHistoryEvent(types.EventTypeExternalWorkflowExecutionCancelRequested)
+				event1.ExternalWorkflowExecutionCancelRequestedEventAttributes = &types.ExternalWorkflowExecutionCancelRequestedEventAttributes{
+					InitiatedEventID: 1,
+				}
+				event2 := msb.CreateNewHistoryEvent(types.EventTypeExternalWorkflowExecutionCancelRequested)
+				event2.ExternalWorkflowExecutionCancelRequestedEventAttributes = &types.ExternalWorkflowExecutionCancelRequestedEventAttributes{
+					InitiatedEventID: 1,
+				}
+
+				return []*types.HistoryEvent{event1, event2}, []*types.HistoryEvent{event1}
+			},
+			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
+				assert.Equal(t, 1, logs.FilterMessage("Duplicate event found").Len())
+			},
+		},
+		{
+			name: "request cancel external workflow execution failed event duplicated",
+			buildEvents: func(msb *mutableStateBuilder) ([]*types.HistoryEvent, []*types.HistoryEvent) {
+				event1 := msb.CreateNewHistoryEvent(types.EventTypeRequestCancelExternalWorkflowExecutionFailed)
+				event1.RequestCancelExternalWorkflowExecutionFailedEventAttributes = &types.RequestCancelExternalWorkflowExecutionFailedEventAttributes{
+					InitiatedEventID: 1,
+				}
+				event2 := msb.CreateNewHistoryEvent(types.EventTypeRequestCancelExternalWorkflowExecutionFailed)
+				event2.RequestCancelExternalWorkflowExecutionFailedEventAttributes = &types.RequestCancelExternalWorkflowExecutionFailedEventAttributes{
+					InitiatedEventID: 1,
+				}
+
+				return []*types.HistoryEvent{event1, event2}, []*types.HistoryEvent{event1}
+			},
+			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
+				assert.Equal(t, 1, logs.FilterMessage("Duplicate event found").Len())
+			},
+		},
+		{
+			name: "external workflow execution signaled event duplicated",
+			buildEvents: func(msb *mutableStateBuilder) ([]*types.HistoryEvent, []*types.HistoryEvent) {
+				event1 := msb.CreateNewHistoryEvent(types.EventTypeExternalWorkflowExecutionSignaled)
+				event1.ExternalWorkflowExecutionSignaledEventAttributes = &types.ExternalWorkflowExecutionSignaledEventAttributes{
+					InitiatedEventID: 1,
+				}
+				event2 := msb.CreateNewHistoryEvent(types.EventTypeExternalWorkflowExecutionSignaled)
+				event2.ExternalWorkflowExecutionSignaledEventAttributes = &types.ExternalWorkflowExecutionSignaledEventAttributes{
+					InitiatedEventID: 1,
+				}
+
+				return []*types.HistoryEvent{event1, event2}, []*types.HistoryEvent{event1}
+			},
+			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
+				assert.Equal(t, 1, logs.FilterMessage("Duplicate event found").Len())
+			},
+		},
+		{
+			name: "signal external workflow execution failed event duplicated",
+			buildEvents: func(msb *mutableStateBuilder) ([]*types.HistoryEvent, []*types.HistoryEvent) {
+				event1 := msb.CreateNewHistoryEvent(types.EventTypeSignalExternalWorkflowExecutionFailed)
+				event1.SignalExternalWorkflowExecutionFailedEventAttributes = &types.SignalExternalWorkflowExecutionFailedEventAttributes{
+					InitiatedEventID: 1,
+				}
+				event2 := msb.CreateNewHistoryEvent(types.EventTypeSignalExternalWorkflowExecutionFailed)
+				event2.SignalExternalWorkflowExecutionFailedEventAttributes = &types.SignalExternalWorkflowExecutionFailedEventAttributes{
+					InitiatedEventID: 1,
+				}
+
+				return []*types.HistoryEvent{event1, event2}, []*types.HistoryEvent{event1}
+			},
+			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
+				assert.Equal(t, 1, logs.FilterMessage("Duplicate event found").Len())
+			},
+		},
+		{
 			name: "reorder events",
 			buildEvents: func(msb *mutableStateBuilder) ([]*types.HistoryEvent, []*types.HistoryEvent) {
 				event1 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskStarted)


### PR DESCRIPTION
Add handling for all remaining buffer-able event types to ensure that they're not duplicated.

<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Add additional handling for buffer-able events that aren't currently covered.

**Why?**
- Duplication can happen for any type of buffered event. Cause is still unknown, either non-idempotent retries with Cassandra persistence or a Cassandra bug. 

Duplicate events generally break the client state machines and cause workflows to report non-determinism.

**How did you test it?**
- Unit tests

**Potential risks**
- Medium. If these parameters are incorrectly and we remove non-duplicate events then we would break workflows..

**Release notes**


**Documentation Changes**

