### PR TITLE
fix(failover): drop failover markers on regressed domain failover version

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -3023,6 +3023,7 @@ const (
 	FailoverMarkerNotificationFailure
 	FailoverMarkerUpdateShardFailure
 	FailoverMarkerCallbackCount
+	FailoverMarkerDroppedRegressedDomain
 	HistoryFailoverCallbackCount
 	WorkflowVersionCount
 	WorkflowTypeCount
@@ -4031,6 +4032,7 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 		FailoverMarkerNotificationFailure:                             {metricName: "failover_marker_notification_failures", metricType: Counter},
 		FailoverMarkerUpdateShardFailure:                              {metricName: "failover_marker_update_shard_failures", metricType: Counter},
 		FailoverMarkerCallbackCount:                                   {metricName: "failover_marker_callback_count", metricType: Counter},
+		FailoverMarkerDroppedRegressedDomain:                          {metricName: "failover_marker_dropped_regressed_domain", metricType: Counter},
 		HistoryFailoverCallbackCount:                                  {metricName: "failover_callback_handler_count", metricType: Counter},
 		TransferTasksCount:                                            {metricName: "transfer_tasks_count", metricType: Timer},
 		TransferTasksCountHistogram:                                   {metricName: "transfer_tasks_count_counts", metricType: Histogram, intExponentialBuckets: Mid1To16k},

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1543,6 +1543,20 @@ func (s *contextImpl) AddingPendingFailoverMarker(
 	// the marker is stale and should be dropped to avoid an infinite re-notify loop
 	failoverCompleted := !domainEntry.IsDomainPendingActive() && domainEntry.GetFailoverVersion() >= marker.GetFailoverVersion()
 
+	// markerVersion > domainVersion violates the monotonic-version
+	// invariant. Refuse to insert so we never persist a marker that
+	// could never be dropped by the existing four conditions.
+	if domainEntry.GetFailoverVersion() < marker.GetFailoverVersion() {
+		s.logger.Error("Skipped pending failover marker: marker version is greater than domain version",
+			tag.WorkflowDomainName(domainEntry.GetInfo().Name),
+			tag.WorkflowDomainID(marker.GetDomainID()),
+			tag.Number(domainEntry.GetFailoverVersion()),
+			tag.NextNumber(marker.GetFailoverVersion()),
+		)
+		s.GetMetricsClient().Scope(metrics.FailoverMarkerScope, metrics.DomainTag(domainEntry.GetInfo().Name)).IncCounter(metrics.FailoverMarkerDroppedRegressedDomain)
+		return nil
+	}
+
 	if domainStatus == persistence.DomainStatusDeprecated || isActive || domainEntry.GetFailoverVersion() > marker.GetFailoverVersion() || failoverCompleted {
 		s.logger.Info("Skipped pending failover marker",
 			tag.WorkflowDomainName(domainEntry.GetInfo().Name),
@@ -1606,6 +1620,23 @@ func (s *contextImpl) ValidateAndUpdateFailoverMarkers() ([]*types.FailoverMarke
 		isActive := domainEntry.IsActiveIn(s.GetClusterMetadata().GetCurrentClusterName())
 		domainStatus := domainEntry.GetInfo().Status
 		failoverCompleted := !domainEntry.IsDomainPendingActive() && domainEntry.GetFailoverVersion() >= marker.GetFailoverVersion()
+
+		// markerVersion > domainVersion violates the monotonic-version
+		// invariant: a marker's FailoverVersion is set from the domain's
+		// FailoverVersion at the moment the marker is written. Drop the
+		// marker so it doesn't ship every 5s forever and falsely advertise
+		// an in-flight graceful failover.
+		if domainEntry.GetFailoverVersion() < marker.GetFailoverVersion() {
+			s.logger.Error("Dropped pending failover marker: marker version is greater than domain version",
+				tag.WorkflowDomainName(domainEntry.GetInfo().Name),
+				tag.WorkflowDomainID(marker.GetDomainID()),
+				tag.Number(domainEntry.GetFailoverVersion()),
+				tag.NextNumber(marker.GetFailoverVersion()),
+			)
+			s.GetMetricsClient().Scope(metrics.FailoverMarkerScope, metrics.DomainTag(domainEntry.GetInfo().Name)).IncCounter(metrics.FailoverMarkerDroppedRegressedDomain)
+			completedFailoverMarkers[marker] = struct{}{}
+			continue
+		}
 
 		// Drop failover markers if domain is deprecated
 		// or domain is already active in the currentCluster

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1544,7 +1544,7 @@ func (s *contextImpl) AddingPendingFailoverMarker(
 	failoverCompleted := !domainEntry.IsDomainPendingActive() && domainEntry.GetFailoverVersion() >= marker.GetFailoverVersion()
 
 	// markerVersion > domainVersion violates the monotonic-version
-	// invariant. Always drop; only alarm on the to-be-active cluster
+	// invariant. Always drop; only alert on the to-be-active cluster
 	// (where graceful-failover ordering guarantees the invariant). On
 	// passive replicas a transient regression can be a benign race
 	// between independent domain and marker replication queues.
@@ -1646,7 +1646,7 @@ func (s *contextImpl) ValidateAndUpdateFailoverMarkers() ([]*types.FailoverMarke
 		// invariant: a marker's FailoverVersion is set from the domain's
 		// FailoverVersion at the moment the marker is written. Always
 		// drop so it doesn't ship every 5s forever and falsely advertise
-		// an in-flight graceful failover; only alarm on the to-be-active
+		// an in-flight graceful failover; only alert on the to-be-active
 		// cluster where the ordering invariant must hold.
 		if domainEntry.GetFailoverVersion() < marker.GetFailoverVersion() {
 			s.logMarkerRegressionIfOnActiveCluster(domainEntry, marker, "Dropped pending failover marker: marker version is greater than domain version")

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1544,16 +1544,11 @@ func (s *contextImpl) AddingPendingFailoverMarker(
 	failoverCompleted := !domainEntry.IsDomainPendingActive() && domainEntry.GetFailoverVersion() >= marker.GetFailoverVersion()
 
 	// markerVersion > domainVersion violates the monotonic-version
-	// invariant. Refuse to insert so we never persist a marker that
-	// could never be dropped by the existing four conditions.
+	// invariant. Always drop; only alarm when a fresh persistence read
+	// still shows the regression and we are the to-be-active cluster
+	// (where graceful-failover ordering guarantees the invariant).
 	if domainEntry.GetFailoverVersion() < marker.GetFailoverVersion() {
-		s.logger.Error("Skipped pending failover marker: marker version is greater than domain version",
-			tag.WorkflowDomainName(domainEntry.GetInfo().Name),
-			tag.WorkflowDomainID(marker.GetDomainID()),
-			tag.Number(domainEntry.GetFailoverVersion()),
-			tag.NextNumber(marker.GetFailoverVersion()),
-		)
-		s.GetMetricsClient().Scope(metrics.FailoverMarkerScope, metrics.DomainTag(domainEntry.GetInfo().Name)).IncCounter(metrics.FailoverMarkerDroppedRegressedDomain)
+		s.verifyAndLogMarkerRegression(domainEntry, marker, "Skipped pending failover marker: marker version is greater than domain version")
 		return nil
 	}
 
@@ -1585,6 +1580,46 @@ func failoverMarkerSkipReason(isActive, failoverCompleted bool, domainFailoverVe
 	default:
 		return "unknown"
 	}
+}
+
+// verifyAndLogMarkerRegression re-reads the domain row from persistence to
+// confirm that markerVersion > domainVersion is not just stale cache, then
+// emits an Error log + counter only when the regression is confirmed AND the
+// local cluster is the to-be-active for the domain (where graceful-failover
+// ordering guarantees the monotonic-version invariant must hold). Marker
+// dropping is the caller's responsibility — this helper is alarm-only.
+func (s *contextImpl) verifyAndLogMarkerRegression(
+	domainEntry *cache.DomainCacheEntry,
+	marker *types.FailoverMarkerAttributes,
+	logMessage string,
+) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := s.GetDomainManager().GetDomain(ctx, &persistence.GetDomainRequest{ID: marker.GetDomainID()})
+	if err != nil {
+		// Couldn't verify; suppress the alarm rather than fire on a
+		// transient persistence error. The marker is dropped anyway.
+		return
+	}
+	if resp.FailoverVersion >= marker.GetFailoverVersion() {
+		// Cache was stale; persistence is at-or-past the marker version,
+		// so there is no real regression to alarm about.
+		return
+	}
+	if resp.ReplicationConfig == nil ||
+		resp.ReplicationConfig.ActiveClusterName != s.GetClusterMetadata().GetCurrentClusterName() {
+		// Ordering is only guaranteed on the to-be-active cluster. On
+		// other replicas a brief regression can be a benign race between
+		// independent domain and marker replication queues.
+		return
+	}
+	s.logger.Error(logMessage,
+		tag.WorkflowDomainName(domainEntry.GetInfo().Name),
+		tag.WorkflowDomainID(marker.GetDomainID()),
+		tag.Number(resp.FailoverVersion),
+		tag.NextNumber(marker.GetFailoverVersion()),
+	)
+	s.GetMetricsClient().Scope(metrics.FailoverMarkerScope, metrics.DomainTag(domainEntry.GetInfo().Name)).IncCounter(metrics.FailoverMarkerDroppedRegressedDomain)
 }
 
 func (s *contextImpl) ValidateAndUpdateFailoverMarkers() ([]*types.FailoverMarkerAttributes, error) {
@@ -1623,17 +1658,12 @@ func (s *contextImpl) ValidateAndUpdateFailoverMarkers() ([]*types.FailoverMarke
 
 		// markerVersion > domainVersion violates the monotonic-version
 		// invariant: a marker's FailoverVersion is set from the domain's
-		// FailoverVersion at the moment the marker is written. Drop the
-		// marker so it doesn't ship every 5s forever and falsely advertise
-		// an in-flight graceful failover.
+		// FailoverVersion at the moment the marker is written. Always
+		// drop so it doesn't ship every 5s forever and falsely advertise
+		// an in-flight graceful failover; only alarm when a fresh
+		// persistence read confirms the regression on the active cluster.
 		if domainEntry.GetFailoverVersion() < marker.GetFailoverVersion() {
-			s.logger.Error("Dropped pending failover marker: marker version is greater than domain version",
-				tag.WorkflowDomainName(domainEntry.GetInfo().Name),
-				tag.WorkflowDomainID(marker.GetDomainID()),
-				tag.Number(domainEntry.GetFailoverVersion()),
-				tag.NextNumber(marker.GetFailoverVersion()),
-			)
-			s.GetMetricsClient().Scope(metrics.FailoverMarkerScope, metrics.DomainTag(domainEntry.GetInfo().Name)).IncCounter(metrics.FailoverMarkerDroppedRegressedDomain)
+			s.verifyAndLogMarkerRegression(domainEntry, marker, "Dropped pending failover marker: marker version is greater than domain version")
 			completedFailoverMarkers[marker] = struct{}{}
 			continue
 		}

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1544,11 +1544,12 @@ func (s *contextImpl) AddingPendingFailoverMarker(
 	failoverCompleted := !domainEntry.IsDomainPendingActive() && domainEntry.GetFailoverVersion() >= marker.GetFailoverVersion()
 
 	// markerVersion > domainVersion violates the monotonic-version
-	// invariant. Always drop; only alarm when a fresh persistence read
-	// still shows the regression and we are the to-be-active cluster
-	// (where graceful-failover ordering guarantees the invariant).
+	// invariant. Always drop; only alarm on the to-be-active cluster
+	// (where graceful-failover ordering guarantees the invariant). On
+	// passive replicas a transient regression can be a benign race
+	// between independent domain and marker replication queues.
 	if domainEntry.GetFailoverVersion() < marker.GetFailoverVersion() {
-		s.verifyAndLogMarkerRegression(domainEntry, marker, "Skipped pending failover marker: marker version is greater than domain version")
+		s.logMarkerRegressionIfOnActiveCluster(domainEntry, marker, "Skipped pending failover marker: marker version is greater than domain version")
 		return nil
 	}
 
@@ -1582,41 +1583,26 @@ func failoverMarkerSkipReason(isActive, failoverCompleted bool, domainFailoverVe
 	}
 }
 
-// verifyAndLogMarkerRegression re-reads the domain row from persistence to
-// confirm that markerVersion > domainVersion is not just stale cache, then
-// emits an Error log + counter only when the regression is confirmed AND the
-// local cluster is the to-be-active for the domain (where graceful-failover
-// ordering guarantees the monotonic-version invariant must hold). Marker
-// dropping is the caller's responsibility — this helper is alarm-only.
-func (s *contextImpl) verifyAndLogMarkerRegression(
+// logMarkerRegressionIfOnActiveCluster emits an Error log + counter only when
+// the local cluster is the active for the domain — i.e. the cluster where
+// graceful-failover ordering guarantees the monotonic-version invariant must
+// hold. On passive replicas a transient regression can be a benign race
+// between the independent domain and marker replication queues, so we drop
+// the marker silently there. This is in-memory only by design: the caller
+// may be holding the shard RLock, and we must not perform I/O under it.
+func (s *contextImpl) logMarkerRegressionIfOnActiveCluster(
 	domainEntry *cache.DomainCacheEntry,
 	marker *types.FailoverMarkerAttributes,
 	logMessage string,
 ) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	resp, err := s.GetDomainManager().GetDomain(ctx, &persistence.GetDomainRequest{ID: marker.GetDomainID()})
-	if err != nil {
-		// Couldn't verify; suppress the alarm rather than fire on a
-		// transient persistence error. The marker is dropped anyway.
-		return
-	}
-	if resp.FailoverVersion >= marker.GetFailoverVersion() {
-		// Cache was stale; persistence is at-or-past the marker version,
-		// so there is no real regression to alarm about.
-		return
-	}
-	if resp.ReplicationConfig == nil ||
-		resp.ReplicationConfig.ActiveClusterName != s.GetClusterMetadata().GetCurrentClusterName() {
-		// Ordering is only guaranteed on the to-be-active cluster. On
-		// other replicas a brief regression can be a benign race between
-		// independent domain and marker replication queues.
+	repl := domainEntry.GetReplicationConfig()
+	if repl == nil || repl.ActiveClusterName != s.GetClusterMetadata().GetCurrentClusterName() {
 		return
 	}
 	s.logger.Error(logMessage,
 		tag.WorkflowDomainName(domainEntry.GetInfo().Name),
 		tag.WorkflowDomainID(marker.GetDomainID()),
-		tag.Number(resp.FailoverVersion),
+		tag.Number(domainEntry.GetFailoverVersion()),
 		tag.NextNumber(marker.GetFailoverVersion()),
 	)
 	s.GetMetricsClient().Scope(metrics.FailoverMarkerScope, metrics.DomainTag(domainEntry.GetInfo().Name)).IncCounter(metrics.FailoverMarkerDroppedRegressedDomain)
@@ -1660,10 +1646,10 @@ func (s *contextImpl) ValidateAndUpdateFailoverMarkers() ([]*types.FailoverMarke
 		// invariant: a marker's FailoverVersion is set from the domain's
 		// FailoverVersion at the moment the marker is written. Always
 		// drop so it doesn't ship every 5s forever and falsely advertise
-		// an in-flight graceful failover; only alarm when a fresh
-		// persistence read confirms the regression on the active cluster.
+		// an in-flight graceful failover; only alarm on the to-be-active
+		// cluster where the ordering invariant must hold.
 		if domainEntry.GetFailoverVersion() < marker.GetFailoverVersion() {
-			s.verifyAndLogMarkerRegression(domainEntry, marker, "Dropped pending failover marker: marker version is greater than domain version")
+			s.logMarkerRegressionIfOnActiveCluster(domainEntry, marker, "Dropped pending failover marker: marker version is greater than domain version")
 			completedFailoverMarkers[marker] = struct{}{}
 			continue
 		}

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -1339,34 +1339,25 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DomainNoLongerEx
 
 func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DomainVersionRegressed() {
 	// Marker carries a higher FailoverVersion than the domain currently reports.
-	// In all three subcases the marker must be dropped; only the active-cluster
-	// case with a confirmed regression should bump the alarm counter.
+	// The marker is always dropped; only the active-cluster case bumps the
+	// alarm counter (passive replicas have no ordering guarantee).
 	const domainFailoverVersion int64 = 5
 	const markerFailoverVersion int64 = 100
 
 	cases := []struct {
-		name                     string
-		domainActiveCluster      string
-		freshPersistenceVersion  int64
-		expectAlarmCounter       bool
+		name                string
+		domainActiveCluster string
+		expectAlarmCounter  bool
 	}{
 		{
-			name:                    "ConfirmedRegressionOnActiveCluster",
-			domainActiveCluster:     cluster.TestCurrentClusterName,
-			freshPersistenceVersion: domainFailoverVersion,
-			expectAlarmCounter:      true,
+			name:                "OnActiveCluster",
+			domainActiveCluster: cluster.TestCurrentClusterName,
+			expectAlarmCounter:  true,
 		},
 		{
-			name:                    "RegressionOnPassiveCluster",
-			domainActiveCluster:     cluster.TestAlternativeClusterName,
-			freshPersistenceVersion: domainFailoverVersion,
-			expectAlarmCounter:      false,
-		},
-		{
-			name:                    "ResolvedByFreshPersistenceRead",
-			domainActiveCluster:     cluster.TestCurrentClusterName,
-			freshPersistenceVersion: markerFailoverVersion,
-			expectAlarmCounter:      false,
+			name:                "OnPassiveCluster",
+			domainActiveCluster: cluster.TestAlternativeClusterName,
+			expectAlarmCounter:  false,
 		},
 	}
 
@@ -1399,14 +1390,6 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DomainVersionReg
 			s.Require().Len(s.context.shardInfo.PendingFailoverMarkers, 1)
 
 			s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainEntry, nil)
-			s.mockResource.MetadataMgr.On("GetDomain", mock.Anything, &persistence.GetDomainRequest{ID: testDomainID}).Return(&persistence.GetDomainResponse{
-				Info:   &persistence.DomainInfo{ID: testDomainID, Name: testDomainID},
-				Config: &persistence.DomainConfig{},
-				ReplicationConfig: &persistence.DomainReplicationConfig{
-					ActiveClusterName: tc.domainActiveCluster,
-				},
-				FailoverVersion: tc.freshPersistenceVersion,
-			}, nil).Once()
 			s.mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(nil)
 
 			before := alarmCounterValue(s.mockResource.MetricsScope)
@@ -1418,9 +1401,9 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DomainVersionReg
 
 			after := alarmCounterValue(s.mockResource.MetricsScope)
 			if tc.expectAlarmCounter {
-				s.Equal(int64(1), after-before, "alarm counter should fire once for confirmed regression on active cluster")
+				s.Equal(int64(1), after-before, "alarm counter should fire once on active cluster")
 			} else {
-				s.Equal(int64(0), after-before, "alarm counter should be suppressed")
+				s.Equal(int64(0), after-before, "alarm counter should be suppressed on passive cluster")
 			}
 		})
 	}
@@ -1430,34 +1413,25 @@ func (s *contextTestSuite) TestAddingPendingFailoverMarker_DomainVersionRegresse
 	// AddingPendingFailoverMarker must refuse to persist a marker whose
 	// FailoverVersion is greater than the domain's current FailoverVersion —
 	// otherwise we'd seed the same forever-stuck marker we're trying to
-	// defend against on the validation side. Same three subcases: only the
-	// confirmed-active path should bump the alarm counter.
+	// defend against on the validation side. Same gating: alarm fires only
+	// on the to-be-active cluster.
 	const domainFailoverVersion int64 = 5
 	const markerFailoverVersion int64 = 100
 
 	cases := []struct {
-		name                     string
-		domainActiveCluster      string
-		freshPersistenceVersion  int64
-		expectAlarmCounter       bool
+		name                string
+		domainActiveCluster string
+		expectAlarmCounter  bool
 	}{
 		{
-			name:                    "ConfirmedRegressionOnActiveCluster",
-			domainActiveCluster:     cluster.TestCurrentClusterName,
-			freshPersistenceVersion: domainFailoverVersion,
-			expectAlarmCounter:      true,
+			name:                "OnActiveCluster",
+			domainActiveCluster: cluster.TestCurrentClusterName,
+			expectAlarmCounter:  true,
 		},
 		{
-			name:                    "RegressionOnPassiveCluster",
-			domainActiveCluster:     cluster.TestAlternativeClusterName,
-			freshPersistenceVersion: domainFailoverVersion,
-			expectAlarmCounter:      false,
-		},
-		{
-			name:                    "ResolvedByFreshPersistenceRead",
-			domainActiveCluster:     cluster.TestCurrentClusterName,
-			freshPersistenceVersion: markerFailoverVersion,
-			expectAlarmCounter:      false,
+			name:                "OnPassiveCluster",
+			domainActiveCluster: cluster.TestAlternativeClusterName,
+			expectAlarmCounter:  false,
 		},
 	}
 
@@ -1482,14 +1456,6 @@ func (s *contextTestSuite) TestAddingPendingFailoverMarker_DomainVersionRegresse
 			)
 
 			s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainEntry, nil)
-			s.mockResource.MetadataMgr.On("GetDomain", mock.Anything, &persistence.GetDomainRequest{ID: testDomainID}).Return(&persistence.GetDomainResponse{
-				Info:   &persistence.DomainInfo{ID: testDomainID, Name: testDomainID},
-				Config: &persistence.DomainConfig{},
-				ReplicationConfig: &persistence.DomainReplicationConfig{
-					ActiveClusterName: tc.domainActiveCluster,
-				},
-				FailoverVersion: tc.freshPersistenceVersion,
-			}, nil).Once()
 
 			regressedMarker := &types.FailoverMarkerAttributes{
 				DomainID:        testDomainID,
@@ -1504,9 +1470,9 @@ func (s *contextTestSuite) TestAddingPendingFailoverMarker_DomainVersionRegresse
 
 			after := alarmCounterValue(s.mockResource.MetricsScope)
 			if tc.expectAlarmCounter {
-				s.Equal(int64(1), after-before, "alarm counter should fire once for confirmed regression on active cluster")
+				s.Equal(int64(1), after-before, "alarm counter should fire once on active cluster")
 			} else {
-				s.Equal(int64(0), after-before, "alarm counter should be suppressed")
+				s.Equal(int64(0), after-before, "alarm counter should be suppressed on passive cluster")
 			}
 		})
 	}

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -1339,78 +1339,191 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DomainNoLongerEx
 
 func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DomainVersionRegressed() {
 	// Marker carries a higher FailoverVersion than the domain currently reports.
-	// The monotonic-version invariant is violated, so the marker must be dropped
-	// rather than re-shipped every 5s forever.
+	// In all three subcases the marker must be dropped; only the active-cluster
+	// case with a confirmed regression should bump the alarm counter.
 	const domainFailoverVersion int64 = 5
 	const markerFailoverVersion int64 = 100
 
-	domainEntry := cache.NewDomainCacheEntryForTest(
-		&persistence.DomainInfo{ID: testDomainID, Name: testDomainID},
-		&persistence.DomainConfig{Retention: 7},
-		true,
-		&persistence.DomainReplicationConfig{
-			ActiveClusterName: cluster.TestAlternativeClusterName,
-			Clusters: []*persistence.ClusterReplicationConfig{
-				{ClusterName: cluster.TestCurrentClusterName},
-				{ClusterName: cluster.TestAlternativeClusterName},
-			},
+	cases := []struct {
+		name                     string
+		domainActiveCluster      string
+		freshPersistenceVersion  int64
+		expectAlarmCounter       bool
+	}{
+		{
+			name:                    "ConfirmedRegressionOnActiveCluster",
+			domainActiveCluster:     cluster.TestCurrentClusterName,
+			freshPersistenceVersion: domainFailoverVersion,
+			expectAlarmCounter:      true,
 		},
-		domainFailoverVersion,
-		nil,
-		0, 0, 0,
-	)
-
-	regressedMarker := &types.FailoverMarkerAttributes{
-		DomainID:        testDomainID,
-		FailoverVersion: markerFailoverVersion,
+		{
+			name:                    "RegressionOnPassiveCluster",
+			domainActiveCluster:     cluster.TestAlternativeClusterName,
+			freshPersistenceVersion: domainFailoverVersion,
+			expectAlarmCounter:      false,
+		},
+		{
+			name:                    "ResolvedByFreshPersistenceRead",
+			domainActiveCluster:     cluster.TestCurrentClusterName,
+			freshPersistenceVersion: markerFailoverVersion,
+			expectAlarmCounter:      false,
+		},
 	}
-	// inject directly to bypass AddingPendingFailoverMarker's own guard
-	s.context.shardInfo.PendingFailoverMarkers = append(s.context.shardInfo.PendingFailoverMarkers, regressedMarker)
-	s.Require().Len(s.context.shardInfo.PendingFailoverMarkers, 1)
 
-	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainEntry, nil)
-	s.mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(nil)
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			// fresh context per subcase so PendingFailoverMarkers and metric snapshots are isolated
+			s.context = s.newContext()
 
-	pendingFailoverMarkers, err := s.context.ValidateAndUpdateFailoverMarkers()
-	s.NoError(err)
-	s.Empty(pendingFailoverMarkers, "regressed-version marker should be dropped")
-	s.Empty(s.context.shardInfo.PendingFailoverMarkers, "shard info should be cleared")
+			domainEntry := cache.NewDomainCacheEntryForTest(
+				&persistence.DomainInfo{ID: testDomainID, Name: testDomainID},
+				&persistence.DomainConfig{Retention: 7},
+				true,
+				&persistence.DomainReplicationConfig{
+					ActiveClusterName: tc.domainActiveCluster,
+					Clusters: []*persistence.ClusterReplicationConfig{
+						{ClusterName: cluster.TestCurrentClusterName},
+						{ClusterName: cluster.TestAlternativeClusterName},
+					},
+				},
+				domainFailoverVersion,
+				nil,
+				0, 0, 0,
+			)
+
+			regressedMarker := &types.FailoverMarkerAttributes{
+				DomainID:        testDomainID,
+				FailoverVersion: markerFailoverVersion,
+			}
+			s.context.shardInfo.PendingFailoverMarkers = append(s.context.shardInfo.PendingFailoverMarkers, regressedMarker)
+			s.Require().Len(s.context.shardInfo.PendingFailoverMarkers, 1)
+
+			s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainEntry, nil)
+			s.mockResource.MetadataMgr.On("GetDomain", mock.Anything, &persistence.GetDomainRequest{ID: testDomainID}).Return(&persistence.GetDomainResponse{
+				Info:   &persistence.DomainInfo{ID: testDomainID, Name: testDomainID},
+				Config: &persistence.DomainConfig{},
+				ReplicationConfig: &persistence.DomainReplicationConfig{
+					ActiveClusterName: tc.domainActiveCluster,
+				},
+				FailoverVersion: tc.freshPersistenceVersion,
+			}, nil).Once()
+			s.mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(nil)
+
+			before := alarmCounterValue(s.mockResource.MetricsScope)
+
+			pendingFailoverMarkers, err := s.context.ValidateAndUpdateFailoverMarkers()
+			s.NoError(err)
+			s.Empty(pendingFailoverMarkers, "regressed-version marker should be dropped")
+			s.Empty(s.context.shardInfo.PendingFailoverMarkers, "shard info should be cleared")
+
+			after := alarmCounterValue(s.mockResource.MetricsScope)
+			if tc.expectAlarmCounter {
+				s.Equal(int64(1), after-before, "alarm counter should fire once for confirmed regression on active cluster")
+			} else {
+				s.Equal(int64(0), after-before, "alarm counter should be suppressed")
+			}
+		})
+	}
 }
 
 func (s *contextTestSuite) TestAddingPendingFailoverMarker_DomainVersionRegressed() {
 	// AddingPendingFailoverMarker must refuse to persist a marker whose
 	// FailoverVersion is greater than the domain's current FailoverVersion —
 	// otherwise we'd seed the same forever-stuck marker we're trying to
-	// defend against on the validation side.
+	// defend against on the validation side. Same three subcases: only the
+	// confirmed-active path should bump the alarm counter.
 	const domainFailoverVersion int64 = 5
 	const markerFailoverVersion int64 = 100
 
-	domainEntry := cache.NewDomainCacheEntryForTest(
-		&persistence.DomainInfo{ID: testDomainID, Name: testDomainID},
-		&persistence.DomainConfig{Retention: 7},
-		true,
-		&persistence.DomainReplicationConfig{
-			ActiveClusterName: cluster.TestAlternativeClusterName,
-			Clusters: []*persistence.ClusterReplicationConfig{
-				{ClusterName: cluster.TestCurrentClusterName},
-				{ClusterName: cluster.TestAlternativeClusterName},
-			},
+	cases := []struct {
+		name                     string
+		domainActiveCluster      string
+		freshPersistenceVersion  int64
+		expectAlarmCounter       bool
+	}{
+		{
+			name:                    "ConfirmedRegressionOnActiveCluster",
+			domainActiveCluster:     cluster.TestCurrentClusterName,
+			freshPersistenceVersion: domainFailoverVersion,
+			expectAlarmCounter:      true,
 		},
-		domainFailoverVersion,
-		nil,
-		0, 0, 0,
-	)
-
-	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainEntry, nil)
-
-	regressedMarker := &types.FailoverMarkerAttributes{
-		DomainID:        testDomainID,
-		FailoverVersion: markerFailoverVersion,
+		{
+			name:                    "RegressionOnPassiveCluster",
+			domainActiveCluster:     cluster.TestAlternativeClusterName,
+			freshPersistenceVersion: domainFailoverVersion,
+			expectAlarmCounter:      false,
+		},
+		{
+			name:                    "ResolvedByFreshPersistenceRead",
+			domainActiveCluster:     cluster.TestCurrentClusterName,
+			freshPersistenceVersion: markerFailoverVersion,
+			expectAlarmCounter:      false,
+		},
 	}
 
-	s.NoError(s.context.AddingPendingFailoverMarker(regressedMarker))
-	s.Empty(s.context.shardInfo.PendingFailoverMarkers, "regressed-version marker must not be persisted")
-	s.mockShardManager.AssertNotCalled(s.T(), "UpdateShard", mock.Anything, mock.Anything)
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			s.context = s.newContext()
+
+			domainEntry := cache.NewDomainCacheEntryForTest(
+				&persistence.DomainInfo{ID: testDomainID, Name: testDomainID},
+				&persistence.DomainConfig{Retention: 7},
+				true,
+				&persistence.DomainReplicationConfig{
+					ActiveClusterName: tc.domainActiveCluster,
+					Clusters: []*persistence.ClusterReplicationConfig{
+						{ClusterName: cluster.TestCurrentClusterName},
+						{ClusterName: cluster.TestAlternativeClusterName},
+					},
+				},
+				domainFailoverVersion,
+				nil,
+				0, 0, 0,
+			)
+
+			s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainEntry, nil)
+			s.mockResource.MetadataMgr.On("GetDomain", mock.Anything, &persistence.GetDomainRequest{ID: testDomainID}).Return(&persistence.GetDomainResponse{
+				Info:   &persistence.DomainInfo{ID: testDomainID, Name: testDomainID},
+				Config: &persistence.DomainConfig{},
+				ReplicationConfig: &persistence.DomainReplicationConfig{
+					ActiveClusterName: tc.domainActiveCluster,
+				},
+				FailoverVersion: tc.freshPersistenceVersion,
+			}, nil).Once()
+
+			regressedMarker := &types.FailoverMarkerAttributes{
+				DomainID:        testDomainID,
+				FailoverVersion: markerFailoverVersion,
+			}
+
+			before := alarmCounterValue(s.mockResource.MetricsScope)
+
+			s.NoError(s.context.AddingPendingFailoverMarker(regressedMarker))
+			s.Empty(s.context.shardInfo.PendingFailoverMarkers, "regressed-version marker must not be persisted")
+			s.mockShardManager.AssertNotCalled(s.T(), "UpdateShard", mock.Anything, mock.Anything)
+
+			after := alarmCounterValue(s.mockResource.MetricsScope)
+			if tc.expectAlarmCounter {
+				s.Equal(int64(1), after-before, "alarm counter should fire once for confirmed regression on active cluster")
+			} else {
+				s.Equal(int64(0), after-before, "alarm counter should be suppressed")
+			}
+		})
+	}
+}
+
+// alarmCounterValue returns the current sum of the
+// failover_marker_dropped_regressed_domain counter across all tag combinations
+// recorded on the tally scope. The metric is tagged with domain name, so the
+// snapshot key includes that tag; summing avoids hard-coding the key.
+func alarmCounterValue(scope tally.TestScope) int64 {
+	var total int64
+	for _, c := range scope.Snapshot().Counters() {
+		if c.Name() == "test.failover_marker_dropped_regressed_domain" {
+			total += c.Value()
+		}
+	}
+	return total
 }
 
 func (s *contextTestSuite) TestGetAndUpdateProcessingQueueStates() {

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -1340,24 +1340,24 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DomainNoLongerEx
 func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DomainVersionRegressed() {
 	// Marker carries a higher FailoverVersion than the domain currently reports.
 	// The marker is always dropped; only the active-cluster case bumps the
-	// alarm counter (passive replicas have no ordering guarantee).
+	// alert counter (passive replicas have no ordering guarantee).
 	const domainFailoverVersion int64 = 5
 	const markerFailoverVersion int64 = 100
 
 	cases := []struct {
 		name                string
 		domainActiveCluster string
-		expectAlarmCounter  bool
+		expectAlertCounter  bool
 	}{
 		{
-			name:                "OnActiveCluster",
+			name:                "active cluster emits alert and drops marker",
 			domainActiveCluster: cluster.TestCurrentClusterName,
-			expectAlarmCounter:  true,
+			expectAlertCounter:  true,
 		},
 		{
-			name:                "OnPassiveCluster",
+			name:                "passive cluster drops marker silently",
 			domainActiveCluster: cluster.TestAlternativeClusterName,
-			expectAlarmCounter:  false,
+			expectAlertCounter:  false,
 		},
 	}
 
@@ -1392,18 +1392,18 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DomainVersionReg
 			s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainEntry, nil)
 			s.mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(nil)
 
-			before := alarmCounterValue(s.mockResource.MetricsScope)
+			before := alertCounterValue(s.mockResource.MetricsScope)
 
 			pendingFailoverMarkers, err := s.context.ValidateAndUpdateFailoverMarkers()
 			s.NoError(err)
 			s.Empty(pendingFailoverMarkers, "regressed-version marker should be dropped")
 			s.Empty(s.context.shardInfo.PendingFailoverMarkers, "shard info should be cleared")
 
-			after := alarmCounterValue(s.mockResource.MetricsScope)
-			if tc.expectAlarmCounter {
-				s.Equal(int64(1), after-before, "alarm counter should fire once on active cluster")
+			after := alertCounterValue(s.mockResource.MetricsScope)
+			if tc.expectAlertCounter {
+				s.Equal(int64(1), after-before, "alert counter should fire once on active cluster")
 			} else {
-				s.Equal(int64(0), after-before, "alarm counter should be suppressed on passive cluster")
+				s.Equal(int64(0), after-before, "alert counter should be suppressed on passive cluster")
 			}
 		})
 	}
@@ -1413,7 +1413,7 @@ func (s *contextTestSuite) TestAddingPendingFailoverMarker_DomainVersionRegresse
 	// AddingPendingFailoverMarker must refuse to persist a marker whose
 	// FailoverVersion is greater than the domain's current FailoverVersion —
 	// otherwise we'd seed the same forever-stuck marker we're trying to
-	// defend against on the validation side. Same gating: alarm fires only
+	// defend against on the validation side. Same gating: alert fires only
 	// on the to-be-active cluster.
 	const domainFailoverVersion int64 = 5
 	const markerFailoverVersion int64 = 100
@@ -1421,17 +1421,17 @@ func (s *contextTestSuite) TestAddingPendingFailoverMarker_DomainVersionRegresse
 	cases := []struct {
 		name                string
 		domainActiveCluster string
-		expectAlarmCounter  bool
+		expectAlertCounter  bool
 	}{
 		{
-			name:                "OnActiveCluster",
+			name:                "active cluster emits alert and drops marker",
 			domainActiveCluster: cluster.TestCurrentClusterName,
-			expectAlarmCounter:  true,
+			expectAlertCounter:  true,
 		},
 		{
-			name:                "OnPassiveCluster",
+			name:                "passive cluster drops marker silently",
 			domainActiveCluster: cluster.TestAlternativeClusterName,
-			expectAlarmCounter:  false,
+			expectAlertCounter:  false,
 		},
 	}
 
@@ -1462,27 +1462,27 @@ func (s *contextTestSuite) TestAddingPendingFailoverMarker_DomainVersionRegresse
 				FailoverVersion: markerFailoverVersion,
 			}
 
-			before := alarmCounterValue(s.mockResource.MetricsScope)
+			before := alertCounterValue(s.mockResource.MetricsScope)
 
 			s.NoError(s.context.AddingPendingFailoverMarker(regressedMarker))
 			s.Empty(s.context.shardInfo.PendingFailoverMarkers, "regressed-version marker must not be persisted")
 			s.mockShardManager.AssertNotCalled(s.T(), "UpdateShard", mock.Anything, mock.Anything)
 
-			after := alarmCounterValue(s.mockResource.MetricsScope)
-			if tc.expectAlarmCounter {
-				s.Equal(int64(1), after-before, "alarm counter should fire once on active cluster")
+			after := alertCounterValue(s.mockResource.MetricsScope)
+			if tc.expectAlertCounter {
+				s.Equal(int64(1), after-before, "alert counter should fire once on active cluster")
 			} else {
-				s.Equal(int64(0), after-before, "alarm counter should be suppressed on passive cluster")
+				s.Equal(int64(0), after-before, "alert counter should be suppressed on passive cluster")
 			}
 		})
 	}
 }
 
-// alarmCounterValue returns the current sum of the
+// alertCounterValue returns the current sum of the
 // failover_marker_dropped_regressed_domain counter across all tag combinations
 // recorded on the tally scope. The metric is tagged with domain name, so the
 // snapshot key includes that tag; summing avoids hard-coding the key.
-func alarmCounterValue(scope tally.TestScope) int64 {
+func alertCounterValue(scope tally.TestScope) int64 {
 	var total int64
 	for _, c := range scope.Snapshot().Counters() {
 		if c.Name() == "test.failover_marker_dropped_regressed_domain" {

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -1141,7 +1141,7 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers() {
 
 	failoverMarker := types.FailoverMarkerAttributes{
 		DomainID:        testDomainID,
-		FailoverVersion: 101,
+		FailoverVersion: int64(domainFailoverVersion),
 	}
 
 	s.mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(nil)
@@ -1335,6 +1335,82 @@ func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DomainNoLongerEx
 	s.NoError(err, "orphan-domain marker must not poison the cleanup loop")
 	s.Empty(pendingFailoverMarkers, "both the orphan and the otherwise-droppable marker should be cleaned")
 	s.Empty(s.context.shardInfo.PendingFailoverMarkers, "shard info should be cleared of both markers")
+}
+
+func (s *contextTestSuite) TestValidateAndUpdateFailoverMarkers_DomainVersionRegressed() {
+	// Marker carries a higher FailoverVersion than the domain currently reports.
+	// The monotonic-version invariant is violated, so the marker must be dropped
+	// rather than re-shipped every 5s forever.
+	const domainFailoverVersion int64 = 5
+	const markerFailoverVersion int64 = 100
+
+	domainEntry := cache.NewDomainCacheEntryForTest(
+		&persistence.DomainInfo{ID: testDomainID, Name: testDomainID},
+		&persistence.DomainConfig{Retention: 7},
+		true,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestAlternativeClusterName,
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+				{ClusterName: cluster.TestAlternativeClusterName},
+			},
+		},
+		domainFailoverVersion,
+		nil,
+		0, 0, 0,
+	)
+
+	regressedMarker := &types.FailoverMarkerAttributes{
+		DomainID:        testDomainID,
+		FailoverVersion: markerFailoverVersion,
+	}
+	// inject directly to bypass AddingPendingFailoverMarker's own guard
+	s.context.shardInfo.PendingFailoverMarkers = append(s.context.shardInfo.PendingFailoverMarkers, regressedMarker)
+	s.Require().Len(s.context.shardInfo.PendingFailoverMarkers, 1)
+
+	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainEntry, nil)
+	s.mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(nil)
+
+	pendingFailoverMarkers, err := s.context.ValidateAndUpdateFailoverMarkers()
+	s.NoError(err)
+	s.Empty(pendingFailoverMarkers, "regressed-version marker should be dropped")
+	s.Empty(s.context.shardInfo.PendingFailoverMarkers, "shard info should be cleared")
+}
+
+func (s *contextTestSuite) TestAddingPendingFailoverMarker_DomainVersionRegressed() {
+	// AddingPendingFailoverMarker must refuse to persist a marker whose
+	// FailoverVersion is greater than the domain's current FailoverVersion —
+	// otherwise we'd seed the same forever-stuck marker we're trying to
+	// defend against on the validation side.
+	const domainFailoverVersion int64 = 5
+	const markerFailoverVersion int64 = 100
+
+	domainEntry := cache.NewDomainCacheEntryForTest(
+		&persistence.DomainInfo{ID: testDomainID, Name: testDomainID},
+		&persistence.DomainConfig{Retention: 7},
+		true,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestAlternativeClusterName,
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+				{ClusterName: cluster.TestAlternativeClusterName},
+			},
+		},
+		domainFailoverVersion,
+		nil,
+		0, 0, 0,
+	)
+
+	s.mockResource.DomainCache.EXPECT().GetDomainByID(testDomainID).Return(domainEntry, nil)
+
+	regressedMarker := &types.FailoverMarkerAttributes{
+		DomainID:        testDomainID,
+		FailoverVersion: markerFailoverVersion,
+	}
+
+	s.NoError(s.context.AddingPendingFailoverMarker(regressedMarker))
+	s.Empty(s.context.shardInfo.PendingFailoverMarkers, "regressed-version marker must not be persisted")
+	s.mockShardManager.AssertNotCalled(s.T(), "UpdateShard", mock.Anything, mock.Anything)
 }
 
 func (s *contextTestSuite) TestGetAndUpdateProcessingQueueStates() {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Add check to drop failover markers if for some reason the domain failover version is lower than the failover marker version

https://github.com/cadence-workflow/cadence/issues/8138

**Why?**
We found some cases of corrupt domain failover version that caused the markers to never be dropped. The regressed failover version is not intended and probably a bigger problem than the markers, but this change helps cleanup the metrics. Also added error log and metrics to improve visibility on the problem

**How did you test it?**
Added test to verify that the markers are removed when a regressed failover version happens

go test -race -count=1 ./service/history/shard/... ./service/history/failover/... ./common/domain/... ./common/metrics/...

**Potential risks**
No clear risk. It's a way to cleanup markers after a bigger issue happened on the domain entry.

**Release notes**
N/A

**Documentation Changes**
N/A
