### PR TITLE
chore: Update history.enableHierarchicalWeightedRoundRobinTaskScheduler's default value to true

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -5362,7 +5362,7 @@ var BoolKeys = map[BoolKey]DynamicBool{
 	EnableHierarchicalWeightedRoundRobinTaskScheduler: {
 		KeyName:      "history.enableHierarchicalWeightedRoundRobinTaskScheduler",
 		Description:  "EnableHierarchicalWeightedRoundRobinTaskScheduler is to enable hierarchical weighted round robin task scheduler",
-		DefaultValue: false,
+		DefaultValue: true,
 	},
 	EnableTaskListAwareTaskSchedulerByDomain: {
 		KeyName:      "history.enableTaskListAwareTaskSchedulerByDomain",


### PR DESCRIPTION

<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Update history.enableHierarchicalWeightedRoundRobinTaskScheduler's default value to true

**Why?**
Enable new feature by default.

**How did you test it?**
go test ./common/dynamicconfig/...

**Potential risks**
No.

**Release notes**
New history task scheduler is enabled by default. It has the ability to ensure fairness of task scheduling at task list level.

**Documentation Changes**

