### PR TITLE
test(schedule): Add unit tests for out of range cron.

### DIFF
--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -153,6 +153,15 @@ func TestCreateSchedule(t *testing.T) {
 			mockFn:  func(f *scheduleTestFixture) {},
 			wantErr: true,
 		},
+		"out-of-range minute in cron expression": {
+			request: &types.CreateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Spec:       &types.ScheduleSpec{CronExpression: "99 * * * *"},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
 		"impossible cron date (Feb 30) parses but never fires": {
 			request: &types.CreateScheduleRequest{
 				Domain:     testDomain,
@@ -968,6 +977,15 @@ func TestUpdateSchedule(t *testing.T) {
 				Domain:     testDomain,
 				ScheduleID: "s1",
 				Spec:       &types.ScheduleSpec{CronExpression: "not-a-cron"},
+			},
+			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"out-of-range minute in cron expression rejects update": {
+			request: &types.UpdateScheduleRequest{
+				Domain:     testDomain,
+				ScheduleID: "s1",
+				Spec:       &types.ScheduleSpec{CronExpression: "99 * * * *"},
 			},
 			mockFn:  func(f *scheduleTestFixture) {},
 			wantErr: true,

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -669,6 +669,16 @@ func TestHandleUpdate(t *testing.T) {
 			wantChanged: false,
 		},
 		{
+			name: "out-of-range minute (99) is rejected, spec unchanged",
+			sig: UpdateSignal{
+				Spec: &types.ScheduleSpec{CronExpression: "99 * * * *"},
+			},
+			wantCron:    "0 * * * *",
+			wantWF:      "old-workflow",
+			wantPol:     types.ScheduleOverlapPolicySkipNew,
+			wantChanged: false,
+		},
+		{
 			name: "invalid cron rejected but action and policies still applied",
 			sig: UpdateSignal{
 				Spec:     &types.ScheduleSpec{CronExpression: "bad"},


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Add unit tests for out-of-range cron like "99 * * * *"

**Why?**
- this test is missing

**How did you test it?**
- unit test

**Potential risks**
- NO 

**Release notes**
N/A

**Documentation Changes**
N/A
