### PR TITLE
fix(queuev2): cap prefetch jitter so timer never fires after upper bound

### DIFF
--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -254,8 +254,14 @@ func (q *cachedQueueReader) nextPrefetchDelay() time.Duration {
 
 	triggerTime := q.exclusiveUpperBound.GetScheduledTime().Add(-q.options.PrefetchTriggerWindow())
 	delay := max(q.options.MinPrefetchInterval(), triggerTime.Sub(q.clock.Now()))
+	jittered := backoff.JitDuration(delay, q.options.PrefetchJitterCoefficient())
 
-	return backoff.JitDuration(delay, q.options.PrefetchJitterCoefficient())
+	// Cap the jittered delay to the original delay: positive jitter must not push the
+	// prefetch past triggerTime, which would cause it to fire after the upper bound and
+	// produce cache misses. MinPrefetchInterval is re-applied as the floor because
+	// negative jitter on a delay already clamped to MinPrefetchInterval can otherwise
+	// return a value below it.
+	return max(q.options.MinPrefetchInterval(), min(delay, jittered))
 }
 
 // isEnabled returns true if the cache is fully enabled

--- a/service/history/queuev2/queue_reader_cached_test.go
+++ b/service/history/queuev2/queue_reader_cached_test.go
@@ -1096,42 +1096,54 @@ func TestCachedQueueReader_StartStop(t *testing.T) {
 
 func TestCachedQueueReader_NextPrefetchDelay(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	// 50% jitter: un-capped range would be [0.5*base, 1.5*base].
+	// The cap (min(delay, jittered)) keeps the result in [0.5*base, base],
+	// and the MinPrefetchInterval floor ensures the result is never below 1s.
 	r, deps := setupMocksForCachedQueueReader(t, ctrl, func(o *cachedQueueReaderOptions) {
 		o.PrefetchTriggerWindow = dynamicproperties.GetDurationPropertyFn(10 * time.Minute)
 		o.MinPrefetchInterval = dynamicproperties.GetDurationPropertyFn(time.Second)
-		o.PrefetchJitterCoefficient = dynamicproperties.GetFloatPropertyFn(0)
+		o.PrefetchJitterCoefficient = dynamicproperties.GetFloatPropertyFn(0.5)
 	})
 	now := deps.clock.Now()
 
 	tests := []struct {
 		name                string
 		exclusiveUpperBound persistence.HistoryTaskKey
-		wantDelay           time.Duration
+		wantMinDelay        time.Duration
+		wantMaxDelay        time.Duration
 	}{
 		{
 			name:                "no upper bound -> clamped to MinPrefetchInterval",
 			exclusiveUpperBound: persistence.MinimumHistoryTaskKey,
-			wantDelay:           time.Second,
+			wantMinDelay:        time.Second,
+			wantMaxDelay:        time.Second,
 		},
 		{
 			name:                "upper in the past -> clamped to MinPrefetchInterval",
 			exclusiveUpperBound: newTimeKey(now.Add(-5 * time.Minute)), // triggerTime = now-15m -> d<0 -> min
-			wantDelay:           time.Second,
+			wantMinDelay:        time.Second,
+			wantMaxDelay:        time.Second,
 		},
 		{
 			name:                "upper within trigger window -> clamped to MinPrefetchInterval",
 			exclusiveUpperBound: newTimeKey(now.Add(5 * time.Minute)), // triggerTime = now-5m -> d<=0 -> min
-			wantDelay:           time.Second,
+			wantMinDelay:        time.Second,
+			wantMaxDelay:        time.Second,
 		},
 		{
 			name:                "upper exactly at trigger boundary -> clamped to MinPrefetchInterval",
 			exclusiveUpperBound: newTimeKey(now.Add(10 * time.Minute)), // triggerTime = now -> d=0 -> min
-			wantDelay:           time.Second,
+			wantMinDelay:        time.Second,
+			wantMaxDelay:        time.Second,
 		},
 		{
-			name:                "upper beyond trigger window -> trigger-window delay",
-			exclusiveUpperBound: newTimeKey(now.Add(20 * time.Minute)), // triggerTime = now+10m -> d=10m
-			wantDelay:           10 * time.Minute,
+			// base delay = 10m; jitter range = [5m, 15m]; cap keeps it in [5m, 10m].
+			// Without the cap, positive jitter could return up to 15m, causing the prefetch
+			// to fire 5m after the upper bound and producing cache misses.
+			name:                "upper beyond trigger window -> jitter capped at base delay",
+			exclusiveUpperBound: newTimeKey(now.Add(20 * time.Minute)), // triggerTime = now+10m -> base=10m
+			wantMinDelay:        5 * time.Minute,                       // 0.5 * base (negative jitter floor)
+			wantMaxDelay:        10 * time.Minute,                      // base delay — the cap that prevents late prefetch
 		},
 	}
 	for _, tc := range tests {
@@ -1139,7 +1151,9 @@ func TestCachedQueueReader_NextPrefetchDelay(t *testing.T) {
 			r.mu.Lock()
 			r.exclusiveUpperBound = tc.exclusiveUpperBound
 			r.mu.Unlock()
-			assert.Equal(t, tc.wantDelay, r.nextPrefetchDelay(), "test %q: delay", tc.name)
+			d := r.nextPrefetchDelay()
+			assert.GreaterOrEqual(t, d, tc.wantMinDelay)
+			assert.LessOrEqual(t, d, tc.wantMaxDelay)
 		})
 	}
 }

--- a/service/history/queuev2/queue_reader_cached_test.go
+++ b/service/history/queuev2/queue_reader_cached_test.go
@@ -1148,9 +1148,7 @@ func TestCachedQueueReader_NextPrefetchDelay(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			r.mu.Lock()
 			r.exclusiveUpperBound = tc.exclusiveUpperBound
-			r.mu.Unlock()
 			d := r.nextPrefetchDelay()
 			assert.GreaterOrEqual(t, d, tc.wantMinDelay)
 			assert.LessOrEqual(t, d, tc.wantMaxDelay)


### PR DESCRIPTION
## What changed?

`nextPrefetchDelay()` now caps the jittered delay at the original (un-jittered) base delay and re-applies `MinPrefetchInterval` as the floor. Relates to #7953.

## Why?

The prefetch timer is designed to fire `PrefetchTriggerWindow` (30 s) before the cache's `exclusiveUpperBound` expires. `nextPrefetchDelay()` computed a base delay of `MaxLookAheadWindow − PrefetchTriggerWindow = 270 s` and then applied ±15% jitter via `backoff.JitDuration`. The maximum positive jitter was `0.15 × 270 s = 40.5 s`, which exceeds the 30 s trigger window. On shards that drew high jitter values (>30 s), the timer fired after the upper bound had already passed, producing cache misses until the prefetch eventually completed (~10 s late in the observed logs).

The fix caps the jittered result at `delay` (preserving negative jitter for load spreading) and re-applies `MinPrefetchInterval` as the floor (so negative jitter on an already-clamped delay cannot go below it).

## How did you test it?

Updated `TestCachedQueueReader_NextPrefetchDelay` to use a 50% jitter coefficient (far exceeding the 15% default) with `[wantMin, wantMax]` range assertions. The "beyond trigger window" case verifies the cap: with base=10 m and 50% jitter the un-capped range would be [5 m, 15 m], but `wantMaxDelay = 10 m` asserts positive jitter cannot exceed the base.

```
go test -race -run TestCachedQueueReader_NextPrefetchDelay ./service/history/queuev2/
# ok  github.com/uber/cadence/service/history/queuev2  2.824s

go test -race ./service/history/queuev2/
# ok  github.com/uber/cadence/service/history/queuev2  3.486s

make pr GEN_DIR=service/history/queuev2
# tidy → go-generate → fmt → lint: all clean, no file changes
```

## Potential risks

None — change is isolated to the prefetch delay calculation in the cached queue reader. No API, schema, or feature flag impact.

## Release notes

N/A — internal change.

## Documentation Changes

N/A