### PR TITLE
fix(replication): make ReplicationTasksReturnedDiffHistogram a gauge metric

### DIFF
--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -89,11 +89,6 @@ var HistogramMigrationMetrics = map[string]struct{}{
 	"replication_task_latency":    {},
 	"replication_task_latency_ns": {},
 
-	"replication_tasks_returned":             {},
-	"replication_tasks_returned_counts":      {},
-	"replication_tasks_returned_diff":        {},
-	"replication_tasks_returned_diff_counts": {},
-
 	"replication_tasks_fetched":        {},
 	"replication_tasks_fetched_counts": {},
 	"replication_tasks_lag_raw":        {},
@@ -455,6 +450,11 @@ var GaugeMigrationMetrics = map[string]struct{}{
 	"cache_size_gauge":                {},
 	"replication_tasks_lag_gauge":     {},
 	"replication_tasks_lag_raw_gauge": {},
+
+	"replication_tasks_returned":            {},
+	"replication_tasks_returned_gauge":      {},
+	"replication_tasks_returned_diff":       {},
+	"replication_tasks_returned_diff_gauge": {},
 }
 
 func (g GaugeMigration) EmitTimer(name string) bool {

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2960,10 +2960,10 @@ const (
 	ReplicationTasksFetchedHistogram
 	ReplicationTasksFetchedCounter
 	ReplicationTasksReturned
-	ReplicationTasksReturnedHistogram
+	ReplicationTasksReturnedGauge
 	ReplicationTasksReturnedCounter
 	ReplicationTasksReturnedDiff
-	ReplicationTasksReturnedDiffHistogram
+	ReplicationTasksReturnedDiffGauge
 	ReplicationTasksReturnedDiffCounter
 	ReplicationTasksAppliedLatency
 	ReplicationTasksAppliedLatencyHistogram
@@ -3968,10 +3968,10 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 		ReplicationTasksFetchedHistogram:                              {metricName: "replication_tasks_fetched_counts", metricType: Histogram, buckets: ResponseRowSizeBuckets},
 		ReplicationTasksFetchedCounter:                                {metricName: "replication_tasks_fetched_counter", metricType: Counter},
 		ReplicationTasksReturned:                                      {metricName: "replication_tasks_returned", metricType: Timer},
-		ReplicationTasksReturnedHistogram:                             {metricName: "replication_tasks_returned_counts", metricType: Histogram, buckets: ResponseRowSizeBuckets},
+		ReplicationTasksReturnedGauge:                                 {metricName: "replication_tasks_returned_gauge", metricType: Gauge},
 		ReplicationTasksReturnedCounter:                               {metricName: "replication_tasks_returned_counter", metricType: Counter},
 		ReplicationTasksReturnedDiff:                                  {metricName: "replication_tasks_returned_diff", metricType: Timer},
-		ReplicationTasksReturnedDiffHistogram:                         {metricName: "replication_tasks_returned_diff_counts", metricType: Histogram, buckets: ResponseRowSizeBuckets},
+		ReplicationTasksReturnedDiffGauge:                             {metricName: "replication_tasks_returned_diff_gauge", metricType: Gauge},
 		ReplicationTasksReturnedDiffCounter:                           {metricName: "replication_tasks_returned_diff_counter", metricType: Counter},
 		ReplicationTasksAppliedLatency:                                {metricName: "replication_tasks_applied_latency", metricType: Timer},
 		ReplicationTasksAppliedLatencyHistogram:                       {metricName: "replication_tasks_applied_latency_ns", metricType: Histogram, exponentialBuckets: Low1ms100s},

--- a/service/history/replication/task_ack_manager.go
+++ b/service/history/replication/task_ack_manager.go
@@ -211,12 +211,12 @@ func (t *TaskAckManager) getTasks(ctx context.Context, pollingCluster string, la
 
 	tasksReturned := len(msgs.ReplicationTasks)
 	t.scope.RecordTimer(metrics.ReplicationTasksReturned, time.Duration(tasksReturned))
-	t.scope.RecordHistogramValue(metrics.ReplicationTasksReturnedHistogram, float64(tasksReturned))
+	t.scope.UpdateGauge(metrics.ReplicationTasksReturnedGauge, float64(tasksReturned))
 	t.scope.AddCounter(metrics.ReplicationTasksReturnedCounter, int64(tasksReturned))
 
 	tasksReturnedDiff := len(taskInfos) - len(msgs.ReplicationTasks)
 	t.scope.RecordTimer(metrics.ReplicationTasksReturnedDiff, time.Duration(tasksReturnedDiff))
-	t.scope.RecordHistogramValue(metrics.ReplicationTasksReturnedDiffHistogram, float64(tasksReturnedDiff))
+	t.scope.UpdateGauge(metrics.ReplicationTasksReturnedDiffGauge, float64(tasksReturnedDiff))
 	t.scope.AddCounter(metrics.ReplicationTasksReturnedDiffCounter, int64(tasksReturnedDiff))
 
 	t.ackLevel(pollingCluster, lastReadTaskID)


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Replaced `ReplicationTasksReturnedDiffHistogram` with `ReplicationTasksReturnedDiffGauge`.

**Why?**
There is no need to have a histogram for this metric. The gauge provides max and values per instance, which is what we want. The counter provides tasks returned per second. The histogram makes it more complex and inaccurate.

**How did you test it?**
This is a pure metric change, tests still pass

go test -race ./service/history/replication/...

**Potential risks**
Just a metric type change.

**Release notes**
N/A

**Documentation Changes**
N/A
