### PR TITLE
fix(schedule): default scheduler worker to false

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -2106,7 +2106,7 @@ const (
 	// Can be filtered by domain to enable/disable per domain.
 	// KeyName: worker.enableScheduler
 	// Value type: Bool
-	// Default value: true
+	// Default value: false
 	// Allowed filters: DomainName
 	EnableScheduler
 	// EnableParentClosePolicyWorker decides whether or not enable system workers for processing parent close policy task
@@ -5105,7 +5105,7 @@ var BoolKeys = map[BoolKey]DynamicBool{
 		KeyName:      "worker.enableScheduler",
 		Filters:      []Filter{DomainName},
 		Description:  "EnableScheduler decides whether to start the scheduler worker for cron-based scheduling. Can be filtered by domain to enable/disable per domain.",
-		DefaultValue: true,
+		DefaultValue: false,
 	},
 	EnableParentClosePolicyWorker: {
 		KeyName:      "system.enableParentClosePolicyWorker",

--- a/host/testdata/dynamicconfig/integration_test.yaml
+++ b/host/testdata/dynamicconfig/integration_test.yaml
@@ -7,6 +7,9 @@ frontend.enableActiveClusterSelectionPolicyInStartWorkflow:
 worker.schedulerRefreshInterval:
 - value: "2s"
   constraints: {}
+worker.enableScheduler:
+- value: true
+  constraints: {}
 system.minRetentionDays:
 - value: 0
   constraints: {}


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
EnableScheduler map entry: DefaultValue: true → false (per-domain filter unchanged).
Added an explicit DC row so host integration keeps schedules working when the global default is false

worker.enableScheduler: with value: true and constraints: {}

**Why?**
Since, it was enabled by default, it was creating tasklist by default for all domains.

**How did you test it?**
go test -count=1 ./common/dynamicconfig/... ./service/worker/scheduler/...

**Potential risks**
N/A

**Release notes**
N/A

**Documentation Changes**
N/A
