### PR TITLE
feat(queuev2): log warning when injected task key is below lower bound

### DIFF
--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -572,6 +572,16 @@ func (q *cachedQueueReader) Inject(tasks []persistence.Task) {
 			q.pendingInjectBuffer = append(q.pendingInjectBuffer, t)
 			continue
 		}
+		// this case should not happen under normal operation,
+		// as the processor should only be persisting tasks near the current upper bound
+		// but log just in case to help debug any unexpected ordering issues
+		if t.GetTaskKey().Less(q.inclusiveLowerBound) {
+			q.logger.Warn("task key is below the lower bound, dropping task",
+				tag.Dynamic("taskKey", t.GetTaskKey()),
+				tag.Dynamic("inclusiveLowerBound", q.inclusiveLowerBound),
+				tag.Dynamic("exclusiveUpperBound", q.exclusiveUpperBound),
+			)
+		}
 	}
 
 	q.putTasks(covered)


### PR DESCRIPTION
## What changed?

In `cachedQueueReader.Inject`, tasks whose key falls below `inclusiveLowerBound` were silently dropped with no observability. Added a `Warn` log with the task key, lower bound, and upper bound when this happens.

## Why?

Under normal operation the processor only injects tasks near the current upper bound, so a key below the lower bound should never occur. Logging the case makes unexpected ordering anomalies debuggable without requiring a code change or a repro.

## How did you test it?

```
make pr GEN_DIR=service/history/queuev2   # tidy + generate + fmt + lint
make build                                 # compile check
```

Existing unit tests in `queue_reader_cached_test.go` cover the Inject path and continue to pass.

## Potential risks

None — log-only change, no logic altered.

## Release notes

N/A — internal change.

## Documentation Changes

N/A