### PR TITLE
fix(schedule): populate Memo and SearchAttributes in DescribeSchedule response

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -183,6 +183,7 @@ func (wh *WorkflowHandler) CreateSchedule(
 		Spec:             *request.GetSpec(),
 		Action:           *request.GetAction(),
 		SearchAttributes: request.GetSearchAttributes(),
+		Memo:             request.GetMemo(),
 	}
 	if request.GetPolicies() != nil {
 		workflowInput.Policies = *request.GetPolicies()
@@ -331,6 +332,8 @@ func (wh *WorkflowHandler) DescribeSchedule(
 			NextRunTime: desc.NextRunTime,
 			TotalRuns:   desc.TotalRuns,
 		},
+		Memo:             desc.Memo,
+		SearchAttributes: desc.SearchAttributes,
 	}, nil
 }
 

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -349,6 +349,32 @@ func TestCreateSchedule(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		"memo forwarded into workflow input": {
+			request: &types.CreateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "my-schedule",
+				Spec:       &types.ScheduleSpec{CronExpression: "*/5 * * * *"},
+				Action: &types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType: &types.WorkflowType{Name: "my-workflow"},
+						TaskList:     &types.TaskList{Name: "my-tasklist"},
+					},
+				},
+				Memo: &types.Memo{Fields: map[string][]byte{"schedMemo": []byte(`"sm"`)}},
+			},
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.HistoryStartWorkflowExecutionRequest, _ ...yarpc.CallOption) (*types.StartWorkflowExecutionResponse, error) {
+						var input scheduler.SchedulerWorkflowInput
+						require.NoError(t, json.Unmarshal(req.StartRequest.Input, &input))
+						require.NotNil(t, input.Memo)
+						assert.Equal(t, []byte(`"sm"`), input.Memo.Fields["schedMemo"])
+						return &types.StartWorkflowExecutionResponse{RunID: "test-run-id"}, nil
+					})
+			},
+			wantErr: false,
+		},
 	}
 
 	for name, tt := range tests {
@@ -380,6 +406,10 @@ func TestDescribeSchedule(t *testing.T) {
 		PauseReason: "maintenance",
 		PausedBy:    "admin",
 		TotalRuns:   42,
+		Memo:        &types.Memo{Fields: map[string][]byte{"schedMemo": []byte(`"sm"`)}},
+		SearchAttributes: &types.SearchAttributes{
+			IndexedFields: map[string][]byte{"CustomIntField": []byte(`7`)},
+		},
 	}
 	descBytes, _ := json.Marshal(descResult)
 
@@ -640,6 +670,10 @@ func TestDescribeSchedule(t *testing.T) {
 				assert.Equal(t, "maintenance", resp.State.PauseInfo.Reason)
 				assert.Equal(t, "admin", resp.State.PauseInfo.PausedBy)
 				assert.Equal(t, int64(42), resp.Info.TotalRuns)
+				require.NotNil(t, resp.Memo)
+				assert.Equal(t, []byte(`"sm"`), resp.Memo.Fields["schedMemo"])
+				require.NotNil(t, resp.SearchAttributes)
+				assert.Equal(t, []byte(`7`), resp.SearchAttributes.IndexedFields["CustomIntField"])
 			},
 		},
 	}

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -146,6 +146,7 @@ type SchedulerWorkflowInput struct {
 	Action           types.ScheduleAction    `json:"action"`
 	Policies         types.SchedulePolicies  `json:"policies"`
 	SearchAttributes *types.SearchAttributes `json:"searchAttributes,omitempty"`
+	Memo             *types.Memo             `json:"memo,omitempty"`
 	State            SchedulerWorkflowState  `json:"state"`
 }
 
@@ -238,19 +239,21 @@ type BackfillSignal struct {
 // ScheduleDescription is the query result returned by the describe query handler.
 // It provides a snapshot of the schedule's current configuration and runtime state.
 type ScheduleDescription struct {
-	ScheduleID  string                 `json:"scheduleId"`
-	Domain      string                 `json:"domain"`
-	Spec        types.ScheduleSpec     `json:"spec"`
-	Action      types.ScheduleAction   `json:"action"`
-	Policies    types.SchedulePolicies `json:"policies"`
-	Paused      bool                   `json:"paused"`
-	PauseReason string                 `json:"pauseReason,omitempty"`
-	PausedBy    string                 `json:"pausedBy,omitempty"`
-	LastRunTime time.Time              `json:"lastRunTime,omitempty"`
-	NextRunTime time.Time              `json:"nextRunTime,omitempty"`
-	TotalRuns   int64                  `json:"totalRuns"`
-	MissedRuns  int64                  `json:"missedRuns"`
-	SkippedRuns int64                  `json:"skippedRuns"`
+	ScheduleID       string                  `json:"scheduleId"`
+	Domain           string                  `json:"domain"`
+	Spec             types.ScheduleSpec      `json:"spec"`
+	Action           types.ScheduleAction    `json:"action"`
+	Policies         types.SchedulePolicies  `json:"policies"`
+	Paused           bool                    `json:"paused"`
+	PauseReason      string                  `json:"pauseReason,omitempty"`
+	PausedBy         string                  `json:"pausedBy,omitempty"`
+	LastRunTime      time.Time               `json:"lastRunTime,omitempty"`
+	NextRunTime      time.Time               `json:"nextRunTime,omitempty"`
+	TotalRuns        int64                   `json:"totalRuns"`
+	MissedRuns       int64                   `json:"missedRuns"`
+	SkippedRuns      int64                   `json:"skippedRuns"`
+	Memo             *types.Memo             `json:"memo,omitempty"`
+	SearchAttributes *types.SearchAttributes `json:"searchAttributes,omitempty"`
 }
 
 // TriggerSource identifies what caused a schedule fire, used to differentiate

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -980,19 +980,21 @@ func processBackfills(ctx workflow.Context, logger *zap.Logger, scope tally.Scop
 // configuration and runtime state for the describe query handler.
 func buildScheduleDescription(input *SchedulerWorkflowInput, state *SchedulerWorkflowState) *ScheduleDescription {
 	return &ScheduleDescription{
-		ScheduleID:  input.ScheduleID,
-		Domain:      input.Domain,
-		Spec:        input.Spec,
-		Action:      input.Action,
-		Policies:    input.Policies,
-		Paused:      state.Paused,
-		PauseReason: state.PauseReason,
-		PausedBy:    state.PausedBy,
-		LastRunTime: state.LastRunTime,
-		NextRunTime: state.NextRunTime,
-		TotalRuns:   state.TotalRuns,
-		MissedRuns:  state.MissedRuns,
-		SkippedRuns: state.SkippedRuns,
+		ScheduleID:       input.ScheduleID,
+		Domain:           input.Domain,
+		Spec:             input.Spec,
+		Action:           input.Action,
+		Policies:         input.Policies,
+		Paused:           state.Paused,
+		PauseReason:      state.PauseReason,
+		PausedBy:         state.PausedBy,
+		LastRunTime:      state.LastRunTime,
+		NextRunTime:      state.NextRunTime,
+		TotalRuns:        state.TotalRuns,
+		MissedRuns:       state.MissedRuns,
+		SkippedRuns:      state.SkippedRuns,
+		Memo:             input.Memo,
+		SearchAttributes: input.SearchAttributes,
 	}
 }
 

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -447,6 +447,26 @@ func TestBuildScheduleDescription(t *testing.T) {
 			state: SchedulerWorkflowState{},
 			want:  &ScheduleDescription{ScheduleID: "sched-new", Domain: "dev"},
 		},
+		{
+			name: "schedule with memo and search attributes",
+			input: SchedulerWorkflowInput{
+				ScheduleID: "sched-sa",
+				Domain:     "test-domain",
+				Memo:       &types.Memo{Fields: map[string][]byte{"k": []byte(`"v"`)}},
+				SearchAttributes: &types.SearchAttributes{
+					IndexedFields: map[string][]byte{"CustomStringField": []byte(`"val"`)},
+				},
+			},
+			state: SchedulerWorkflowState{},
+			want: &ScheduleDescription{
+				ScheduleID: "sched-sa",
+				Domain:     "test-domain",
+				Memo:       &types.Memo{Fields: map[string][]byte{"k": []byte(`"v"`)}},
+				SearchAttributes: &types.SearchAttributes{
+					IndexedFields: map[string][]byte{"CustomStringField": []byte(`"val"`)},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Added Memo *types.Memo to SchedulerWorkflowInput so it survives ContinueAsNew alongside the existing SearchAttributes field.
  - Added Memo and SearchAttributes fields to ScheduleDescription, so the describe query handler can carry them back to the frontend.
  - Updated buildScheduleDescription to populate both fields from input.
  - Updated CreateSchedule to store Memo
  - Updated DescribeSchedule to set Memo and SearchAttributes on the returned DescribeScheduleResponse.

**Why?**
The mappers correctly wire them but the server never populated them. A client that creates a schedule with Memo or SearchAttributes had no way to retrieve them via Describe.

Note: DescribeScheduleResponse.SearchAttributes returns the user's original schedule-level SAs only not the combined visibility index.

**How did you test it?**
 go test -race -run 'TestBuildScheduleDescription' ./service/worker/scheduler/
go test -race -run 'TestDescribeSchedule|TestCreateSchedule' ./service/frontend/api/
go build ./...


**Potential risks**
- No changes to UpdateSchedule behavior. Memo is immutable after creation. SearchAttributes update path is unchanged.

**Release notes**
N/A

**Documentation Changes**
N/A
