### PR TITLE
refactor(matching): gate shard-distributor onboarding via Enabled callback and operational config

### DIFF
--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -170,10 +170,7 @@ func (s *server) startService() common.Daemon {
 	)
 	params.PercentageOnboarded = membership.NewPercentageOnboarded(
 		params.MetricsClient,
-		dc.GetIntProperty(dynamicproperties.MatchingPercentageOnboardedToShardManager),
 		operationalDC.GetIntProperty(dynamicproperties.MatchingPercentageOnboardedToShardManager),
-		operationalDC.GetBoolProperty(dynamicproperties.MatchingPercentageOnboardedReadFromOperationalStore),
-		dc.GetBoolProperty(dynamicproperties.MatchingEmergencyOffboardingFromShardManager),
 	)
 
 	rpcParams, err := rpc.NewParams(params.Name, &s.cfg, dc, params.Logger, params.MetricsClient)

--- a/cmd/server/go.mod
+++ b/cmd/server/go.mod
@@ -64,7 +64,7 @@ require (
 )
 
 require (
-	github.com/cadence-workflow/shard-manager v0.0.0-20260608084258-925b1a8234ba
+	github.com/cadence-workflow/shard-manager v0.0.0-20260610143419-4bef35311802
 	github.com/uber/cadence v0.0.0-00010101000000-000000000000
 	github.com/uber/cadence/common/archiver/gcloud v0.0.0-00010101000000-000000000000
 	go.uber.org/automaxprocs v1.6.0

--- a/cmd/server/go.sum
+++ b/cmd/server/go.sum
@@ -81,8 +81,8 @@ github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b h1:AP/Y7sqYicnjGDf
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
 github.com/cactus/go-statsd-client/statsd v0.0.0-20191106001114-12b4e2b38748 h1:bXxS5/Z3/dfc8iFniQfgogNBomo0u+1//9eP+jl8GVo=
 github.com/cactus/go-statsd-client/statsd v0.0.0-20191106001114-12b4e2b38748/go.mod h1:l/bIBLeOl9eX+wxJAzxS4TveKRtAqlyDpHjhkfO0MEI=
-github.com/cadence-workflow/shard-manager v0.0.0-20260608084258-925b1a8234ba h1:HjmNs63xPFlnigC1yC0638MAcEpSb8P4vIlog7GjgRs=
-github.com/cadence-workflow/shard-manager v0.0.0-20260608084258-925b1a8234ba/go.mod h1:T/E4zl51bVOZjBNp2Ul1nVp7qfbpctLmZXFU9WnYe14=
+github.com/cadence-workflow/shard-manager v0.0.0-20260610143419-4bef35311802 h1:5YWpDAQeyETGpvXkdzQgIPa6PhsPBpBeTDwta+UWFn8=
+github.com/cadence-workflow/shard-manager v0.0.0-20260610143419-4bef35311802/go.mod h1:T/E4zl51bVOZjBNp2Ul1nVp7qfbpctLmZXFU9WnYe14=
 github.com/cch123/elasticsql v0.0.0-20190321073543-a1a440758eb9 h1:2rukpuvOpZryti4j58JHH5f0qJXxYdTYpkgNYx8iLdg=
 github.com/cch123/elasticsql v0.0.0-20190321073543-a1a440758eb9/go.mod h1:h4Tt1A91nOVAYsWdoxlXwKYPfxkxeTuRFkEMUQaRVBo=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/cmd/sharddistributor-canary/main.go
+++ b/cmd/sharddistributor-canary/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cadence-workflow/shard-manager/service/sharddistributor/client/clientcommon"
 	"github.com/cadence-workflow/shard-manager/service/sharddistributor/client/executorclient"
 	"github.com/cadence-workflow/shard-manager/service/sharddistributor/client/spectatorclient"
-	smsdconfig "github.com/cadence-workflow/shard-manager/service/sharddistributor/config"
 	"github.com/uber-go/tally"
 	"github.com/urfave/cli/v2"
 	"go.uber.org/fx"
@@ -59,8 +58,8 @@ func runApp(c *cli.Context) {
 func opts(fixedNamespace, ephemeralNamespace, endpoint string, canaryGRPCPort int, numFixedExecutors, numEphemeral int) fx.Option {
 	configuration := clientcommon.Config{
 		Namespaces: []clientcommon.NamespaceConfig{
-			{Namespace: fixedNamespace, HeartBeatInterval: 1 * time.Second, MigrationMode: smsdconfig.MigrationModeONBOARDED},
-			{Namespace: ephemeralNamespace, HeartBeatInterval: 1 * time.Second, MigrationMode: smsdconfig.MigrationModeONBOARDED},
+			{Namespace: fixedNamespace, HeartBeatInterval: 1 * time.Second},
+			{Namespace: ephemeralNamespace, HeartBeatInterval: 1 * time.Second},
 		},
 	}
 

--- a/common/archiver/gcloud/go.mod
+++ b/common/archiver/gcloud/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c // indirect
 	github.com/apache/thrift v0.17.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cadence-workflow/shard-manager v0.0.0-20260608084258-925b1a8234ba // indirect
+	github.com/cadence-workflow/shard-manager v0.0.0-20260610143419-4bef35311802 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/common/archiver/gcloud/go.sum
+++ b/common/archiver/gcloud/go.sum
@@ -68,8 +68,8 @@ github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b h1:AP/Y7sqYicnjGDf
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
 github.com/cactus/go-statsd-client/statsd v0.0.0-20191106001114-12b4e2b38748 h1:bXxS5/Z3/dfc8iFniQfgogNBomo0u+1//9eP+jl8GVo=
 github.com/cactus/go-statsd-client/statsd v0.0.0-20191106001114-12b4e2b38748/go.mod h1:l/bIBLeOl9eX+wxJAzxS4TveKRtAqlyDpHjhkfO0MEI=
-github.com/cadence-workflow/shard-manager v0.0.0-20260608084258-925b1a8234ba h1:HjmNs63xPFlnigC1yC0638MAcEpSb8P4vIlog7GjgRs=
-github.com/cadence-workflow/shard-manager v0.0.0-20260608084258-925b1a8234ba/go.mod h1:T/E4zl51bVOZjBNp2Ul1nVp7qfbpctLmZXFU9WnYe14=
+github.com/cadence-workflow/shard-manager v0.0.0-20260610143419-4bef35311802 h1:5YWpDAQeyETGpvXkdzQgIPa6PhsPBpBeTDwta+UWFn8=
+github.com/cadence-workflow/shard-manager v0.0.0-20260610143419-4bef35311802/go.mod h1:T/E4zl51bVOZjBNp2Ul1nVp7qfbpctLmZXFU9WnYe14=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -2393,23 +2393,6 @@ const (
 	// Default value: true
 	// Allowed filters: N/A
 	MatchingExcludeShortLivedTaskListsFromShardManager
-	// MatchingEmergencyOffboardingFromShardManager is a kill switch to immediately offboard all task lists from the shard manager.
-	// When true, all task lists fall back to the hash ring, ignoring MatchingPercentageOnboardedToShardManager.
-	// KeyName: matching.emergencyOffboardingFromShardManager
-	// Value type: Bool
-	// Default value: false
-	// Allowed filters: N/A
-	MatchingEmergencyOffboardingFromShardManager
-	// MatchingPercentageOnboardedReadFromOperationalStore selects the source of
-	// MatchingPercentageOnboardedToShardManager during the migration to the cassandra-backed
-	// operational dynamic config store.
-	// When false (default), cadence reads the value from the generic dynamic config.
-	// When true, cadence reads the value from the operational dynamic config store.
-	// KeyName: matching.percentageOnboardedReadFromOperationalStore
-	// Value type: Bool
-	// Default value: false
-	// Allowed filters: N/A
-	MatchingPercentageOnboardedReadFromOperationalStore
 
 	// EnableHierarchicalWeightedRoundRobinTaskScheduler is to enable hierarchical weighted round robin task scheduler
 	// KeyName: history.enableHierarchicalWeightedRoundRobinTaskScheduler
@@ -5242,16 +5225,6 @@ var BoolKeys = map[BoolKey]DynamicBool{
 		KeyName:      "matching.excludeShortLivedTaskListsFromShardManager",
 		Description:  "MatchingExcludeShortLivedTaskListsFromShardManager excludes short-lived task lists (e.g. bits task lists and sticky task lists) from the shard manager",
 		DefaultValue: true,
-	},
-	MatchingEmergencyOffboardingFromShardManager: {
-		KeyName:      "matching.emergencyOffboardingFromShardManager",
-		Description:  "MatchingEmergencyOffboardingFromShardManager is a kill switch to immediately offboard all task lists from the shard manager, ignoring the onboarding percentage",
-		DefaultValue: false,
-	},
-	MatchingPercentageOnboardedReadFromOperationalStore: {
-		KeyName:      "matching.percentageOnboardedReadFromOperationalStore",
-		Description:  "MatchingPercentageOnboardedReadFromOperationalStore selects the source of MatchingPercentageOnboardedToShardManager: false (default) reads from the generic dynamic config, true reads from the cassandra-backed operational dynamic config store",
-		DefaultValue: false,
 	},
 	EnableHierarchicalWeightedRoundRobinTaskScheduler: {
 		KeyName:      "history.enableHierarchicalWeightedRoundRobinTaskScheduler",

--- a/common/membership/percentage_onboarded.go
+++ b/common/membership/percentage_onboarded.go
@@ -8,33 +8,24 @@ import (
 //go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination percentage_onboarded_mock.go -self_package github.com/uber/cadence/common/membership
 
 // PercentageOnboarded is the shared read path for the shard-manager onboarding
-// percentage. Value returns 0 when emergency offboarding is on.
+// percentage.
 type PercentageOnboarded interface {
 	Value() int
 }
 
 func NewPercentageOnboarded(
 	metricsClient metrics.Client,
-	fromDynamicConfig dynamicproperties.IntPropertyFn,
-	fromOperational dynamicproperties.IntPropertyFn,
-	useOperational dynamicproperties.BoolPropertyFn,
-	emergencyOffboarding dynamicproperties.BoolPropertyFn,
+	value dynamicproperties.IntPropertyFn,
 ) PercentageOnboarded {
 	return &percentageOnboarded{
-		metricsClient:        metricsClient,
-		fromDynamicConfig:    fromDynamicConfig,
-		fromOperational:      fromOperational,
-		useOperational:       useOperational,
-		emergencyOffboarding: emergencyOffboarding,
+		metricsClient: metricsClient,
+		value:         value,
 	}
 }
 
 type percentageOnboarded struct {
-	metricsClient        metrics.Client
-	fromDynamicConfig    dynamicproperties.IntPropertyFn
-	fromOperational      dynamicproperties.IntPropertyFn
-	useOperational       dynamicproperties.BoolPropertyFn
-	emergencyOffboarding dynamicproperties.BoolPropertyFn
+	metricsClient metrics.Client
+	value         dynamicproperties.IntPropertyFn
 }
 
 // StaticPercentageOnboarded always returns the given value. Intended for test
@@ -48,25 +39,10 @@ type staticPercentageOnboarded int
 func (s staticPercentageOnboarded) Value() int { return int(s) }
 
 func (p *percentageOnboarded) Value() int {
-	if p.emergencyOffboarding() {
-		return 0
-	}
+	value := p.value()
 
-	operational := p.useOperational()
-	dynamicValue := p.fromDynamicConfig()
-	operationalValue := p.fromOperational()
+	p.metricsClient.Scope(metrics.ShardManagerOnboardingScope).
+		UpdateGauge(metrics.PercentageOnboardedToShardManagerGauge, float64(value))
 
-	p.metricsClient.Scope(metrics.ShardManagerOnboardingScope,
-		metrics.OnboardingSourceTag("dynamicconfig"),
-		metrics.OnboardingActiveTag(!operational),
-	).UpdateGauge(metrics.PercentageOnboardedToShardManagerGauge, float64(dynamicValue))
-	p.metricsClient.Scope(metrics.ShardManagerOnboardingScope,
-		metrics.OnboardingSourceTag("operational"),
-		metrics.OnboardingActiveTag(operational),
-	).UpdateGauge(metrics.PercentageOnboardedToShardManagerGauge, float64(operationalValue))
-
-	if operational {
-		return operationalValue
-	}
-	return dynamicValue
+	return value
 }

--- a/common/membership/percentage_onboarded_test.go
+++ b/common/membership/percentage_onboarded_test.go
@@ -12,92 +12,31 @@ import (
 
 func TestPercentageOnboarded(t *testing.T) {
 	tests := []struct {
-		name                  string
-		useOperational        bool
-		emergency             bool
-		dynamicValue          int
-		operationalValue      int
-		want                  int
-		wantDynamicConfigMode string
-		wantOperationalMode   string
+		name  string
+		value int
 	}{
-		{
-			name:                  "reads from dynamic config when flag is off",
-			useOperational:        false,
-			emergency:             false,
-			dynamicValue:          42,
-			operationalValue:      99,
-			want:                  42,
-			wantDynamicConfigMode: "active",
-			wantOperationalMode:   "shadow",
-		},
-		{
-			name:                  "reads from operational store when flag is on",
-			useOperational:        true,
-			emergency:             false,
-			dynamicValue:          42,
-			operationalValue:      99,
-			want:                  99,
-			wantDynamicConfigMode: "shadow",
-			wantOperationalMode:   "active",
-		},
-		{
-			name:                  "emergency offboarding returns 0 even when reading from dynamic config",
-			useOperational:        false,
-			emergency:             true,
-			dynamicValue:          42,
-			operationalValue:      99,
-			want:                  0,
-			wantDynamicConfigMode: "active",
-			wantOperationalMode:   "shadow",
-		},
-		{
-			name:                  "emergency offboarding returns 0 even when reading from operational store",
-			useOperational:        true,
-			emergency:             true,
-			dynamicValue:          42,
-			operationalValue:      99,
-			want:                  0,
-			wantDynamicConfigMode: "shadow",
-			wantOperationalMode:   "active",
-		},
+		{name: "zero", value: 0},
+		{name: "partial", value: 42},
+		{name: "full", value: 100},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testScope := tally.NewTestScope("", nil)
 			mc := metrics.NewClient(testScope, metrics.Matching, metrics.MigrationConfig{})
-			po := NewPercentageOnboarded(
-				mc,
-				dynamicproperties.GetIntPropertyFn(tt.dynamicValue),
-				dynamicproperties.GetIntPropertyFn(tt.operationalValue),
-				dynamicproperties.GetBoolPropertyFn(tt.useOperational),
-				dynamicproperties.GetBoolPropertyFn(tt.emergency),
-			)
+			po := NewPercentageOnboarded(mc, dynamicproperties.GetIntPropertyFn(tt.value))
 
-			assert.Equal(t, tt.want, po.Value())
+			assert.Equal(t, tt.value, po.Value())
 
 			gauges := findGauges(testScope.Snapshot().Gauges(), "percentage_onboarded_to_shard_manager")
-			if tt.emergency {
-				assert.Empty(t, gauges, "no gauges emitted during emergency offboarding")
-				return
-			}
-			assert.Len(t, gauges, 2, "expected one gauge per source")
-			for _, g := range gauges {
-				tagsMap := g.Tags()
-				switch tagsMap["onboarding_source"] {
-				case "dynamicconfig":
-					assert.Equal(t, float64(tt.dynamicValue), g.Value())
-					assert.Equal(t, tt.wantDynamicConfigMode, tagsMap["onboarding_active"])
-				case "operational":
-					assert.Equal(t, float64(tt.operationalValue), g.Value(), "operational gauge should reflect the operational source value")
-					assert.Equal(t, tt.wantOperationalMode, tagsMap["onboarding_active"])
-				default:
-					t.Fatalf("unexpected onboarding_source tag: %q", tagsMap["onboarding_source"])
-				}
-			}
+			assert.Len(t, gauges, 1, "expected a single operational gauge")
+			assert.Equal(t, float64(tt.value), gauges[0].Value())
 		})
 	}
+}
+
+func TestStaticPercentageOnboarded(t *testing.T) {
+	assert.Equal(t, 7, StaticPercentageOnboarded(7).Value())
 }
 
 func findGauges(all map[string]tally.GaugeSnapshot, suffix string) []tally.GaugeSnapshot {

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -84,10 +84,6 @@ const (
 	overlapPolicy = "overlap_policy"
 	triggerSource = "trigger_source"
 
-	// operational dynamic config migration tags
-	onboardingSource = "onboarding_source"
-	onboardingActive = "onboarding_active"
-
 	allValue     = "all"
 	unknownValue = "_unknown_"
 )
@@ -385,25 +381,6 @@ func OverlapPolicyTag(value string) Tag {
 // TriggerSourceTag returns a new trigger_source tag for scheduler metrics.
 func TriggerSourceTag(value string) Tag {
 	return metricWithUnknown(triggerSource, value)
-}
-
-// OnboardingSourceTag tags a metric with the source the value was read from
-// during the operational dynamic config migration. Expected values are
-// "dynamicconfig" (generic dynamic config) and "operational" (cassandra-backed
-// operational dynamic config store).
-func OnboardingSourceTag(value string) Tag {
-	return metricWithUnknown(onboardingSource, value)
-}
-
-// OnboardingActiveTag tags a metric with whether the source it was read from
-// is the currently-active source of truth. Tag value is "active" when the
-// source is authoritative and "shadow" when it is read only for comparison.
-func OnboardingActiveTag(active bool) Tag {
-	value := "shadow"
-	if active {
-		value = "active"
-	}
-	return simpleMetric{key: onboardingActive, value: value}
 }
 
 // QueryConsistencyLevelTag returns a new query consistency level tag.

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -140,6 +140,5 @@ shard-distributor-matching:
   namespaces:
     - namespace: cadence-matching-dev
       heartbeat_interval: 1s
-      migration_mode: local_pass
       ttl_shard: 5m
       ttl_report: 1m

--- a/config/development_queuev2_cached.yaml
+++ b/config/development_queuev2_cached.yaml
@@ -140,6 +140,5 @@ shard-distributor-matching:
   namespaces:
     - namespace: cadence-matching-dev
       heartbeat_interval: 1s
-      migration_mode: local_pass
       ttl_shard: 5m
       ttl_report: 1m

--- a/config/development_xdc_cluster0.yaml
+++ b/config/development_xdc_cluster0.yaml
@@ -141,6 +141,5 @@ shard-distributor-matching:
   namespaces:
     - namespace: cadence-matching-dev
       heartbeat_interval: 1s
-      migration_mode: local_pass
       ttl_shard: 5m
       ttl_report: 1m

--- a/config/development_xdc_cluster1.yaml
+++ b/config/development_xdc_cluster1.yaml
@@ -138,6 +138,5 @@ shard-distributor-matching:
   namespaces:
     - namespace: cadence-matching-dev
       heartbeat_interval: 1s
-      migration_mode: local_pass
       ttl_shard: 5m
       ttl_report: 1m

--- a/config/development_xdc_cluster2.yaml
+++ b/config/development_xdc_cluster2.yaml
@@ -138,6 +138,5 @@ shard-distributor-matching:
   namespaces:
     - namespace: cadence-matching-dev
       heartbeat_interval: 1s
-      migration_mode: local_pass
       ttl_shard: 5m
       ttl_report: 1m

--- a/docker/config/server/custom-config.yaml
+++ b/docker/config/server/custom-config.yaml
@@ -135,6 +135,5 @@ shard-distributor-matching:
   namespaces:
     - namespace: "cadence-matching"
       heartbeat_interval: "1s"
-      migration_mode: "local_pass"
       ttl_shard: "5m"
       ttl_report: "1m"

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -341,6 +341,5 @@ shard-distributor-matching:
   namespaces:
     - namespace: {{ default .Env.SHARD_DISTRIBUTOR_MATCHING_NAMESPACE "cadence-matching" }}
       heartbeat_interval: {{ default .Env.SHARD_DISTRIBUTOR_MATCHING_HEARTBEAT_INTERVAL "1s" }}
-      migration_mode: {{ default .Env.SHARD_DISTRIBUTOR_MATCHING_MIGRATION_MODE "local_pass" }}
       ttl_shard: {{ default .Env.SHARD_DISTRIBUTOR_MATCHING_TTL_SHARD "5m" }}
       ttl_report: {{ default .Env.SHARD_DISTRIBUTOR_MATCHING_TTL_REPORT "1m" }}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/VividCortex/mysqlerr v1.0.0
 	github.com/aws/aws-sdk-go v1.54.12
 	github.com/cactus/go-statsd-client/statsd v0.0.0-20191106001114-12b4e2b38748
-	github.com/cadence-workflow/shard-manager v0.0.0-20260608084258-925b1a8234ba
+	github.com/cadence-workflow/shard-manager v0.0.0-20260610143419-4bef35311802
 	github.com/cch123/elasticsql v0.0.0-20190321073543-a1a440758eb9
 	github.com/dave/dst v0.26.2
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b h1:AP/Y7sqYicnjGDf
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
 github.com/cactus/go-statsd-client/statsd v0.0.0-20191106001114-12b4e2b38748 h1:bXxS5/Z3/dfc8iFniQfgogNBomo0u+1//9eP+jl8GVo=
 github.com/cactus/go-statsd-client/statsd v0.0.0-20191106001114-12b4e2b38748/go.mod h1:l/bIBLeOl9eX+wxJAzxS4TveKRtAqlyDpHjhkfO0MEI=
-github.com/cadence-workflow/shard-manager v0.0.0-20260608084258-925b1a8234ba h1:HjmNs63xPFlnigC1yC0638MAcEpSb8P4vIlog7GjgRs=
-github.com/cadence-workflow/shard-manager v0.0.0-20260608084258-925b1a8234ba/go.mod h1:T/E4zl51bVOZjBNp2Ul1nVp7qfbpctLmZXFU9WnYe14=
+github.com/cadence-workflow/shard-manager v0.0.0-20260610143419-4bef35311802 h1:5YWpDAQeyETGpvXkdzQgIPa6PhsPBpBeTDwta+UWFn8=
+github.com/cadence-workflow/shard-manager v0.0.0-20260610143419-4bef35311802/go.mod h1:T/E4zl51bVOZjBNp2Ul1nVp7qfbpctLmZXFU9WnYe14=
 github.com/cch123/elasticsql v0.0.0-20190321073543-a1a440758eb9 h1:2rukpuvOpZryti4j58JHH5f0qJXxYdTYpkgNYx8iLdg=
 github.com/cch123/elasticsql v0.0.0-20190321073543-a1a440758eb9/go.mod h1:h4Tt1A91nOVAYsWdoxlXwKYPfxkxeTuRFkEMUQaRVBo=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/cadence-workflow/shard-manager/service/sharddistributor/client/clientcommon"
-	smsdconfig "github.com/cadence-workflow/shard-manager/service/sharddistributor/config"
 	"github.com/pborman/uuid"
 	"github.com/uber-go/tally"
 	"github.com/uber-go/tally/prometheus"
@@ -888,7 +887,6 @@ func (c *cadenceImpl) startMatching(hosts map[string][]membership.HostInfo, star
 			Namespaces: []clientcommon.NamespaceConfig{{
 				Namespace:         "cadence-matching-integration",
 				HeartBeatInterval: 1 * time.Second,
-				MigrationMode:     smsdconfig.MigrationModeLOCALPASSTHROUGH,
 				TTLShard:          5 * time.Minute,
 				TTLReport:         1 * time.Minute,
 			}},

--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -237,6 +237,7 @@ func (e *matchingEngineImpl) setupExecutor(shardDistributorExecutorClient execut
 		ShardProcessorFactory: taskListFactory,
 		Config:                cfg,
 		TimeSource:            smTimeSource,
+		Enabled:               e.shardDistributorOnboarded,
 		Metadata: map[string]string{
 			"tchannel": fmt.Sprintf("%d", e.config.RPCConfig.Port),
 			"grpc":     fmt.Sprintf("%d", e.config.RPCConfig.GRPCPort),
@@ -250,6 +251,13 @@ func (e *matchingEngineImpl) setupExecutor(shardDistributorExecutorClient execut
 	}
 
 	e.executor = executor
+}
+
+// shardDistributorOnboarded reports whether this matching host should heartbeat
+// to the shard distributor, gated on the onboarding percentage. It is consulted
+// on every heartbeat tick, so driving the percentage to 0 offboards the executor.
+func (e *matchingEngineImpl) shardDistributorOnboarded() bool {
+	return e.percentageOnboarded.Value() > 0
 }
 
 func (e *matchingEngineImpl) getValidatedShardDistributorConfig() (clientcommon.Config, time.Duration) {

--- a/service/matching/handler/engine_integration_test.go
+++ b/service/matching/handler/engine_integration_test.go
@@ -34,7 +34,6 @@ import (
 
 	"github.com/cadence-workflow/shard-manager/service/sharddistributor/client/clientcommon"
 	"github.com/cadence-workflow/shard-manager/service/sharddistributor/client/executorclient"
-	smsdconfig "github.com/cadence-workflow/shard-manager/service/sharddistributor/config"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-go/tally"
@@ -1436,7 +1435,6 @@ func defaultSDExecutorConfig() clientcommon.Config {
 		Namespaces: []clientcommon.NamespaceConfig{{
 			Namespace:         "cadence-matching",
 			HeartBeatInterval: 1 * time.Second,
-			MigrationMode:     smsdconfig.MigrationModeONBOARDED,
 			TTLShard:          5 * time.Minute,
 			TTLReport:         1 * time.Minute,
 		}},

--- a/service/matching/handler/engine_test.go
+++ b/service/matching/handler/engine_test.go
@@ -1921,6 +1921,29 @@ func TestSetupExecutorWithEmptyConfig(t *testing.T) {
 	require.NotNil(t, engine.executor)
 	require.NotNil(t, engine.taskListsFactory)
 
-	// The no-op executor reports itself as not onboarded to SD.
-	assert.False(t, engine.executor.IsOnboardedToSD())
+	// The no-op executor owns no shards, so any lookup falls back to local
+	// hash-ring ownership by returning ErrShardProcessNotFound.
+	_, err := engine.executor.GetShardProcess(context.Background(), "any-shard")
+	assert.ErrorIs(t, err, executorclient.ErrShardProcessNotFound)
+}
+
+func TestShardDistributorOnboarded(t *testing.T) {
+	tests := []struct {
+		name       string
+		percentage int
+		want       bool
+	}{
+		{name: "offboarded at zero", percentage: 0, want: false},
+		{name: "onboarded above zero", percentage: 1, want: true},
+		{name: "onboarded at full", percentage: 100, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			pct := membership.NewMockPercentageOnboarded(ctrl)
+			pct.EXPECT().Value().Return(tt.percentage)
+			engine := &matchingEngineImpl{percentageOnboarded: pct}
+			assert.Equal(t, tt.want, engine.shardDistributorOnboarded())
+		})
+	}
 }

--- a/service/sharddistributor/canary/executors/executors_test.go
+++ b/service/sharddistributor/canary/executors/executors_test.go
@@ -111,7 +111,6 @@ func TestNewExecutor_InvalidConfig(t *testing.T) {
 						{
 							Namespace:         "wrong-namespace",
 							HeartBeatInterval: 5 * time.Second,
-							MigrationMode:     "onboarded",
 						},
 					},
 				},
@@ -193,7 +192,6 @@ func createMockParams[SP executorclient.ShardProcessor](
 				{
 					Namespace:         namespace,
 					HeartBeatInterval: 5 * time.Second,
-					MigrationMode:     "onboarded",
 				},
 			},
 		},

--- a/service/sharddistributor/canary/module_test.go
+++ b/service/sharddistributor/canary/module_test.go
@@ -50,8 +50,8 @@ func TestModule(t *testing.T) {
 
 	config := clientcommon.Config{
 		Namespaces: []clientcommon.NamespaceConfig{
-			{Namespace: "shard-distributor-canary", HeartBeatInterval: 5 * time.Second, MigrationMode: "onboarded"},
-			{Namespace: "shard-distributor-canary-ephemeral", HeartBeatInterval: 5 * time.Second, MigrationMode: "onboarded"},
+			{Namespace: "shard-distributor-canary", HeartBeatInterval: 5 * time.Second},
+			{Namespace: "shard-distributor-canary-ephemeral", HeartBeatInterval: 5 * time.Second},
 		},
 	}
 


### PR DESCRIPTION
**What changed?**

Completes the move of matching's shard-distributor onboarding control to the operational onboarding percentage, in two commits:

1. **Read the onboarding percentage from operational config only.** `MatchingPercentageOnboardedToShardManager` is now read solely from the operational config store. `NewPercentageOnboarded` takes the metrics client and the operational value; the dynamic-config source and the `MatchingPercentageOnboardedReadFromOperationalStore` migration toggle are removed. The `MatchingEmergencyOffboardingFromShardManager` kill switch is retired as well, and `Value()` now emits a single onboarding-percentage gauge (the source/active comparison tags and their dead helpers are gone). Both dynamic config keys are deleted.

2. **Adopt the shard-manager `Enabled` callback and drop `MigrationMode`.** Bumps the shard-manager client to the version that removes the per-namespace `MigrationMode` config and replaces it with a runtime `Enabled func() bool` on the executor params. The matching executor's `Enabled` is wired to the onboarding percentage (`percentageOnboarded.Value() > 0`), so it gates heartbeating to the shard distributor on every tick. All now-invalid `MigrationMode` fields are removed from `NamespaceConfig` literals.

**Why?**

The dynamic-to-operational config migration for this value is complete, so the dual-source read path and toggle are dead weight — the operational store is the single source of truth.

These two changes ship together because they are coupled: removing the emergency kill switch is only safe once the `Enabled` callback exists, since gating the executor on the onboarding percentage (which can be driven to 0) becomes the offboarding mechanism that replaces it.

**How did you test it?**

- `make build` (all packages + test files) passes.
- `go test ./common/membership/... ./common/metrics/... ./common/dynamicconfig/... ./cmd/server/cadence/... ./service/matching/handler/... ./service/sharddistributor/canary/...` — pass.
- `make tidy`, `make fmt`, `make lint` — clean.

**Potential risks**

The `PercentageOnboarded` interface and all of its consumers are unchanged. Operationally: the onboarding percentage must be set in the operational config store (the generic dynamic-config value is no longer read), and the instant emergency fallback-to-hash-ring switch no longer exists — driving the percentage to 0 is now the path to offboard the executor.

**Release notes**

None.

**Documentation Changes**

None.
