### PR TITLE
fix: set up connection to all sharded database eagerly

### DIFF
--- a/common/persistence/nosql/factory.go
+++ b/common/persistence/nosql/factory.go
@@ -157,7 +157,7 @@ func newExecutionStoreFactory(
 	taskSerializer serialization.TaskSerializer,
 	dc *persistence.DynamicConfiguration,
 ) (*executionStoreFactory, error) {
-	s, err := newShardedNosqlStore(cfg, logger, metricsClient, dc)
+	s, err := newShardedNosqlStore(cfg, logger, metricsClient, dc, true)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/nosql/nosql_config_store.go
+++ b/common/persistence/nosql/nosql_config_store.go
@@ -41,7 +41,7 @@ func NewNoSQLConfigStore(
 	metricsClient metrics.Client,
 	dc *persistence.DynamicConfiguration,
 ) (persistence.ConfigStore, error) {
-	shardedStore, err := newShardedNosqlStore(cfg, logger, metricsClient, dc)
+	shardedStore, err := newShardedNosqlStore(cfg, logger, metricsClient, dc, false)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/nosql/nosql_domain_audit_store.go
+++ b/common/persistence/nosql/nosql_domain_audit_store.go
@@ -42,7 +42,7 @@ func newNoSQLDomainAuditStore(
 	metricsClient metrics.Client,
 	dc *persistence.DynamicConfiguration,
 ) (persistence.DomainAuditStore, error) {
-	shardedStore, err := newShardedNosqlStore(cfg, logger, metricsClient, dc)
+	shardedStore, err := newShardedNosqlStore(cfg, logger, metricsClient, dc, false)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/nosql/nosql_domain_store.go
+++ b/common/persistence/nosql/nosql_domain_store.go
@@ -48,7 +48,7 @@ func newNoSQLDomainStore(
 	metricsClient metrics.Client,
 	dc *persistence.DynamicConfiguration,
 ) (persistence.DomainStore, error) {
-	shardedStore, err := newShardedNosqlStore(cfg, logger, metricsClient, dc)
+	shardedStore, err := newShardedNosqlStore(cfg, logger, metricsClient, dc, false)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/nosql/nosql_history_dlq_task_store.go
+++ b/common/persistence/nosql/nosql_history_dlq_task_store.go
@@ -42,7 +42,7 @@ func newNoSQLHistoryDLQTaskStore(
 	metricsClient metrics.Client,
 	dc *persistence.DynamicConfiguration,
 ) (persistence.HistoryDLQTaskStore, error) {
-	shardedStore, err := newShardedNosqlStore(cfg, logger, metricsClient, dc)
+	shardedStore, err := newShardedNosqlStore(cfg, logger, metricsClient, dc, false)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/nosql/nosql_history_store.go
+++ b/common/persistence/nosql/nosql_history_store.go
@@ -46,7 +46,7 @@ func newNoSQLHistoryStore(
 	metricsClient metrics.Client,
 	dc *persistence.DynamicConfiguration,
 ) (persistence.HistoryStore, error) {
-	s, err := newShardedNosqlStore(cfg, logger, metricsClient, dc)
+	s, err := newShardedNosqlStore(cfg, logger, metricsClient, dc, true)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/nosql/nosql_queue_store.go
+++ b/common/persistence/nosql/nosql_queue_store.go
@@ -49,7 +49,7 @@ func newNoSQLQueueStore(
 	queueType persistence.QueueType,
 	dc *persistence.DynamicConfiguration,
 ) (persistence.QueueStore, error) {
-	shardedStore, err := newShardedNosqlStore(cfg, logger, metricsClient, dc)
+	shardedStore, err := newShardedNosqlStore(cfg, logger, metricsClient, dc, false)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/nosql/nosql_shard_store.go
+++ b/common/persistence/nosql/nosql_shard_store.go
@@ -52,7 +52,7 @@ func newNoSQLShardStore(
 	dc *persistence.DynamicConfiguration,
 	parser serialization.Parser,
 ) (persistence.ShardStore, error) {
-	s, err := newShardedNosqlStore(cfg, logger, metricsClient, dc)
+	s, err := newShardedNosqlStore(cfg, logger, metricsClient, dc, true)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/nosql/nosql_task_store.go
+++ b/common/persistence/nosql/nosql_task_store.go
@@ -56,7 +56,7 @@ func newNoSQLTaskStore(
 	metricsClient metrics.Client,
 	dc *persistence.DynamicConfiguration,
 ) (persistence.TaskStore, error) {
-	s, err := newShardedNosqlStore(cfg, logger, metricsClient, dc)
+	s, err := newShardedNosqlStore(cfg, logger, metricsClient, dc, true)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/nosql/nosql_visibility_store.go
+++ b/common/persistence/nosql/nosql_visibility_store.go
@@ -52,7 +52,7 @@ func newNoSQLVisibilityStore(
 	metricsClient metrics.Client,
 	dc *persistence.DynamicConfiguration,
 ) (persistence.VisibilityStore, error) {
-	shardedStore, err := newShardedNosqlStore(cfg, logger, metricsClient, dc)
+	shardedStore, err := newShardedNosqlStore(cfg, logger, metricsClient, dc, false)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/nosql/sharded_nosql_store.go
+++ b/common/persistence/nosql/sharded_nosql_store.go
@@ -26,6 +26,8 @@ import (
 	"fmt"
 	"sync"
 
+	"go.uber.org/multierr"
+
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -57,32 +59,67 @@ type shardedNosqlStoreImpl struct {
 	shardingPolicy  shardingPolicy
 }
 
-func newShardedNosqlStore(cfg config.ShardedNoSQL, logger log.Logger, metricsClient metrics.Client, dc *persistence.DynamicConfiguration) (shardedNosqlStore, error) {
+func newShardedNosqlStore(cfg config.ShardedNoSQL, logger log.Logger, metricsClient metrics.Client, dc *persistence.DynamicConfiguration, eagerConnect bool) (_ shardedNosqlStore, retErr error) {
 	sn := shardedNosqlStoreImpl{
-		config:        cfg,
-		dc:            dc,
-		logger:        logger,
-		metricsClient: metricsClient,
+		config:          cfg,
+		dc:              dc,
+		logger:          logger,
+		metricsClient:   metricsClient,
+		connectedShards: make(map[string]nosqlStore),
 	}
 
-	// Connect to the default shard
-	defaultShardName := cfg.DefaultShard
-	store, err := sn.connectToShard(defaultShardName)
-	if err != nil {
-		return nil, err
-	}
-	sn.defaultShard = *store
-	sn.connectedShards = map[string]nosqlStore{
-		defaultShardName: sn.defaultShard,
+	defer func() {
+		if retErr != nil {
+			sn.Close()
+		}
+	}()
+
+	if eagerConnect {
+		// Connect to all shards in parallel.
+		type result struct {
+			name  string
+			store *nosqlStore
+			err   error
+		}
+		results := make(chan result, len(cfg.Connections))
+		for shardName := range cfg.Connections {
+			go func(shardName string) {
+				store, err := sn.connectToShard(shardName)
+				results <- result{name: shardName, store: store, err: err}
+			}(shardName)
+		}
+		var combinedErr error
+		for range cfg.Connections {
+			r := <-results
+			if r.err != nil {
+				combinedErr = multierr.Append(combinedErr, r.err)
+				continue
+			}
+			sn.connectedShards[r.name] = *r.store
+		}
+		if combinedErr != nil {
+			retErr = combinedErr
+			return nil, retErr
+		}
+		sn.defaultShard = sn.connectedShards[cfg.DefaultShard]
+	} else {
+		// Connect to the default shard
+		defaultShardName := cfg.DefaultShard
+		store, err := sn.connectToShard(defaultShardName)
+		if err != nil {
+			return nil, err
+		}
+		sn.defaultShard = *store
+		sn.connectedShards[defaultShardName] = *store
 	}
 
 	// Parse & validate the sharding policy
-	sn.shardingPolicy, err = newShardingPolicy(logger, cfg)
-	if err != nil {
-		return nil, err
+	sn.shardingPolicy, retErr = newShardingPolicy(logger, cfg)
+	if retErr != nil {
+		return nil, retErr
 	}
 
-	return &sn, nil
+	return &sn, retErr
 }
 
 func (sn *shardedNosqlStoreImpl) GetStoreShardByHistoryShard(shardID int) (*nosqlStore, error) {

--- a/common/persistence/nosql/sharded_nosql_store_test.go
+++ b/common/persistence/nosql/sharded_nosql_store_test.go
@@ -31,6 +31,7 @@ import (
 	. "github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 )
 
@@ -103,7 +104,7 @@ func (s *shardedNosqlStoreTestSuite) TestStoreSelectionForHistoryShard() {
 	defer store.Close()
 
 	s.Equal(1, len(store.connectedShards))
-	s.True(mockDB1 == store.defaultShard.db)
+	s.True(mockDB1 == store.connectedShards["shard-1"].db)
 
 	// Shard 0 is same default shard in this test, so connectedShards shouldn't change
 	storeShard1, err := store.GetStoreShardByHistoryShard(0)
@@ -153,7 +154,7 @@ func (s *shardedNosqlStoreTestSuite) TestStoreSelectionForHistoryShard() {
 func (s *shardedNosqlStoreTestSuite) newShardedStoreForTest() *shardedNosqlStoreImpl {
 	cfg := getValidShardedNoSQLConfig()
 	logger := log.NewNoop()
-	storeInterface, err := newShardedNosqlStore(cfg, logger, metrics.NewNoopMetricsClient(), nil)
+	storeInterface, err := newShardedNosqlStore(cfg, logger, metrics.NewNoopMetricsClient(), nil, false)
 	s.NoError(err)
 	s.Equal("shardedNosql", storeInterface.GetName())
 	s.Equal(logger, storeInterface.GetLogger())
@@ -219,6 +220,61 @@ func (s *shardedNosqlStoreTestSuite) TestStoreSelectionForTasklist() {
 	s.NoError(err)
 	s.Equal(2, len(store.connectedShards))
 	s.True(mockDB2 == storeShard2.db)
+}
+
+func (s *shardedNosqlStoreTestSuite) TestEagerConnectConnectsAllShards() {
+	mockDB1 := nosqlplugin.NewMockDB(s.mockController)
+	mockDB1.EXPECT().Close().Times(1)
+	mockDB2 := nosqlplugin.NewMockDB(s.mockController)
+	mockDB2.EXPECT().Close().Times(1)
+
+	mockPlugin := nosqlplugin.NewMockPlugin(s.mockController)
+	mockPlugin.EXPECT().
+		CreateDB(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(cfg *NoSQL, _ log.Logger, _ *persistence.DynamicConfiguration) (nosqlplugin.DB, error) {
+			if cfg.Port == 1234 {
+				return mockDB1, nil
+			}
+			return mockDB2, nil
+		}).Times(2)
+	delete(supportedPlugins, "cassandra")
+	RegisterPlugin("cassandra", mockPlugin)
+
+	cfg := getValidShardedNoSQLConfig()
+	logger := log.NewNoop()
+	storeInterface, err := newShardedNosqlStore(cfg, logger, metrics.NewNoopMetricsClient(), nil, true)
+	s.NoError(err)
+	s.Equal("shardedNosql", storeInterface.GetName())
+	s.Equal(logger, storeInterface.GetLogger())
+	defer storeInterface.Close()
+
+	store := storeInterface.(*shardedNosqlStoreImpl)
+	s.Equal(2, len(store.connectedShards))
+	s.True(mockDB1 == store.connectedShards["shard-1"].db)
+	s.True(mockDB2 == store.connectedShards["shard-2"].db)
+	s.Equal(store.GetDefaultShard(), store.defaultShard)
+	s.Equal(store.connectedShards["shard-1"], store.defaultShard)
+}
+
+func (s *shardedNosqlStoreTestSuite) TestEagerConnectFailsIfOneShardFails() {
+	mockDB := nosqlplugin.NewMockDB(s.mockController)
+	mockDB.EXPECT().Close().Times(1)
+
+	mockPlugin := nosqlplugin.NewMockPlugin(s.mockController)
+	mockPlugin.EXPECT().
+		CreateDB(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(cfg *NoSQL, _ log.Logger, _ *persistence.DynamicConfiguration) (nosqlplugin.DB, error) {
+			if cfg.Port == 1234 {
+				return mockDB, nil
+			}
+			return nil, errors.New("failed to connect to shard-2")
+		}).Times(2)
+	delete(supportedPlugins, "cassandra")
+	RegisterPlugin("cassandra", mockPlugin)
+
+	_, err := newShardedNosqlStore(getValidShardedNoSQLConfig(), log.NewNoop(), metrics.NewNoopMetricsClient(), nil, true)
+	s.Error(err)
+	s.ErrorContains(err, "failed to connect to shard-2")
 }
 
 func getValidShardedNoSQLConfig() ShardedNoSQL {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Update execution store, history store, task store and shard store to set up connections eagerly 

**Why?**
We observed high persistence latency from environment using sharded nosql persistence store on service start up when using Cassandra as our database.

#### Problem Analysis
The getShard method in [sharded_nosql_store.go](https://github.com/cadence-workflow/cadence/blob/master/common/persistence/nosql/sharded_nosql_store.go#L130):
```
func (sn *shardedNosqlStoreImpl) getShard(shardName string) (*nosqlStore, error) {
    sn.RLock()
    shard, found := sn.connectedShards[shardName]
    sn.RUnlock()

    if found { return &shard, nil }

    // ← Not connected yet
    sn.Lock()          // WRITE lock — blocks ALL other reads
    defer sn.Unlock()

    s, err := sn.connectToShard(shardName)   // creates a new gocql session WHILE holding the lock
    ...
}
```
And connectToShard creates a new gocql session, which:
1. Establishes TCP connections to every Cassandra host (connectTimeout: 2s per connection, sequential per host)
2. Loads the full keyspace schema metadata from Cassandra
3. Builds the connection pool
  
This entire process executes while holding the write lock. Every other persistence call blocks until CreateSession() finishes.

**How did you test it?**
go test -race ./common/persistence/nosql/...

**Potential risks**


**Release notes**


**Documentation Changes**

