### PR TITLE
feat(schedule): make scheduler worker redundancy per-domain dynamic config

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -1660,6 +1660,18 @@ const (
 	// Default value: 1
 	OperationalConfigStoreUpdateRetryAttempts
 
+	// SchedulerWorkerRedundancyFactor is the number of cadence-worker hosts
+	// that concurrently run a scheduler worker for each enabled domain.
+	// Re-evaluated every refresh tick, so changes take effect within one
+	// refresh interval without a restart. Non-positive values fall back to
+	// the in-process default. Per-domain overrides let tier-1 domains
+	// request more redundancy than the cluster default.
+	// KeyName: worker.schedulerWorkerRedundancyFactor
+	// Value type: Int
+	// Default value: 2
+	// Allowed filters: DomainName
+	SchedulerWorkerRedundancyFactor
+
 	// LastIntKey must be the last one in this const group
 	LastIntKey
 )
@@ -4694,6 +4706,12 @@ var IntKeys = map[IntKey]DynamicInt{
 		KeyName:      "system.operationalConfigStoreUpdateRetryAttempts",
 		Description:  "Number of attempts to push a value to the operational dynamic config store on conflict",
 		DefaultValue: 1,
+	},
+	SchedulerWorkerRedundancyFactor: {
+		KeyName:      "worker.schedulerWorkerRedundancyFactor",
+		Filters:      []Filter{DomainName},
+		Description:  "Number of cadence-worker hosts that concurrently run a scheduler worker for each enabled domain. Re-read live every refresh tick.",
+		DefaultValue: 2,
 	},
 }
 

--- a/service/worker/scheduler/client_worker.go
+++ b/service/worker/scheduler/client_worker.go
@@ -69,6 +69,12 @@ type BootstrapParams struct {
 	// tick so live dynamic-config changes take effect on the next iteration.
 	// Nil falls back to a sensible default.
 	RefreshInterval dynamicproperties.DurationPropertyFn
+	// RedundancyFactor returns the number of cadence-worker hosts that
+	// concurrently run a worker for each enabled domain. Looked up per
+	// domain on every refresh tick, so changes propagate within one tick
+	// without a worker restart. Nil or a non-positive return falls back to
+	// workerRedundancyFactor.
+	RedundancyFactor dynamicproperties.IntPropertyFnWithDomainFilter
 }
 
 // workerHandle is the subset of cadenceworker.Worker used by the manager,
@@ -98,6 +104,7 @@ type WorkerManager struct {
 	hostInfo           membership.HostInfo
 	timeSrc            clock.TimeSource
 	refreshInterval    dynamicproperties.DurationPropertyFn
+	redundancyFactor   dynamicproperties.IntPropertyFnWithDomainFilter
 	shutdownTimeout    time.Duration
 	ctx                context.Context
 	cancelFn           context.CancelFunc
@@ -114,6 +121,10 @@ func NewWorkerManager(params *BootstrapParams, enabledFn dynamicproperties.BoolP
 	if refresh == nil {
 		refresh = dynamicproperties.GetDurationPropertyFn(defaultRefreshInterval)
 	}
+	redundancy := params.RedundancyFactor
+	if redundancy == nil {
+		redundancy = dynamicproperties.GetIntPropertyFilteredByDomain(workerRedundancyFactor)
+	}
 	wm := &WorkerManager{
 		enabledFn:          enabledFn,
 		serviceClient:      params.ServiceClient,
@@ -125,6 +136,7 @@ func NewWorkerManager(params *BootstrapParams, enabledFn dynamicproperties.BoolP
 		hostInfo:           params.HostInfo,
 		timeSrc:            clock.NewRealTimeSource(),
 		refreshInterval:    refresh,
+		redundancyFactor:   redundancy,
 		shutdownTimeout:    defaultShutdownTimeout,
 		ctx:                ctx,
 		cancelFn:           cancel,
@@ -214,7 +226,12 @@ func (m *WorkerManager) refreshWorkers() {
 
 		domainName := domainEntry.GetInfo().Name
 
-		owners, err := m.membershipResolver.LookupN(service.Worker, domainName, workerRedundancyFactor)
+		redundancy := m.redundancyFactor(domainName)
+		if redundancy < 1 {
+			redundancy = workerRedundancyFactor
+		}
+
+		owners, err := m.membershipResolver.LookupN(service.Worker, domainName, redundancy)
 		if err != nil {
 			m.logger.Warn("failed to look up domain owners, skipping",
 				tag.WorkflowDomainName(domainName),

--- a/service/worker/scheduler/client_worker_test.go
+++ b/service/worker/scheduler/client_worker_test.go
@@ -182,6 +182,7 @@ func TestRefreshWorkers(t *testing.T) {
 				membershipResolver: mockResolver,
 				hostInfo:           selfHost,
 				activeWorkers:      make(map[string]workerHandle),
+				redundancyFactor:   dynamicproperties.GetIntPropertyFilteredByDomain(workerRedundancyFactor),
 				ctx:                ctx,
 				createWorker: func(domainName string) (workerHandle, error) {
 					started[domainName] = true
@@ -248,6 +249,7 @@ func TestRefreshWorkers_StopsWorkerWhenDomainDisabled(t *testing.T) {
 		membershipResolver: mockResolver,
 		hostInfo:           selfHost,
 		activeWorkers:      make(map[string]workerHandle),
+		redundancyFactor:   dynamicproperties.GetIntPropertyFilteredByDomain(workerRedundancyFactor),
 		ctx:                ctx,
 		createWorker: func(domainName string) (workerHandle, error) {
 			t.Fatal("should not start a worker for a disabled domain")
@@ -291,6 +293,7 @@ func TestRefreshWorkersHandlesCreateWorkerError(t *testing.T) {
 		membershipResolver: mockResolver,
 		hostInfo:           selfHost,
 		activeWorkers:      make(map[string]workerHandle),
+		redundancyFactor:   dynamicproperties.GetIntPropertyFilteredByDomain(workerRedundancyFactor),
 		ctx:                ctx,
 		createWorker: func(domainName string) (workerHandle, error) {
 			return nil, fmt.Errorf("connection refused")
@@ -300,6 +303,68 @@ func TestRefreshWorkersHandlesCreateWorkerError(t *testing.T) {
 	wm.refreshWorkers()
 
 	assert.Empty(t, wm.activeWorkers, "worker should not be added on creation error")
+}
+
+func TestRefreshWorkers_HonorsPerDomainRedundancyFactor(t *testing.T) {
+	selfHost := membership.NewDetailedHostInfo("10.0.0.1:7933", "self", nil)
+	otherHost := membership.NewDetailedHostInfo("10.0.0.2:7933", "other", nil)
+
+	domains := map[string]*cache.DomainCacheEntry{
+		"domain-bumped":   cache.NewDomainCacheEntryForTest(&persistence.DomainInfo{Name: "domain-bumped"}, nil, false, nil, 0, nil, 0, 0, 0),
+		"domain-shrunk":   cache.NewDomainCacheEntryForTest(&persistence.DomainInfo{Name: "domain-shrunk"}, nil, false, nil, 0, nil, 0, 0, 0),
+		"domain-fallback": cache.NewDomainCacheEntryForTest(&persistence.DomainInfo{Name: "domain-fallback"}, nil, false, nil, 0, nil, 0, 0, 0),
+	}
+
+	// Per-domain override map. domain-fallback is set to 0 to exercise the
+	// non-positive guard rail that falls back to the in-process default.
+	redundancyByDomain := map[string]int{
+		"domain-bumped":   5,
+		"domain-shrunk":   1,
+		"domain-fallback": 0,
+	}
+	wantLookupN := map[string]int{
+		"domain-bumped":   5,
+		"domain-shrunk":   1,
+		"domain-fallback": workerRedundancyFactor,
+	}
+
+	ctrl := gomock.NewController(t)
+	mockDomainCache := cache.NewMockDomainCache(ctrl)
+	mockDomainCache.EXPECT().GetAllDomain().Return(domains)
+
+	mockResolver := membership.NewMockResolver(ctrl)
+	for domainName, want := range wantLookupN {
+		mockResolver.EXPECT().
+			LookupN(service.Worker, domainName, want).
+			Return([]membership.HostInfo{selfHost, otherHost}, nil)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wm := &WorkerManager{
+		enabledFn:          dynamicproperties.GetBoolPropertyFnFilteredByDomain(true),
+		metricsClient:      metrics.NewNoopMetricsClient(),
+		logger:             testlogger.New(t),
+		domainCache:        mockDomainCache,
+		membershipResolver: mockResolver,
+		hostInfo:           selfHost,
+		activeWorkers:      make(map[string]workerHandle),
+		redundancyFactor:   func(domain string) int { return redundancyByDomain[domain] },
+		ctx:                ctx,
+		createWorker: func(domainName string) (workerHandle, error) {
+			return &fakeWorker{}, nil
+		},
+	}
+
+	wm.refreshWorkers()
+
+	// Mock expectations are the contract: if the per-domain redundancy
+	// wasn't piped through, the gomock controller would fail with an
+	// unexpected/missing call. The active-worker assertion just sanity-
+	// checks that we did successfully claim all three domains.
+	assert.Len(t, wm.activeWorkers, len(domains),
+		"all domains should have an active worker on this host")
 }
 
 func TestStopAllWorkers(t *testing.T) {
@@ -540,6 +605,7 @@ func TestRefreshWorkersMetrics(t *testing.T) {
 				membershipResolver: mockResolver,
 				hostInfo:           selfHost,
 				activeWorkers:      make(map[string]workerHandle),
+				redundancyFactor:   dynamicproperties.GetIntPropertyFilteredByDomain(workerRedundancyFactor),
 				ctx:                ctx,
 				createWorker: func(domainName string) (workerHandle, error) {
 					if tc.workerStartErr != nil {

--- a/service/worker/scheduler/client_worker_test.go
+++ b/service/worker/scheduler/client_worker_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
+	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
 
 	"github.com/uber/cadence/common/cache"
@@ -450,6 +451,43 @@ func TestMembershipChangeTriggersRefresh(t *testing.T) {
 		t.Fatal("timed out waiting for membership change to trigger refresh")
 	}
 
+	wm.Stop()
+}
+
+// TestWorkerManager_StartStop_NoGoroutineLeak verifies that the manager's
+// Start/Stop pair leaves no leaked goroutines: the background run loop must
+// observe context cancellation, the membership subscription must be released,
+// and Stop must drain the wait group before returning.
+func TestWorkerManager_StartStop_NoGoroutineLeak(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	ctrl := gomock.NewController(t)
+
+	// Empty domain cache so refreshWorkers does not spawn any per-domain
+	// SDK workers (which would pull in real Cadence client goroutines that
+	// goleak isn't the right tool to police).
+	mockDomainCache := cache.NewMockDomainCache(ctrl)
+	mockDomainCache.EXPECT().GetAllDomain().Return(map[string]*cache.DomainCacheEntry{}).AnyTimes()
+
+	mockResolver := membership.NewMockResolver(ctrl)
+	mockResolver.EXPECT().
+		Subscribe(service.Worker, membershipSubscriberName, gomock.Any()).
+		Return(nil)
+	mockResolver.EXPECT().
+		Unsubscribe(service.Worker, membershipSubscriberName).
+		Return(nil)
+
+	selfHost := membership.NewDetailedHostInfo("10.0.0.1:7933", "self", nil)
+
+	wm := NewWorkerManager(&BootstrapParams{
+		Logger:             testlogger.New(t),
+		MetricsClient:      metrics.NewNoopMetricsClient(),
+		DomainCache:        mockDomainCache,
+		MembershipResolver: mockResolver,
+		HostInfo:           selfHost,
+	}, dynamicproperties.GetBoolPropertyFnFilteredByDomain(false))
+
+	wm.Start()
 	wm.Stop()
 }
 

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -87,6 +87,7 @@ type (
 		EnableBatcher                       dynamicproperties.BoolPropertyFn
 		EnableScheduler                     dynamicproperties.BoolPropertyFnWithDomainFilter
 		SchedulerWorkerRefreshInterval      dynamicproperties.DurationPropertyFn
+		SchedulerWorkerRedundancyFactor     dynamicproperties.IntPropertyFnWithDomainFilter
 		EnableParentClosePolicyWorker       dynamicproperties.BoolPropertyFn
 		NumParentClosePolicySystemWorkflows dynamicproperties.IntPropertyFn
 		EnableFailoverManager               dynamicproperties.BoolPropertyFn
@@ -186,6 +187,7 @@ func NewConfig(params *resource.Params) *Config {
 		EnableBatcher:                       dc.GetBoolProperty(dynamicproperties.EnableBatcher),
 		EnableScheduler:                     dc.GetBoolPropertyFilteredByDomain(dynamicproperties.EnableScheduler),
 		SchedulerWorkerRefreshInterval:      dc.GetDurationProperty(dynamicproperties.SchedulerWorkerRefreshInterval),
+		SchedulerWorkerRedundancyFactor:     dc.GetIntPropertyFilteredByDomain(dynamicproperties.SchedulerWorkerRedundancyFactor),
 		EnableParentClosePolicyWorker:       dc.GetBoolProperty(dynamicproperties.EnableParentClosePolicyWorker),
 		NumParentClosePolicySystemWorkflows: dc.GetIntProperty(dynamicproperties.NumParentClosePolicySystemWorkflows),
 		EnableESAnalyzer:                    dc.GetBoolProperty(dynamicproperties.EnableESAnalyzer),
@@ -355,6 +357,7 @@ func (s *Service) startSchedulerWorkerManager() *scheduler.WorkerManager {
 		MembershipResolver: s.GetMembershipResolver(),
 		HostInfo:           s.GetHostInfo(),
 		RefreshInterval:    s.config.SchedulerWorkerRefreshInterval,
+		RedundancyFactor:   s.config.SchedulerWorkerRedundancyFactor,
 	}
 	wm := scheduler.NewWorkerManager(params, s.config.EnableScheduler)
 	wm.Start()


### PR DESCRIPTION
**What changed?**

Adds a new dynamic config key `worker.schedulerWorkerRedundancyFactor` (int, `DomainName`-filtered, default 2) and threads it through `scheduler.WorkerManager.refreshWorkers` so the number of cadence-worker hosts that concurrently run a scheduler worker for a given domain can be tuned at runtime, per domain. The previous hard-coded `workerRedundancyFactor = 2` const is retained as the safe fallback used when the dynconfig fn is nil or returns a non-positive value.


**Why?**

`WorkerManager` chooses which cadence-worker hosts own each domain's scheduler worker via `membershipResolver.LookupN(service.Worker, domainName, N)`, where `N` was the const `workerRedundancyFactor = 2`. That meant the change of number of workers is not possible per domain/cluster and we would have to change overall. It is useful for tier-1 domains that want more redundancy, or for shared-environment domains that need to shed connections.

Now, we with this additional dynamic property: 
- Default behavior unchanged: 2 hosts per domain
- Per-domain override in flipr: DomainName=foo, value=3 → next refresh tick (~1 min) → membership ring lookup returns 3 hosts for that domain → ring redistributes → workers start on the new owners, stop on hosts that lost ownership
- Setting value to 0 or negative: silently falls back to the const default 2 (safe guard against misconfiguration)
- No restart. Flipr change → live within ~90s on every cadence-worker host.

**How did you test it?**

Unit tests, including the new coverage for the dynamic path:

```
go test -race -count=1 -run TestRefreshWorkers ./service/worker/scheduler/
go test -race -count=1 ./service/worker/scheduler/ ./common/dynamicconfig/...
```

**Potential risks**

- **Default behavior is unchanged.** With no flipr override, `dc.GetIntPropertyFilteredByDomain(SchedulerWorkerRedundancyFactor)` returns the registered default of 2, which is identical to the previous const, so existing clusters see no behavior change after deploy.
- **Safety net for misconfiguration.** A non-positive flipr value (0 or negative) falls back to the in-process const default rather than calling `LookupN` with `N=0`, which would currently return `ErrInsufficientHosts` and skip the domain entirely.
- **Reconciliation latency.** Live changes propagate within ~one `SchedulerWorkerRefreshInterval` (default 60s) after the dynconfig refresh, plus the dynconfig polling interval. There is a brief overlap window during scale-down where the host that lost ownership runs `defaultShutdownTimeout = 5s` to drain before stopping the worker.
- **Operationally**: setting the value too high on many domains at once could create new gRPC long-poll connection load (every additional owner host opens 4 pollers by SDK default i.e. 2 decision + 2 activity). That risk is inherent to the test plan this knob is for and is the reason it exists.

**Release notes**
New dynamic config key `worker.schedulerWorkerRedundancyFactor` (int, per-domain, default 2) controls the number of cadence-worker hosts that concurrently run a scheduler worker for each schedule-enabled domain. Changes are picked up live on the next scheduler worker manager refresh (~60s); no restart needed. Non-positive values fall back to the default.

**Documentation Changes**
N/A