### PR TITLE
fix(queuev2): InMemQueue.GetTasks returns correct NextTaskKey on full page

### DIFF
--- a/service/history/queuev2/queue_mem.go
+++ b/service/history/queuev2/queue_mem.go
@@ -131,9 +131,10 @@ func (q *inMemQueueImpl) GetTasks(inclusiveMinTaskKey, exclusiveMaxTaskKey persi
 
 		tasks = append(tasks, q.tasks[i])
 		if len(tasks) > pageSize {
-			// Trim the extra task so we return at most pageSize tasks
-			// and set nextTaskKey to the key of the first excluded task
-			return tasks[:pageSize], tasks[pageSize].GetTaskKey()
+			// Trim the extra task so we return at most pageSize tasks.
+			// Use .Next() of the last returned task as NextTaskKey, matching
+			// simpleQueueReader's convention for consistent pagination boundaries.
+			return tasks[:pageSize], tasks[pageSize-1].GetTaskKey().Next()
 		}
 	}
 

--- a/service/history/queuev2/queue_mem_test.go
+++ b/service/history/queuev2/queue_mem_test.go
@@ -339,14 +339,14 @@ func TestInMemQueue_GetTasks(t *testing.T) {
 			wantNextKey:  persistence.NewHistoryTaskKey(time.Unix(50, 0), 5),
 		},
 		{
-			name:         "pageSize truncates result and returns a key of a dropped task",
+			name:         "pageSize truncates result and returns next task key after last returned task",
 			tasks:        allTasks,
 			inclusiveMin: persistence.NewHistoryTaskKey(time.Unix(10, 0), 1),
 			exclusiveMax: persistence.NewHistoryTaskKey(time.Unix(50, 0), 5),
 			predicate:    NewUniversalPredicate(),
 			pageSize:     2,
 			wantTaskIDs:  []int64{1, 2},
-			wantNextKey:  newTestTask(time.Unix(30, 0), 3).GetTaskKey(),
+			wantNextKey:  newTestTask(time.Unix(20, 0), 2).GetTaskKey().Next(),
 		},
 	}
 


### PR DESCRIPTION
## What changed?

`InMemQueue.GetTasks` returned `tasks[pageSize].GetTaskKey()` (the actual key of the first excluded task) when the result was truncated to `pageSize`. The DB reader (`simpleQueueReader`) instead returns `tasks[pageSize-1].GetTaskKey().Next()` — the next task key after the last returned task. This inconsistency makes the two implementations return different `NextTaskKey` values for the same request.

## Why?

Consistent `NextTaskKey` between the in-memory cache and the DB reader is required for the shadow comparison in #8190 (`CachedQueueReader` shadow mode). Both sides should produce the same next-page start key for the same task set so mismatches can be reliably attributed to real cache divergence.

Using `.Next()` of the last returned task is also safer: the next page starts strictly after the last returned task without depending on what the cache happens to hold as `tasks[pageSize]`.

## How did you test it?

```
go test -race -count=1 ./service/history/queuev2/...
```

## Potential risks

None — this changes `NextTaskKey` in the full-page case only. Callers that use `NextTaskKey` as the next page's `InclusiveMinTaskKey` receive a slightly different boundary, but since `GetTasks` uses `key >= inclusiveMin`, the result set is identical.

## Release notes

N/A — internal change, no user-facing behaviour change.

## Documentation Changes

N/A