### PR TITLE
fix: cover the missing call sites for emitting timer metrics

### DIFF
--- a/common/archiver/gcloud/historyArchiver.go
+++ b/common/archiver/gcloud/historyArchiver.go
@@ -106,7 +106,7 @@ func newHistoryArchiver(
 func (h *historyArchiver) Archive(ctx context.Context, URI archiver.URI, request *archiver.ArchiveHistoryRequest, opts ...archiver.ArchiveOption) (err error) {
 	scope := h.container.MetricsClient.Scope(metrics.HistoryArchiverScope, metrics.DomainTag(request.DomainName))
 	featureCatalog := archiver.GetFeatureCatalog(opts...)
-	sw := scope.StartTimer(metrics.CadenceLatency)
+	sw := scope.StartTimerWithExponentialHistogram(metrics.CadenceLatency, metrics.CadenceLatencyHistogram)
 	defer func() {
 		sw.Stop()
 		if err != nil {

--- a/common/archiver/gcloud/visibilityArchiver.go
+++ b/common/archiver/gcloud/visibilityArchiver.go
@@ -88,7 +88,7 @@ func NewVisibilityArchiver(container *archiver.VisibilityBootstrapContainer, con
 func (v *visibilityArchiver) Archive(ctx context.Context, URI archiver.URI, request *archiver.ArchiveVisibilityRequest, opts ...archiver.ArchiveOption) (err error) {
 	scope := v.container.MetricsClient.Scope(metrics.HistoryArchiverScope, metrics.DomainTag(request.DomainName))
 	featureCatalog := archiver.GetFeatureCatalog(opts...)
-	sw := scope.StartTimer(metrics.CadenceLatency)
+	sw := scope.StartTimerWithExponentialHistogram(metrics.CadenceLatency, metrics.CadenceLatencyHistogram)
 	defer func() {
 		sw.Stop()
 		if err != nil {

--- a/common/archiver/s3store/historyArchiver.go
+++ b/common/archiver/s3store/historyArchiver.go
@@ -132,7 +132,7 @@ func (h *historyArchiver) Archive(
 ) (err error) {
 	scope := h.container.MetricsClient.Scope(metrics.HistoryArchiverScope, metrics.DomainTag(request.DomainName))
 	featureCatalog := archiver.GetFeatureCatalog(opts...)
-	sw := scope.StartTimer(metrics.CadenceLatency)
+	sw := scope.StartTimerWithExponentialHistogram(metrics.CadenceLatency, metrics.CadenceLatencyHistogram)
 	defer func() {
 		sw.Stop()
 		if err != nil {

--- a/common/archiver/s3store/visibilityArchiver.go
+++ b/common/archiver/s3store/visibilityArchiver.go
@@ -104,7 +104,7 @@ func (v *visibilityArchiver) Archive(
 ) (err error) {
 	scope := v.container.MetricsClient.Scope(metrics.VisibilityArchiverScope, metrics.DomainTag(request.DomainName))
 	featureCatalog := archiver.GetFeatureCatalog(opts...)
-	sw := scope.StartTimer(metrics.CadenceLatency)
+	sw := scope.StartTimerWithExponentialHistogram(metrics.CadenceLatency, metrics.CadenceLatencyHistogram)
 	logger := archiver.TagLoggerWithArchiveVisibilityRequestAndURI(v.container.Logger, request, URI.String())
 	archiveFailReason := ""
 	defer func() {

--- a/common/messaging/metrics_producer.go
+++ b/common/messaging/metrics_producer.go
@@ -61,7 +61,7 @@ func NewMetricProducer(
 func (p *MetricsProducer) Publish(ctx context.Context, msg interface{}) error {
 	p.scope.IncCounter(metrics.CadenceClientRequests)
 
-	sw := p.scope.StartTimer(metrics.CadenceClientLatency)
+	sw := p.scope.StartTimerWithExponentialHistogram(metrics.CadenceClientLatency, metrics.CadenceClientLatencyHistogram)
 	err := p.producer.Publish(ctx, msg)
 	sw.Stop()
 

--- a/common/messaging/metrics_producer_test.go
+++ b/common/messaging/metrics_producer_test.go
@@ -54,7 +54,7 @@ func TestPublish(t *testing.T) {
 				metricsScope.On("IncCounter", metrics.CadenceClientRequests).Once()
 
 				sw := metrics.NoopScope.StartTimer(-1)
-				metricsScope.On("StartTimer", metrics.CadenceClientLatency).Return(sw).Once()
+				metricsScope.On("StartTimerWithExponentialHistogram", metrics.CadenceClientLatency, metrics.CadenceClientLatencyHistogram).Return(sw).Once()
 				return metricsClient
 			},
 		},
@@ -75,7 +75,7 @@ func TestPublish(t *testing.T) {
 				metricsScope.On("IncCounter", metrics.CadenceClientFailures).Once()
 
 				sw := metrics.NoopScope.StartTimer(-1)
-				metricsScope.On("StartTimer", metrics.CadenceClientLatency).Return(sw).Once()
+				metricsScope.On("StartTimerWithExponentialHistogram", metrics.CadenceClientLatency, metrics.CadenceClientLatencyHistogram).Return(sw).Once()
 				return metricsClient
 			},
 		},

--- a/common/metrics/interfaces.go
+++ b/common/metrics/interfaces.go
@@ -58,6 +58,15 @@ type (
 		// StartTimer starts a timer for the given metric name.
 		// Time will be recorded when stopwatch is stopped.
 		StartTimer(timer MetricIdx) Stopwatch
+		// StartTimerWithExponentialHistogram is like StartTimer but the returned
+		// Stopwatch also records the elapsed duration into the given
+		// exponential histogram metric on Stop. Use during the
+		// timer→histogram migration so callers can dual-emit without
+		// changing call sites that already defer Stop on the returned
+		// stopwatch. The histogram metric must be defined with
+		// exponentialBuckets in defs.go — other histogram bucket
+		// strategies are not supported by this helper.
+		StartTimerWithExponentialHistogram(timer MetricIdx, histogram MetricIdx) Stopwatch
 		// RecordTimer starts a timer for the given metric name
 		RecordTimer(timer MetricIdx, d time.Duration)
 		// RecordHistogramDuration records a histogram duration value for the given

--- a/common/metrics/mocks/Scope.go
+++ b/common/metrics/mocks/Scope.go
@@ -406,6 +406,63 @@ func (_c *Scope_StartTimer_Call) RunAndReturn(run func(timer metrics.MetricIdx) 
 	return _c
 }
 
+// StartTimerWithExponentialHistogram provides a mock function for the type Scope
+func (_mock *Scope) StartTimerWithExponentialHistogram(timer metrics.MetricIdx, histogram metrics.MetricIdx) metrics.Stopwatch {
+	ret := _mock.Called(timer, histogram)
+
+	if len(ret) == 0 {
+		panic("no return value specified for StartTimerWithExponentialHistogram")
+	}
+
+	var r0 metrics.Stopwatch
+	if returnFunc, ok := ret.Get(0).(func(metrics.MetricIdx, metrics.MetricIdx) metrics.Stopwatch); ok {
+		r0 = returnFunc(timer, histogram)
+	} else {
+		r0 = ret.Get(0).(metrics.Stopwatch)
+	}
+	return r0
+}
+
+// Scope_StartTimerWithExponentialHistogram_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'StartTimerWithExponentialHistogram'
+type Scope_StartTimerWithExponentialHistogram_Call struct {
+	*mock.Call
+}
+
+// StartTimerWithExponentialHistogram is a helper method to define mock.On call
+//   - timer metrics.MetricIdx
+//   - histogram metrics.MetricIdx
+func (_e *Scope_Expecter) StartTimerWithExponentialHistogram(timer interface{}, histogram interface{}) *Scope_StartTimerWithExponentialHistogram_Call {
+	return &Scope_StartTimerWithExponentialHistogram_Call{Call: _e.mock.On("StartTimerWithExponentialHistogram", timer, histogram)}
+}
+
+func (_c *Scope_StartTimerWithExponentialHistogram_Call) Run(run func(timer metrics.MetricIdx, histogram metrics.MetricIdx)) *Scope_StartTimerWithExponentialHistogram_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 metrics.MetricIdx
+		if args[0] != nil {
+			arg0 = args[0].(metrics.MetricIdx)
+		}
+		var arg1 metrics.MetricIdx
+		if args[1] != nil {
+			arg1 = args[1].(metrics.MetricIdx)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *Scope_StartTimerWithExponentialHistogram_Call) Return(stopwatch metrics.Stopwatch) *Scope_StartTimerWithExponentialHistogram_Call {
+	_c.Call.Return(stopwatch)
+	return _c
+}
+
+func (_c *Scope_StartTimerWithExponentialHistogram_Call) RunAndReturn(run func(timer metrics.MetricIdx, histogram metrics.MetricIdx) metrics.Stopwatch) *Scope_StartTimerWithExponentialHistogram_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Tagged provides a mock function for the type Scope
 func (_mock *Scope) Tagged(tags ...metrics.Tag) metrics.Scope {
 	var tmpRet mock.Arguments

--- a/common/metrics/nop.go
+++ b/common/metrics/nop.go
@@ -77,6 +77,10 @@ func (n *noopScopeImpl) StartTimer(timer MetricIdx) Stopwatch {
 	return NewTestStopwatch()
 }
 
+func (n *noopScopeImpl) StartTimerWithExponentialHistogram(timer MetricIdx, histogram MetricIdx) Stopwatch {
+	return NewTestStopwatch()
+}
+
 func (n *noopScopeImpl) RecordTimer(timer MetricIdx, d time.Duration) {}
 
 func (n *noopScopeImpl) RecordHistogramDuration(timer MetricIdx, d time.Duration) {}

--- a/common/metrics/scope.go
+++ b/common/metrics/scope.go
@@ -99,6 +99,19 @@ func (m *metricsScope) StartTimer(id MetricIdx) Stopwatch {
 	return Stopwatch{} // noop
 }
 
+// StartTimerWithExponentialHistogram dual-emits to the named timer and the
+// named exponential histogram when Stop is called on the returned Stopwatch.
+// The histogram emission goes through the same path as ExponentialHistogram so
+// it picks up exponential bucket definitions, rollups, and migration-config
+// gating. The histogram metric must be defined with exponentialBuckets in
+// defs.go.
+func (m *metricsScope) StartTimerWithExponentialHistogram(timerID MetricIdx, histogramID MetricIdx) Stopwatch {
+	sw := m.StartTimer(timerID)
+	return newStopwatchWithCallback(sw.timers, func(d time.Duration) {
+		m.ExponentialHistogram(histogramID, d)
+	})
+}
+
 func (m *metricsScope) RecordTimer(id MetricIdx, d time.Duration) {
 	def := m.defs[id]
 	if m.migrationConfig.EmitTimer(def.metricName.String()) {

--- a/common/metrics/stopwatch.go
+++ b/common/metrics/stopwatch.go
@@ -30,19 +30,37 @@ import (
 // Stop() method to report time elapsed since its created back to the
 // timer or histogram.
 type Stopwatch struct {
-	start  time.Time
-	timers []tally.Timer
+	start     time.Time
+	timers    []tally.Timer
+	callbacks []func(time.Duration)
 }
 
 // NewStopwatch creates a new immutable stopwatch for recording the start
 // time to a stopwatch reporter.
 func NewStopwatch(timers ...tally.Timer) Stopwatch {
-	return Stopwatch{time.Now(), timers}
+	return Stopwatch{start: time.Now(), timers: timers}
+}
+
+// newStopwatchWithCallback creates a stopwatch that records to the given
+// timers and also invokes each callback with the elapsed duration on Stop.
+//
+// This is an unexported migration shim for StartTimerWithExponentialHistogram —
+// it lets one Stopwatch fan out to both a timer and a histogram so callsites
+// during the timer→histogram migration can keep their existing
+// `defer sw.Stop()` patterns. Once the migration is complete and the
+// StartTimerWithExponentialHistogram helper is retired, this constructor and
+// the callbacks field can be removed.
+//
+// Kept unexported on purpose: outside the metrics package, callers should use
+// Scope.StartTimerWithExponentialHistogram rather than constructing
+// callback-bearing stopwatches directly.
+func newStopwatchWithCallback(timers []tally.Timer, callbacks ...func(time.Duration)) Stopwatch {
+	return Stopwatch{start: time.Now(), timers: timers, callbacks: callbacks}
 }
 
 // NewTestStopwatch returns a new test stopwatch
 func NewTestStopwatch() Stopwatch {
-	return Stopwatch{time.Now(), []tally.Timer{}}
+	return Stopwatch{start: time.Now(), timers: []tally.Timer{}}
 }
 
 // Stop reports time elapsed since the stopwatch start to the recorder.
@@ -50,5 +68,8 @@ func (sw Stopwatch) Stop() {
 	d := time.Since(sw.start)
 	for _, timer := range sw.timers {
 		timer.Record(d)
+	}
+	for _, cb := range sw.callbacks {
+		cb(d)
 	}
 }

--- a/service/frontend/admin/handler.go
+++ b/service/frontend/admin/handler.go
@@ -1519,7 +1519,7 @@ func (adh *adminHandlerImpl) validatePaginationToken(
 // startRequestProfile initiates recording of request metrics
 func (adh *adminHandlerImpl) startRequestProfile(ctx context.Context, scope metrics.ScopeIdx) (metrics.Scope, metrics.Stopwatch) {
 	metricsScope := adh.GetMetricsClient().Scope(scope).Tagged(metrics.DomainUnknownTag()).Tagged(metrics.GetContextTags(ctx)...)
-	sw := metricsScope.StartTimer(metrics.CadenceLatency)
+	sw := metricsScope.StartTimerWithExponentialHistogram(metrics.CadenceLatency, metrics.CadenceLatencyHistogram)
 	metricsScope.IncCounter(metrics.CadenceRequests)
 	return metricsScope, sw
 }

--- a/service/history/handler/handler.go
+++ b/service/history/handler/handler.go
@@ -2273,7 +2273,7 @@ func (h *handlerImpl) emitInfoOrDebugLog(
 func (h *handlerImpl) startRequestProfile(ctx context.Context, scope metrics.ScopeIdx) (metrics.Scope, metrics.Stopwatch) {
 	metricsScope := h.GetMetricsClient().Scope(scope, metrics.GetContextTags(ctx)...)
 	metricsScope.IncCounter(metrics.CadenceRequests)
-	sw := metricsScope.StartTimer(metrics.CadenceLatency)
+	sw := metricsScope.StartTimerWithExponentialHistogram(metrics.CadenceLatency, metrics.CadenceLatencyHistogram)
 	return metricsScope, sw
 }
 

--- a/service/history/task/timer_standby_task_executor.go
+++ b/service/history/task/timer_standby_task_executor.go
@@ -523,8 +523,12 @@ func (t *timerStandbyTaskExecutor) fetchHistoryFromRemote(
 	resendInfo := postActionInfo.(*historyResendInfo)
 
 	t.metricsClient.IncCounter(metrics.HistoryRereplicationByTimerTaskScope, metrics.CadenceClientRequests)
+	rereplicationLatencyStart := time.Now()
 	stopwatch := t.metricsClient.StartTimer(metrics.HistoryRereplicationByTimerTaskScope, metrics.CadenceClientLatency)
-	defer stopwatch.Stop()
+	defer func() {
+		stopwatch.Stop()
+		t.metricsClient.Scope(metrics.HistoryRereplicationByTimerTaskScope).ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(rereplicationLatencyStart))
+	}()
 
 	remoteClusterName, err := t.getRemoteClusterNameFn(ctx, taskInfo)
 	if err != nil {

--- a/service/history/task/transfer_standby_task_executor.go
+++ b/service/history/task/transfer_standby_task_executor.go
@@ -715,8 +715,12 @@ func (t *transferStandbyTaskExecutor) fetchHistoryFromRemote(
 	resendInfo := postActionInfo.(*historyResendInfo)
 
 	t.metricsClient.IncCounter(metrics.HistoryRereplicationByTransferTaskScope, metrics.CadenceClientRequests)
+	rereplicationLatencyStart := time.Now()
 	stopwatch := t.metricsClient.StartTimer(metrics.HistoryRereplicationByTransferTaskScope, metrics.CadenceClientLatency)
-	defer stopwatch.Stop()
+	defer func() {
+		stopwatch.Stop()
+		t.metricsClient.Scope(metrics.HistoryRereplicationByTransferTaskScope).ExponentialHistogram(metrics.CadenceClientLatencyHistogram, time.Since(rereplicationLatencyStart))
+	}()
 
 	remoteClusterName, err := t.getRemoteClusterNameFn(ctx, taskInfo)
 	if err != nil {

--- a/service/worker/archiver/activities.go
+++ b/service/worker/archiver/activities.go
@@ -53,7 +53,7 @@ var (
 func uploadHistoryActivity(ctx context.Context, request ArchiveRequest) (err error) {
 	container := ctx.Value(bootstrapContainerKey).(*BootstrapContainer)
 	scope := container.MetricsClient.Scope(metrics.ArchiverUploadHistoryActivityScope, metrics.DomainTag(request.DomainName))
-	sw := scope.StartTimer(metrics.CadenceLatency)
+	sw := scope.StartTimerWithExponentialHistogram(metrics.CadenceLatency, metrics.CadenceLatencyHistogram)
 	defer func() {
 		sw.Stop()
 		if err != nil {
@@ -106,7 +106,7 @@ func uploadHistoryActivity(ctx context.Context, request ArchiveRequest) (err err
 func deleteHistoryActivity(ctx context.Context, request ArchiveRequest) (err error) {
 	container := ctx.Value(bootstrapContainerKey).(*BootstrapContainer)
 	scope := container.MetricsClient.Scope(metrics.ArchiverDeleteHistoryActivityScope, metrics.DomainTag(request.DomainName))
-	sw := scope.StartTimer(metrics.CadenceLatency)
+	sw := scope.StartTimerWithExponentialHistogram(metrics.CadenceLatency, metrics.CadenceLatencyHistogram)
 	defer func() {
 		sw.Stop()
 		if err != nil {
@@ -135,7 +135,7 @@ func deleteHistoryActivity(ctx context.Context, request ArchiveRequest) (err err
 func archiveVisibilityActivity(ctx context.Context, request ArchiveRequest) (err error) {
 	container := ctx.Value(bootstrapContainerKey).(*BootstrapContainer)
 	scope := container.MetricsClient.Scope(metrics.ArchiverArchiveVisibilityActivityScope, metrics.DomainTag(request.DomainName))
-	sw := scope.StartTimer(metrics.CadenceLatency)
+	sw := scope.StartTimerWithExponentialHistogram(metrics.CadenceLatency, metrics.CadenceLatencyHistogram)
 	defer func() {
 		sw.Stop()
 		if err != nil {

--- a/service/worker/archiver/activities_test.go
+++ b/service/worker/archiver/activities_test.go
@@ -85,6 +85,7 @@ func (s *activitiesSuite) SetupTest() {
 	s.historyArchiver = &carchiver.HistoryArchiverMock{}
 	s.visibilityArchiver = &carchiver.VisibilityArchiverMock{}
 	s.metricsScope.On("StartTimer", metrics.CadenceLatency).Return(metrics.NewTestStopwatch()).Maybe()
+	s.metricsScope.On("StartTimerWithExponentialHistogram", metrics.CadenceLatency, metrics.CadenceLatencyHistogram).Return(metrics.NewTestStopwatch()).Maybe()
 	s.metricsScope.On("RecordTimer", mock.Anything, mock.Anything).Maybe()
 }
 

--- a/service/worker/archiver/pump.go
+++ b/service/worker/archiver/pump.go
@@ -84,7 +84,12 @@ func NewPump(
 // Returns a PumpResult which contains a summary of what was pumped.
 // Upon returning request channel is closed.
 func (p *pump) Run() PumpResult {
+	pumpLatencyStart := workflow.Now(p.ctx)
 	sw := p.metricsClient.StartTimer(metrics.ArchiverPumpScope, metrics.CadenceLatency)
+	stopTimers := func() {
+		sw.Stop()
+		p.metricsClient.Scope(metrics.ArchiverPumpScope).ExponentialHistogram(metrics.CadenceLatencyHistogram, workflow.Now(p.ctx).Sub(pumpLatencyStart))
+	}
 
 	carryoverBoundIndex := len(p.carryover)
 	if carryoverBoundIndex > p.requestLimit {
@@ -104,7 +109,7 @@ func (p *pump) Run() PumpResult {
 		pumpResult.PumpedHashes = append(pumpResult.PumpedHashes, hash(request))
 	}
 	if len(pumpResult.PumpedHashes) == p.requestLimit {
-		sw.Stop()
+		stopTimers()
 		p.requestCh.Close()
 		return pumpResult
 	}
@@ -137,7 +142,7 @@ func (p *pump) Run() PumpResult {
 	for !finished {
 		selector.Select(p.ctx)
 	}
-	sw.Stop()
+	stopTimers()
 	p.requestCh.Close()
 	return pumpResult
 }

--- a/service/worker/archiver/pump_test.go
+++ b/service/worker/archiver/pump_test.go
@@ -60,6 +60,12 @@ func (s *pumpSuite) SetupSuite() {
 func (s *pumpSuite) SetupTest() {
 	pumpTestMetrics = &mmocks.Client{}
 	pumpTestMetrics.On("StartTimer", mock.Anything, mock.Anything).Return(metrics.NopStopwatch()).Once()
+	// pump dual-emits CadenceLatency timer + CadenceLatencyHistogram via
+	// metricsClient.Scope(...).ExponentialHistogram(...). Wire a permissive scope mock
+	// so we don't have to repeat the expectation in every test.
+	pumpScopeMock := &mmocks.Scope{}
+	pumpScopeMock.On("ExponentialHistogram", metrics.CadenceLatencyHistogram, mock.Anything).Maybe()
+	pumpTestMetrics.On("Scope", metrics.ArchiverPumpScope).Return(pumpScopeMock).Maybe()
 	pumpTestLogger = log.NewMockLogger(gomock.NewController(s.T()))
 }
 

--- a/service/worker/archiver/replay_metrics_client.go
+++ b/service/worker/archiver/replay_metrics_client.go
@@ -134,6 +134,14 @@ func (r *replayMetricsScope) StartTimer(timer metrics.MetricIdx) metrics.Stopwat
 	return r.scope.StartTimer(timer)
 }
 
+// StartTimerWithExponentialHistogram starts a stopwatch that records to both a timer and an exponential histogram on Stop.
+func (r *replayMetricsScope) StartTimerWithExponentialHistogram(timer metrics.MetricIdx, histogram metrics.MetricIdx) metrics.Stopwatch {
+	if workflow.IsReplaying(r.ctx) {
+		return metrics.NewTestStopwatch()
+	}
+	return r.scope.StartTimerWithExponentialHistogram(timer, histogram)
+}
+
 // RecordTimer starts a timer for the given metric name
 func (r *replayMetricsScope) RecordTimer(timer metrics.MetricIdx, d time.Duration) {
 	if workflow.IsReplaying(r.ctx) {

--- a/service/worker/archiver/workflow.go
+++ b/service/worker/archiver/workflow.go
@@ -51,7 +51,12 @@ func archivalWorkflowHelper(
 ) error {
 	metricsClient = NewReplayMetricsClient(metricsClient, ctx)
 	metricsClient.IncCounter(metrics.ArchiverArchivalWorkflowScope, metrics.ArchiverWorkflowStartedCount)
+	archivalLatencyStart := workflow.Now(ctx)
 	sw := metricsClient.StartTimer(metrics.ArchiverArchivalWorkflowScope, metrics.CadenceLatency)
+	stopTimers := func() {
+		sw.Stop()
+		metricsClient.Scope(metrics.ArchiverArchivalWorkflowScope).ExponentialHistogram(metrics.CadenceLatencyHistogram, workflow.Now(ctx).Sub(archivalLatencyStart))
+	}
 	workflowInfo := workflow.GetInfo(ctx)
 	logger = logger.WithTags(
 		tag.WorkflowID(workflowInfo.WorkflowExecution.ID),
@@ -98,7 +103,7 @@ func archivalWorkflowHelper(
 	if pumpResult.TimeoutWithoutSignals {
 		logger.Info("workflow stopping because pump did not get any signals within timeout threshold")
 		metricsClient.IncCounter(metrics.ArchiverArchivalWorkflowScope, metrics.ArchiverWorkflowStoppingCount)
-		sw.Stop()
+		stopTimers()
 		return nil
 	}
 	for {
@@ -111,6 +116,6 @@ func archivalWorkflowHelper(
 	logger.Info("archival system workflow continue as new")
 	ctx = workflow.WithExecutionStartToCloseTimeout(ctx, workflowStartToCloseTimeout)
 	ctx = workflow.WithWorkflowTaskStartToCloseTimeout(ctx, workflowTaskStartToCloseTimeout)
-	sw.Stop()
+	stopTimers()
 	return workflow.NewContinueAsNewError(ctx, archivalWorkflowFnName, pumpResult.UnhandledCarryover)
 }

--- a/service/worker/archiver/workflow_test.go
+++ b/service/worker/archiver/workflow_test.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-go/tally"
 	"go.uber.org/cadence/testsuite"
@@ -70,6 +71,13 @@ func (s *workflowSuite) SetupTest() {
 		ArchivalsPerIteration:         dynamicproperties.GetIntPropertyFn(0),
 		TimeLimitPerArchivalIteration: dynamicproperties.GetDurationPropertyFn(MaxArchivalIterationTimeout()),
 	}
+
+	// archival workflow dual-emits CadenceLatency timer + CadenceLatencyHistogram via
+	// metricsClient.Scope(ArchiverArchivalWorkflowScope).ExponentialHistogram(...). Wire a
+	// permissive scope mock so we don't have to repeat the expectation in every test.
+	archivalScopeMock := &mmocks.Scope{}
+	archivalScopeMock.On("ExponentialHistogram", metrics.CadenceLatencyHistogram, mock.Anything).Maybe()
+	workflowTestMetrics.On("Scope", metrics.ArchiverArchivalWorkflowScope).Return(archivalScopeMock).Maybe()
 }
 
 func (s *workflowSuite) TestArchivalWorkflow_Fail_HashesDoNotEqual() {

--- a/service/worker/scanner/shardscanner/activities.go
+++ b/service/worker/scanner/shardscanner/activities.go
@@ -160,7 +160,7 @@ func scanShard(
 		metrics.WorkflowTypeTag(info.WorkflowType.Name),
 		metrics.DomainTag(constants.SystemLocalDomainName),
 	)
-	sw := scope.StartTimer(metrics.CadenceLatency)
+	sw := scope.StartTimerWithExponentialHistogram(metrics.CadenceLatency, metrics.CadenceLatencyHistogram)
 	defer sw.Stop()
 
 	if ctx.Hooks == nil {
@@ -384,7 +384,7 @@ func fixShard(
 		metrics.WorkflowTypeTag(info.WorkflowType.Name),
 		metrics.DomainTag(constants.SystemLocalDomainName),
 	)
-	sw := scope.StartTimer(metrics.CadenceLatency)
+	sw := scope.StartTimerWithExponentialHistogram(metrics.CadenceLatency, metrics.CadenceLatencyHistogram)
 	defer sw.Stop()
 
 	if ctx.Hooks == nil {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Some call sites in the generated wrappers are missing histogram metrics for cadence-latency, this PR is fixing those call sites to emit histogram metrics

- Adds dual-emit (timer + exponential histogram) to CadenceLatency and CadenceClientLatencyNs call sites that were previously missing the histogram counterpart, completing the timer → histogram migration tracked in #7741 / #8124.
-  To avoid touching ~40 defer sw.Stop() call sites individually, this introduces a small Scope.StartTimerWithExponentialHistogram(timer, histogram) helper that returns a Stopwatch which records to both the legacy timer and a paired exponentialBuckets histogram on Stop(). Existing code only needs a one-line swap; semantics and defer patterns are preserved.

**Why?**
This is batch 8 of the ongoing timer→histogram migration (https://github.com/cadence-workflow/cadence/issues/7741)

**How did you test it?**
go test ./common/metrics/... ./common/task/... ./service/history/execution/... ./service/history/shard/... ./service/history/workflowcache/...

Potential risks
Low. All changes are additive (dual-emit). New histogram definitions are validated at init() time.

Release notes
N/A — internal observability improvement, no behavior change.

Documentation Changes
This is batch 8 of the ongoing timer→histogram migration (https://github.com/cadence-workflow/cadence/issues/7741)