### PR TITLE
fix(schedule): allow re-creation of deleted schedule within retention window

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -196,7 +196,11 @@ func (wh *WorkflowHandler) CreateSchedule(
 
 	wfID := scheduleWorkflowID(scheduleID)
 	requestID := uuid.New().String()
-	reusePolicy := types.WorkflowIDReusePolicyRejectDuplicate
+	// AllowDuplicate lets a re-created schedule start a new scheduler workflow even when the
+	// previous (deleted) run is still within the retention window. A currently-running
+	// scheduler still causes WorkflowExecutionAlreadyStartedError, which the block below
+	// converts into the user-visible "schedule already exists" error.
+	reusePolicy := types.WorkflowIDReusePolicyAllowDuplicate
 	executionTimeout := int32(schedulerWorkflowExecutionTimeout.Seconds())
 	decisionTimeout := int32(schedulerWorkflowDecisionTimeout.Seconds())
 

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -348,6 +348,23 @@ func TestCreateSchedule(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		"recreate after delete succeeds (AllowDuplicate reuse policy)": {
+			// Deleting a schedule terminates the scheduler workflow but the closed run stays
+			// within the retention window. With RejectDuplicate the server would reject a new
+			// StartWorkflowExecution for the same workflow ID; AllowDuplicate lets it through.
+			// This test verifies both that the policy sent to history is AllowDuplicate and that
+			// the handler succeeds when history accepts the start (as it does for closed runs).
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, req *types.HistoryStartWorkflowExecutionRequest, _ ...yarpc.CallOption) (*types.StartWorkflowExecutionResponse, error) {
+						assert.Equal(t, types.WorkflowIDReusePolicyAllowDuplicate, *req.StartRequest.WorkflowIDReusePolicy)
+						return &types.StartWorkflowExecutionResponse{RunID: "new-run-id"}, nil
+					})
+			},
+			wantErr: false,
+		},
 		"memo forwarded into workflow input": {
 			request: &types.CreateScheduleRequest{
 				Domain:     testDomain,


### PR DESCRIPTION
## What

`CreateSchedule` used `WorkflowIDReusePolicyRejectDuplicate` when starting the scheduler workflow. This policy rejects `StartWorkflowExecution` whenever **any** closed run with the same workflow ID exists in the retention window including terminated ones.

## Problem

The scheduler workflow ID is derived directly from the schedule ID (`cadence-scheduler:<scheduleID>`). When a schedule is deleted, the scheduler workflow is terminated but remains in the retention window. Immediately re-creating a schedule with the same ID would fail with a spurious "schedule already exists" error, even though the schedule no longer exists from the user's perspective.

## Fix

Change the reuse policy to `AllowDuplicate`. The history engine enforces `WorkflowExecutionAlreadyStartedError` for **open/running** workflows regardless of reuse policy (it checks `WorkflowStateRunning` before reading the policy), so the existing "schedule already exists" guard in the handler is unaffected. Only the closed-run path changes: re-creation after deletion now succeeds.

## Test

Added `"recreate after delete succeeds (AllowDuplicate reuse policy)"` to `TestCreateSchedule`. It asserts that:
1. The reuse policy sent to history is `AllowDuplicate`
2. The handler returns success when history accepts the start (as it does for closed runs)

## How to test

```bash
go test -race -run TestCreateSchedule ./service/frontend/api/...
```