### PR TITLE
fix(graceful failover): bug that does not remove markers

### DIFF
--- a/common/domain/failover_watcher.go
+++ b/common/domain/failover_watcher.go
@@ -161,13 +161,18 @@ func (p *failoverWatcherImpl) handleFailoverTimeout(
 	if domain.IsDomainPendingActive() && p.timeSource.Now().After(time.Unix(0, *failoverEndTime)) {
 		domainID := domain.GetInfo().ID
 		// force failover the domain without setting the failover timeout
-		if err := CleanPendingActiveState(
+		updated, err := CleanPendingActiveState(
 			p.domainManager,
 			domainID,
 			domain.GetFailoverVersion(),
 			p.retryPolicy,
-		); err != nil {
+		)
+		if err != nil {
 			p.logger.Error("Failed to update pending-active domain to active", tag.WorkflowDomainID(domainID), tag.WorkflowDomainName(domain.GetInfo().Name), tag.Error(err))
+			return
+		}
+		if !updated {
+			// another path already cleared the pending-active state — nothing to announce
 			return
 		}
 		sourceCluster, err := p.clusterMetadata.ClusterNameForFailoverVersion(domain.GetPreviousFailoverVersion())
@@ -185,13 +190,17 @@ func (p *failoverWatcherImpl) handleFailoverTimeout(
 	}
 }
 
-// CleanPendingActiveState removes the pending active state from the domain
+// CleanPendingActiveState removes the pending active state from the domain.
+// Returns (updated, err) where updated is true only when the domain row was
+// actually modified. When the domain is no longer pending-active or the
+// failover version no longer matches, the call is a no-op and returns
+// (false, nil) so callers can avoid emitting misleading "completed" signals.
 func CleanPendingActiveState(
 	domainManager persistence.DomainManager,
 	domainID string,
 	failoverVersion int64,
 	policy backoff.RetryPolicy,
-) error {
+) (bool, error) {
 
 	// must get the metadata (notificationVersion) first
 	// this version can be regarded as the lock on the v2 domain table
@@ -199,12 +208,12 @@ func CleanPendingActiveState(
 	// this call has to be made
 	metadata, err := domainManager.GetMetadata(context.Background())
 	if err != nil {
-		return fmt.Errorf("getting metadata: %w", err)
+		return false, fmt.Errorf("getting metadata: %w", err)
 	}
 
 	domainResponse, err := domainManager.GetDomain(context.Background(), &persistence.GetDomainRequest{ID: domainID})
 	if err != nil {
-		return fmt.Errorf("getting domain: %w", err)
+		return false, fmt.Errorf("getting domain: %w", err)
 	}
 	localFailoverVersion := domainResponse.FailoverVersion
 	isGlobalDomain := domainResponse.IsGlobalDomain
@@ -230,10 +239,11 @@ func CleanPendingActiveState(
 			backoff.WithRetryableError(isUpdateDomainRetryable),
 		)
 		if err := throttleRetry.Do(context.Background(), op); err != nil {
-			return err
+			return false, err
 		}
+		return true, nil
 	}
-	return nil
+	return false, nil
 }
 
 func isUpdateDomainRetryable(

--- a/common/domain/failover_watcher_test.go
+++ b/common/domain/failover_watcher_test.go
@@ -141,8 +141,9 @@ func (s *failoverWatcherSuite) TestCleanPendingActiveState() {
 	}, nil).Times(1)
 
 	// does not have failover end time
-	err := CleanPendingActiveState(s.mockMetadataMgr, domainName, 1, s.watcher.retryPolicy)
+	updated, err := CleanPendingActiveState(s.mockMetadataMgr, domainName, 1, s.watcher.retryPolicy)
 	s.NoError(err)
+	s.False(updated, "no failover end time → no update")
 
 	s.mockMetadataMgr.On("GetDomain", mock.Anything, &persistence.GetDomainRequest{
 		ID: domainName,
@@ -159,8 +160,9 @@ func (s *failoverWatcherSuite) TestCleanPendingActiveState() {
 	}, nil).Times(1)
 
 	// does not match failover versions
-	err = CleanPendingActiveState(s.mockMetadataMgr, domainName, 5, s.watcher.retryPolicy)
+	updated, err = CleanPendingActiveState(s.mockMetadataMgr, domainName, 5, s.watcher.retryPolicy)
 	s.NoError(err)
+	s.False(updated, "failover version mismatch → no update")
 
 	s.mockMetadataMgr.On("UpdateDomain", mock.Anything, &persistence.UpdateDomainRequest{
 		Info:                        info,
@@ -186,8 +188,9 @@ func (s *failoverWatcherSuite) TestCleanPendingActiveState() {
 		NotificationVersion:         1,
 	}, nil).Times(1)
 
-	err = CleanPendingActiveState(s.mockMetadataMgr, domainName, 2, s.watcher.retryPolicy)
+	updated, err = CleanPendingActiveState(s.mockMetadataMgr, domainName, 2, s.watcher.retryPolicy)
 	s.NoError(err)
+	s.True(updated, "happy path actually updates the domain")
 }
 
 func (s *failoverWatcherSuite) TestHandleFailoverTimeout() {

--- a/service/history/failover/coordinator.go
+++ b/service/history/failover/coordinator.go
@@ -306,12 +306,13 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 	}
 
 	if len(record.shards) == c.config.NumberOfShards {
-		if err := domain.CleanPendingActiveState(
+		updated, err := domain.CleanPendingActiveState(
 			c.domainManager,
 			domainID,
 			record.failoverVersion,
 			c.retryPolicy,
-		); err != nil {
+		)
+		if err != nil {
 			c.logger.Error("Coordinator failed to update domain after receiving failover markers from all shards",
 				tag.WorkflowDomainID(domainID),
 				tag.Error(err),
@@ -320,6 +321,22 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 			return
 		}
 		delete(c.recorder, domainID)
+		// reset the gauge so it reflects the current (empty) pending state for this domain
+		// rather than the last partial-count value, which would otherwise linger forever
+		c.scope.Tagged(
+			metrics.DomainTag(domainName),
+		).UpdateGauge(
+			metrics.FailoverMarkerCount,
+			0,
+		)
+
+		if !updated {
+			// another path already cleared the pending-active state — avoid the
+			// misleading "Updated domain from pending-active to active" log and
+			// the bogus GracefulFailoverLatency (which would otherwise report
+			// now - marker.CreationTime on a long-stale marker)
+			return
+		}
 
 		now := c.timeSource.Now()
 		// use the last marker to calculate the failover duration

--- a/service/history/failover/coordinator_test.go
+++ b/service/history/failover/coordinator_test.go
@@ -421,6 +421,69 @@ func (s *coordinatorSuite) TestHandleFailoverMarkers_CleanPendingActiveState_Err
 	s.Equal(1, len(s.coordinator.recorder))
 }
 
+func (s *coordinatorSuite) TestHandleFailoverMarkers_CleanPendingActiveState_NoOp() {
+	domainID := uuid.New()
+	attributes1 := &types.FailoverMarkerAttributes{
+		DomainID:        domainID,
+		FailoverVersion: 2,
+		CreationTime:    common.Int64Ptr(1),
+	}
+	attributes2 := &types.FailoverMarkerAttributes{
+		DomainID:        domainID,
+		FailoverVersion: 2,
+		CreationTime:    common.Int64Ptr(1),
+	}
+	request1 := &receiveRequest{
+		shardIDs: []int32{1},
+		marker:   attributes1,
+	}
+	request2 := &receiveRequest{
+		shardIDs: []int32{2},
+		marker:   attributes2,
+	}
+	info := &persistence.DomainInfo{
+		ID:          domainID,
+		Name:        uuid.New(),
+		Status:      persistence.DomainStatusRegistered,
+		Description: "some random description",
+		OwnerEmail:  "some random email",
+		Data:        nil,
+	}
+	domainConfig := &persistence.DomainConfig{
+		Retention:  1,
+		EmitMetric: true,
+	}
+	replicationConfig := &persistence.DomainReplicationConfig{
+		ActiveClusterName: "active",
+		Clusters: []*persistence.ClusterReplicationConfig{
+			{ClusterName: "active"},
+		},
+	}
+
+	s.mockMetadataManager.On("GetMetadata", mock.Anything).Return(&persistence.GetMetadataResponse{
+		NotificationVersion: 1,
+	}, nil)
+	// FailoverEndTime is nil → CleanPendingActiveState is a no-op, no UpdateDomain expected.
+	s.mockMetadataManager.On("GetDomain", mock.Anything, &persistence.GetDomainRequest{
+		ID: domainID,
+	}).Return(&persistence.GetDomainResponse{
+		Info:                        info,
+		Config:                      domainConfig,
+		ReplicationConfig:           replicationConfig,
+		IsGlobalDomain:              true,
+		ConfigVersion:               1,
+		FailoverVersion:             2,
+		FailoverNotificationVersion: 2,
+		FailoverEndTime:             nil,
+		NotificationVersion:         1,
+	}, nil).Times(1)
+
+	s.coordinator.handleFailoverMarkers(request1)
+	s.coordinator.handleFailoverMarkers(request2)
+	s.Equal(0, len(s.coordinator.recorder), "recorder entry should be cleared even when CleanPendingActiveState is a no-op")
+	s.mockMetadataManager.AssertNotCalled(s.T(), "UpdateDomain", mock.Anything, mock.Anything)
+}
+
 func (s *coordinatorSuite) TestGetFailoverInfo_Success() {
 	domainID := uuid.New()
 

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1586,6 +1586,19 @@ func (s *contextImpl) ValidateAndUpdateFailoverMarkers() ([]*types.FailoverMarke
 	for _, marker := range s.shardInfo.PendingFailoverMarkers {
 		domainEntry, err := s.GetDomainCache().GetDomainByID(marker.GetDomainID())
 		if err != nil {
+			// if the domain no longer exists, drop the marker so it does not
+			// stay stuck in PendingFailoverMarkers forever — otherwise this
+			// one orphan marker would also bail the loop and prevent cleanup
+			// of every other marker in the slice
+			var notExists *types.EntityNotExistsError
+			if errors.As(err, &notExists) {
+				s.logger.Info("Dropped pending failover marker",
+					tag.WorkflowDomainID(marker.GetDomainID()),
+					tag.Reason("domain no longer exists"),
+				)
+				completedFailoverMarkers[marker] = struct{}{}
+				continue
+			}
 			s.RUnlock()
 			return nil, err
 		}

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1539,11 +1539,14 @@ func (s *contextImpl) AddingPendingFailoverMarker(
 	// if the domain is active the marker is expired
 	isActive := domainEntry.IsActiveIn(s.GetClusterMetadata().GetCurrentClusterName())
 	domainStatus := domainEntry.GetInfo().Status
+	// if the domain is no longer pending-active and the marker belongs to that completed failover,
+	// the marker is stale and should be dropped to avoid an infinite re-notify loop
+	failoverCompleted := !domainEntry.IsDomainPendingActive() && domainEntry.GetFailoverVersion() >= marker.GetFailoverVersion()
 
-	if domainStatus == persistence.DomainStatusDeprecated || isActive || domainEntry.GetFailoverVersion() > marker.GetFailoverVersion() {
+	if domainStatus == persistence.DomainStatusDeprecated || isActive || domainEntry.GetFailoverVersion() > marker.GetFailoverVersion() || failoverCompleted {
 		s.logger.Info("Skipped pending failover marker",
 			tag.WorkflowDomainName(domainEntry.GetInfo().Name),
-			tag.Reason(failoverMarkerSkipReason(isActive, domainEntry.GetFailoverVersion(), marker.GetFailoverVersion(), domainStatus)),
+			tag.Reason(failoverMarkerSkipReason(isActive, failoverCompleted, domainEntry.GetFailoverVersion(), marker.GetFailoverVersion(), domainStatus)),
 		)
 		return nil
 	}
@@ -1555,7 +1558,7 @@ func (s *contextImpl) AddingPendingFailoverMarker(
 	return s.forceUpdateShardInfoLocked()
 }
 
-func failoverMarkerSkipReason(isActive bool, domainFailoverVersion, markerFailoverVersion int64, domainStatus int) string {
+func failoverMarkerSkipReason(isActive, failoverCompleted bool, domainFailoverVersion, markerFailoverVersion int64, domainStatus int) string {
 	switch {
 	case domainStatus == persistence.DomainStatusDeprecated:
 		return "domain is deprecated"
@@ -1563,6 +1566,8 @@ func failoverMarkerSkipReason(isActive bool, domainFailoverVersion, markerFailov
 		return "domain is active in current cluster"
 	case domainFailoverVersion > markerFailoverVersion:
 		return "domain failover version is newer than marker"
+	case failoverCompleted:
+		return "domain failover already completed"
 	default:
 		return "unknown"
 	}
@@ -1587,14 +1592,16 @@ func (s *contextImpl) ValidateAndUpdateFailoverMarkers() ([]*types.FailoverMarke
 
 		isActive := domainEntry.IsActiveIn(s.GetClusterMetadata().GetCurrentClusterName())
 		domainStatus := domainEntry.GetInfo().Status
+		failoverCompleted := !domainEntry.IsDomainPendingActive() && domainEntry.GetFailoverVersion() >= marker.GetFailoverVersion()
 
 		// Drop failover markers if domain is deprecated
 		// or domain is already active in the currentCluster
 		// or domain have been failed over
-		if domainStatus == persistence.DomainStatusDeprecated || isActive || domainEntry.GetFailoverVersion() > marker.GetFailoverVersion() {
+		// or the failover this marker belongs to has already completed (no longer pending-active)
+		if domainStatus == persistence.DomainStatusDeprecated || isActive || domainEntry.GetFailoverVersion() > marker.GetFailoverVersion() || failoverCompleted {
 			s.logger.Info("Dropped pending failover marker",
 				tag.WorkflowDomainName(domainEntry.GetInfo().Name),
-				tag.Reason(failoverMarkerSkipReason(isActive, domainEntry.GetFailoverVersion(), marker.GetFailoverVersion(), domainStatus)),
+				tag.Reason(failoverMarkerSkipReason(isActive, failoverCompleted, domainEntry.GetFailoverVersion(), marker.GetFailoverVersion(), domainStatus)),
 			)
 			completedFailoverMarkers[marker] = struct{}{}
 		}

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -1109,9 +1109,11 @@ func (s *contextTestSuite) TestAppendHistoryV2Events() {
 func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers() {
 	// This test verifies that failover markers are processed when a domain becomes active
 	domainFailoverVersion := 100
-	domainCacheEntryInactiveCluster := cache.NewGlobalDomainCacheEntryForTest(
+	pendingActiveEndTime := common.Int64Ptr(1)
+	domainCacheEntryInactivePendingActive := cache.NewDomainCacheEntryForTest(
 		&persistence.DomainInfo{ID: testDomainID},
 		&persistence.DomainConfig{Retention: 7},
+		true,
 		&persistence.DomainReplicationConfig{
 			ActiveClusterName: cluster.TestAlternativeClusterName, // active is TestCurrentClusterName
 			Clusters: []*persistence.ClusterReplicationConfig{
@@ -1120,6 +1122,8 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers() {
 			},
 		},
 		int64(domainFailoverVersion),
+		pendingActiveEndTime,
+		0, 0, 0,
 	)
 	domainCacheEntryActiveCluster := cache.NewGlobalDomainCacheEntryForTest(
 		&persistence.DomainInfo{ID: testDomainID},
@@ -1133,7 +1137,7 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers() {
 		},
 		int64(domainFailoverVersion),
 	)
-	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntryInactiveCluster, nil)
+	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntryInactivePendingActive, nil)
 
 	failoverMarker := types.FailoverMarkerAttributes{
 		DomainID:        testDomainID,
@@ -1159,9 +1163,11 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DeprecatedDomain
 	// At insert time the domain is not deprecated, so the markers are saved.
 	// Between insert and validation, the domain becomes deprecated, so they are dropped.
 	domainFailoverVersion := 100
-	domainCacheEntryInactiveCluster := cache.NewGlobalDomainCacheEntryForTest(
+	pendingActiveEndTime := common.Int64Ptr(1)
+	domainCacheEntryInactivePendingActive := cache.NewDomainCacheEntryForTest(
 		&persistence.DomainInfo{ID: testDomainID},
 		&persistence.DomainConfig{Retention: 7},
+		true,
 		&persistence.DomainReplicationConfig{
 			ActiveClusterName: cluster.TestAlternativeClusterName, // current cluster is NOT active
 			Clusters: []*persistence.ClusterReplicationConfig{
@@ -1170,10 +1176,13 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DeprecatedDomain
 			},
 		},
 		int64(domainFailoverVersion),
+		pendingActiveEndTime,
+		0, 0, 0,
 	)
-	domainCacheEntryInactiveClusterDeprecated := cache.NewGlobalDomainCacheEntryForTest(
+	domainCacheEntryInactiveClusterDeprecated := cache.NewDomainCacheEntryForTest(
 		&persistence.DomainInfo{ID: testDomainID},
 		&persistence.DomainConfig{Retention: 7},
+		true,
 		&persistence.DomainReplicationConfig{
 			ActiveClusterName: cluster.TestAlternativeClusterName, // still not active here
 			Clusters: []*persistence.ClusterReplicationConfig{
@@ -1182,11 +1191,13 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DeprecatedDomain
 			},
 		},
 		int64(domainFailoverVersion),
+		pendingActiveEndTime,
+		0, 0, 0,
 	)
 	domainCacheEntryInactiveClusterDeprecated.GetInfo().Status = persistence.DomainStatusDeprecated
 
-	// Insertion: domain is inactive and not deprecated → markers get saved.
-	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntryInactiveCluster, nil).Times(2)
+	// Insertion: domain is inactive, pending-active, and not deprecated → markers get saved.
+	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntryInactivePendingActive, nil).Times(2)
 
 	failoverMarker := types.FailoverMarkerAttributes{
 		DomainID:        testDomainID,
@@ -1207,6 +1218,59 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DeprecatedDomain
 	s.NoError(err)
 	s.Empty(pendingFailoverMarkers, "pending failover markers should be dropped when the domain is deprecated")
 	s.Empty(s.context.shardInfo.PendingFailoverMarkers, "pending failover markers should be dropped from shard info when domain is deprecated")
+}
+
+func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_FailoverCompleted() {
+	domainFailoverVersion := 100
+	pendingActiveEndTime := common.Int64Ptr(1)
+	domainCacheEntryPendingActive := cache.NewDomainCacheEntryForTest(
+		&persistence.DomainInfo{ID: testDomainID},
+		&persistence.DomainConfig{Retention: 7},
+		true,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestAlternativeClusterName,
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+				{ClusterName: cluster.TestAlternativeClusterName},
+			},
+		},
+		int64(domainFailoverVersion),
+		pendingActiveEndTime,
+		0, 0, 0,
+	)
+	domainCacheEntryFailoverDone := cache.NewDomainCacheEntryForTest(
+		&persistence.DomainInfo{ID: testDomainID},
+		&persistence.DomainConfig{Retention: 7},
+		true,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestAlternativeClusterName, // still not active here (third standby)
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+				{ClusterName: cluster.TestAlternativeClusterName},
+			},
+		},
+		int64(domainFailoverVersion),
+		nil, // FailoverEndTime cleared → failover completed
+		0, 0, 0,
+	)
+
+	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntryPendingActive, nil)
+
+	failoverMarker := types.FailoverMarkerAttributes{
+		DomainID:        testDomainID,
+		FailoverVersion: int64(domainFailoverVersion),
+	}
+
+	s.mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(nil)
+	s.NoError(s.context.AddingPendingFailoverMarker(&failoverMarker))
+	s.Require().Len(s.context.shardInfo.PendingFailoverMarkers, 1)
+
+	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntryFailoverDone, nil)
+
+	pendingFailoverMarkers, err := s.context.ValidateAndUpdateFailoverMarkers()
+	s.NoError(err)
+	s.Empty(pendingFailoverMarkers, "stale marker should be dropped once the failover is no longer pending")
+	s.Empty(s.context.shardInfo.PendingFailoverMarkers, "shard info should be cleared too")
 }
 
 func (s *contextTestSuite) TestGetAndUpdateProcessingQueueStates() {
@@ -1856,6 +1920,7 @@ func TestFailoverMarkerSkipReason(t *testing.T) {
 	tests := []struct {
 		name                  string
 		isActive              bool
+		failoverCompleted     bool
 		domainFailoverVersion int64
 		markerFailoverVersion int64
 		domainStatus          int
@@ -1886,8 +1951,18 @@ func TestFailoverMarkerSkipReason(t *testing.T) {
 			want:                  "domain failover version is newer than marker",
 		},
 		{
+			name:                  "failover already completed",
+			isActive:              false,
+			failoverCompleted:     true,
+			domainFailoverVersion: 100,
+			markerFailoverVersion: 100,
+			domainStatus:          persistence.DomainStatusRegistered,
+			want:                  "domain failover already completed",
+		},
+		{
 			name:                  "all skip conditions match",
 			isActive:              true,
+			failoverCompleted:     true,
 			domainFailoverVersion: 200,
 			markerFailoverVersion: 100,
 			domainStatus:          persistence.DomainStatusDeprecated,
@@ -1896,6 +1971,7 @@ func TestFailoverMarkerSkipReason(t *testing.T) {
 		{
 			name:                  "no skip condition matches",
 			isActive:              false,
+			failoverCompleted:     false,
 			domainFailoverVersion: 100,
 			markerFailoverVersion: 100,
 			domainStatus:          persistence.DomainStatusRegistered,
@@ -1905,7 +1981,7 @@ func TestFailoverMarkerSkipReason(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := failoverMarkerSkipReason(tc.isActive, tc.domainFailoverVersion, tc.markerFailoverVersion, tc.domainStatus)
+			got := failoverMarkerSkipReason(tc.isActive, tc.failoverCompleted, tc.domainFailoverVersion, tc.markerFailoverVersion, tc.domainStatus)
 			assert.Equal(t, tc.want, got)
 		})
 	}

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -1273,6 +1273,70 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_FailoverComplete
 	s.Empty(s.context.shardInfo.PendingFailoverMarkers, "shard info should be cleared too")
 }
 
+func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DomainNoLongerExists() {
+	domainFailoverVersion := 100
+	pendingActiveEndTime := common.Int64Ptr(1)
+	deletedDomainID := "deleted-domain-id"
+
+	domainCacheEntryPendingActive := cache.NewDomainCacheEntryForTest(
+		&persistence.DomainInfo{ID: testDomainID},
+		&persistence.DomainConfig{Retention: 7},
+		true,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestAlternativeClusterName,
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+				{ClusterName: cluster.TestAlternativeClusterName},
+			},
+		},
+		int64(domainFailoverVersion),
+		pendingActiveEndTime,
+		0, 0, 0,
+	)
+	domainCacheEntryFailoverDone := cache.NewDomainCacheEntryForTest(
+		&persistence.DomainInfo{ID: testDomainID},
+		&persistence.DomainConfig{Retention: 7},
+		true,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestAlternativeClusterName,
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+				{ClusterName: cluster.TestAlternativeClusterName},
+			},
+		},
+		int64(domainFailoverVersion),
+		nil,
+		0, 0, 0,
+	)
+
+	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntryPendingActive, nil)
+	s.mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(nil)
+
+	validMarker := types.FailoverMarkerAttributes{
+		DomainID:        testDomainID,
+		FailoverVersion: int64(domainFailoverVersion),
+	}
+	s.NoError(s.context.AddingPendingFailoverMarker(&validMarker))
+	s.Require().Len(s.context.shardInfo.PendingFailoverMarkers, 1)
+
+	// inject an orphan marker directly into shardInfo — simulates a marker whose
+	// domain has since been deleted from the metadata store
+	orphanMarker := &types.FailoverMarkerAttributes{
+		DomainID:        deletedDomainID,
+		FailoverVersion: int64(domainFailoverVersion),
+	}
+	s.context.shardInfo.PendingFailoverMarkers = append(s.context.shardInfo.PendingFailoverMarkers, orphanMarker)
+	s.Require().Len(s.context.shardInfo.PendingFailoverMarkers, 2)
+
+	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainCacheEntryFailoverDone, nil)
+	s.mockResource.DomainCache.EXPECT().GetDomainByID(deletedDomainID).Return(nil, &types.EntityNotExistsError{Message: "domain not found"})
+
+	pendingFailoverMarkers, err := s.context.ValidateAndUpdateFailoverMarkers()
+	s.NoError(err, "orphan-domain marker must not poison the cleanup loop")
+	s.Empty(pendingFailoverMarkers, "both the orphan and the otherwise-droppable marker should be cleaned")
+	s.Empty(s.context.shardInfo.PendingFailoverMarkers, "shard info should be cleared of both markers")
+}
+
 func (s *contextTestSuite) TestGetAndUpdateProcessingQueueStates() {
 	clusterName := cluster.TestCurrentClusterName
 	var initialQueueStates [][]*types.ProcessingQueueState


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Remove pending failover markers when graceful failover is completed. Added boolean return to CleanPendingActiveState that return true when pending active state is actually cleaned. Set metric FailoverMarkerCount gauge to 0 when all shards have received the failover markers. Remove pending failover markers when domain does not exist and not return error.

https://github.com/cadence-workflow/cadence/issues/8138

**Why?**
The check to remove pending markers didn't account for the failover completed (!domainEntry.IsDomainPendingActive() && domainEntry.GetFailoverVersion() >= marker.GetFailoverVersion()). That caused pending failover markers to never be removed and stay in the system until a new graceful failover happened.

We also didn't know if CleanPendingActiveState actually cleaned the state. It could be a noop, but we still logged as if it was cleaned up. Fixed that, now it only emits the log when it actually cleans up.

Set the gauge to 0 when all shards have received their failover markers and the failover completed. This way we avoid stale values in the metric gauge.

When a domain doesn't exist we return an error in the loop and do not continue. This causes the pending marker for that domain to not be removed as well as other pending markers. This fixes that and remove bad markers from the system.

**How did you test it?**
go test -race -count=1 ./service/history/shard/... ./service/history/failover/... ./common/domain/...

Running locally:
```
pkill -9  -f cadence-server
make bins
tmux \
    split-window -h './cadence-server --config config --zone xdc --env development_xdc_cluster0 start' \; \
    split-window -h './cadence-server --config config --zone xdc --env development_xdc_cluster1 start' \; \
    split-window -h './cadence-server --config config --zone xdc --env development_xdc_cluster2 start' \; \
select-layout tiled
./cadence --domain test domain register --gd true --clusters cluster0,cluster1,cluster2
./cadence --transport grpc --ad localhost:8833 --domain test domain update --ft grace --ac cluster1 --fts 60
```

Only returns "Updated domain from pending-active to active" once (which was not the case before) and we can see the pending markers being dropped after the failover is complete (which was also not the case)

**Potential risks**
No risks. This fixes three existing bugs.

**Release notes**
Fixed bug in graceful failover that caused incorrect logs and metrics, not removing pending failover markers from the system until another graceful failover happen.

**Documentation Changes**
N/A
