### PR TITLE
test(schedule): add full-field CreateSchedule round-trip integration test

### DIFF
--- a/common/domain/failover_watcher.go
+++ b/common/domain/failover_watcher.go
@@ -161,13 +161,18 @@ func (p *failoverWatcherImpl) handleFailoverTimeout(
 	if domain.IsDomainPendingActive() && p.timeSource.Now().After(time.Unix(0, *failoverEndTime)) {
 		domainID := domain.GetInfo().ID
 		// force failover the domain without setting the failover timeout
-		if err := CleanPendingActiveState(
+		updated, err := CleanPendingActiveState(
 			p.domainManager,
 			domainID,
 			domain.GetFailoverVersion(),
 			p.retryPolicy,
-		); err != nil {
+		)
+		if err != nil {
 			p.logger.Error("Failed to update pending-active domain to active", tag.WorkflowDomainID(domainID), tag.WorkflowDomainName(domain.GetInfo().Name), tag.Error(err))
+			return
+		}
+		if !updated {
+			// another path already cleared the pending-active state — nothing to announce
 			return
 		}
 		sourceCluster, err := p.clusterMetadata.ClusterNameForFailoverVersion(domain.GetPreviousFailoverVersion())
@@ -185,13 +190,17 @@ func (p *failoverWatcherImpl) handleFailoverTimeout(
 	}
 }
 
-// CleanPendingActiveState removes the pending active state from the domain
+// CleanPendingActiveState removes the pending active state from the domain.
+// Returns (updated, err) where updated is true only when the domain row was
+// actually modified. When the domain is no longer pending-active or the
+// failover version no longer matches, the call is a no-op and returns
+// (false, nil) so callers can avoid emitting misleading "completed" signals.
 func CleanPendingActiveState(
 	domainManager persistence.DomainManager,
 	domainID string,
 	failoverVersion int64,
 	policy backoff.RetryPolicy,
-) error {
+) (bool, error) {
 
 	// must get the metadata (notificationVersion) first
 	// this version can be regarded as the lock on the v2 domain table
@@ -199,12 +208,12 @@ func CleanPendingActiveState(
 	// this call has to be made
 	metadata, err := domainManager.GetMetadata(context.Background())
 	if err != nil {
-		return fmt.Errorf("getting metadata: %w", err)
+		return false, fmt.Errorf("getting metadata: %w", err)
 	}
 
 	domainResponse, err := domainManager.GetDomain(context.Background(), &persistence.GetDomainRequest{ID: domainID})
 	if err != nil {
-		return fmt.Errorf("getting domain: %w", err)
+		return false, fmt.Errorf("getting domain: %w", err)
 	}
 	localFailoverVersion := domainResponse.FailoverVersion
 	isGlobalDomain := domainResponse.IsGlobalDomain
@@ -230,10 +239,11 @@ func CleanPendingActiveState(
 			backoff.WithRetryableError(isUpdateDomainRetryable),
 		)
 		if err := throttleRetry.Do(context.Background(), op); err != nil {
-			return err
+			return false, err
 		}
+		return true, nil
 	}
-	return nil
+	return false, nil
 }
 
 func isUpdateDomainRetryable(

--- a/common/domain/failover_watcher_test.go
+++ b/common/domain/failover_watcher_test.go
@@ -141,8 +141,9 @@ func (s *failoverWatcherSuite) TestCleanPendingActiveState() {
 	}, nil).Times(1)
 
 	// does not have failover end time
-	err := CleanPendingActiveState(s.mockMetadataMgr, domainName, 1, s.watcher.retryPolicy)
+	updated, err := CleanPendingActiveState(s.mockMetadataMgr, domainName, 1, s.watcher.retryPolicy)
 	s.NoError(err)
+	s.False(updated, "no failover end time → no update")
 
 	s.mockMetadataMgr.On("GetDomain", mock.Anything, &persistence.GetDomainRequest{
 		ID: domainName,
@@ -159,8 +160,9 @@ func (s *failoverWatcherSuite) TestCleanPendingActiveState() {
 	}, nil).Times(1)
 
 	// does not match failover versions
-	err = CleanPendingActiveState(s.mockMetadataMgr, domainName, 5, s.watcher.retryPolicy)
+	updated, err = CleanPendingActiveState(s.mockMetadataMgr, domainName, 5, s.watcher.retryPolicy)
 	s.NoError(err)
+	s.False(updated, "failover version mismatch → no update")
 
 	s.mockMetadataMgr.On("UpdateDomain", mock.Anything, &persistence.UpdateDomainRequest{
 		Info:                        info,
@@ -186,8 +188,9 @@ func (s *failoverWatcherSuite) TestCleanPendingActiveState() {
 		NotificationVersion:         1,
 	}, nil).Times(1)
 
-	err = CleanPendingActiveState(s.mockMetadataMgr, domainName, 2, s.watcher.retryPolicy)
+	updated, err = CleanPendingActiveState(s.mockMetadataMgr, domainName, 2, s.watcher.retryPolicy)
 	s.NoError(err)
+	s.True(updated, "happy path actually updates the domain")
 }
 
 func (s *failoverWatcherSuite) TestHandleFailoverTimeout() {

--- a/host/schedule_test.go
+++ b/host/schedule_test.go
@@ -156,3 +156,145 @@ func (s *IntegrationSuite) TestScheduleSmokeTest() {
 		}
 	}
 }
+
+// TestScheduleFullCreateRoundTrip creates a schedule with every optional field set
+// and asserts DescribeSchedule returns them unchanged. It exercises the full
+// CreateSchedule -> DescribeSchedule mapping path that the CLI cannot reach (the
+// CLI only exposes cron/workflowType/taskList/timeouts/input/overlap/catchup/
+// concurrencyLimit).
+func (s *IntegrationSuite) TestScheduleFullCreateRoundTrip() {
+	if s.TestClusterConfig.WorkerConfig == nil || !s.TestClusterConfig.WorkerConfig.EnableScheduler {
+		s.T().Skip("scheduler worker manager not enabled on this cluster")
+	}
+
+	scheduleID := s.RandomizeStr("full-create")
+	start := time.Now().Add(2 * time.Minute).Round(time.Second).UTC()
+	end := start.Add(time.Hour)
+
+	createReq := &types.CreateScheduleRequest{
+		Domain:     s.DomainName,
+		ScheduleID: scheduleID,
+		Spec: &types.ScheduleSpec{
+			CronExpression: "@every 30s",
+			StartTime:      start,
+			EndTime:        end,
+			Jitter:         15 * time.Second,
+		},
+		Action: &types.ScheduleAction{
+			StartWorkflow: &types.StartWorkflowAction{
+				WorkflowType:                        &types.WorkflowType{Name: "full-create-target"},
+				TaskList:                            &types.TaskList{Name: s.RandomizeStr("full-tl")},
+				Input:                               []byte(`"hello"`),
+				WorkflowIDPrefix:                    "wfpfx-",
+				ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(60),
+				TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(10),
+				RetryPolicy: &types.RetryPolicy{
+					InitialIntervalInSeconds:    1,
+					BackoffCoefficient:          2.0,
+					MaximumIntervalInSeconds:    10,
+					MaximumAttempts:             3,
+					ExpirationIntervalInSeconds: 100,
+				},
+				Memo: &types.Memo{Fields: map[string][]byte{"actionMemo": []byte(`"m"`)}},
+				SearchAttributes: &types.SearchAttributes{
+					IndexedFields: map[string][]byte{"CustomKeywordField": []byte(`"sa"`)},
+				},
+			},
+		},
+		Policies: &types.SchedulePolicies{
+			OverlapPolicy:    types.ScheduleOverlapPolicyBuffer,
+			CatchUpPolicy:    types.ScheduleCatchUpPolicyOne,
+			CatchUpWindow:    time.Hour,
+			PauseOnFailure:   true,
+			BufferLimit:      common.Int32Ptr(5),
+			ConcurrencyLimit: common.Int32Ptr(0),
+		},
+		Memo: &types.Memo{Fields: map[string][]byte{"schedMemo": []byte(`"sm"`)}},
+		SearchAttributes: &types.SearchAttributes{
+			IndexedFields: map[string][]byte{"CustomIntField": []byte(`7`)},
+		},
+	}
+
+	createCtx, createCancel := createContext()
+	_, err := s.Engine.CreateSchedule(createCtx, createReq)
+	createCancel()
+	s.Require().NoError(err, "CreateSchedule failed")
+
+	defer func() {
+		delCtx, delCancel := createContext()
+		defer delCancel()
+		if _, derr := s.Engine.DeleteSchedule(delCtx, &types.DeleteScheduleRequest{
+			Domain:     s.DomainName,
+			ScheduleID: scheduleID,
+		}); derr != nil {
+			s.Logger.Warn("DeleteSchedule (cleanup) failed", tag.Error(derr))
+		}
+	}()
+
+	// DescribeSchedule queries the scheduler workflow, which must handle its first
+	// decision task before it can be queried; retry briefly to ride out that window.
+	var desc *types.DescribeScheduleResponse
+	s.Require().Eventually(func() bool {
+		c, cc := createContext()
+		defer cc()
+		d, e := s.Engine.DescribeSchedule(c, &types.DescribeScheduleRequest{
+			Domain:     s.DomainName,
+			ScheduleID: scheduleID,
+		})
+		if e != nil {
+			s.Logger.Info("DescribeSchedule not ready yet", tag.Error(e))
+			return false
+		}
+		desc = d
+		return true
+	}, 20*time.Second, time.Second, "DescribeSchedule never became queryable")
+
+	// Spec round-trip.
+	s.Equal("@every 30s", desc.GetSpec().GetCronExpression())
+	s.WithinDuration(start, desc.GetSpec().GetStartTime(), time.Second)
+	s.WithinDuration(end, desc.GetSpec().GetEndTime(), time.Second)
+	s.Equal(15*time.Second, desc.GetSpec().GetJitter())
+
+	// Action round-trip.
+	sw := desc.GetAction().GetStartWorkflow()
+	s.Require().NotNil(sw)
+	s.Equal("full-create-target", sw.GetWorkflowType().GetName())
+	s.Equal("wfpfx-", sw.GetWorkflowIDPrefix())
+	s.Equal([]byte(`"hello"`), sw.GetInput())
+	s.Equal(int32(60), sw.GetExecutionStartToCloseTimeoutSeconds())
+	s.Equal(int32(10), sw.GetTaskStartToCloseTimeoutSeconds())
+	s.Require().NotNil(sw.GetRetryPolicy())
+
+	// Retry policy
+	rp := sw.GetRetryPolicy()
+	s.Equal(int32(1), rp.InitialIntervalInSeconds)
+	s.InDelta(2.0, rp.BackoffCoefficient, 0.001)
+	s.Equal(int32(10), rp.MaximumIntervalInSeconds)
+	s.Equal(int32(3), rp.MaximumAttempts)
+	s.Equal(int32(100), rp.ExpirationIntervalInSeconds)
+	s.Require().NotNil(sw.GetMemo())
+	s.Equal([]byte(`"m"`), sw.GetMemo().Fields["actionMemo"])
+	s.Require().NotNil(sw.GetSearchAttributes())
+	s.Equal([]byte(`"sa"`), sw.GetSearchAttributes().IndexedFields["CustomKeywordField"])
+
+	// Policies round-trip, including the nullable limit fields.
+	pol := desc.GetPolicies()
+	s.Require().NotNil(pol)
+	s.Equal(types.ScheduleOverlapPolicyBuffer, pol.GetOverlapPolicy())
+	s.Equal(types.ScheduleCatchUpPolicyOne, pol.GetCatchUpPolicy())
+	s.Equal(time.Hour, pol.GetCatchUpWindow())
+	s.True(pol.GetPauseOnFailure())
+	s.Require().NotNil(pol.GetBufferLimit())
+	s.Equal(int32(5), *pol.GetBufferLimit())
+	s.Require().NotNil(pol.GetConcurrencyLimit())
+	s.Equal(int32(0), *pol.GetConcurrencyLimit())
+
+	// Schedule-level Memo and SearchAttributes round-trip.
+	s.Require().NotNil(desc.GetMemo())
+	s.Equal([]byte(`"sm"`), desc.GetMemo().Fields["schedMemo"])
+	s.Require().NotNil(desc.GetSearchAttributes())
+	s.Equal([]byte(`7`), desc.GetSearchAttributes().IndexedFields["CustomIntField"])
+
+	// Schedule starts active.
+	s.False(desc.GetState().GetPaused())
+}

--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.uber.org/yarpc/yarpcerrors"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
@@ -817,9 +818,7 @@ func (wh *WorkflowHandler) describeSchedulerExecution(
 }
 
 // querySchedulerWorkflow issues a QueryWorkflow call for the scheduler's
-// describe query, retrying briefly if the workflow has not yet processed its
-// first decision task. That transient state occurs right after CreateSchedule
-// or immediately after a ContinueAsNew run starts.
+// describe query, retrying on transient errors until the workflow is queryable.
 func (wh *WorkflowHandler) querySchedulerWorkflow(
 	ctx context.Context,
 	domainName, scheduleID string,
@@ -839,7 +838,11 @@ func (wh *WorkflowHandler) querySchedulerWorkflow(
 			return resp, nil
 		}
 		var qfe *types.QueryFailedError
-		if !errors.As(err, &qfe) || !strings.Contains(qfe.Message, "decision task") {
+		decisionTaskPending := errors.As(err, &qfe) && strings.Contains(qfe.Message, "decision task")
+		queryTimeout := (errors.Is(err, context.DeadlineExceeded) ||
+			yarpcerrors.IsStatus(err) && yarpcerrors.FromError(err).Code() == yarpcerrors.CodeDeadlineExceeded) &&
+			ctx.Err() == nil
+		if !decisionTaskPending && !queryTimeout {
 			return nil, normalizeScheduleError(err, scheduleID, domainName)
 		}
 		lastErr = err

--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -183,6 +183,7 @@ func (wh *WorkflowHandler) CreateSchedule(
 		Spec:             *request.GetSpec(),
 		Action:           *request.GetAction(),
 		SearchAttributes: request.GetSearchAttributes(),
+		Memo:             request.GetMemo(),
 	}
 	if request.GetPolicies() != nil {
 		workflowInput.Policies = *request.GetPolicies()
@@ -331,6 +332,8 @@ func (wh *WorkflowHandler) DescribeSchedule(
 			NextRunTime: desc.NextRunTime,
 			TotalRuns:   desc.TotalRuns,
 		},
+		Memo:             desc.Memo,
+		SearchAttributes: desc.SearchAttributes,
 	}, nil
 }
 

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -349,6 +349,32 @@ func TestCreateSchedule(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		"memo forwarded into workflow input": {
+			request: &types.CreateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "my-schedule",
+				Spec:       &types.ScheduleSpec{CronExpression: "*/5 * * * *"},
+				Action: &types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType: &types.WorkflowType{Name: "my-workflow"},
+						TaskList:     &types.TaskList{Name: "my-tasklist"},
+					},
+				},
+				Memo: &types.Memo{Fields: map[string][]byte{"schedMemo": []byte(`"sm"`)}},
+			},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.HistoryStartWorkflowExecutionRequest, _ ...yarpc.CallOption) (*types.StartWorkflowExecutionResponse, error) {
+						var input scheduler.SchedulerWorkflowInput
+						require.NoError(t, json.Unmarshal(req.StartRequest.Input, &input))
+						require.NotNil(t, input.Memo)
+						assert.Equal(t, []byte(`"sm"`), input.Memo.Fields["schedMemo"])
+						return &types.StartWorkflowExecutionResponse{RunID: "test-run-id"}, nil
+					})
+			},
+			wantErr: false,
+		},
 	}
 
 	for name, tt := range tests {
@@ -380,6 +406,10 @@ func TestDescribeSchedule(t *testing.T) {
 		PauseReason: "maintenance",
 		PausedBy:    "admin",
 		TotalRuns:   42,
+		Memo:        &types.Memo{Fields: map[string][]byte{"schedMemo": []byte(`"sm"`)}},
+		SearchAttributes: &types.SearchAttributes{
+			IndexedFields: map[string][]byte{"CustomIntField": []byte(`7`)},
+		},
 	}
 	descBytes, _ := json.Marshal(descResult)
 
@@ -640,6 +670,10 @@ func TestDescribeSchedule(t *testing.T) {
 				assert.Equal(t, "maintenance", resp.State.PauseInfo.Reason)
 				assert.Equal(t, "admin", resp.State.PauseInfo.PausedBy)
 				assert.Equal(t, int64(42), resp.Info.TotalRuns)
+				require.NotNil(t, resp.Memo)
+				assert.Equal(t, []byte(`"sm"`), resp.Memo.Fields["schedMemo"])
+				require.NotNil(t, resp.SearchAttributes)
+				assert.Equal(t, []byte(`7`), resp.SearchAttributes.IndexedFields["CustomIntField"])
 			},
 		},
 	}

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -1438,6 +1438,44 @@ func TestValidateSchedulePolicies(t *testing.T) {
 	}
 }
 
+// TestValidateUserSearchAttributes verifies that user-supplied search attributeAdd a comment on  lines R1381 to R1401Add diff commentMarkdown input:  edit mode selected.WritePreviewHeadingBoldItalicQuoteCodeLinkUnordered listNumbered listTask listMentionReferenceMore Formatting tools items 0Saved repliesAdd FilesPaste, drop, or click to add filesCancelCommentStart a review
+// keys colliding with the scheduler-reserved "CadenceSchedule" prefix are
+// rejected, while other keys (including a lowercase near-miss) are allowed. The
+// prefix check is case-sensitive.
+func TestValidateUserSearchAttributes(t *testing.T) {
+	sa := func(keys ...string) *types.SearchAttributes {
+		fields := make(map[string][]byte, len(keys))
+		for _, k := range keys {
+			fields[k] = []byte(`"v"`)
+		}
+		return &types.SearchAttributes{IndexedFields: fields}
+	}
+
+	tests := map[string]struct {
+		sa      *types.SearchAttributes
+		wantErr bool
+	}{
+		"nil search attributes":       {sa: nil, wantErr: false},
+		"empty indexed fields":        {sa: &types.SearchAttributes{}, wantErr: false},
+		"reserved exact prefix":       {sa: sa("CadenceSchedule"), wantErr: true},
+		"reserved CadenceScheduleID":  {sa: sa("CadenceScheduleID"), wantErr: true},
+		"reserved CadenceScheduleFoo": {sa: sa("CadenceScheduleFoo"), wantErr: true},
+		"lowercase not reserved":      {sa: sa("cadenceschedule"), wantErr: false},
+		"unrelated key allowed":       {sa: sa("MyKey"), wantErr: false},
+		"mixed reserved + allowed":    {sa: sa("MyKey", "CadenceScheduleX"), wantErr: true},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := validateUserSearchAttributes(tt.sa)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 // TestValidateScheduleSpecTimeRange verifies the spec StartTime/EndTime ordering
 // check: both must be set for the check to apply, and EndTime must be strictly
 // after StartTime.

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -419,6 +419,7 @@ func TestDescribeSchedule(t *testing.T) {
 	}
 
 	tests := map[string]struct {
+		ctx      context.Context
 		request  *types.DescribeScheduleRequest
 		mockFn   func(*scheduleTestFixture)
 		wantErr  bool
@@ -610,6 +611,83 @@ func TestDescribeSchedule(t *testing.T) {
 				assert.Contains(t, qfe.Message, "decision task")
 			},
 		},
+		// History's internal query wait times out before the scheduler workflow
+		// processes its first decision task. The frontend retries the same as for
+		// the QueryFailedError case; here it succeeds on the second attempt.
+		"history query timeout - retried until ready": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+					}, nil)
+				gomock.InOrder(
+					f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+						Return(nil, yarpcerrors.DeadlineExceededErrorf("query wait timed out")),
+					f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+						Return(&types.HistoryQueryWorkflowResponse{
+							Response: &types.QueryWorkflowResponse{QueryResult: descBytes},
+						}, nil),
+				)
+			},
+			wantErr: false,
+		},
+		// If history keeps returning deadline exceeded past the retry budget, the
+		// last error is returned.
+		"history query timeout - retry budget exhausted": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+					}, nil)
+				f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+					Return(nil, yarpcerrors.DeadlineExceededErrorf("query wait timed out")).
+					Times(describeScheduleQueryRetryAttempts)
+			},
+			wantErr: true,
+		},
+		// History returns the stdlib context.DeadlineExceeded (not yarpc's CodeDeadlineExceeded)
+		// while the caller's context is still live. The frontend treats this as a history-side
+		// timeout and retries; here it succeeds on the second attempt.
+		"history query timeout (stdlib context.DeadlineExceeded) - retried until ready": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+					}, nil)
+				gomock.InOrder(
+					f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+						Return(nil, context.DeadlineExceeded),
+					f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+						Return(&types.HistoryQueryWorkflowResponse{
+							Response: &types.QueryWorkflowResponse{QueryResult: descBytes},
+						}, nil),
+				)
+			},
+			wantErr: false,
+		},
+		// When history returns DeadlineExceeded but the caller's own context is already expired,
+		// ctx.Err() != nil so the queryTimeout guard is false and the error is returned immediately
+		// without retrying.
+		"history query timeout - caller context expired - not retried": {
+			ctx:     func() context.Context { ctx, cancel := context.WithCancel(context.Background()); cancel(); return ctx }(),
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+					}, nil)
+				f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+					Return(nil, context.DeadlineExceeded)
+			},
+			wantErr: true,
+		},
 		// If the scheduler closes between the DWE probe and the QueryWorkflow call,
 		// the reject condition on the query stops the history layer from replaying
 		// closed history and reporting stale ACTIVE state.
@@ -684,7 +762,11 @@ func TestDescribeSchedule(t *testing.T) {
 			defer f.finish()
 			tt.mockFn(f)
 
-			resp, err := f.handler.DescribeSchedule(context.Background(), tt.request)
+			ctx := tt.ctx
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			resp, err := f.handler.DescribeSchedule(ctx, tt.request)
 			if tt.wantErr {
 				assert.Error(t, err)
 				if tt.checkErr != nil {

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -1438,7 +1438,7 @@ func TestValidateSchedulePolicies(t *testing.T) {
 	}
 }
 
-// TestValidateUserSearchAttributes verifies that user-supplied search attributeAdd a comment on  lines R1381 to R1401Add diff commentMarkdown input:  edit mode selected.WritePreviewHeadingBoldItalicQuoteCodeLinkUnordered listNumbered listTask listMentionReferenceMore Formatting tools items 0Saved repliesAdd FilesPaste, drop, or click to add filesCancelCommentStart a review
+// TestValidateUserSearchAttributes verifies that user-supplied search attribute
 // keys colliding with the scheduler-reserved "CadenceSchedule" prefix are
 // rejected, while other keys (including a lowercase near-miss) are allowed. The
 // prefix check is case-sensitive.

--- a/service/history/failover/coordinator.go
+++ b/service/history/failover/coordinator.go
@@ -306,12 +306,13 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 	}
 
 	if len(record.shards) == c.config.NumberOfShards {
-		if err := domain.CleanPendingActiveState(
+		updated, err := domain.CleanPendingActiveState(
 			c.domainManager,
 			domainID,
 			record.failoverVersion,
 			c.retryPolicy,
-		); err != nil {
+		)
+		if err != nil {
 			c.logger.Error("Coordinator failed to update domain after receiving failover markers from all shards",
 				tag.WorkflowDomainID(domainID),
 				tag.Error(err),
@@ -320,6 +321,22 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 			return
 		}
 		delete(c.recorder, domainID)
+		// reset the gauge so it reflects the current (empty) pending state for this domain
+		// rather than the last partial-count value, which would otherwise linger forever
+		c.scope.Tagged(
+			metrics.DomainTag(domainName),
+		).UpdateGauge(
+			metrics.FailoverMarkerCount,
+			0,
+		)
+
+		if !updated {
+			// another path already cleared the pending-active state — avoid the
+			// misleading "Updated domain from pending-active to active" log and
+			// the bogus GracefulFailoverLatency (which would otherwise report
+			// now - marker.CreationTime on a long-stale marker)
+			return
+		}
 
 		now := c.timeSource.Now()
 		// use the last marker to calculate the failover duration

--- a/service/history/failover/coordinator_test.go
+++ b/service/history/failover/coordinator_test.go
@@ -421,6 +421,69 @@ func (s *coordinatorSuite) TestHandleFailoverMarkers_CleanPendingActiveState_Err
 	s.Equal(1, len(s.coordinator.recorder))
 }
 
+func (s *coordinatorSuite) TestHandleFailoverMarkers_CleanPendingActiveState_NoOp() {
+	domainID := uuid.New()
+	attributes1 := &types.FailoverMarkerAttributes{
+		DomainID:        domainID,
+		FailoverVersion: 2,
+		CreationTime:    common.Int64Ptr(1),
+	}
+	attributes2 := &types.FailoverMarkerAttributes{
+		DomainID:        domainID,
+		FailoverVersion: 2,
+		CreationTime:    common.Int64Ptr(1),
+	}
+	request1 := &receiveRequest{
+		shardIDs: []int32{1},
+		marker:   attributes1,
+	}
+	request2 := &receiveRequest{
+		shardIDs: []int32{2},
+		marker:   attributes2,
+	}
+	info := &persistence.DomainInfo{
+		ID:          domainID,
+		Name:        uuid.New(),
+		Status:      persistence.DomainStatusRegistered,
+		Description: "some random description",
+		OwnerEmail:  "some random email",
+		Data:        nil,
+	}
+	domainConfig := &persistence.DomainConfig{
+		Retention:  1,
+		EmitMetric: true,
+	}
+	replicationConfig := &persistence.DomainReplicationConfig{
+		ActiveClusterName: "active",
+		Clusters: []*persistence.ClusterReplicationConfig{
+			{ClusterName: "active"},
+		},
+	}
+
+	s.mockMetadataManager.On("GetMetadata", mock.Anything).Return(&persistence.GetMetadataResponse{
+		NotificationVersion: 1,
+	}, nil)
+	// FailoverEndTime is nil → CleanPendingActiveState is a no-op, no UpdateDomain expected.
+	s.mockMetadataManager.On("GetDomain", mock.Anything, &persistence.GetDomainRequest{
+		ID: domainID,
+	}).Return(&persistence.GetDomainResponse{
+		Info:                        info,
+		Config:                      domainConfig,
+		ReplicationConfig:           replicationConfig,
+		IsGlobalDomain:              true,
+		ConfigVersion:               1,
+		FailoverVersion:             2,
+		FailoverNotificationVersion: 2,
+		FailoverEndTime:             nil,
+		NotificationVersion:         1,
+	}, nil).Times(1)
+
+	s.coordinator.handleFailoverMarkers(request1)
+	s.coordinator.handleFailoverMarkers(request2)
+	s.Equal(0, len(s.coordinator.recorder), "recorder entry should be cleared even when CleanPendingActiveState is a no-op")
+	s.mockMetadataManager.AssertNotCalled(s.T(), "UpdateDomain", mock.Anything, mock.Anything)
+}
+
 func (s *coordinatorSuite) TestGetFailoverInfo_Success() {
 	domainID := uuid.New()
 

--- a/service/history/queue/transfer_queue_processor.go
+++ b/service/history/queue/transfer_queue_processor.go
@@ -92,7 +92,7 @@ func NewTransferQueueProcessor(
 ) Processor {
 	logger := shard.GetLogger().WithTags(tag.ComponentTransferQueue)
 	currentClusterName := shard.GetClusterMetadata().GetCurrentClusterName()
-	config := shard.GetConfig()
+	cfg := shard.GetConfig()
 	taskAllocator := NewTaskAllocator(shard)
 
 	activeLogger := logger.WithTags(tag.QueueTypeActive)
@@ -103,7 +103,7 @@ func NewTransferQueueProcessor(
 		executionCache,
 		workflowResetter,
 		activeLogger,
-		config,
+		cfg,
 		wfIDCache,
 	)
 
@@ -123,7 +123,7 @@ func NewTransferQueueProcessor(
 			func(ctx context.Context, request *types.ReplicateEventsV2Request) error {
 				return shard.GetEngine().ReplicateEventsV2(ctx, request)
 			},
-			config.StandbyTaskReReplicationContextTimeout,
+			cfg.StandbyTaskReReplicationContextTimeout,
 			executionCheck,
 			shard.GetLogger(),
 		)
@@ -135,7 +135,7 @@ func NewTransferQueueProcessor(
 			historyResender,
 			standByLogger,
 			clusterName,
-			config,
+			cfg,
 			shard.GetService().GetHistoryTaskDLQManager(),
 		)
 		standbyQueueProcessors[clusterName] = newTransferQueueStandbyProcessor(
@@ -151,7 +151,7 @@ func NewTransferQueueProcessor(
 	return &transferQueueProcessor{
 		shard:                  shard,
 		taskProcessor:          taskProcessor,
-		config:                 config,
+		config:                 cfg,
 		currentClusterName:     currentClusterName,
 		metricsClient:          shard.GetMetricsClient(),
 		logger:                 logger,
@@ -245,9 +245,9 @@ func (t *transferQueueProcessor) FailoverDomain(domainIDs map[string]struct{}) {
 		return
 	}
 
-	// Failover queue is used to scan all inflight tasks, if queue processor is not
-	// started, there's no inflight task and we don't need to create a failover processor.
-	// Also the HandleAction will be blocked if queue processor processing loop is not running.
+	// Failover queue is used to scan all inflight tasks. If queue processor is not
+	// started, there's no inflight task, and we don't need to create a failover processor.
+	// Also, the HandleAction will be blocked if queue processor processing loop is not running.
 	if atomic.LoadInt32(&t.status) != common.DaemonStatusStarted {
 		return
 	}
@@ -266,7 +266,7 @@ func (t *transferQueueProcessor) FailoverDomain(domainIDs map[string]struct{}) {
 	actionResult, err := t.HandleAction(context.Background(), t.currentClusterName, NewGetStateAction())
 	if err != nil {
 		t.logger.Error("Transfer Failover Failed", tag.WorkflowDomainIDs(domainIDs), tag.Error(err))
-		if err == errProcessorShutdown {
+		if errors.Is(err, errProcessorShutdown) {
 			// processor/shard already shutdown, we don't need to create failover queue processor
 			return
 		}
@@ -506,8 +506,8 @@ func newTransferQueueActiveProcessor(
 	taskExecutor task.Executor,
 	logger log.Logger,
 ) *transferQueueProcessorBase {
-	config := shard.GetConfig()
-	options := newTransferQueueProcessorOptions(config, true, false)
+	cfg := shard.GetConfig()
+	options := newTransferQueueProcessorOptions(cfg, true, false)
 
 	currentClusterName := shard.GetClusterMetadata().GetCurrentClusterName()
 	logger = logger.WithTags(tag.ClusterName(currentClusterName))
@@ -565,8 +565,8 @@ func newTransferQueueStandbyProcessor(
 	taskExecutor task.Executor,
 	logger log.Logger,
 ) *transferQueueProcessorBase {
-	config := shard.GetConfig()
-	options := newTransferQueueProcessorOptions(config, false, false)
+	cfg := shard.GetConfig()
+	options := newTransferQueueProcessorOptions(cfg, false, false)
 
 	logger = logger.WithTags(tag.ClusterName(clusterName))
 
@@ -587,7 +587,8 @@ func newTransferQueueStandbyProcessor(
 					return true, nil
 				}
 			} else {
-				if _, ok := err.(*types.EntityNotExistsError); !ok {
+				var entityNotExistsError *types.EntityNotExistsError
+				if !errors.As(err, &entityNotExistsError) {
 					// retry the task if failed to find the domain
 					logger.Warn("Cannot find domain", tag.WorkflowDomainID(task.GetDomainID()))
 					return false, err
@@ -643,8 +644,8 @@ func newTransferQueueFailoverProcessor(
 	domainIDs map[string]struct{},
 	standbyClusterName string,
 ) (updateClusterAckLevelFn, *transferQueueProcessorBase) {
-	config := shardContext.GetConfig()
-	options := newTransferQueueProcessorOptions(config, true, true)
+	cfg := shardContext.GetConfig()
+	options := newTransferQueueProcessorOptions(cfg, true, true)
 
 	currentClusterName := shardContext.GetService().GetClusterMetadata().GetCurrentClusterName()
 	failoverUUID := uuid.New()

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1539,11 +1539,14 @@ func (s *contextImpl) AddingPendingFailoverMarker(
 	// if the domain is active the marker is expired
 	isActive := domainEntry.IsActiveIn(s.GetClusterMetadata().GetCurrentClusterName())
 	domainStatus := domainEntry.GetInfo().Status
+	// if the domain is no longer pending-active and the marker belongs to that completed failover,
+	// the marker is stale and should be dropped to avoid an infinite re-notify loop
+	failoverCompleted := !domainEntry.IsDomainPendingActive() && domainEntry.GetFailoverVersion() >= marker.GetFailoverVersion()
 
-	if domainStatus == persistence.DomainStatusDeprecated || isActive || domainEntry.GetFailoverVersion() > marker.GetFailoverVersion() {
+	if domainStatus == persistence.DomainStatusDeprecated || isActive || domainEntry.GetFailoverVersion() > marker.GetFailoverVersion() || failoverCompleted {
 		s.logger.Info("Skipped pending failover marker",
 			tag.WorkflowDomainName(domainEntry.GetInfo().Name),
-			tag.Reason(failoverMarkerSkipReason(isActive, domainEntry.GetFailoverVersion(), marker.GetFailoverVersion(), domainStatus)),
+			tag.Reason(failoverMarkerSkipReason(isActive, failoverCompleted, domainEntry.GetFailoverVersion(), marker.GetFailoverVersion(), domainStatus)),
 		)
 		return nil
 	}
@@ -1555,7 +1558,7 @@ func (s *contextImpl) AddingPendingFailoverMarker(
 	return s.forceUpdateShardInfoLocked()
 }
 
-func failoverMarkerSkipReason(isActive bool, domainFailoverVersion, markerFailoverVersion int64, domainStatus int) string {
+func failoverMarkerSkipReason(isActive, failoverCompleted bool, domainFailoverVersion, markerFailoverVersion int64, domainStatus int) string {
 	switch {
 	case domainStatus == persistence.DomainStatusDeprecated:
 		return "domain is deprecated"
@@ -1563,6 +1566,8 @@ func failoverMarkerSkipReason(isActive bool, domainFailoverVersion, markerFailov
 		return "domain is active in current cluster"
 	case domainFailoverVersion > markerFailoverVersion:
 		return "domain failover version is newer than marker"
+	case failoverCompleted:
+		return "domain failover already completed"
 	default:
 		return "unknown"
 	}
@@ -1581,20 +1586,35 @@ func (s *contextImpl) ValidateAndUpdateFailoverMarkers() ([]*types.FailoverMarke
 	for _, marker := range s.shardInfo.PendingFailoverMarkers {
 		domainEntry, err := s.GetDomainCache().GetDomainByID(marker.GetDomainID())
 		if err != nil {
+			// if the domain no longer exists, drop the marker so it does not
+			// stay stuck in PendingFailoverMarkers forever — otherwise this
+			// one orphan marker would also bail the loop and prevent cleanup
+			// of every other marker in the slice
+			var notExists *types.EntityNotExistsError
+			if errors.As(err, &notExists) {
+				s.logger.Info("Dropped pending failover marker",
+					tag.WorkflowDomainID(marker.GetDomainID()),
+					tag.Reason("domain no longer exists"),
+				)
+				completedFailoverMarkers[marker] = struct{}{}
+				continue
+			}
 			s.RUnlock()
 			return nil, err
 		}
 
 		isActive := domainEntry.IsActiveIn(s.GetClusterMetadata().GetCurrentClusterName())
 		domainStatus := domainEntry.GetInfo().Status
+		failoverCompleted := !domainEntry.IsDomainPendingActive() && domainEntry.GetFailoverVersion() >= marker.GetFailoverVersion()
 
 		// Drop failover markers if domain is deprecated
 		// or domain is already active in the currentCluster
 		// or domain have been failed over
-		if domainStatus == persistence.DomainStatusDeprecated || isActive || domainEntry.GetFailoverVersion() > marker.GetFailoverVersion() {
+		// or the failover this marker belongs to has already completed (no longer pending-active)
+		if domainStatus == persistence.DomainStatusDeprecated || isActive || domainEntry.GetFailoverVersion() > marker.GetFailoverVersion() || failoverCompleted {
 			s.logger.Info("Dropped pending failover marker",
 				tag.WorkflowDomainName(domainEntry.GetInfo().Name),
-				tag.Reason(failoverMarkerSkipReason(isActive, domainEntry.GetFailoverVersion(), marker.GetFailoverVersion(), domainStatus)),
+				tag.Reason(failoverMarkerSkipReason(isActive, failoverCompleted, domainEntry.GetFailoverVersion(), marker.GetFailoverVersion(), domainStatus)),
 			)
 			completedFailoverMarkers[marker] = struct{}{}
 		}

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -1109,9 +1109,11 @@ func (s *contextTestSuite) TestAppendHistoryV2Events() {
 func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers() {
 	// This test verifies that failover markers are processed when a domain becomes active
 	domainFailoverVersion := 100
-	domainCacheEntryInactiveCluster := cache.NewGlobalDomainCacheEntryForTest(
+	pendingActiveEndTime := common.Int64Ptr(1)
+	domainCacheEntryInactivePendingActive := cache.NewDomainCacheEntryForTest(
 		&persistence.DomainInfo{ID: testDomainID},
 		&persistence.DomainConfig{Retention: 7},
+		true,
 		&persistence.DomainReplicationConfig{
 			ActiveClusterName: cluster.TestAlternativeClusterName, // active is TestCurrentClusterName
 			Clusters: []*persistence.ClusterReplicationConfig{
@@ -1120,6 +1122,8 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers() {
 			},
 		},
 		int64(domainFailoverVersion),
+		pendingActiveEndTime,
+		0, 0, 0,
 	)
 	domainCacheEntryActiveCluster := cache.NewGlobalDomainCacheEntryForTest(
 		&persistence.DomainInfo{ID: testDomainID},
@@ -1133,7 +1137,7 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers() {
 		},
 		int64(domainFailoverVersion),
 	)
-	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntryInactiveCluster, nil)
+	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntryInactivePendingActive, nil)
 
 	failoverMarker := types.FailoverMarkerAttributes{
 		DomainID:        testDomainID,
@@ -1159,9 +1163,11 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DeprecatedDomain
 	// At insert time the domain is not deprecated, so the markers are saved.
 	// Between insert and validation, the domain becomes deprecated, so they are dropped.
 	domainFailoverVersion := 100
-	domainCacheEntryInactiveCluster := cache.NewGlobalDomainCacheEntryForTest(
+	pendingActiveEndTime := common.Int64Ptr(1)
+	domainCacheEntryInactivePendingActive := cache.NewDomainCacheEntryForTest(
 		&persistence.DomainInfo{ID: testDomainID},
 		&persistence.DomainConfig{Retention: 7},
+		true,
 		&persistence.DomainReplicationConfig{
 			ActiveClusterName: cluster.TestAlternativeClusterName, // current cluster is NOT active
 			Clusters: []*persistence.ClusterReplicationConfig{
@@ -1170,10 +1176,13 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DeprecatedDomain
 			},
 		},
 		int64(domainFailoverVersion),
+		pendingActiveEndTime,
+		0, 0, 0,
 	)
-	domainCacheEntryInactiveClusterDeprecated := cache.NewGlobalDomainCacheEntryForTest(
+	domainCacheEntryInactiveClusterDeprecated := cache.NewDomainCacheEntryForTest(
 		&persistence.DomainInfo{ID: testDomainID},
 		&persistence.DomainConfig{Retention: 7},
+		true,
 		&persistence.DomainReplicationConfig{
 			ActiveClusterName: cluster.TestAlternativeClusterName, // still not active here
 			Clusters: []*persistence.ClusterReplicationConfig{
@@ -1182,11 +1191,13 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DeprecatedDomain
 			},
 		},
 		int64(domainFailoverVersion),
+		pendingActiveEndTime,
+		0, 0, 0,
 	)
 	domainCacheEntryInactiveClusterDeprecated.GetInfo().Status = persistence.DomainStatusDeprecated
 
-	// Insertion: domain is inactive and not deprecated → markers get saved.
-	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntryInactiveCluster, nil).Times(2)
+	// Insertion: domain is inactive, pending-active, and not deprecated → markers get saved.
+	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntryInactivePendingActive, nil).Times(2)
 
 	failoverMarker := types.FailoverMarkerAttributes{
 		DomainID:        testDomainID,
@@ -1207,6 +1218,123 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DeprecatedDomain
 	s.NoError(err)
 	s.Empty(pendingFailoverMarkers, "pending failover markers should be dropped when the domain is deprecated")
 	s.Empty(s.context.shardInfo.PendingFailoverMarkers, "pending failover markers should be dropped from shard info when domain is deprecated")
+}
+
+func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_FailoverCompleted() {
+	domainFailoverVersion := 100
+	pendingActiveEndTime := common.Int64Ptr(1)
+	domainCacheEntryPendingActive := cache.NewDomainCacheEntryForTest(
+		&persistence.DomainInfo{ID: testDomainID},
+		&persistence.DomainConfig{Retention: 7},
+		true,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestAlternativeClusterName,
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+				{ClusterName: cluster.TestAlternativeClusterName},
+			},
+		},
+		int64(domainFailoverVersion),
+		pendingActiveEndTime,
+		0, 0, 0,
+	)
+	domainCacheEntryFailoverDone := cache.NewDomainCacheEntryForTest(
+		&persistence.DomainInfo{ID: testDomainID},
+		&persistence.DomainConfig{Retention: 7},
+		true,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestAlternativeClusterName, // still not active here (third standby)
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+				{ClusterName: cluster.TestAlternativeClusterName},
+			},
+		},
+		int64(domainFailoverVersion),
+		nil, // FailoverEndTime cleared → failover completed
+		0, 0, 0,
+	)
+
+	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntryPendingActive, nil)
+
+	failoverMarker := types.FailoverMarkerAttributes{
+		DomainID:        testDomainID,
+		FailoverVersion: int64(domainFailoverVersion),
+	}
+
+	s.mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(nil)
+	s.NoError(s.context.AddingPendingFailoverMarker(&failoverMarker))
+	s.Require().Len(s.context.shardInfo.PendingFailoverMarkers, 1)
+
+	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntryFailoverDone, nil)
+
+	pendingFailoverMarkers, err := s.context.ValidateAndUpdateFailoverMarkers()
+	s.NoError(err)
+	s.Empty(pendingFailoverMarkers, "stale marker should be dropped once the failover is no longer pending")
+	s.Empty(s.context.shardInfo.PendingFailoverMarkers, "shard info should be cleared too")
+}
+
+func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DomainNoLongerExists() {
+	domainFailoverVersion := 100
+	pendingActiveEndTime := common.Int64Ptr(1)
+	deletedDomainID := "deleted-domain-id"
+
+	domainCacheEntryPendingActive := cache.NewDomainCacheEntryForTest(
+		&persistence.DomainInfo{ID: testDomainID},
+		&persistence.DomainConfig{Retention: 7},
+		true,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestAlternativeClusterName,
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+				{ClusterName: cluster.TestAlternativeClusterName},
+			},
+		},
+		int64(domainFailoverVersion),
+		pendingActiveEndTime,
+		0, 0, 0,
+	)
+	domainCacheEntryFailoverDone := cache.NewDomainCacheEntryForTest(
+		&persistence.DomainInfo{ID: testDomainID},
+		&persistence.DomainConfig{Retention: 7},
+		true,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestAlternativeClusterName,
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+				{ClusterName: cluster.TestAlternativeClusterName},
+			},
+		},
+		int64(domainFailoverVersion),
+		nil,
+		0, 0, 0,
+	)
+
+	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntryPendingActive, nil)
+	s.mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(nil)
+
+	validMarker := types.FailoverMarkerAttributes{
+		DomainID:        testDomainID,
+		FailoverVersion: int64(domainFailoverVersion),
+	}
+	s.NoError(s.context.AddingPendingFailoverMarker(&validMarker))
+	s.Require().Len(s.context.shardInfo.PendingFailoverMarkers, 1)
+
+	// inject an orphan marker directly into shardInfo — simulates a marker whose
+	// domain has since been deleted from the metadata store
+	orphanMarker := &types.FailoverMarkerAttributes{
+		DomainID:        deletedDomainID,
+		FailoverVersion: int64(domainFailoverVersion),
+	}
+	s.context.shardInfo.PendingFailoverMarkers = append(s.context.shardInfo.PendingFailoverMarkers, orphanMarker)
+	s.Require().Len(s.context.shardInfo.PendingFailoverMarkers, 2)
+
+	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntryFailoverDone, nil)
+	s.mockResource.DomainCache.EXPECT().GetDomainByID(deletedDomainID).Return(nil, &types.EntityNotExistsError{Message: "domain not found"})
+
+	pendingFailoverMarkers, err := s.context.ValidateAndUpdateFailoverMarkers()
+	s.NoError(err, "orphan-domain marker must not poison the cleanup loop")
+	s.Empty(pendingFailoverMarkers, "both the orphan and the otherwise-droppable marker should be cleaned")
+	s.Empty(s.context.shardInfo.PendingFailoverMarkers, "shard info should be cleared of both markers")
 }
 
 func (s *contextTestSuite) TestGetAndUpdateProcessingQueueStates() {
@@ -1856,6 +1984,7 @@ func TestFailoverMarkerSkipReason(t *testing.T) {
 	tests := []struct {
 		name                  string
 		isActive              bool
+		failoverCompleted     bool
 		domainFailoverVersion int64
 		markerFailoverVersion int64
 		domainStatus          int
@@ -1886,8 +2015,18 @@ func TestFailoverMarkerSkipReason(t *testing.T) {
 			want:                  "domain failover version is newer than marker",
 		},
 		{
+			name:                  "failover already completed",
+			isActive:              false,
+			failoverCompleted:     true,
+			domainFailoverVersion: 100,
+			markerFailoverVersion: 100,
+			domainStatus:          persistence.DomainStatusRegistered,
+			want:                  "domain failover already completed",
+		},
+		{
 			name:                  "all skip conditions match",
 			isActive:              true,
+			failoverCompleted:     true,
 			domainFailoverVersion: 200,
 			markerFailoverVersion: 100,
 			domainStatus:          persistence.DomainStatusDeprecated,
@@ -1896,6 +2035,7 @@ func TestFailoverMarkerSkipReason(t *testing.T) {
 		{
 			name:                  "no skip condition matches",
 			isActive:              false,
+			failoverCompleted:     false,
 			domainFailoverVersion: 100,
 			markerFailoverVersion: 100,
 			domainStatus:          persistence.DomainStatusRegistered,
@@ -1905,7 +2045,7 @@ func TestFailoverMarkerSkipReason(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := failoverMarkerSkipReason(tc.isActive, tc.domainFailoverVersion, tc.markerFailoverVersion, tc.domainStatus)
+			got := failoverMarkerSkipReason(tc.isActive, tc.failoverCompleted, tc.domainFailoverVersion, tc.markerFailoverVersion, tc.domainStatus)
 			assert.Equal(t, tc.want, got)
 		})
 	}

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -146,6 +146,7 @@ type SchedulerWorkflowInput struct {
 	Action           types.ScheduleAction    `json:"action"`
 	Policies         types.SchedulePolicies  `json:"policies"`
 	SearchAttributes *types.SearchAttributes `json:"searchAttributes,omitempty"`
+	Memo             *types.Memo             `json:"memo,omitempty"`
 	State            SchedulerWorkflowState  `json:"state"`
 }
 
@@ -238,19 +239,21 @@ type BackfillSignal struct {
 // ScheduleDescription is the query result returned by the describe query handler.
 // It provides a snapshot of the schedule's current configuration and runtime state.
 type ScheduleDescription struct {
-	ScheduleID  string                 `json:"scheduleId"`
-	Domain      string                 `json:"domain"`
-	Spec        types.ScheduleSpec     `json:"spec"`
-	Action      types.ScheduleAction   `json:"action"`
-	Policies    types.SchedulePolicies `json:"policies"`
-	Paused      bool                   `json:"paused"`
-	PauseReason string                 `json:"pauseReason,omitempty"`
-	PausedBy    string                 `json:"pausedBy,omitempty"`
-	LastRunTime time.Time              `json:"lastRunTime,omitempty"`
-	NextRunTime time.Time              `json:"nextRunTime,omitempty"`
-	TotalRuns   int64                  `json:"totalRuns"`
-	MissedRuns  int64                  `json:"missedRuns"`
-	SkippedRuns int64                  `json:"skippedRuns"`
+	ScheduleID       string                  `json:"scheduleId"`
+	Domain           string                  `json:"domain"`
+	Spec             types.ScheduleSpec      `json:"spec"`
+	Action           types.ScheduleAction    `json:"action"`
+	Policies         types.SchedulePolicies  `json:"policies"`
+	Paused           bool                    `json:"paused"`
+	PauseReason      string                  `json:"pauseReason,omitempty"`
+	PausedBy         string                  `json:"pausedBy,omitempty"`
+	LastRunTime      time.Time               `json:"lastRunTime,omitempty"`
+	NextRunTime      time.Time               `json:"nextRunTime,omitempty"`
+	TotalRuns        int64                   `json:"totalRuns"`
+	MissedRuns       int64                   `json:"missedRuns"`
+	SkippedRuns      int64                   `json:"skippedRuns"`
+	Memo             *types.Memo             `json:"memo,omitempty"`
+	SearchAttributes *types.SearchAttributes `json:"searchAttributes,omitempty"`
 }
 
 // TriggerSource identifies what caused a schedule fire, used to differentiate

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -980,19 +980,21 @@ func processBackfills(ctx workflow.Context, logger *zap.Logger, scope tally.Scop
 // configuration and runtime state for the describe query handler.
 func buildScheduleDescription(input *SchedulerWorkflowInput, state *SchedulerWorkflowState) *ScheduleDescription {
 	return &ScheduleDescription{
-		ScheduleID:  input.ScheduleID,
-		Domain:      input.Domain,
-		Spec:        input.Spec,
-		Action:      input.Action,
-		Policies:    input.Policies,
-		Paused:      state.Paused,
-		PauseReason: state.PauseReason,
-		PausedBy:    state.PausedBy,
-		LastRunTime: state.LastRunTime,
-		NextRunTime: state.NextRunTime,
-		TotalRuns:   state.TotalRuns,
-		MissedRuns:  state.MissedRuns,
-		SkippedRuns: state.SkippedRuns,
+		ScheduleID:       input.ScheduleID,
+		Domain:           input.Domain,
+		Spec:             input.Spec,
+		Action:           input.Action,
+		Policies:         input.Policies,
+		Paused:           state.Paused,
+		PauseReason:      state.PauseReason,
+		PausedBy:         state.PausedBy,
+		LastRunTime:      state.LastRunTime,
+		NextRunTime:      state.NextRunTime,
+		TotalRuns:        state.TotalRuns,
+		MissedRuns:       state.MissedRuns,
+		SkippedRuns:      state.SkippedRuns,
+		Memo:             input.Memo,
+		SearchAttributes: input.SearchAttributes,
 	}
 }
 

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -447,6 +447,26 @@ func TestBuildScheduleDescription(t *testing.T) {
 			state: SchedulerWorkflowState{},
 			want:  &ScheduleDescription{ScheduleID: "sched-new", Domain: "dev"},
 		},
+		{
+			name: "schedule with memo and search attributes",
+			input: SchedulerWorkflowInput{
+				ScheduleID: "sched-sa",
+				Domain:     "test-domain",
+				Memo:       &types.Memo{Fields: map[string][]byte{"k": []byte(`"v"`)}},
+				SearchAttributes: &types.SearchAttributes{
+					IndexedFields: map[string][]byte{"CustomStringField": []byte(`"val"`)},
+				},
+			},
+			state: SchedulerWorkflowState{},
+			want: &ScheduleDescription{
+				ScheduleID: "sched-sa",
+				Domain:     "test-domain",
+				Memo:       &types.Memo{Fields: map[string][]byte{"k": []byte(`"v"`)}},
+				SearchAttributes: &types.SearchAttributes{
+					IndexedFields: map[string][]byte{"CustomStringField": []byte(`"val"`)},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

- Added TestScheduleFullCreateRoundTrip to host/schedule_test.go.
- The test creates a schedule with every optional field populated — spec (StartTime/EndTime/Jitter), action (Input, WorkflowIDPrefix, timeouts, RetryPolicy, target Memo/SearchAttributes), policies (overlap, catch-up, CatchUpWindow, PauseOnFailure, BufferLimit, ConcurrencyLimit), and schedule-level Memo/SearchAttributes — then asserts DescribeSchedule returns them unchanged, field by field (including the nullable BufferLimit/ConcurrencyLimit). The test self-skips when the scheduler worker is not enabled on the cluster.
- Added tests for reserved keywords

**Why?**
- The existing TestScheduleSmokeTest only exercises a minimal create. Most schedule fields are not settable through the CLI, so the full CreateSchedule → DescribeSchedule mapping path had no end-to-end coverage.
- This closes that gap — in particular it guards the recently added nullable BufferLimit/ConcurrencyLimit round-trip — and gives a repeatable check that surfaces any fields dropped or mis-mapped by the Describe response.

**How did you test it?**
- go vet ./host/ passes (compiles cleanly).
- Run with: go test -race -run 'TestIntegrationSuite/TestScheduleFullCreateRoundTrip' ./host/

**Potential risks**
N/A

**Release notes**
N/A

**Documentation Changes**
N/A
