### PR TITLE
fix(failover): complete round trip for failover marker creation time

### DIFF
--- a/common/persistence/data_store_interfaces.go
+++ b/common/persistence/data_store_interfaces.go
@@ -1288,8 +1288,9 @@ func (t *InternalReplicationTaskInfo) ToTask() (Task, error) {
 	case ReplicationTaskTypeFailoverMarker:
 		return &FailoverMarkerTask{
 			TaskData: TaskData{
-				Version: t.Version,
-				TaskID:  t.TaskID,
+				Version:             t.Version,
+				TaskID:              t.TaskID,
+				VisibilityTimestamp: t.CreationTime,
 			},
 			DomainID: t.DomainID,
 		}, nil

--- a/common/persistence/data_store_interfaces_test.go
+++ b/common/persistence/data_store_interfaces_test.go
@@ -24,8 +24,10 @@ package persistence
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/types"
@@ -186,5 +188,102 @@ func TestDataBlob(t *testing.T) {
 				})
 			}, "should panic when decoding from unhandled encoding %q", unknownType)
 		})
+	})
+}
+
+func TestInternalReplicationTaskInfo_ToTask(t *testing.T) {
+	creationTime := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	base := InternalReplicationTaskInfo{
+		DomainID:     "domain-id",
+		WorkflowID:   "wf-id",
+		RunID:        "run-id",
+		TaskID:       42,
+		Version:      7,
+		CreationTime: creationTime,
+	}
+
+	cases := []struct {
+		name     string
+		mutate   func(i *InternalReplicationTaskInfo)
+		expected Task
+	}{
+		{
+			name: "history replication task",
+			mutate: func(i *InternalReplicationTaskInfo) {
+				i.TaskType = ReplicationTaskTypeHistory
+				i.FirstEventID = 1
+				i.NextEventID = 5
+				i.BranchToken = []byte("branch")
+				i.NewRunBranchToken = []byte("new-run")
+			},
+			expected: &HistoryReplicationTask{
+				WorkflowIdentifier: WorkflowIdentifier{
+					DomainID:   "domain-id",
+					WorkflowID: "wf-id",
+					RunID:      "run-id",
+				},
+				TaskData: TaskData{
+					Version:             7,
+					TaskID:              42,
+					VisibilityTimestamp: creationTime,
+				},
+				FirstEventID:      1,
+				NextEventID:       5,
+				BranchToken:       []byte("branch"),
+				NewRunBranchToken: []byte("new-run"),
+			},
+		},
+		{
+			name: "sync activity task",
+			mutate: func(i *InternalReplicationTaskInfo) {
+				i.TaskType = ReplicationTaskTypeSyncActivity
+				i.ScheduledID = 99
+			},
+			expected: &SyncActivityTask{
+				WorkflowIdentifier: WorkflowIdentifier{
+					DomainID:   "domain-id",
+					WorkflowID: "wf-id",
+					RunID:      "run-id",
+				},
+				TaskData: TaskData{
+					Version:             7,
+					TaskID:              42,
+					VisibilityTimestamp: creationTime,
+				},
+				ScheduledID: 99,
+			},
+		},
+		{
+			name: "failover marker task",
+			mutate: func(i *InternalReplicationTaskInfo) {
+				i.TaskType = ReplicationTaskTypeFailoverMarker
+			},
+			expected: &FailoverMarkerTask{
+				TaskData: TaskData{
+					Version:             7,
+					TaskID:              42,
+					VisibilityTimestamp: creationTime,
+				},
+				DomainID: "domain-id",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			info := base
+			tc.mutate(&info)
+			task, err := info.ToTask()
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, task)
+		})
+	}
+
+	t.Run("unknown task type returns error", func(t *testing.T) {
+		info := base
+		info.TaskType = -1
+		task, err := info.ToTask()
+		assert.Nil(t, task)
+		assert.Error(t, err)
 	})
 }

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -6015,11 +6015,12 @@ func (s *ExecutionManagerSuite) TestCreateFailoverMarkerTasks() {
 	defer cancel()
 
 	domainID := uuid.New()
+	visibilityTimestamp := time.Now().Truncate(p.DBTimestampMinPrecision)
 	markers := []*p.FailoverMarkerTask{
 		{
 			TaskData: p.TaskData{
 				TaskID:              1,
-				VisibilityTimestamp: time.Now(),
+				VisibilityTimestamp: visibilityTimestamp,
 				Version:             1,
 			},
 			DomainID: domainID,
@@ -6035,6 +6036,9 @@ func (s *ExecutionManagerSuite) TestCreateFailoverMarkerTasks() {
 	s.Equal(tasks[0].GetTaskID(), int64(1))
 	s.Equal(tasks[0].GetDomainID(), domainID)
 	s.Equal(tasks[0].GetTaskType(), p.ReplicationTaskTypeFailoverMarker)
+	s.True(tasks[0].GetVisibilityTimestamp().Equal(visibilityTimestamp),
+		"VisibilityTimestamp should round-trip; got %v, want %v",
+		tasks[0].GetVisibilityTimestamp(), visibilityTimestamp)
 }
 
 func copyWorkflowExecutionInfo(sourceInfo *p.WorkflowExecutionInfo) *p.WorkflowExecutionInfo {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Complete round trip for failover marker CreationTime in persistence.

https://github.com/cadence-workflow/cadence/issues/8138

**Why?**
The VisibilityTimestamp was not being set when returning the FailoverMarkerTask when ReadNoSQLHistoryTaskFromDataBlob is set to false.

**How did you test it?**
Added tests to ToTask to test that it's being set

go test -race -run TestInternalReplicationTaskInfo_ToTask ./common/persistence/

And verified that it's being set in persistence tests

go test -race -run 'TestCassandraExecutionManagerSuite/TestCreateFailoverMarkerTasks' ./common/persistence/persistence-tests/

**Potential risks**
No risk. Just passing the value that was being dropped.

**Release notes**
N/A

**Documentation Changes**
N/A