### PR TITLE
fix(schedule): validate RetryPolicy in CreateSchedule and UpdateSchedule handlers

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -144,6 +144,9 @@ func (wh *WorkflowHandler) CreateSchedule(
 	if request.GetAction() == nil || request.GetAction().GetStartWorkflow() == nil {
 		return nil, &types.BadRequestError{Message: "Action.StartWorkflow is not set on request."}
 	}
+	if err := common.ValidateRetryPolicy(request.GetAction().GetStartWorkflow().GetRetryPolicy()); err != nil {
+		return nil, err
+	}
 	if err := validateSchedulePolicies(request.GetPolicies()); err != nil {
 		return nil, err
 	}
@@ -337,6 +340,11 @@ func (wh *WorkflowHandler) UpdateSchedule(
 	wh.warnIfBufferLimitExceedsSystemLimit(scheduleID, domainName, request.GetPolicies())
 	if spec := request.GetSpec(); spec != nil && spec.GetCronExpression() != "" {
 		if _, err := backoff.ValidateSchedule(spec.GetCronExpression()); err != nil {
+			return nil, err
+		}
+	}
+	if action := request.GetAction(); action != nil && action.GetStartWorkflow() != nil {
+		if err := common.ValidateRetryPolicy(action.GetStartWorkflow().GetRetryPolicy()); err != nil {
 			return nil, err
 		}
 	}

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -172,6 +172,27 @@ func TestCreateSchedule(t *testing.T) {
 			mockFn:  func(f *scheduleTestFixture) {},
 			wantErr: true,
 		},
+		"retry policy with no bounds rejected at create": {
+			request: &types.CreateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Spec:       &types.ScheduleSpec{CronExpression: "* * * * *"},
+				Action: &types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType: &types.WorkflowType{Name: "wf"},
+						TaskList:     &types.TaskList{Name: "tl"},
+						RetryPolicy: &types.RetryPolicy{
+							InitialIntervalInSeconds: 1,
+							MaximumIntervalInSeconds: 60,
+							BackoffCoefficient:       2,
+							// MaximumAttempts and ExpirationIntervalInSeconds both zero
+						},
+					},
+				},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
 		"invalid SKIP_NEW + CATCH_UP_ALL": {
 			request: &types.CreateScheduleRequest{
 				Domain:     testDomain,
@@ -815,6 +836,26 @@ func TestUpdateSchedule(t *testing.T) {
 				ScheduleID: "s1",
 				SearchAttributes: &types.SearchAttributes{
 					IndexedFields: map[string][]byte{"CadenceScheduleState": []byte(`"active"`)},
+				},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"retry policy with no bounds rejected at update": {
+			request: &types.UpdateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Action: &types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType: &types.WorkflowType{Name: "wf"},
+						TaskList:     &types.TaskList{Name: "tl"},
+						RetryPolicy: &types.RetryPolicy{
+							InitialIntervalInSeconds: 1,
+							MaximumIntervalInSeconds: 60,
+							BackoffCoefficient:       2,
+							// MaximumAttempts and ExpirationIntervalInSeconds both zero
+						},
+					},
 				},
 			},
 			mockFn:  func(f *scheduleTestFixture) {},


### PR DESCRIPTION
## What changed and why

- `CreateSchedule` and `UpdateSchedule` accepted a `RetryPolicy` on `Action.StartWorkflow` with both `MaximumAttempts=0` and `ExpirationIntervalInSeconds=0` without error.
- The schedule would be stored successfully, but at fire time `StartWorkflowExecution` would fail with a `BadRequestError` from `ValidateRetryPolicy`, silently breaking every fire for that schedule with no error visible at create time.
- Fix: apply `common.ValidateRetryPolicy` in both handlers, the same check `StartWorkflowExecution` already uses, so the invalid config is caught at create/update time instead of at first fire.

## Test plan

- Added `"retry policy with no bounds rejected at create"` to `TestCreateSchedule`
- Added `"retry policy with no bounds rejected at update"` to `TestUpdateSchedule`
- Both verify a `RetryPolicy` with `InitialInterval` and `MaximumInterval` set but both bounds zero is rejected with an error before any signal or workflow start is attempted