### PR TITLE
fix(schedule): retry DescribeSchedule on history query timeout

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.uber.org/yarpc/yarpcerrors"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
@@ -814,9 +815,7 @@ func (wh *WorkflowHandler) describeSchedulerExecution(
 }
 
 // querySchedulerWorkflow issues a QueryWorkflow call for the scheduler's
-// describe query, retrying briefly if the workflow has not yet processed its
-// first decision task. That transient state occurs right after CreateSchedule
-// or immediately after a ContinueAsNew run starts.
+// describe query, retrying on transient errors until the workflow is queryable.
 func (wh *WorkflowHandler) querySchedulerWorkflow(
 	ctx context.Context,
 	domainName, scheduleID string,
@@ -836,7 +835,11 @@ func (wh *WorkflowHandler) querySchedulerWorkflow(
 			return resp, nil
 		}
 		var qfe *types.QueryFailedError
-		if !errors.As(err, &qfe) || !strings.Contains(qfe.Message, "decision task") {
+		decisionTaskPending := errors.As(err, &qfe) && strings.Contains(qfe.Message, "decision task")
+		queryTimeout := (errors.Is(err, context.DeadlineExceeded) ||
+			yarpcerrors.IsStatus(err) && yarpcerrors.FromError(err).Code() == yarpcerrors.CodeDeadlineExceeded) &&
+			ctx.Err() == nil
+		if !decisionTaskPending && !queryTimeout {
 			return nil, normalizeScheduleError(err, scheduleID, domainName)
 		}
 		lastErr = err

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -580,6 +580,44 @@ func TestDescribeSchedule(t *testing.T) {
 				assert.Contains(t, qfe.Message, "decision task")
 			},
 		},
+		// History's internal query wait times out before the scheduler workflow
+		// processes its first decision task. The frontend retries the same as for
+		// the QueryFailedError case; here it succeeds on the second attempt.
+		"history query timeout - retried until ready": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+					}, nil)
+				gomock.InOrder(
+					f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+						Return(nil, yarpcerrors.DeadlineExceededErrorf("query wait timed out")),
+					f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+						Return(&types.HistoryQueryWorkflowResponse{
+							Response: &types.QueryWorkflowResponse{QueryResult: descBytes},
+						}, nil),
+				)
+			},
+			wantErr: false,
+		},
+		// If history keeps returning deadline exceeded past the retry budget, the
+		// last error is returned.
+		"history query timeout - retry budget exhausted": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+					}, nil)
+				f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+					Return(nil, yarpcerrors.DeadlineExceededErrorf("query wait timed out")).
+					Times(describeScheduleQueryRetryAttempts)
+			},
+			wantErr: true,
+		},
 		// If the scheduler closes between the DWE probe and the QueryWorkflow call,
 		// the reject condition on the query stops the history layer from replaying
 		// closed history and reporting stale ACTIVE state.

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -389,6 +389,7 @@ func TestDescribeSchedule(t *testing.T) {
 	}
 
 	tests := map[string]struct {
+		ctx      context.Context
 		request  *types.DescribeScheduleRequest
 		mockFn   func(*scheduleTestFixture)
 		wantErr  bool
@@ -618,6 +619,45 @@ func TestDescribeSchedule(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		// History returns the stdlib context.DeadlineExceeded (not yarpc's CodeDeadlineExceeded)
+		// while the caller's context is still live. The frontend treats this as a history-side
+		// timeout and retries; here it succeeds on the second attempt.
+		"history query timeout (stdlib context.DeadlineExceeded) - retried until ready": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+					}, nil)
+				gomock.InOrder(
+					f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+						Return(nil, context.DeadlineExceeded),
+					f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+						Return(&types.HistoryQueryWorkflowResponse{
+							Response: &types.QueryWorkflowResponse{QueryResult: descBytes},
+						}, nil),
+				)
+			},
+			wantErr: false,
+		},
+		// When history returns DeadlineExceeded but the caller's own context is already expired,
+		// ctx.Err() != nil so the queryTimeout guard is false and the error is returned immediately
+		// without retrying.
+		"history query timeout - caller context expired - not retried": {
+			ctx:     func() context.Context { ctx, cancel := context.WithCancel(context.Background()); cancel(); return ctx }(),
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+					}, nil)
+				f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+					Return(nil, context.DeadlineExceeded)
+			},
+			wantErr: true,
+		},
 		// If the scheduler closes between the DWE probe and the QueryWorkflow call,
 		// the reject condition on the query stops the history layer from replaying
 		// closed history and reporting stale ACTIVE state.
@@ -688,7 +728,11 @@ func TestDescribeSchedule(t *testing.T) {
 			defer f.finish()
 			tt.mockFn(f)
 
-			resp, err := f.handler.DescribeSchedule(context.Background(), tt.request)
+			ctx := tt.ctx
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			resp, err := f.handler.DescribeSchedule(ctx, tt.request)
 			if tt.wantErr {
 				assert.Error(t, err)
 				if tt.checkErr != nil {


### PR DESCRIPTION
## What changed

`querySchedulerWorkflow` now retries when `QueryWorkflow` returns a deadline exceeded error from the history service, in addition to the existing retry on `QueryFailedError` containing "decision task". A `ctx.Err() == nil` guard ensures only history's internal timeout is retried, not a caller-expired context.

Both yarpc `CodeDeadlineExceeded` and the stdlib `context.DeadlineExceeded` are handled, since each can surface depending on where in the call stack the timeout originates.

## Why

When `DescribeSchedule` is called immediately after `CreateSchedule`, the scheduler workflow has been started but may not have processed its first decision task yet. `QueryWorkflow` blocks inside the history service waiting for the workflow to become queryable. On a slow host (CI, high-load cluster), that internal wait can exceed history's query timeout, returning `DEADLINE_EXCEEDED` instead of `QueryFailedError`.

The existing retry loop only handled `QueryFailedError`. `DEADLINE_EXCEEDED` hit the fast-return path, causing `DescribeSchedule` to fail with no retry even though the workflow would have been queryable moments later. 

This was the root cause of the flaky `test_create_describe_delete` integration test in the Python client.

## How did you test it

- Added unit tests

## Potential risk

Low. The change only adds a new retryable condition inside the bounded retry loop (`describeScheduleQueryRetryAttempts = 5`, 1s between attempts). The `ctx.Err() == nil` guard prevents infinite retries if the caller's own deadline has passed. The worst-case latency added is unchanged from the existing decision-task retry path (~5s total budget).