### PR TITLE
fix(graceful failover): bug in metrics and comments

### DIFF
--- a/common/cache/domainCache.go
+++ b/common/cache/domainCache.go
@@ -896,7 +896,7 @@ func (entry *DomainCacheEntry) NewDomainNotActiveError(currentCluster, activeClu
 	}
 }
 
-// IsActive return whether the domain is active in the current cluster,
+// IsActiveIn return whether the domain is active in the current cluster,
 // - for local domain, it is always active
 // - for global domain, it is active if it is not pending active and the domain's active cluster is the current cluster or if the domain is active-active and the active cluster of one of the cluster attributes is the current cluster
 // TODO(active-active): for active-active domains, we should review this logic because now workflows can be active in different clusters based on the cluster attribute.

--- a/common/domain/failover_watcher.go
+++ b/common/domain/failover_watcher.go
@@ -202,23 +202,23 @@ func CleanPendingActiveState(
 		return fmt.Errorf("getting metadata: %w", err)
 	}
 
-	getResponse, err := domainManager.GetDomain(context.Background(), &persistence.GetDomainRequest{ID: domainID})
+	domainResponse, err := domainManager.GetDomain(context.Background(), &persistence.GetDomainRequest{ID: domainID})
 	if err != nil {
 		return fmt.Errorf("getting domain: %w", err)
 	}
-	localFailoverVersion := getResponse.FailoverVersion
-	isGlobalDomain := getResponse.IsGlobalDomain
-	gracefulFailoverEndTime := getResponse.FailoverEndTime
+	localFailoverVersion := domainResponse.FailoverVersion
+	isGlobalDomain := domainResponse.IsGlobalDomain
+	gracefulFailoverEndTime := domainResponse.FailoverEndTime
 
+	// if the domain is still pending active and the failover versions are the same, clean the state
 	if isGlobalDomain && gracefulFailoverEndTime != nil && failoverVersion == localFailoverVersion {
-		// if the domain is still pending active and the failover versions are the same, clean the state
 		updateReq := &persistence.UpdateDomainRequest{
-			Info:                        getResponse.Info,
-			Config:                      getResponse.Config,
-			ReplicationConfig:           getResponse.ReplicationConfig,
-			ConfigVersion:               getResponse.ConfigVersion,
+			Info:                        domainResponse.Info,
+			Config:                      domainResponse.Config,
+			ReplicationConfig:           domainResponse.ReplicationConfig,
+			ConfigVersion:               domainResponse.ConfigVersion,
 			FailoverVersion:             localFailoverVersion,
-			FailoverNotificationVersion: getResponse.FailoverNotificationVersion,
+			FailoverNotificationVersion: domainResponse.FailoverNotificationVersion,
 			FailoverEndTime:             nil,
 			NotificationVersion:         metadata.NotificationVersion,
 		}
@@ -237,7 +237,7 @@ func CleanPendingActiveState(
 }
 
 func isUpdateDomainRetryable(
-	err error,
+	_ error,
 ) bool {
 	return true
 }

--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -3236,7 +3236,7 @@ const (
 	// Default value: time.Minute*5
 	// Allowed filters: DomainName
 	NormalDecisionScheduleToStartTimeout
-	// NotifyFailoverMarkerInterval controls the cadence of failover-marker polling and per-host coordinator batch flushes.
+	// NotifyFailoverMarkerInterval controls the cadence of failover-marker polling and per-host coordinator batch flushes
 	// KeyName: history.NotifyFailoverMarkerInterval
 	// Value type: Duration
 	// Default value: 5s (5*time.Second)

--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -3235,13 +3235,13 @@ const (
 	// Default value: time.Minute*5
 	// Allowed filters: DomainName
 	NormalDecisionScheduleToStartTimeout
-	// NotifyFailoverMarkerInterval is determines the frequency to notify failover marker
+	// NotifyFailoverMarkerInterval controls the cadence of failover-marker polling and per-host coordinator batch flushes.
 	// KeyName: history.NotifyFailoverMarkerInterval
 	// Value type: Duration
 	// Default value: 5s (5*time.Second)
 	// Allowed filters: N/A
 	NotifyFailoverMarkerInterval
-	// ActivityMaxScheduleToStartTimeoutForRetry is maximum value allowed when overwritting the schedule to start timeout for activities with retry policy
+	// ActivityMaxScheduleToStartTimeoutForRetry is maximum value allowed when overwriting the schedule to start timeout for activities with retry policy
 	// KeyName: history.activityMaxScheduleToStartTimeoutForRetry
 	// Value type: Duration
 	// Default value: 30m (30*time.Minute)

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -4010,7 +4010,7 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 		WorkflowRepairFailure:                                         {metricName: "workflow_repair_failure", metricType: Counter},
 		WorkflowRepairTimeout:                                         {metricName: "workflow_repair_timeout", metricType: Counter},
 		WorkflowRepairDuration:                                        {metricName: "workflow_repair_duration_ns", metricType: Histogram, exponentialBuckets: Low1ms100s},
-		FailoverMarkerCount:                                           {metricName: "failover_marker_count", metricType: Counter},
+		FailoverMarkerCount:                                           {metricName: "failover_marker_count", metricType: Gauge},
 		FailoverMarkerInsertFailure:                                   {metricName: "failover_marker_insert_failures", metricType: Counter},
 		FailoverMarkerNotificationFailure:                             {metricName: "failover_marker_notification_failures", metricType: Counter},
 		FailoverMarkerUpdateShardFailure:                              {metricName: "failover_marker_update_shard_failures", metricType: Counter},

--- a/service/history/failover/coordinator.go
+++ b/service/history/failover/coordinator.go
@@ -242,7 +242,7 @@ func (c *coordinatorImpl) notifyFailoverMarkerLoop() {
 		case <-c.shutdownChan:
 			return
 		case notificationReq := <-c.notificationChan:
-			// if there is a shard movement happen, it is fine to have duplicate shard ID in the request
+			// if a shard movement happens, it is fine to have duplicated shard IDs in the request
 			// The receiver side will de-dup the shard IDs. See: handleFailoverMarkers
 			aggregateNotificationRequests(notificationReq, requestByMarker)
 		case <-timer.C:
@@ -267,13 +267,13 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 	marker := request.marker
 	domainID := marker.GetDomainID()
 	if record, ok := c.recorder[domainID]; ok {
-		// if the local failover version is smaller than the new received marker,
-		// it means there is another failover happened and the local one should be invalid.
+		// if the local failover version is less than the failover version in the marker,
+		// it means that another failover happened for this domain and the local one should be invalidated
 		if record.failoverVersion < marker.GetFailoverVersion() {
 			delete(c.recorder, domainID)
 		}
 
-		// if the local failover version is larger than the new received marker,
+		// if the local failover version is larger than the failover version in the marker,
 		// ignore the incoming marker
 		if record.failoverVersion > marker.GetFailoverVersion() {
 			return
@@ -296,7 +296,7 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 
 	domainName, err := c.domainCache.GetDomainName(domainID)
 	if err != nil {
-		c.logger.Error("Coordinator failed to get domain after receiving all failover markers",
+		c.logger.Error("Coordinator failed to get domain name while recording failover markers from request",
 			tag.WorkflowDomainID(domainID),
 			tag.Error(err),
 		)
@@ -312,7 +312,7 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 			record.failoverVersion,
 			c.retryPolicy,
 		); err != nil {
-			c.logger.Error("Coordinator failed to update domain after receiving all failover markers",
+			c.logger.Error("Coordinator failed to update domain after receiving failover markers from all shards",
 				tag.WorkflowDomainID(domainID),
 				tag.Error(err),
 			)
@@ -320,29 +320,33 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 			return
 		}
 		delete(c.recorder, domainID)
+
 		now := c.timeSource.Now()
+		// use the last marker to calculate the failover duration
+		failoverDuration := now.Sub(time.Unix(0, marker.GetCreationTime()))
 		c.scope.Tagged(
 			metrics.DomainTag(domainName),
 		).RecordTimer(
 			metrics.GracefulFailoverLatency,
-			now.Sub(time.Unix(0, marker.GetCreationTime())),
+			failoverDuration,
 		)
 		c.scope.Tagged(
 			metrics.DomainTag(domainName),
 		).RecordHistogramDuration(
 			metrics.GracefulFailoverLatencyHistogram,
-			now.Sub(time.Unix(0, marker.GetCreationTime())),
+			failoverDuration,
 		)
 		c.logger.Info("Updated domain from pending-active to active",
 			tag.WorkflowDomainName(domainName),
 			tag.FailoverVersion(marker.FailoverVersion),
+			tag.Duration(failoverDuration),
 		)
 	} else {
 		c.scope.Tagged(
 			metrics.DomainTag(domainName),
-		).RecordTimer(
+		).UpdateGauge(
 			metrics.FailoverMarkerCount,
-			time.Duration(len(record.shards)),
+			float64(len(record.shards)),
 		)
 	}
 }

--- a/service/history/replication/task_executor.go
+++ b/service/history/replication/task_executor.go
@@ -22,6 +22,7 @@ package replication
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/uber/cadence/common"
@@ -58,7 +59,7 @@ type (
 
 var _ TaskExecutor = (*taskExecutorImpl)(nil)
 
-// NewTaskExecutor creates an replication task executor
+// NewTaskExecutor creates a replication task executor
 // The executor uses by 1) DLQ replication task handler 2) history replication task processor
 func NewTaskExecutor(
 	sourceCluster string,
@@ -196,7 +197,7 @@ func (e *taskExecutorImpl) handleActivityTask(
 	switch {
 	case resendErr == nil:
 		break
-	case resendErr == ndc.ErrSkipTask:
+	case errors.Is(resendErr, ndc.ErrSkipTask):
 		e.logger.Error(
 			"skip replication sync activity task",
 			tag.WorkflowDomainID(retryErr.GetDomainID()),
@@ -215,7 +216,7 @@ func (e *taskExecutorImpl) handleActivityTask(
 		// should return the replication error, not the resending error
 		return err
 	}
-	// should try again after back fill the history
+	// should try again after backfill the history
 	return syncActivityAction()
 }
 
@@ -301,7 +302,7 @@ func (e *taskExecutorImpl) handleHistoryReplicationTaskV2(
 	switch {
 	case resendErr == nil:
 		break
-	case resendErr == ndc.ErrSkipTask:
+	case errors.Is(resendErr, ndc.ErrSkipTask):
 		e.logger.Error(
 			"skip replication history task",
 			tag.WorkflowDomainID(retryErr.GetDomainID()),
@@ -332,6 +333,10 @@ func (e *taskExecutorImpl) handleFailoverReplicationTask(
 	task *types.ReplicationTask,
 ) error {
 	failoverAttributes := task.GetFailoverMarkerAttributes()
+	if failoverAttributes == nil {
+		e.logger.Error("FailoverMarker replication task with nil attributes")
+		return ErrEmptyFailoverMarkerAttributes
+	}
 	failoverAttributes.CreationTime = task.CreationTime
 	return e.shard.AddingPendingFailoverMarker(failoverAttributes)
 }
@@ -358,6 +363,7 @@ func (e *taskExecutorImpl) filterTask(
 }
 
 func toRetryTaskV2Error(err error) (*types.RetryTaskV2Error, bool) {
-	retError, ok := err.(*types.RetryTaskV2Error)
+	var retError *types.RetryTaskV2Error
+	ok := errors.As(err, &retError)
 	return retError, ok
 }

--- a/service/history/replication/task_executor_test.go
+++ b/service/history/replication/task_executor_test.go
@@ -550,6 +550,18 @@ func (s *taskExecutorSuite) TestProcess_FailoverReplicationTask() {
 	s.NoError(err)
 }
 
+func (s *taskExecutorSuite) TestProcess_FailoverReplicationTask_NilAttributes() {
+	task := &types.ReplicationTask{
+		TaskType:                 types.ReplicationTaskTypeFailoverMarker.Ptr(),
+		FailoverMarkerAttributes: nil,
+		CreationTime:             common.Ptr(int64(222)),
+	}
+
+	_, err := s.taskHandler.execute(task, true)
+	s.Error(err)
+	s.ErrorIs(err, ErrEmptyFailoverMarkerAttributes)
+}
+
 func (s *taskExecutorSuite) TestProcess_UnknownTask() {
 	task := &types.ReplicationTask{
 		TaskType: common.Ptr(types.ReplicationTaskType(-100)),

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -63,6 +63,8 @@ const (
 var (
 	// ErrUnknownReplicationTask is the error to indicate unknown replication task type
 	ErrUnknownReplicationTask = &types.BadRequestError{Message: "unknown replication task"}
+	// ErrEmptyFailoverMarkerAttributes is the error returned when a failover marker replication task has nil attributes
+	ErrEmptyFailoverMarkerAttributes = &types.BadRequestError{Message: "empty failover marker attributes"}
 )
 
 type (

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1498,9 +1498,11 @@ func (s *contextImpl) AddingPendingFailoverMarker(
 	if err != nil {
 		return err
 	}
-	// domain is active, the marker is expired
+	// if the domain is active the marker is expired
 	isActive := domainEntry.IsActiveIn(s.GetClusterMetadata().GetCurrentClusterName())
-	if isActive || domainEntry.GetFailoverVersion() > marker.GetFailoverVersion() {
+	domainStatus := domainEntry.GetInfo().Status
+
+	if isActive || domainEntry.GetFailoverVersion() > marker.GetFailoverVersion() || domainStatus == persistence.DomainStatusDeprecated {
 		s.logger.Info("Skipped out-of-date failover marker", tag.WorkflowDomainName(domainEntry.GetInfo().Name))
 		return nil
 	}
@@ -1518,7 +1520,7 @@ func (s *contextImpl) ValidateAndUpdateFailoverMarkers() ([]*types.FailoverMarke
 	var pendingMarkers []*types.FailoverMarkerAttributes
 
 	s.RLock()
-	// Get a copy of pending markers while holding read lock
+	// get a copy of pending markers while holding read lock
 	pendingMarkers = make([]*types.FailoverMarkerAttributes, len(s.shardInfo.PendingFailoverMarkers))
 	copy(pendingMarkers, s.shardInfo.PendingFailoverMarkers)
 

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1503,7 +1503,10 @@ func (s *contextImpl) AddingPendingFailoverMarker(
 	domainStatus := domainEntry.GetInfo().Status
 
 	if isActive || domainEntry.GetFailoverVersion() > marker.GetFailoverVersion() || domainStatus == persistence.DomainStatusDeprecated {
-		s.logger.Info("Skipped out-of-date failover marker", tag.WorkflowDomainName(domainEntry.GetInfo().Name))
+		s.logger.Info("Skipped pending failover marker",
+			tag.WorkflowDomainName(domainEntry.GetInfo().Name),
+			tag.Reason(failoverMarkerSkipReason(isActive, domainEntry.GetFailoverVersion(), marker.GetFailoverVersion(), domainStatus)),
+		)
 		return nil
 	}
 
@@ -1512,6 +1515,19 @@ func (s *contextImpl) AddingPendingFailoverMarker(
 
 	s.shardInfo.PendingFailoverMarkers = append(s.shardInfo.PendingFailoverMarkers, marker)
 	return s.forceUpdateShardInfoLocked()
+}
+
+func failoverMarkerSkipReason(isActive bool, domainFailoverVersion, markerFailoverVersion int64, domainStatus int) string {
+	switch {
+	case isActive:
+		return "domain is active in current cluster"
+	case domainStatus == persistence.DomainStatusDeprecated:
+		return "domain is deprecated"
+	case domainFailoverVersion > markerFailoverVersion:
+		return "domain failover version is newer than marker"
+	default:
+		return "unknown"
+	}
 }
 
 func (s *contextImpl) ValidateAndUpdateFailoverMarkers() ([]*types.FailoverMarkerAttributes, error) {
@@ -1538,6 +1554,10 @@ func (s *contextImpl) ValidateAndUpdateFailoverMarkers() ([]*types.FailoverMarke
 		// or domain have been failed over
 		// or domain is deprecated
 		if isActive || domainEntry.GetFailoverVersion() > marker.GetFailoverVersion() || domainStatus == persistence.DomainStatusDeprecated {
+			s.logger.Info("Dropped pending failover marker",
+				tag.WorkflowDomainName(domainEntry.GetInfo().Name),
+				tag.Reason(failoverMarkerSkipReason(isActive, domainEntry.GetFailoverVersion(), marker.GetFailoverVersion(), domainStatus)),
+			)
 			completedFailoverMarkers[marker] = struct{}{}
 		}
 	}

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1540,7 +1540,7 @@ func (s *contextImpl) AddingPendingFailoverMarker(
 	isActive := domainEntry.IsActiveIn(s.GetClusterMetadata().GetCurrentClusterName())
 	domainStatus := domainEntry.GetInfo().Status
 
-	if isActive || domainEntry.GetFailoverVersion() > marker.GetFailoverVersion() || domainStatus == persistence.DomainStatusDeprecated {
+	if domainStatus == persistence.DomainStatusDeprecated || isActive || domainEntry.GetFailoverVersion() > marker.GetFailoverVersion() {
 		s.logger.Info("Skipped pending failover marker",
 			tag.WorkflowDomainName(domainEntry.GetInfo().Name),
 			tag.Reason(failoverMarkerSkipReason(isActive, domainEntry.GetFailoverVersion(), marker.GetFailoverVersion(), domainStatus)),
@@ -1557,10 +1557,10 @@ func (s *contextImpl) AddingPendingFailoverMarker(
 
 func failoverMarkerSkipReason(isActive bool, domainFailoverVersion, markerFailoverVersion int64, domainStatus int) string {
 	switch {
-	case isActive:
-		return "domain is active in current cluster"
 	case domainStatus == persistence.DomainStatusDeprecated:
 		return "domain is deprecated"
+	case isActive:
+		return "domain is active in current cluster"
 	case domainFailoverVersion > markerFailoverVersion:
 		return "domain failover version is newer than marker"
 	default:
@@ -1588,10 +1588,10 @@ func (s *contextImpl) ValidateAndUpdateFailoverMarkers() ([]*types.FailoverMarke
 		isActive := domainEntry.IsActiveIn(s.GetClusterMetadata().GetCurrentClusterName())
 		domainStatus := domainEntry.GetInfo().Status
 
-		// Drop failover markers if domain is already active in the currentCluster
+		// Drop failover markers if domain is deprecated
+		// or domain is already active in the currentCluster
 		// or domain have been failed over
-		// or domain is deprecated
-		if isActive || domainEntry.GetFailoverVersion() > marker.GetFailoverVersion() || domainStatus == persistence.DomainStatusDeprecated {
+		if domainStatus == persistence.DomainStatusDeprecated || isActive || domainEntry.GetFailoverVersion() > marker.GetFailoverVersion() {
 			s.logger.Info("Dropped pending failover marker",
 				tag.WorkflowDomainName(domainEntry.GetInfo().Name),
 				tag.Reason(failoverMarkerSkipReason(isActive, domainEntry.GetFailoverVersion(), marker.GetFailoverVersion(), domainStatus)),

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -1864,15 +1864,15 @@ func TestFailoverMarkerSkipReason(t *testing.T) {
 		{
 			name:                  "active domain",
 			isActive:              true,
-			domainFailoverVersion: 200,
+			domainFailoverVersion: 100,
 			markerFailoverVersion: 100,
-			domainStatus:          persistence.DomainStatusDeprecated,
+			domainStatus:          persistence.DomainStatusRegistered,
 			want:                  "domain is active in current cluster",
 		},
 		{
 			name:                  "deprecated domain",
 			isActive:              false,
-			domainFailoverVersion: 200,
+			domainFailoverVersion: 100,
 			markerFailoverVersion: 100,
 			domainStatus:          persistence.DomainStatusDeprecated,
 			want:                  "domain is deprecated",
@@ -1884,6 +1884,14 @@ func TestFailoverMarkerSkipReason(t *testing.T) {
 			markerFailoverVersion: 100,
 			domainStatus:          persistence.DomainStatusRegistered,
 			want:                  "domain failover version is newer than marker",
+		},
+		{
+			name:                  "all skip conditions match",
+			isActive:              true,
+			domainFailoverVersion: 200,
+			markerFailoverVersion: 100,
+			domainStatus:          persistence.DomainStatusDeprecated,
+			want:                  "domain is deprecated",
 		},
 		{
 			name:                  "no skip condition matches",

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -1154,13 +1154,16 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers() {
 }
 
 func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DeprecatedDomain() {
-	// This test verifies that failover markers are dropped (not processed) when a domain is deprecated
+	// This test verifies that pending failover markers are dropped during validation
+	// when the domain is deprecated.
+	// At insert time the domain is not deprecated, so the markers are saved.
+	// Between insert and validation, the domain becomes deprecated, so they are dropped.
 	domainFailoverVersion := 100
 	domainCacheEntryInactiveCluster := cache.NewGlobalDomainCacheEntryForTest(
 		&persistence.DomainInfo{ID: testDomainID},
 		&persistence.DomainConfig{Retention: 7},
 		&persistence.DomainReplicationConfig{
-			ActiveClusterName: cluster.TestAlternativeClusterName, // active is TestCurrentClusterName
+			ActiveClusterName: cluster.TestAlternativeClusterName, // current cluster is NOT active
 			Clusters: []*persistence.ClusterReplicationConfig{
 				{ClusterName: cluster.TestCurrentClusterName},
 				{ClusterName: cluster.TestAlternativeClusterName},
@@ -1168,11 +1171,11 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DeprecatedDomain
 		},
 		int64(domainFailoverVersion),
 	)
-	domainCacheEntryActiveCluster := cache.NewGlobalDomainCacheEntryForTest(
+	domainCacheEntryInactiveClusterDeprecated := cache.NewGlobalDomainCacheEntryForTest(
 		&persistence.DomainInfo{ID: testDomainID},
 		&persistence.DomainConfig{Retention: 7},
 		&persistence.DomainReplicationConfig{
-			ActiveClusterName: cluster.TestCurrentClusterName, // active cluster
+			ActiveClusterName: cluster.TestAlternativeClusterName, // still not active here
 			Clusters: []*persistence.ClusterReplicationConfig{
 				{ClusterName: cluster.TestCurrentClusterName},
 				{ClusterName: cluster.TestAlternativeClusterName},
@@ -1180,9 +1183,9 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DeprecatedDomain
 		},
 		int64(domainFailoverVersion),
 	)
-	domainCacheEntryInactiveCluster.GetInfo().Status = persistence.DomainStatusDeprecated
-	domainCacheEntryActiveCluster.GetInfo().Status = persistence.DomainStatusDeprecated
+	domainCacheEntryInactiveClusterDeprecated.GetInfo().Status = persistence.DomainStatusDeprecated
 
+	// Insertion: domain is inactive and not deprecated → markers get saved.
 	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntryInactiveCluster, nil).Times(2)
 
 	failoverMarker := types.FailoverMarkerAttributes{
@@ -1192,16 +1195,13 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DeprecatedDomain
 
 	s.mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(nil)
 
-	// adding failover marker
-	domainFailoverVersion++
 	s.NoError(s.context.AddingPendingFailoverMarker(&failoverMarker))
-	s.Require().Len(s.context.shardInfo.PendingFailoverMarkers, 1, "we should have one failover marker saved since the cluster is not active")
-
-	// adding more failover markers
-	domainFailoverVersion++
+	s.Require().Len(s.context.shardInfo.PendingFailoverMarkers, 1, "we should have one failover marker saved since the cluster is not active and not deprecated")
 	s.NoError(s.context.AddingPendingFailoverMarker(&failoverMarker))
+	s.Require().Len(s.context.shardInfo.PendingFailoverMarkers, 2)
 
-	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntryActiveCluster, nil).Times(2)
+	// Validation: domain is still inactive but now deprecated → markers are dropped.
+	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntryInactiveClusterDeprecated, nil).Times(2)
 
 	pendingFailoverMarkers, err := s.context.ValidateAndUpdateFailoverMarkers()
 	s.NoError(err)

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -1619,3 +1619,54 @@ func (s *contextTestSuite) TestAllocateTimerIDsLocked_WhenMultipleTasksProvidedA
 	s.True(task1.GetTaskID() > 0, "Task 1 ID should be positive")
 	s.True(task2.GetTaskID() > 0, "Task 2 ID should be positive")
 }
+
+func TestFailoverMarkerSkipReason(t *testing.T) {
+	tests := []struct {
+		name                  string
+		isActive              bool
+		domainFailoverVersion int64
+		markerFailoverVersion int64
+		domainStatus          int
+		want                  string
+	}{
+		{
+			name:                  "active domain",
+			isActive:              true,
+			domainFailoverVersion: 200,
+			markerFailoverVersion: 100,
+			domainStatus:          persistence.DomainStatusDeprecated,
+			want:                  "domain is active in current cluster",
+		},
+		{
+			name:                  "deprecated domain",
+			isActive:              false,
+			domainFailoverVersion: 200,
+			markerFailoverVersion: 100,
+			domainStatus:          persistence.DomainStatusDeprecated,
+			want:                  "domain is deprecated",
+		},
+		{
+			name:                  "newer domain failover version",
+			isActive:              false,
+			domainFailoverVersion: 200,
+			markerFailoverVersion: 100,
+			domainStatus:          persistence.DomainStatusRegistered,
+			want:                  "domain failover version is newer than marker",
+		},
+		{
+			name:                  "no skip condition matches",
+			isActive:              false,
+			domainFailoverVersion: 100,
+			markerFailoverVersion: 100,
+			domainStatus:          persistence.DomainStatusRegistered,
+			want:                  "unknown",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := failoverMarkerSkipReason(tc.isActive, tc.domainFailoverVersion, tc.markerFailoverVersion, tc.domainStatus)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Fixed failover_marker_count metric emission (set to gauge), renamed ambiguous variables and fixed comments. Added deprecated check before adding to pending failover makers

https://github.com/cadence-workflow/cadence/issues/8138

**Why?**
The failover_marker_count was being emitted as a timer but registered as a counter. There were some typos and confusing comments that were fixed. Adding failover markers from deprecated domains is unnecessary.

**How did you test it?**
go test -race ./service/history/replication/...
go test -race ./service/history/failover/...
go test -race ./common/domain/...
go test -race ./common/cache/...
go test -race ./service/history/shard/...
go test -race ./common/metrics/...
go test -race ./common/dynamicconfig/...

**Potential risks**
No big risks. Some minor changes on log messages and a metric fix that was not correctly implemented.

**Release notes**
N/A

**Documentation Changes**
N/A
