### PR TITLE
fix(replication): ReplicationTasksLag metric

### DIFF
--- a/service/history/replication/task_ack_manager.go
+++ b/service/history/replication/task_ack_manager.go
@@ -167,6 +167,7 @@ func (t *TaskAckManager) getTasks(ctx context.Context, pollingCluster string, la
 		// this means there are no tasks to process, so the lag is 0
 		oldestUnprocessedTaskID = t.ackLevels.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryReplication, pollingCluster).GetTaskID()
 		oldestUnprocessedTaskTimestamp = t.timeSource.Now().UnixNano()
+		msgs.LastRetrievedMessageID = oldestUnprocessedTaskID
 	}
 
 	lagRaw := int(t.ackLevels.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryReplication, pollingCluster).GetTaskID() - oldestUnprocessedTaskID)

--- a/service/history/replication/task_ack_manager.go
+++ b/service/history/replication/task_ack_manager.go
@@ -141,7 +141,8 @@ func (t *TaskAckManager) getTasks(ctx context.Context, pollingCluster string, la
 	batchSize := t.dynamicTaskBatchSizer.value()
 	t.scope.UpdateGauge(metrics.ReplicationTasksBatchSize, float64(batchSize))
 
-	taskInfos, hasMore, err := t.reader.Read(ctx, lastReadTaskID, t.ackLevels.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryReplication, pollingCluster).GetTaskID(), batchSize)
+	maxReadLevel := t.ackLevels.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryReplication, pollingCluster).GetTaskID()
+	taskInfos, hasMore, err := t.reader.Read(ctx, lastReadTaskID, maxReadLevel, batchSize)
 	if err != nil {
 		return nil, err
 	}
@@ -165,12 +166,12 @@ func (t *TaskAckManager) getTasks(ctx context.Context, pollingCluster string, la
 	} else {
 		// if there are no replication tasks, use the max read level as the oldest unprocessed task
 		// this means there are no tasks to process, so the lag is 0
-		oldestUnprocessedTaskID = t.ackLevels.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryReplication, pollingCluster).GetTaskID()
+		oldestUnprocessedTaskID = maxReadLevel
 		oldestUnprocessedTaskTimestamp = t.timeSource.Now().UnixNano()
-		msgs.LastRetrievedMessageID = oldestUnprocessedTaskID
+		msgs.LastRetrievedMessageID = maxReadLevel
 	}
 
-	lagRaw := int(t.ackLevels.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryReplication, pollingCluster).GetTaskID() - oldestUnprocessedTaskID)
+	lagRaw := int(maxReadLevel - oldestUnprocessedTaskID)
 	t.scope.RecordTimer(metrics.ReplicationTasksLagRaw, time.Duration(lagRaw))
 	t.scope.RecordHistogramValue(metrics.ReplicationTasksLagRawHistogram, float64(lagRaw))
 	t.scope.UpdateGauge(metrics.ReplicationTasksLagRawGauge, float64(lagRaw))
@@ -205,7 +206,7 @@ func (t *TaskAckManager) getTasks(ctx context.Context, pollingCluster string, la
 		return nil, err
 	}
 
-	replicationLag := int(t.ackLevels.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryReplication, pollingCluster).GetTaskID() - msgs.LastRetrievedMessageID)
+	replicationLag := int(maxReadLevel - msgs.LastRetrievedMessageID)
 	t.scope.RecordTimer(metrics.ReplicationTasksLag, time.Duration(replicationLag))
 	t.scope.RecordHistogramValue(metrics.ReplicationTasksLagHistogram, float64(replicationLag))
 	t.scope.UpdateGauge(metrics.ReplicationTasksLagGauge, float64(replicationLag))

--- a/service/history/replication/task_ack_manager_test.go
+++ b/service/history/replication/task_ack_manager_test.go
@@ -137,7 +137,7 @@ func TestTaskAckManager_GetTasks(t *testing.T) {
 			batchSize:      10,
 			expectResult: &types.ReplicationMessages{
 				ReplicationTasks:       []*types.ReplicationTask{},
-				LastRetrievedMessageID: 5,
+				LastRetrievedMessageID: 200,
 				HasMore:                false,
 			},
 			expectAckLevel: 5,


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Reset `LastRetrievedMessageID` to `oldestUnprocessedTaskID` when there are no replication tasks.

Get maxReadLevel only once to avoid inconsistencies and possibly skipping replication tasks with the new change.

**Why?**
The `immediateTaskMaxReadLevel` is shared with other types of tasks, not only replication task. `lastReadTaskID` is the value returned by the remote cluster with the last task ID received. If there are no replication tasks, the `immediateTaskMaxReadLevel` can still increase. If we don't reset `LastRetrievedMessageID` we would be counting only non replication tasks.

maxReadLevel needs to be read once because it could advance during the getTasks processing and it could cause replication tasks to be missed in the new flow. This may cause the metric to be less fresh but it avoids a bug with the incoming changes and make the metric more consistent.

**How did you test it?**
Updated test to verify the new behavior when there are no replication tasks

go test -race ./service/history/replication/...

**Potential risks**
There was a risk of potentially missing replication tasks. Avoid that by getting maxReadLevel only once in the method.

**Release notes**
N/A

**Documentation Changes**
N/A
