### PR TITLE
fix(queuev2): advance cache lower bound when virtual queue is empty

### DIFF
--- a/service/history/queuev2/queue_scheduled_cached.go
+++ b/service/history/queuev2/queue_scheduled_cached.go
@@ -25,6 +25,7 @@ package queuev2
 import (
 	"context"
 
+	"github.com/uber/cadence/common/persistence"
 	hcommon "github.com/uber/cadence/service/history/common"
 )
 
@@ -39,7 +40,12 @@ func newCachedScheduledQueue(inner *scheduledQueue, reader CachedQueueReader) Qu
 	originalUpdateFn := inner.base.updateQueueStateFn
 	inner.base.updateQueueStateFn = func(ctx context.Context) {
 		originalUpdateFn(ctx)
-		reader.UpdateReadLevel(inner.base.virtualQueueManager.GetMinReadLevel())
+		// MaximumHistoryTaskKey means no slices — fall back to ack level.
+		readLevel := inner.base.virtualQueueManager.GetMinReadLevel()
+		if readLevel.Equal(persistence.MaximumHistoryTaskKey) {
+			readLevel = inner.base.exclusiveAckLevel
+		}
+		reader.UpdateReadLevel(readLevel)
 	}
 
 	return &cachedScheduledQueue{

--- a/service/history/queuev2/queue_scheduled_cached_test.go
+++ b/service/history/queuev2/queue_scheduled_cached_test.go
@@ -193,6 +193,53 @@ func TestCachedScheduledQueue_EvictionHookWired(t *testing.T) {
 	csq.scheduledQueue.base.updateQueueStateFn(context.Background())
 }
 
+func TestCachedScheduledQueue_UpdateQueueStateFn_PropagatesReadLevel(t *testing.T) {
+	now := time.Now()
+	sliceReadLevel := persistence.NewHistoryTaskKey(now, 100)
+	ackLevel := persistence.NewHistoryTaskKey(now.Add(-time.Minute), 50)
+
+	tests := []struct {
+		name          string
+		minReadLevel  persistence.HistoryTaskKey
+		expectedLevel persistence.HistoryTaskKey
+	}{
+		{
+			name:          "slices exist - use min read level",
+			minReadLevel:  sliceReadLevel,
+			expectedLevel: sliceReadLevel,
+		},
+		{
+			name:          "no slices - fall back to ack level",
+			minReadLevel:  persistence.MaximumHistoryTaskKey,
+			expectedLevel: ackLevel,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockReader := NewMockCachedQueueReader(ctrl)
+			mockVQM := NewMockVirtualQueueManager(ctrl)
+
+			inner := &scheduledQueue{
+				base: &queueBase{
+					metricsScope:        metrics.NoopScope,
+					virtualQueueManager: mockVQM,
+					exclusiveAckLevel:   ackLevel,
+				},
+				newTimerCh: make(chan struct{}, 1),
+			}
+			inner.base.updateQueueStateFn = func(ctx context.Context) {}
+
+			mockVQM.EXPECT().GetMinReadLevel().Return(tt.minReadLevel)
+			mockReader.EXPECT().UpdateReadLevel(tt.expectedLevel)
+
+			q := newCachedScheduledQueue(inner, mockReader)
+			q.(*cachedScheduledQueue).scheduledQueue.base.updateQueueStateFn(context.Background())
+		})
+	}
+}
+
 func testScheduledQueueOptions() *Options {
 	return &Options{
 		DeleteBatchSize:                      dynamicproperties.GetIntPropertyFn(100),


### PR DESCRIPTION
**What changed?**

In `newCachedScheduledQueue`, the `updateQueueStateFn` hook now falls back to `exclusiveAckLevel` when `GetMinReadLevel()` returns `MaximumHistoryTaskKey` (which signals an empty virtual queue — no active slices).

**Why?**

`CachedQueueReader.inclusiveLowerBound` is the eviction floor: tasks below it are dropped from the cache. It advances via `UpdateReadLevel`, which is called with `GetMinReadLevel()` on every `updateQueueStateFn` cycle.

`GetMinReadLevel()` returns `MaximumHistoryTaskKey` when the virtual queue has no slices (all tasks processed, nothing pending). A healthy, fast shard spends most of its time in this empty state — tasks are fetched, processed, and acked before the next batch arrives. During this period `UpdateReadLevel` is a no-op (the `MaximumHistoryTaskKey` guard filters it out), so `inclusiveLowerBound` stays anchored at the startup value (`now − TimeEvictionWindow`, hours in the past).

The next time a real task batch arrives and creates slices, `GetMinReadLevel()` returns the current frontier (≈ now), causing a single multi-hour jump in the eviction window instead of incremental advances every `UpdateAckInterval`.

When the virtual queue is empty, `exclusiveAckLevel` equals `ExclusiveMaxReadLevel` (the current processing frontier), so it is the correct fallback: nothing below it needs to remain in cache. The invariant `exclusiveAckLevel ≤ GetMinReadLevel()` guarantees we never evict tasks that are still in-flight.

The bug was confirmed by analysing production logs: shards with fast task processing showed `prevLowerBound` stuck at startup values 2–5 hours old, with a single large jump once the first new task batch was processed.

Related to #7953 

**How did you test it?**

New table-driven unit tests in `queue_scheduled_cached_test.go` cover both paths:

```
go test -run TestCachedScheduledQueue_UpdateQueueStateFn_PropagatesReadLevel ./service/history/queuev2/
```

- `slices exist — use min read level`: `GetMinReadLevel()` returns a real key → `UpdateReadLevel` called with that key.
- `no slices — fall back to ack level`: `GetMinReadLevel()` returns `MaximumHistoryTaskKey` → `UpdateReadLevel` called with `exclusiveAckLevel`.

Full package:

```
go test ./service/history/queuev2/...
```

**Potential risks**

The change is in the eviction path only and does not affect task fetching, processing, or acking. The fallback value (`exclusiveAckLevel`) is always ≤ the real `GetMinReadLevel()`, so it is conservative: in the worst case it advances the lower bound less than optimal, never more.

**Release notes**

N/A — internal cache eviction fix with no user-visible behavior change.

**Documentation Changes**

N/A