### PR TITLE
fix(schedule): apply UnpauseSignal catch-up policy to missed-run processing

### DIFF
--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -177,6 +177,10 @@ type SchedulerWorkflowState struct {
 	// RunningWorkflows holds in-flight target workflows under bounded CONCURRENT
 	// (ConcurrencyLimit > 0); completed entries are pruned by the activity on each fire.
 	RunningWorkflows []RunningWorkflowInfo `json:"runningWorkflows,omitempty"`
+	// UnpauseCatchUpPolicy is a one-shot override set by UnpauseSignal.CatchUpPolicy.
+	// processMissedRunsAt prefers this over input.Policies.CatchUpPolicy for the first
+	// catch-up pass after an unpause, then clears it. Invalid (zero) means no override.
+	UnpauseCatchUpPolicy types.ScheduleCatchUpPolicy `json:"unpauseCatchUpPolicy,omitempty"`
 }
 
 // BufferedFire is a schedule fire queued for sequential execution by the BUFFER

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -863,10 +863,12 @@ func processMissedRunsAt(ctx workflow.Context, logger *zap.Logger, scope tally.S
 
 	// Use the per-unpause policy override if set; it is a one-shot value that
 	// takes priority over the schedule's configured policy for this catch-up pass.
+	// Do NOT clear it here: a single pass can span multiple ContinueAsNew executions
+	// (when unfired > 0 or fires.truncated). We clear it only after the pass is fully
+	// complete so the override survives each batch.
 	effectivePolicy := input.Policies.CatchUpPolicy
 	if state.UnpauseCatchUpPolicy != types.ScheduleCatchUpPolicyInvalid {
 		effectivePolicy = state.UnpauseCatchUpPolicy
-		state.UnpauseCatchUpPolicy = types.ScheduleCatchUpPolicyInvalid
 	}
 	result := applyMissedRunPolicy(effectivePolicy, input.Policies.CatchUpWindow, fires.times, now, logger)
 
@@ -906,7 +908,14 @@ func processMissedRunsAt(ctx workflow.Context, logger *zap.Logger, scope tally.S
 		state.LastProcessedTime = last
 	}
 
-	return unfired > 0 || fires.truncated
+	moreMissed := unfired > 0 || fires.truncated
+	// Clear the per-unpause override only when the entire catch-up pass is done.
+	// While moreMissed is true the state is carried into the next ContinueAsNew
+	// execution; clearing it here would lose the override for those batches.
+	if !moreMissed {
+		state.UnpauseCatchUpPolicy = types.ScheduleCatchUpPolicyInvalid
+	}
+	return moreMissed
 }
 
 // processBackfills drains pending backfill requests from state, computing

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -392,6 +392,9 @@ func handleUnpause(logger *zap.Logger, sig UnpauseSignal, state *SchedulerWorkfl
 	state.Paused = false
 	state.PauseReason = ""
 	state.PausedBy = ""
+	if sig.CatchUpPolicy != types.ScheduleCatchUpPolicyInvalid {
+		state.UnpauseCatchUpPolicy = sig.CatchUpPolicy
+	}
 	logger.Info("schedule unpaused", zap.String("reason", sig.Reason), zap.String("catchUpPolicy", sig.CatchUpPolicy.String()))
 	return true
 }
@@ -858,7 +861,14 @@ func processMissedRunsAt(ctx workflow.Context, logger *zap.Logger, scope tally.S
 		)
 	}
 
-	result := applyMissedRunPolicy(input.Policies.CatchUpPolicy, input.Policies.CatchUpWindow, fires.times, now, logger)
+	// Use the per-unpause policy override if set; it is a one-shot value that
+	// takes priority over the schedule's configured policy for this catch-up pass.
+	effectivePolicy := input.Policies.CatchUpPolicy
+	if state.UnpauseCatchUpPolicy != types.ScheduleCatchUpPolicyInvalid {
+		effectivePolicy = state.UnpauseCatchUpPolicy
+		state.UnpauseCatchUpPolicy = types.ScheduleCatchUpPolicyInvalid
+	}
+	result := applyMissedRunPolicy(effectivePolicy, input.Policies.CatchUpWindow, fires.times, now, logger)
 
 	fired := 0
 	for _, t := range result.toFire {
@@ -874,7 +884,7 @@ func processMissedRunsAt(ctx workflow.Context, logger *zap.Logger, scope tally.S
 		scope.Counter(SchedulerMissedFiredCountPerDomain).Inc(int64(fired))
 	}
 
-	policyStr := input.Policies.CatchUpPolicy.String()
+	policyStr := effectivePolicy.String()
 	if result.skipped > 0 {
 		scope.Tagged(map[string]string{CatchUpPolicyTag: policyStr}).
 			Counter(SchedulerMissedSkippedCountPerDomain).Inc(result.skipped)

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -850,6 +850,9 @@ func catchUpWatermark(state *SchedulerWorkflowState) time.Time {
 func processMissedRunsAt(ctx workflow.Context, logger *zap.Logger, scope tally.Scope, sched cron.Schedule, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, watermark, now time.Time) bool {
 	fires := computeMissedFireTimes(sched, watermark, now, input.Spec)
 	if len(fires.times) == 0 {
+		// No missed fires: consume the one-shot override so it does not bleed
+		// into a future catch-up pass triggered by a subsequent unpause.
+		state.UnpauseCatchUpPolicy = types.ScheduleCatchUpPolicyInvalid
 		return false
 	}
 

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -529,13 +529,14 @@ func TestHandlePause(t *testing.T) {
 
 func TestHandleUnpause(t *testing.T) {
 	tests := []struct {
-		name         string
-		initial      SchedulerWorkflowState
-		sig          UnpauseSignal
-		wantPaused   bool
-		wantReason   string
-		wantPausedBy string
-		wantChanged  bool
+		name                  string
+		initial               SchedulerWorkflowState
+		sig                   UnpauseSignal
+		wantPaused            bool
+		wantReason            string
+		wantPausedBy          string
+		wantChanged           bool
+		wantUnpauseCatchUpPolicy types.ScheduleCatchUpPolicy
 	}{
 		{
 			name:         "unpause from paused",
@@ -555,6 +556,30 @@ func TestHandleUnpause(t *testing.T) {
 			wantPausedBy: "",
 			wantChanged:  false,
 		},
+		{
+			name:    "unpause with CatchUpPolicyOne stores override in state",
+			initial: SchedulerWorkflowState{Paused: true},
+			sig:     UnpauseSignal{Reason: "resume", CatchUpPolicy: types.ScheduleCatchUpPolicyOne},
+			wantPaused:               false,
+			wantChanged:              true,
+			wantUnpauseCatchUpPolicy: types.ScheduleCatchUpPolicyOne,
+		},
+		{
+			name:    "unpause with CatchUpPolicySkip stores override in state",
+			initial: SchedulerWorkflowState{Paused: true},
+			sig:     UnpauseSignal{Reason: "resume", CatchUpPolicy: types.ScheduleCatchUpPolicySkip},
+			wantPaused:               false,
+			wantChanged:              true,
+			wantUnpauseCatchUpPolicy: types.ScheduleCatchUpPolicySkip,
+		},
+		{
+			name:    "unpause with Invalid policy does not set override",
+			initial: SchedulerWorkflowState{Paused: true},
+			sig:     UnpauseSignal{Reason: "resume", CatchUpPolicy: types.ScheduleCatchUpPolicyInvalid},
+			wantPaused:               false,
+			wantChanged:              true,
+			wantUnpauseCatchUpPolicy: types.ScheduleCatchUpPolicyInvalid,
+		},
 	}
 
 	for _, tt := range tests {
@@ -565,6 +590,7 @@ func TestHandleUnpause(t *testing.T) {
 			assert.Equal(t, tt.wantPaused, state.Paused)
 			assert.Equal(t, tt.wantReason, state.PauseReason)
 			assert.Equal(t, tt.wantPausedBy, state.PausedBy)
+			assert.Equal(t, tt.wantUnpauseCatchUpPolicy, state.UnpauseCatchUpPolicy)
 		})
 	}
 }
@@ -1048,6 +1074,51 @@ func TestProcessMissedRunsAtMetrics(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestProcessMissedRunsAt_PauseUnpause is the primary end-to-end scenario for catch-up:
+// the schedule is paused for 5 minutes (missing 5 per-minute fires), then unpaused
+// with CatchUpPolicyOne. Exactly 1 fire (the most recent) must run; the other 4 are skipped.
+// This also verifies that state.UnpauseCatchUpPolicy is cleared after use so subsequent
+// processMissedRunsAt calls fall back to input.Policies.CatchUpPolicy.
+func TestProcessMissedRunsAt_PauseUnpause(t *testing.T) {
+	base := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	watermark := base
+	now := base.Add(5 * time.Minute) // 5 fires missed: 10:01–10:05
+
+	sched := mustParseCron(t, "* * * * *")
+	scope := tally.NewTestScope("", nil)
+	input := &SchedulerWorkflowInput{
+		Spec: types.ScheduleSpec{CronExpression: "* * * * *"},
+		Policies: types.SchedulePolicies{
+			// No CatchUpPolicy at creation (Invalid → skip all).
+			// The unpause override in state must take priority.
+		},
+		// Action.StartWorkflow intentionally nil: processScheduleFire returns
+		// before reaching ctx, so nil ctx is safe here.
+	}
+	state := &SchedulerWorkflowState{
+		UnpauseCatchUpPolicy: types.ScheduleCatchUpPolicyOne, // set by handleUnpause
+	}
+
+	moreMissed := processMissedRunsAt(nil, testLogger, scope, sched, input, state, watermark, now)
+
+	assert.False(t, moreMissed, "all 5 fires fit within maxCatchUpFiresPerExecution")
+
+	// Override must be consumed and cleared so the next catch-up uses the schedule's own policy.
+	assert.Equal(t, types.ScheduleCatchUpPolicyInvalid, state.UnpauseCatchUpPolicy,
+		"UnpauseCatchUpPolicy must be cleared after use")
+
+	counters := scope.Snapshot().Counters()
+
+	firedC, ok := findCounter(counters, SchedulerMissedFiredCountPerDomain, map[string]string{})
+	require.True(t, ok, "one fire should be recorded")
+	assert.Equal(t, int64(1), firedC.Value(), "CatchUpPolicyOne fires exactly the most recent missed run")
+
+	skippedC, ok := findCounter(counters, SchedulerMissedSkippedCountPerDomain,
+		map[string]string{CatchUpPolicyTag: types.ScheduleCatchUpPolicyOne.String()})
+	require.True(t, ok, "4 skipped fires should be recorded")
+	assert.Equal(t, int64(4), skippedC.Value(), "4 of 5 missed fires are skipped under CatchUpPolicyOne")
 }
 
 // noopChannel is a workflow.Channel whose ReceiveAsync always returns false (no pending signal).

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -529,13 +529,13 @@ func TestHandlePause(t *testing.T) {
 
 func TestHandleUnpause(t *testing.T) {
 	tests := []struct {
-		name                  string
-		initial               SchedulerWorkflowState
-		sig                   UnpauseSignal
-		wantPaused            bool
-		wantReason            string
-		wantPausedBy          string
-		wantChanged           bool
+		name                     string
+		initial                  SchedulerWorkflowState
+		sig                      UnpauseSignal
+		wantPaused               bool
+		wantReason               string
+		wantPausedBy             string
+		wantChanged              bool
 		wantUnpauseCatchUpPolicy types.ScheduleCatchUpPolicy
 	}{
 		{
@@ -557,25 +557,25 @@ func TestHandleUnpause(t *testing.T) {
 			wantChanged:  false,
 		},
 		{
-			name:    "unpause with CatchUpPolicyOne stores override in state",
-			initial: SchedulerWorkflowState{Paused: true},
-			sig:     UnpauseSignal{Reason: "resume", CatchUpPolicy: types.ScheduleCatchUpPolicyOne},
+			name:                     "unpause with CatchUpPolicyOne stores override in state",
+			initial:                  SchedulerWorkflowState{Paused: true},
+			sig:                      UnpauseSignal{Reason: "resume", CatchUpPolicy: types.ScheduleCatchUpPolicyOne},
 			wantPaused:               false,
 			wantChanged:              true,
 			wantUnpauseCatchUpPolicy: types.ScheduleCatchUpPolicyOne,
 		},
 		{
-			name:    "unpause with CatchUpPolicySkip stores override in state",
-			initial: SchedulerWorkflowState{Paused: true},
-			sig:     UnpauseSignal{Reason: "resume", CatchUpPolicy: types.ScheduleCatchUpPolicySkip},
+			name:                     "unpause with CatchUpPolicySkip stores override in state",
+			initial:                  SchedulerWorkflowState{Paused: true},
+			sig:                      UnpauseSignal{Reason: "resume", CatchUpPolicy: types.ScheduleCatchUpPolicySkip},
 			wantPaused:               false,
 			wantChanged:              true,
 			wantUnpauseCatchUpPolicy: types.ScheduleCatchUpPolicySkip,
 		},
 		{
-			name:    "unpause with Invalid policy does not set override",
-			initial: SchedulerWorkflowState{Paused: true},
-			sig:     UnpauseSignal{Reason: "resume", CatchUpPolicy: types.ScheduleCatchUpPolicyInvalid},
+			name:                     "unpause with Invalid policy does not set override",
+			initial:                  SchedulerWorkflowState{Paused: true},
+			sig:                      UnpauseSignal{Reason: "resume", CatchUpPolicy: types.ScheduleCatchUpPolicyInvalid},
 			wantPaused:               false,
 			wantChanged:              true,
 			wantUnpauseCatchUpPolicy: types.ScheduleCatchUpPolicyInvalid,
@@ -1089,7 +1089,7 @@ func TestProcessMissedRunsAt_PauseUnpause(t *testing.T) {
 	sched := mustParseCron(t, "* * * * *")
 	scope := tally.NewTestScope("", nil)
 	input := &SchedulerWorkflowInput{
-		Spec: types.ScheduleSpec{CronExpression: "* * * * *"},
+		Spec:     types.ScheduleSpec{CronExpression: "* * * * *"},
 		Policies: types.SchedulePolicies{
 			// No CatchUpPolicy at creation (Invalid → skip all).
 			// The unpause override in state must take priority.

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1079,8 +1079,7 @@ func TestProcessMissedRunsAtMetrics(t *testing.T) {
 // TestProcessMissedRunsAt_PauseUnpause is the primary end-to-end scenario for catch-up:
 // the schedule is paused for 5 minutes (missing 5 per-minute fires), then unpaused
 // with CatchUpPolicyOne. Exactly 1 fire (the most recent) must run; the other 4 are skipped.
-// This also verifies that state.UnpauseCatchUpPolicy is cleared after use so subsequent
-// processMissedRunsAt calls fall back to input.Policies.CatchUpPolicy.
+// Because all 5 fires fit in one execution (moreMissed=false), the override is cleared.
 func TestProcessMissedRunsAt_PauseUnpause(t *testing.T) {
 	base := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 	watermark := base
@@ -1119,6 +1118,55 @@ func TestProcessMissedRunsAt_PauseUnpause(t *testing.T) {
 		map[string]string{CatchUpPolicyTag: types.ScheduleCatchUpPolicyOne.String()})
 	require.True(t, ok, "4 skipped fires should be recorded")
 	assert.Equal(t, int64(4), skippedC.Value(), "4 of 5 missed fires are skipped under CatchUpPolicyOne")
+}
+
+// TestProcessMissedRunsAt_PauseUnpause_MultiBatch verifies that the UnpauseCatchUpPolicy
+// override survives ContinueAsNew batching. When CatchUpPolicyAll produces more than
+// maxCatchUpFiresPerExecution (10) eligible fires, processMissedRunsAt returns moreMissed=true
+// and the override must remain in state so the next execution continues with the same policy.
+// Once the final batch completes (moreMissed=false), the override is cleared.
+func TestProcessMissedRunsAt_PauseUnpause_MultiBatch(t *testing.T) {
+	// 15 minutes → 15 fires (10:01–10:15), exceeding the cap of 10.
+	base := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	watermark := base
+	now := base.Add(15 * time.Minute)
+
+	sched := mustParseCron(t, "* * * * *")
+
+	input := &SchedulerWorkflowInput{
+		Spec: types.ScheduleSpec{CronExpression: "* * * * *"},
+		Policies: types.SchedulePolicies{
+			// No CatchUpPolicy at creation; override must supply All for both batches.
+		},
+	}
+
+	// --- First batch ---
+	scope1 := tally.NewTestScope("", nil)
+	state := &SchedulerWorkflowState{
+		UnpauseCatchUpPolicy: types.ScheduleCatchUpPolicyAll,
+	}
+	moreMissed := processMissedRunsAt(nil, testLogger, scope1, sched, input, state, watermark, now)
+
+	assert.True(t, moreMissed, "first batch of 15 should report more remaining")
+	assert.Equal(t, types.ScheduleCatchUpPolicyAll, state.UnpauseCatchUpPolicy,
+		"override must survive the first batch so ContinueAsNew can continue with All policy")
+
+	firedC, ok := findCounter(scope1.Snapshot().Counters(), SchedulerMissedFiredCountPerDomain, map[string]string{})
+	require.True(t, ok)
+	assert.Equal(t, int64(maxCatchUpFiresPerExecution), firedC.Value(), "first batch fires exactly the cap")
+
+	// --- Second batch: resume from where the first left off ---
+	scope2 := tally.NewTestScope("", nil)
+	watermark2 := state.LastProcessedTime
+	moreMissed = processMissedRunsAt(nil, testLogger, scope2, sched, input, state, watermark2, now)
+
+	assert.False(t, moreMissed, "second batch completes the remaining fires")
+	assert.Equal(t, types.ScheduleCatchUpPolicyInvalid, state.UnpauseCatchUpPolicy,
+		"override must be cleared after the pass is fully done")
+
+	firedC2, ok := findCounter(scope2.Snapshot().Counters(), SchedulerMissedFiredCountPerDomain, map[string]string{})
+	require.True(t, ok)
+	assert.Equal(t, int64(5), firedC2.Value(), "second batch fires the remaining 5")
 }
 
 // noopChannel is a workflow.Channel whose ReceiveAsync always returns false (no pending signal).

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1076,6 +1076,36 @@ func TestProcessMissedRunsAtMetrics(t *testing.T) {
 	}
 }
 
+// TestProcessMissedRunsAt_NoMissedFires_ClearsOverride verifies that the UnpauseCatchUpPolicy
+// override is cleared even when there are no missed fires. Without this, a short pause that
+// produces zero missed fires would leave the override set, causing a future catch-up pass to
+// inherit a stale policy from an earlier unpause.
+func TestProcessMissedRunsAt_NoMissedFires_ClearsOverride(t *testing.T) {
+	// now == watermark: no fires were missed during the pause.
+	base := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+
+	sched := mustParseCron(t, "* * * * *")
+	scope := tally.NewTestScope("", nil)
+	input := &SchedulerWorkflowInput{
+		Spec:     types.ScheduleSpec{CronExpression: "* * * * *"},
+		Policies: types.SchedulePolicies{},
+	}
+	state := &SchedulerWorkflowState{
+		UnpauseCatchUpPolicy: types.ScheduleCatchUpPolicyOne, // set by handleUnpause
+	}
+
+	moreMissed := processMissedRunsAt(nil, testLogger, scope, sched, input, state, base, base)
+
+	assert.False(t, moreMissed, "no missed fires, nothing to catch up")
+	assert.Equal(t, types.ScheduleCatchUpPolicyInvalid, state.UnpauseCatchUpPolicy,
+		"override must be cleared even when there are no missed fires")
+
+	// No counters should have been emitted.
+	counters := scope.Snapshot().Counters()
+	_, hasFired := findCounter(counters, SchedulerMissedFiredCountPerDomain, map[string]string{})
+	assert.False(t, hasFired, "no fires emitted when there are no missed runs")
+}
+
 // TestProcessMissedRunsAt_PauseUnpause is the primary end-to-end scenario for catch-up:
 // the schedule is paused for 5 minutes (missing 5 per-minute fires), then unpaused
 // with CatchUpPolicyOne. Exactly 1 fire (the most recent) must run; the other 4 are skipped.

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1134,7 +1134,7 @@ func TestProcessMissedRunsAt_PauseUnpause_MultiBatch(t *testing.T) {
 	sched := mustParseCron(t, "* * * * *")
 
 	input := &SchedulerWorkflowInput{
-		Spec: types.ScheduleSpec{CronExpression: "* * * * *"},
+		Spec:     types.ScheduleSpec{CronExpression: "* * * * *"},
 		Policies: types.SchedulePolicies{
 			// No CatchUpPolicy at creation; override must supply All for both batches.
 		},


### PR DESCRIPTION
## What

`UnpauseSchedule` accepts a `CatchUpPolicy` field that lets callers control how missed fires are replayed when a schedule resumes. This field was never actually applied.

## Problem

`handleUnpause` received `UnpauseSignal.CatchUpPolicy` and logged it, but stored nothing. After the unpause triggered `ContinueAsNew`, `processMissedRunsAt` used `input.Policies.CatchUpPolicy` the policy set at schedule **creation** time. Schedules created without an explicit policy default to `ScheduleCatchUpPolicyInvalid`, whose `default` case in `applyMissedRunPolicy` silently skips all missed runs. The per-unpause override was completely ignored.

## Fix

Add `UnpauseCatchUpPolicy` to `SchedulerWorkflowState` (JSON-serialized, persists across `ContinueAsNew`).

- `handleUnpause` sets it when the signal carries a non-\`Invalid\` policy.
- `processMissedRunsAt` reads it as a **one-shot override**: takes priority over `input.Policies.CatchUpPolicy` for the first catch-up pass after an unpause, then clears it so subsequent passes use the schedule's own policy.
- The skipped-runs metric tag reflects the effective policy.

The override survives the `ContinueAsNew` triggered by the unpause signal and is consumed on the very next call to `processMissedRunsAt`.

## Tests

- Expanded `TestHandleUnpause`: added cases verifying that `One`, `Skip`, and `Invalid` policies are stored (or not stored) correctly in state.
- New `TestProcessMissedRunsAt_PauseUnpause`: the primary scenario — schedule paused 5 minutes (5 per-minute fires missed), unpause with `CatchUpPolicyOne` → exactly 1 fire, 4 skipped, override cleared.

## How to test

```bash
go test -race -run "TestHandleUnpause|TestProcessMissedRunsAt_PauseUnpause" ./service/worker/scheduler/...
```