### PR TITLE
fix: move workflowRatelimted to before loading mutableState

### DIFF
--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -184,6 +184,11 @@ func (t *transferActiveTaskExecutor) processActivityTask(
 	}
 	defer func() { release(retError) }()
 
+	if !t.allowTask(task) {
+		release(nil)
+		return errWorkflowRateLimited
+	}
+
 	mutableState, err := loadMutableState(ctx, wfContext, task, t.metricsClient.Scope(metrics.TransferQueueProcessorScope), t.logger, task.ScheduleID)
 	if err != nil {
 		return err
@@ -215,11 +220,6 @@ func (t *transferActiveTaskExecutor) processActivityTask(
 	// release the context lock since we no longer need mutable state builder and
 	// the rest of logic is making RPC call, which takes time.
 	release(nil)
-
-	// Rate limiting task processing requests
-	if !t.allowTask(task) {
-		return errWorkflowRateLimited
-	}
 
 	pushActivityInfo := &pushActivityToMatchingInfo{
 		activityScheduleToStartTimeout: timeout,

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -171,6 +171,10 @@ func (t *transferActiveTaskExecutor) processActivityTask(
 	task *persistence.ActivityTask,
 ) (retError error) {
 
+	if !t.allowTask(task) {
+		return errWorkflowRateLimited
+	}
+
 	wfContext, release, err := t.executionCache.GetOrCreateWorkflowExecutionWithTimeout(
 		task.DomainID,
 		getWorkflowExecution(task),
@@ -183,11 +187,6 @@ func (t *transferActiveTaskExecutor) processActivityTask(
 		return err
 	}
 	defer func() { release(retError) }()
-
-	if !t.allowTask(task) {
-		release(nil)
-		return errWorkflowRateLimited
-	}
 
 	mutableState, err := loadMutableState(ctx, wfContext, task, t.metricsClient.Scope(metrics.TransferQueueProcessorScope), t.logger, task.ScheduleID)
 	if err != nil {

--- a/service/history/task/transfer_active_task_executor_test.go
+++ b/service/history/task/transfer_active_task_executor_test.go
@@ -318,35 +318,31 @@ func (s *transferActiveTaskExecutorSuite) TestProcessActivityTask_Ratelimits() {
 		ScheduleID:     event.ID,
 	})
 
-	persistenceMutableState, err := test.CreatePersistenceMutableState(s.T(), mutableState, event.ID, event.Version)
-	s.NoError(err)
-	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
-
-	// expected calls to the matching service if task processing is allowed
-	s.mockMatchingClient.EXPECT().AddActivityTask(gomock.Any(), createAddActivityTaskRequest(transferTaskInRatelimitedDomain, ai, mutableState.GetExecutionInfo().PartitionConfig)).Return(&types.AddActivityTaskResponse{}, nil).Times(1)
-	s.mockMatchingClient.EXPECT().AddActivityTask(gomock.Any(), createAddActivityTaskRequest(transferTask, ai, mutableState.GetExecutionInfo().PartitionConfig)).Return(&types.AddActivityTaskResponse{}, nil).Times(1)
-
-	// RPS still below allowed value so the task can be executed
-	s.mockWFCache.EXPECT().AllowInternal(constants.TestRateLimitedDomainID, constants.TestWorkflowID).Return(true).Times(1)
-	_, err = s.transferActiveTaskExecutor.Execute(transferTaskInRatelimitedDomain)
-	s.Nil(err)
-
-	// RPS more than allowed limit so the task cannot be executed
+	// Rate limited cases: rate check happens before mutable state is loaded, so no DB call needed.
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestRateLimitedDomainID, constants.TestWorkflowID).Return(false).Times(1)
 	_, err = s.transferActiveTaskExecutor.Execute(transferTaskInRatelimitedDomain)
 	s.Error(err)
 	s.Equal("workflow is being rate limited for making too many requests", err.Error())
 
-	// RPS still below allowed value so the task can be executed
-	s.mockWFCache.EXPECT().AllowInternal(constants.TestDomainID, constants.TestWorkflowID).Return(true).Times(1)
-	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
-	s.Nil(err)
-
-	// RPS more than allowed limit so the task cannot be executed
 	s.mockWFCache.EXPECT().AllowInternal(constants.TestDomainID, constants.TestWorkflowID).Return(false).Times(1)
 	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Error(err)
 	s.Equal("workflow is being rate limited for making too many requests", err.Error())
+
+	// Allowed cases: mutable state is loaded and the task is pushed to matching.
+	persistenceMutableState, err := test.CreatePersistenceMutableState(s.T(), mutableState, event.ID, event.Version)
+	s.NoError(err)
+	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
+	s.mockMatchingClient.EXPECT().AddActivityTask(gomock.Any(), createAddActivityTaskRequest(transferTaskInRatelimitedDomain, ai, mutableState.GetExecutionInfo().PartitionConfig)).Return(&types.AddActivityTaskResponse{}, nil).Times(1)
+	s.mockMatchingClient.EXPECT().AddActivityTask(gomock.Any(), createAddActivityTaskRequest(transferTask, ai, mutableState.GetExecutionInfo().PartitionConfig)).Return(&types.AddActivityTaskResponse{}, nil).Times(1)
+
+	s.mockWFCache.EXPECT().AllowInternal(constants.TestRateLimitedDomainID, constants.TestWorkflowID).Return(true).Times(1)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTaskInRatelimitedDomain)
+	s.Nil(err)
+
+	s.mockWFCache.EXPECT().AllowInternal(constants.TestDomainID, constants.TestWorkflowID).Return(true).Times(1)
+	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
+	s.Nil(err)
 }
 
 func (s *transferActiveTaskExecutorSuite) TestProcessActivityTask_Duplication() {
@@ -386,6 +382,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessActivityTask_Duplication() 
 	persistenceMutableState, err := test.CreatePersistenceMutableState(s.T(), mutableState, event.ID, event.Version)
 	s.NoError(err)
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
+	s.mockWFCache.EXPECT().AllowInternal(s.domainID, constants.TestWorkflowID).Return(true).Times(1)
 
 	_, err = s.transferActiveTaskExecutor.Execute(transferTask)
 	s.Nil(err)


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Run the workflow rate limit check (`allowTask`) before loading mutable state in `processActivityTask`. On rate limit, release the workflow context and return without a persistence read. Tests updated accordingly.


**Why?**
Reducing history DB load.


**How did you test it?**
Unit test

**Potential risks**


**Release notes**


**Documentation Changes**

