### PR TITLE
fix(schedule): validate spec time range in Create and UpdateSchedule

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -75,6 +75,16 @@ func validateSchedulePolicies(policies *types.SchedulePolicies) error {
 	return nil
 }
 
+func validateScheduleSpec(spec *types.ScheduleSpec) error {
+	if spec == nil {
+		return nil
+	}
+	if !spec.StartTime.IsZero() && !spec.EndTime.IsZero() && !spec.EndTime.After(spec.StartTime) {
+		return &types.BadRequestError{Message: "Spec.EndTime must be after Spec.StartTime."}
+	}
+	return nil
+}
+
 // warnIfBufferLimitExceedsSystemLimit logs a warning when buffer_limit exceeds
 // MaxBufferedFiresSystemLimit. The value is accepted (the policy still queues
 // up to the system limit), but drops at that cap will be tagged
@@ -145,6 +155,9 @@ func (wh *WorkflowHandler) CreateSchedule(
 		return nil, &types.BadRequestError{Message: "Action.StartWorkflow is not set on request."}
 	}
 	if err := validateSchedulePolicies(request.GetPolicies()); err != nil {
+		return nil, err
+	}
+	if err := validateScheduleSpec(request.GetSpec()); err != nil {
 		return nil, err
 	}
 	wh.warnIfBufferLimitExceedsSystemLimit(scheduleID, domainName, request.GetPolicies())
@@ -339,6 +352,9 @@ func (wh *WorkflowHandler) UpdateSchedule(
 		if _, err := backoff.ValidateSchedule(spec.GetCronExpression()); err != nil {
 			return nil, err
 		}
+	}
+	if err := validateScheduleSpec(request.GetSpec()); err != nil {
+		return nil, err
 	}
 	if err := validateUserSearchAttributes(request.GetSearchAttributes()); err != nil {
 		return nil, err

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -191,6 +191,44 @@ func TestCreateSchedule(t *testing.T) {
 			mockFn:  func(f *scheduleTestFixture) {},
 			wantErr: true,
 		},
+		"spec end time before start time": {
+			request: &types.CreateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Spec: &types.ScheduleSpec{
+					CronExpression: "* * * * *",
+					StartTime:      time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
+					EndTime:        time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+				Action: &types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType: &types.WorkflowType{Name: "wf"},
+						TaskList:     &types.TaskList{Name: "tl"},
+					},
+				},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"spec end time equal to start time": {
+			request: &types.CreateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Spec: &types.ScheduleSpec{
+					CronExpression: "* * * * *",
+					StartTime:      time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+					EndTime:        time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+				},
+				Action: &types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType: &types.WorkflowType{Name: "wf"},
+						TaskList:     &types.TaskList{Name: "tl"},
+					},
+				},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
 		"domain not found": {
 			request: validRequest,
 			mockFn: func(f *scheduleTestFixture) {
@@ -809,6 +847,32 @@ func TestUpdateSchedule(t *testing.T) {
 			mockFn:  func(f *scheduleTestFixture) {},
 			wantErr: true,
 		},
+		"spec end time before start time": {
+			request: &types.UpdateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Spec: &types.ScheduleSpec{
+					CronExpression: "* * * * *",
+					StartTime:      time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
+					EndTime:        time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"spec end time equal to start time": {
+			request: &types.UpdateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Spec: &types.ScheduleSpec{
+					CronExpression: "* * * * *",
+					StartTime:      time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+					EndTime:        time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
 		"reserved SA key rejected": {
 			request: &types.UpdateScheduleRequest{
 				Domain:     testDomain,
@@ -1369,6 +1433,50 @@ func TestValidateSchedulePolicies(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			err := validateSchedulePolicies(tt.policies)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateScheduleSpec(t *testing.T) {
+	t0 := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	t1 := time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC)
+	tests := map[string]struct {
+		spec    *types.ScheduleSpec
+		wantErr bool
+	}{
+		"nil spec": {
+			spec:    nil,
+			wantErr: false,
+		},
+		"only start time set": {
+			spec:    &types.ScheduleSpec{StartTime: t0},
+			wantErr: false,
+		},
+		"only end time set": {
+			spec:    &types.ScheduleSpec{EndTime: t1},
+			wantErr: false,
+		},
+		"valid range": {
+			spec:    &types.ScheduleSpec{StartTime: t0, EndTime: t1},
+			wantErr: false,
+		},
+		"end time equal to start time": {
+			spec:    &types.ScheduleSpec{StartTime: t0, EndTime: t0},
+			wantErr: true,
+		},
+		"end time before start time": {
+			spec:    &types.ScheduleSpec{StartTime: t1, EndTime: t0},
+			wantErr: true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := validateScheduleSpec(tt.spec)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Reject requests where Spec.EndTime is set but not strictly after Spec.StartTime. Previously only BackfillSchedule enforced this; a schedule created with EndTime <= StartTime would never fire.

**Why?**
Bug fix: CreateSchedule) and UpdateSchedule validate CronExpression and Policies only. No spec-time range check. BackfillSchedule  does validate (EndTime.After(StartTime)), so the validation exists in the codebase — it's just missing from the schedule-create path

**How did you test it?**
Added unit tests

**Potential risks**
N/A

**Release notes**
N/A

**Documentation Changes**
N/A
