### PR TITLE
fix(persistence): propagate shard ID on remaining execution call sites

### DIFF
--- a/service/history/engine/engineimpl/request_cancel_workflow_execution.go
+++ b/service/history/engine/engineimpl/request_cancel_workflow_execution.go
@@ -52,7 +52,7 @@ func (e *historyEngineImpl) RequestCancelWorkflowExecution(
 	}
 	domainID := domainEntry.GetInfo().ID
 
-	return workflow.UpdateCurrentWithActionFunc(ctx, e.logger, e.executionCache, e.executionManager, domainID, e.shard.GetDomainCache(), workflowExecution, e.timeSource.Now(),
+	return workflow.UpdateCurrentWithActionFunc(ctx, e.logger, e.executionCache, e.executionManager, e.shard.GetShardID(), domainID, e.shard.GetDomainCache(), workflowExecution, e.timeSource.Now(),
 		func(wfContext execution.Context, mutableState execution.MutableState) (*workflow.UpdateAction, error) {
 			isCancelRequested, cancelRequestID := mutableState.IsCancelRequested()
 			if !mutableState.IsWorkflowExecutionRunning() {

--- a/service/history/engine/engineimpl/signal_workflow_execution.go
+++ b/service/history/engine/engineimpl/signal_workflow_execution.go
@@ -56,6 +56,7 @@ func (e *historyEngineImpl) SignalWorkflowExecution(
 		e.logger,
 		e.executionCache,
 		e.executionManager,
+		e.shard.GetShardID(),
 		domainID,
 		e.shard.GetDomainCache(),
 		workflowExecution,

--- a/service/history/engine/engineimpl/terminate_workflow_execution.go
+++ b/service/history/engine/engineimpl/terminate_workflow_execution.go
@@ -55,6 +55,7 @@ func (e *historyEngineImpl) TerminateWorkflowExecution(
 		e.logger,
 		e.executionCache,
 		e.executionManager,
+		e.shard.GetShardID(),
 		domainID,
 		e.shard.GetDomainCache(),
 		workflowExecution,

--- a/service/history/queuev2/queue_reader.go
+++ b/service/history/queuev2/queue_reader.go
@@ -134,6 +134,7 @@ func (r *simpleQueueReader) LookAHead(ctx context.Context, req *LookAHeadRequest
 		InclusiveMinTaskKey: req.InclusiveMinTaskKey,
 		ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(maxTime, 0),
 		PageSize:            1,
+		ShardID:             common.Ptr(r.shard.GetShardID()),
 	})
 	if err != nil {
 		return nil, err

--- a/service/history/queuev2/queue_reader_test.go
+++ b/service/history/queuev2/queue_reader_test.go
@@ -255,12 +255,14 @@ func TestSimpleQueueReader_LookAHead(t *testing.T) {
 		{
 			name: "task found",
 			mockSetup: func(mockShard *shard.MockContext, mockExec *persistence.MockExecutionManager) {
+				mockShard.EXPECT().GetShardID().Return(0)
 				mockShard.EXPECT().GetExecutionManager().Return(mockExec)
 				mockExec.EXPECT().GetHistoryTasks(gomock.Any(), &persistence.GetHistoryTasksRequest{
 					TaskCategory:        persistence.HistoryTaskCategoryTimer,
 					InclusiveMinTaskKey: minTaskKey,
 					ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(expectedMaxTime, 0),
 					PageSize:            1,
+					ShardID:             common.Ptr(0),
 				}).Return(&persistence.GetHistoryTasksResponse{
 					Tasks: []persistence.Task{foundTask},
 				}, nil)
@@ -270,6 +272,7 @@ func TestSimpleQueueReader_LookAHead(t *testing.T) {
 		{
 			name: "no task found",
 			mockSetup: func(mockShard *shard.MockContext, mockExec *persistence.MockExecutionManager) {
+				mockShard.EXPECT().GetShardID().Return(0)
 				mockShard.EXPECT().GetExecutionManager().Return(mockExec)
 				mockExec.EXPECT().GetHistoryTasks(gomock.Any(), gomock.Any()).Return(&persistence.GetHistoryTasksResponse{
 					Tasks: nil,
@@ -280,6 +283,7 @@ func TestSimpleQueueReader_LookAHead(t *testing.T) {
 		{
 			name: "DB error",
 			mockSetup: func(mockShard *shard.MockContext, mockExec *persistence.MockExecutionManager) {
+				mockShard.EXPECT().GetShardID().Return(0)
 				mockShard.EXPECT().GetExecutionManager().Return(mockExec)
 				mockExec.EXPECT().GetHistoryTasks(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("db error"))
 			},

--- a/service/history/workflow/util.go
+++ b/service/history/workflow/util.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -85,6 +86,7 @@ func Load(
 	ctx context.Context,
 	cache execution.Cache,
 	executionManager persistence.ExecutionManager,
+	shardID int,
 	domainID string,
 	domainName string,
 	workflowID string,
@@ -110,6 +112,7 @@ func Load(
 		resp, err := executionManager.GetCurrentExecution(
 			ctx,
 			&persistence.GetCurrentExecutionRequest{
+				ShardID:    common.Ptr(shardID),
 				DomainID:   domainID,
 				WorkflowID: workflowID,
 				DomainName: domainName,
@@ -161,6 +164,7 @@ func UpdateCurrentWithActionFunc(
 	logger log.Logger,
 	cache execution.Cache,
 	executionManager persistence.ExecutionManager,
+	shardID int,
 	domainID string,
 	domainCache cache.DomainCache,
 	execution types.WorkflowExecution,
@@ -172,7 +176,7 @@ func UpdateCurrentWithActionFunc(
 	if err != nil {
 		return nil
 	}
-	workflowContext, err := Load(ctx, cache, executionManager, domainID, domainName, execution.GetWorkflowID(), execution.GetRunID())
+	workflowContext, err := Load(ctx, cache, executionManager, shardID, domainID, domainName, execution.GetWorkflowID(), execution.GetRunID())
 	if err != nil {
 		return err
 	}

--- a/service/history/workflow/util_test.go
+++ b/service/history/workflow/util_test.go
@@ -188,6 +188,7 @@ func TestWorkflowLoad(t *testing.T) {
 				context.Background(),
 				execution.NewCache(mockShard),
 				mockShard.Resource.ExecutionMgr,
+				mockShard.GetShardID(),
 				constants.TestDomainID,
 				constants.TestDomainName,
 				constants.TestWorkflowID,

--- a/tools/cli/admin_commands.go
+++ b/tools/cli/admin_commands.go
@@ -347,6 +347,7 @@ func AdminDeleteWorkflow(c *cli.Context) error {
 	}
 
 	req := &persistence.DeleteWorkflowExecutionRequest{
+		ShardID:    common.Ptr(shardIDInt),
 		DomainID:   domainID,
 		WorkflowID: wid,
 		RunID:      rid,
@@ -364,6 +365,7 @@ func AdminDeleteWorkflow(c *cli.Context) error {
 	fmt.Println("delete mutableState row successfully")
 
 	deleteCurrentReq := &persistence.DeleteCurrentWorkflowExecutionRequest{
+		ShardID:    common.Ptr(shardIDInt),
 		DomainID:   domainID,
 		WorkflowID: wid,
 		RunID:      rid,

--- a/tools/cli/admin_timers.go
+++ b/tools/cli/admin_timers.go
@@ -61,6 +61,7 @@ type Reporter struct {
 type dbLoadCloser struct {
 	ctx              *cli.Context
 	executionManager persistence.ExecutionManager
+	shardID          int
 }
 
 type fileLoadCloser struct {
@@ -90,6 +91,7 @@ func NewDBLoadCloser(c *cli.Context) (LoadCloser, error) {
 	return &dbLoadCloser{
 		ctx:              c,
 		executionManager: executionManager,
+		shardID:          shardID,
 	}, nil
 }
 
@@ -266,6 +268,7 @@ func (cl *dbLoadCloser) Load() ([]*persistence.TimerTaskInfo, error) {
 	for isFirstIteration || len(token) != 0 {
 		isFirstIteration = false
 		req := persistence.GetHistoryTasksRequest{
+			ShardID:             common.Ptr(cl.shardID),
 			TaskCategory:        persistence.HistoryTaskCategoryTimer,
 			InclusiveMinTaskKey: persistence.NewHistoryTaskKey(st, 0),
 			ExclusiveMaxTaskKey: persistence.NewHistoryTaskKey(et, 0),


### PR DESCRIPTION
## What changed?
Populate `ShardID` on a few direct `ExecutionManager` call sites that were still omitting it: queuev2 `LookAHead`, `workflow.Load` / `UpdateCurrentWithActionFunc`, and admin CLI delete/timer paths.

Part of #7643. Addresses the production warn logs Shaddoll flagged on #8076.

## Why?
#7919 started logging when request `ShardID` is missing (warn + fallback on per-shard stores). #7854/#8070 fixed most history paths but a handful were left. These are the stragglers for the operations called out in review.

## How did you test it?
```
go test -race ./service/history/queuev2/... ./service/history/workflow/...
go test -race -run 'AdminTimers|DeleteWorkflow' ./tools/cli/...
go build -o /dev/null ./service/history/engine/engineimpl/... ./service/history/queuev2/... ./service/history/workflow/... ./tools/cli/...
```

## Potential risks
None — passes through an existing field on requests callers already had access to. No API/schema/flag changes.

## Release notes
N/A — internal change.

## Documentation Changes
N/A