### PR TITLE
fix(metrics): normalize cadence_authorization_latency labels for Prometheus

### DIFF
--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -130,6 +130,11 @@ func DomainTag(value string) Tag {
 	return metricWithUnknown(domain, value)
 }
 
+// NonDomainTag is used for metrics that need a stable domain label but are not scoped to a real domain.
+func NonDomainTag() Tag {
+	return DomainTag("-1")
+}
+
 // DomainTypeTag returns a tag for domain type.
 // This allows differentiating between global/local domains.
 func DomainTypeTag(isGlobal bool) Tag {

--- a/service/frontend/templates/accesscontrolled.tmpl
+++ b/service/frontend/templates/accesscontrolled.tmpl
@@ -96,7 +96,7 @@ func (a *{{$decorator}}) {{$method.Declaration}} {
 	{{- if or (eq $interfaceType "admin.Handler") (hasKey $permissionMap $method.Name) }}
 	{{- if and (eq $interfaceType "api.Handler") (ge (len $method.Params) 2)}}
 	{{- if has $method.Name $nonDomainAuthAPIs}}
-	scope := a.GetMetricsClient().Scope(metrics.Frontend{{$method.Name}}Scope)
+	scope := a.GetMetricsClient().Scope(metrics.Frontend{{$method.Name}}Scope).Tagged(metrics.NonDomainTag())
 	{{- else}}
 	scope := a.getMetricsScopeWithDomain(metrics.Frontend{{$method.Name}}Scope, {{(index $method.Params 1).Name}}.GetDomain())
 	{{- end}}

--- a/service/frontend/wrappers/accesscontrolled/access_controlled_test.go
+++ b/service/frontend/wrappers/accesscontrolled/access_controlled_test.go
@@ -26,17 +26,72 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
+	p8s "github.com/m3db/prometheus_client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	tallyp8s "github.com/uber-go/tally/prometheus"
 	"go.uber.org/mock/gomock"
 
 	"github.com/uber/cadence/common/authorization"
+	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/metrics/mocks"
+	"github.com/uber/cadence/common/resource"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/frontend/admin"
+	"github.com/uber/cadence/service/frontend/api"
 )
+
+func TestAuthorizationMetricsLabelConsistency(t *testing.T) {
+	var registrationErrors []error
+	promCfg := &tallyp8s.Configuration{
+		OnError:   "none",
+		TimerType: "histogram",
+	}
+	reporter, err := promCfg.NewReporter(tallyp8s.ConfigurationOptions{
+		Registry: p8s.NewRegistry(),
+		OnError: func(err error) {
+			registrationErrors = append(registrationErrors, err)
+		},
+	})
+	require.NoError(t, err)
+
+	rootScope, closer := tally.NewRootScope(tally.ScopeOptions{
+		Tags: map[string]string{
+			metrics.CadenceServiceTagName: "frontend",
+		},
+		CachedReporter: reporter,
+		Separator:      tallyp8s.DefaultSeparator,
+	}, time.Second)
+	defer closer.Close()
+
+	frontendMetrics := metrics.NewClient(rootScope, metrics.Frontend, metrics.MigrationConfig{})
+
+	ctrl := gomock.NewController(t)
+	mockResource := resource.NewMockResource(ctrl)
+	mockResource.EXPECT().GetMetricsClient().Return(frontendMetrics).AnyTimes()
+
+	mockAuthorizer := authorization.NewMockAuthorizer(ctrl)
+	mockAuthorizer.EXPECT().Authorize(gomock.Any(), gomock.Any()).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil).Times(2)
+
+	mockHandler := api.NewMockHandler(ctrl)
+	mockHandler.EXPECT().RegisterDomain(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	mockHandler.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).Return(&types.DescribeWorkflowExecutionResponse{}, nil).Times(1)
+
+	handler := NewAPIHandler(mockHandler, mockResource, mockAuthorizer, config.Authorization{})
+
+	ctx := context.Background()
+	_, err = handler.DescribeWorkflowExecution(ctx, &types.DescribeWorkflowExecutionRequest{Domain: "my-domain"})
+	require.NoError(t, err)
+	err = handler.RegisterDomain(ctx, &types.RegisterDomainRequest{Name: "my-name"})
+	require.NoError(t, err)
+
+	assert.Empty(t, registrationErrors, "Prometheus registration errors must not be emitted")
+}
 
 func TestIsAuthorized(t *testing.T) {
 	testCases := []struct {

--- a/service/frontend/wrappers/accesscontrolled/api_generated.go
+++ b/service/frontend/wrappers/accesscontrolled/api_generated.go
@@ -94,7 +94,7 @@ func (a *apiHandler) CreateSchedule(ctx context.Context, cp1 *types.CreateSchedu
 }
 
 func (a *apiHandler) DeleteDomain(ctx context.Context, dp1 *types.DeleteDomainRequest) (err error) {
-	scope := a.GetMetricsClient().Scope(metrics.FrontendDeleteDomainScope)
+	scope := a.GetMetricsClient().Scope(metrics.FrontendDeleteDomainScope).Tagged(metrics.NonDomainTag())
 	attr := &authorization.Attributes{
 		APIName:     "DeleteDomain",
 		Permission:  authorization.PermissionAdmin,
@@ -129,7 +129,7 @@ func (a *apiHandler) DeleteSchedule(ctx context.Context, dp1 *types.DeleteSchedu
 }
 
 func (a *apiHandler) DeprecateDomain(ctx context.Context, dp1 *types.DeprecateDomainRequest) (err error) {
-	scope := a.GetMetricsClient().Scope(metrics.FrontendDeprecateDomainScope)
+	scope := a.GetMetricsClient().Scope(metrics.FrontendDeprecateDomainScope).Tagged(metrics.NonDomainTag())
 	attr := &authorization.Attributes{
 		APIName:     "DeprecateDomain",
 		Permission:  authorization.PermissionAdmin,
@@ -146,7 +146,7 @@ func (a *apiHandler) DeprecateDomain(ctx context.Context, dp1 *types.DeprecateDo
 }
 
 func (a *apiHandler) DescribeDomain(ctx context.Context, dp1 *types.DescribeDomainRequest) (dp2 *types.DescribeDomainResponse, err error) {
-	scope := a.GetMetricsClient().Scope(metrics.FrontendDescribeDomainScope)
+	scope := a.GetMetricsClient().Scope(metrics.FrontendDescribeDomainScope).Tagged(metrics.NonDomainTag())
 	attr := &authorization.Attributes{
 		APIName:     "DescribeDomain",
 		Permission:  authorization.PermissionRead,
@@ -504,7 +504,7 @@ func (a *apiHandler) RefreshWorkflowTasks(ctx context.Context, rp1 *types.Refres
 }
 
 func (a *apiHandler) RegisterDomain(ctx context.Context, rp1 *types.RegisterDomainRequest) (err error) {
-	scope := a.GetMetricsClient().Scope(metrics.FrontendRegisterDomainScope)
+	scope := a.GetMetricsClient().Scope(metrics.FrontendRegisterDomainScope).Tagged(metrics.NonDomainTag())
 	attr := &authorization.Attributes{
 		APIName:     "RegisterDomain",
 		Permission:  authorization.PermissionAdmin,
@@ -767,7 +767,7 @@ func (a *apiHandler) UnpauseSchedule(ctx context.Context, up1 *types.UnpauseSche
 }
 
 func (a *apiHandler) UpdateDomain(ctx context.Context, up1 *types.UpdateDomainRequest) (up2 *types.UpdateDomainResponse, err error) {
-	scope := a.GetMetricsClient().Scope(metrics.FrontendUpdateDomainScope)
+	scope := a.GetMetricsClient().Scope(metrics.FrontendUpdateDomainScope).Tagged(metrics.NonDomainTag())
 	attr := &authorization.Attributes{
 		APIName:     "UpdateDomain",
 		Permission:  authorization.PermissionAdmin,


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Non-domain frontend auth APIs now tag their authorization metrics scope with `metrics.NonDomainTag()` instead of a plain `Scope()`

**Why?**
I went beyond the scope of https://github.com/cadence-workflow/cadence/issues/7844 and discovered another metric name collision.

The accesscontrolled wrapper emitted cadence_authorization_latency with inconsistent label sets:

- Domain APIs used getMetricsScopeWithDomain()  -> labels: cadence_service, operation, domain
- Non-domain auth APIs used plain Scope() -> labels: cadence_service, operation only

Prometheus requires every emission path for a metric name to use the same label-name set. The first registration wins; later mismatches produce warnings and those scopes are dropped.

**How did you test it?**
```
go test -race -run TestAuthorizationMetricsLabelConsistency ./service/frontend/wrappers/accesscontrolled/...
```

**Potential risks**


**Release notes**


**Documentation Changes**

