### PR TITLE
fix(schedule): preserve nullable limits on partial UpdateSchedule

### DIFF
--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -432,7 +432,19 @@ func handleUpdate(logger *zap.Logger, sig UpdateSignal, input *SchedulerWorkflow
 	}
 	if sig.Policies != nil {
 		previousOverlap := input.Policies.OverlapPolicy
-		input.Policies = *sig.Policies
+		// Field-level merge for the nullable *int32 limits: nil from the caller
+		// means "preserve existing", non-nil (including *int32(0) for explicit
+		// unlimited) means "overwrite". Without this, a partial Update that
+		// only sets OverlapPolicy would silently wipe a previously-set limit,
+		// because the rest of the struct is still full-replaced.
+		merged := *sig.Policies
+		if merged.BufferLimit == nil {
+			merged.BufferLimit = input.Policies.BufferLimit
+		}
+		if merged.ConcurrencyLimit == nil {
+			merged.ConcurrencyLimit = input.Policies.ConcurrencyLimit
+		}
+		input.Policies = merged
 		changed = true
 		// Drop buffered fires if the overlap policy is no longer BUFFER:
 		// draining a queue under non-BUFFER semantics is ill-defined.

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -434,9 +434,7 @@ func handleUpdate(logger *zap.Logger, sig UpdateSignal, input *SchedulerWorkflow
 		previousOverlap := input.Policies.OverlapPolicy
 		// Field-level merge for the nullable *int32 limits: nil from the caller
 		// means "preserve existing", non-nil (including *int32(0) for explicit
-		// unlimited) means "overwrite". Without this, a partial Update that
-		// only sets OverlapPolicy would silently wipe a previously-set limit,
-		// because the rest of the struct is still full-replaced.
+		// unlimited) means "overwrite".
 		merged := *sig.Policies
 		if merged.BufferLimit == nil {
 			merged.BufferLimit = input.Policies.BufferLimit

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -707,6 +707,85 @@ func TestHandleUpdate(t *testing.T) {
 		assert.False(t, changed)
 		assert.Len(t, state.PendingBackfills, 1)
 	})
+
+	t.Run("policies merge preserves BufferLimit when sig leaves it nil", func(t *testing.T) {
+		input := original
+		input.Policies = types.SchedulePolicies{
+			OverlapPolicy: types.ScheduleOverlapPolicyBuffer,
+			BufferLimit:   common.Int32Ptr(5),
+		}
+		changed := handleUpdate(testLogger, UpdateSignal{
+			Policies: &types.SchedulePolicies{OverlapPolicy: types.ScheduleOverlapPolicyBuffer},
+		}, &input, &SchedulerWorkflowState{})
+		assert.True(t, changed)
+		require.NotNil(t, input.Policies.BufferLimit, "nil incoming must preserve existing BufferLimit")
+		assert.Equal(t, int32(5), *input.Policies.BufferLimit)
+	})
+
+	t.Run("policies merge preserves ConcurrencyLimit when sig leaves it nil", func(t *testing.T) {
+		input := original
+		input.Policies = types.SchedulePolicies{
+			OverlapPolicy:    types.ScheduleOverlapPolicyConcurrent,
+			ConcurrencyLimit: common.Int32Ptr(7),
+		}
+		changed := handleUpdate(testLogger, UpdateSignal{
+			Policies: &types.SchedulePolicies{OverlapPolicy: types.ScheduleOverlapPolicyConcurrent},
+		}, &input, &SchedulerWorkflowState{})
+		assert.True(t, changed)
+		require.NotNil(t, input.Policies.ConcurrencyLimit, "nil incoming must preserve existing ConcurrencyLimit")
+		assert.Equal(t, int32(7), *input.Policies.ConcurrencyLimit)
+	})
+
+	t.Run("policies merge: explicit *int32(0) overwrites BufferLimit to unlimited", func(t *testing.T) {
+		input := original
+		input.Policies = types.SchedulePolicies{
+			OverlapPolicy: types.ScheduleOverlapPolicyBuffer,
+			BufferLimit:   common.Int32Ptr(5),
+		}
+		changed := handleUpdate(testLogger, UpdateSignal{
+			Policies: &types.SchedulePolicies{
+				OverlapPolicy: types.ScheduleOverlapPolicyBuffer,
+				BufferLimit:   common.Int32Ptr(0),
+			},
+		}, &input, &SchedulerWorkflowState{})
+		assert.True(t, changed)
+		require.NotNil(t, input.Policies.BufferLimit)
+		assert.Equal(t, int32(0), *input.Policies.BufferLimit, "*int32(0) must overwrite to explicit unlimited")
+	})
+
+	t.Run("policies merge: explicit *int32(0) overwrites ConcurrencyLimit to unlimited", func(t *testing.T) {
+		input := original
+		input.Policies = types.SchedulePolicies{
+			OverlapPolicy:    types.ScheduleOverlapPolicyConcurrent,
+			ConcurrencyLimit: common.Int32Ptr(7),
+		}
+		changed := handleUpdate(testLogger, UpdateSignal{
+			Policies: &types.SchedulePolicies{
+				OverlapPolicy:    types.ScheduleOverlapPolicyConcurrent,
+				ConcurrencyLimit: common.Int32Ptr(0),
+			},
+		}, &input, &SchedulerWorkflowState{})
+		assert.True(t, changed)
+		require.NotNil(t, input.Policies.ConcurrencyLimit)
+		assert.Equal(t, int32(0), *input.Policies.ConcurrencyLimit, "*int32(0) must overwrite to explicit unlimited")
+	})
+
+	t.Run("policies merge: non-nil overwrites existing BufferLimit", func(t *testing.T) {
+		input := original
+		input.Policies = types.SchedulePolicies{
+			OverlapPolicy: types.ScheduleOverlapPolicyBuffer,
+			BufferLimit:   common.Int32Ptr(5),
+		}
+		changed := handleUpdate(testLogger, UpdateSignal{
+			Policies: &types.SchedulePolicies{
+				OverlapPolicy: types.ScheduleOverlapPolicyBuffer,
+				BufferLimit:   common.Int32Ptr(20),
+			},
+		}, &input, &SchedulerWorkflowState{})
+		assert.True(t, changed)
+		require.NotNil(t, input.Policies.BufferLimit)
+		assert.Equal(t, int32(20), *input.Policies.BufferLimit)
+	})
 }
 
 func TestHandleBackfill(t *testing.T) {
@@ -1616,13 +1695,13 @@ func TestHandleUpdate_RunningWorkflowsClearedOnOverlapPolicyChange(t *testing.T)
 			wantNil:           true,
 		},
 		{
-			name:              "CONCURRENT(limit=2) -> CONCURRENT(limit=nil) clears running workflows",
+			name:              "CONCURRENT(limit=2) -> CONCURRENT(limit=nil) preserves running workflows (nil means preserve)",
 			fromOverlap:       types.ScheduleOverlapPolicyConcurrent,
 			fromLimit:         common.Int32Ptr(2),
 			toOverlap:         types.ScheduleOverlapPolicyConcurrent,
 			toLimit:           nil,
 			initialRunningWFs: runningWFs,
-			wantNil:           true,
+			wantNil:           false,
 		},
 		{
 			name:              "CONCURRENT(limit=2) -> BUFFER clears running workflows",


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

- handleUpdate in the scheduler workflow now does a field-level merge for the two nullable *int32 policy fields (BufferLimit, ConcurrencyLimit) instead of full-replacing input.Policies. When the incoming signal leaves either field nil, the existing value is preserved; non-nil values (including *int32(0) for explicit unlimited) still overwrite.
- Other SchedulePolicies fields (OverlapPolicy, CatchUpPolicy, PauseOnFailure, CatchUpWindow) remain full-replaced for now — their on-the-wire types can't express "unset" yet. Extending merge to them needs an IDL change and is tracked as a follow-up.


**Why?**

- https://github.com/cadence-workflow/cadence/pull/8160 made BufferLimit and ConcurrencyLimit nullable end-to-end so callers could express the three states (nil = preserve, *0 = explicit unlimited, *N = limit N), and the proto docstring promises that semantics: "Unset (nil) means 'preserve existing value' on Update". But the merge layer in handleUpdate was never updated — it still does input.Policies = *sig.Policies, which silently wipes any previously-set limit when a partial Update omits the field.

**How did you test it?**

- Added 5 subtests to TestHandleUpdate:
    - BufferLimit preserved when sig leaves it nil
    - ConcurrencyLimit preserved when sig leaves it nil
    - explicit *int32(0) overwrites BufferLimit to unlimited
    - explicit *int32(0) overwrites ConcurrencyLimit to unlimited
    - non-nil overwrites existing BufferLimit

**Potential risks**

- only BufferLimit and ConcurrencyLimit are merged. A partial Update that omits CatchUpPolicy, PauseOnFailure, or CatchUpWindow still resets them to the zero value (and OverlapPolicy to INVALID) — same behavior as today, but now inconsistent with how the two limits behave. Follow-up will address this once the IDL gains field presence for those types.

**Release notes**

- UpdateSchedule: when the caller leaves **BufferLimit** or **ConcurrencyLimit** nil, the server now preserves the existing value instead of clearing it. 
- To explicitly set "unlimited", pass *int32(0). Matches the documented semantics on the proto.


**Documentation Changes**
N/A
