### PR TITLE
fix(queuev2): clear CachedQueueReader cache when mode switches to disabled

### DIFF
--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -292,6 +292,20 @@ func (q *cachedQueueReader) isDisabled() bool {
 	return isCachedQueueReaderDisabled(q.options.Mode())
 }
 
+// IsEmpty reports whether the cache queue reader is empty
+func (q *cachedQueueReader) IsEmpty() bool {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return q.exclusiveUpperBound.Equal(persistence.MinimumHistoryTaskKey)
+}
+
+// clearIfNotEmpty clears cached state only when the cache has data
+func (q *cachedQueueReader) clearIfNotEmpty() {
+	if !q.IsEmpty() {
+		q.Clear()
+	}
+}
+
 // Clear wipes all cached state and triggers a fresh prefetch from the DB.
 func (q *cachedQueueReader) Clear() {
 	q.mu.Lock()
@@ -313,6 +327,9 @@ func (q *cachedQueueReader) Clear() {
 // (prefetchLoop) schedules the next attempt.
 func (q *cachedQueueReader) prefetch() error {
 	if q.isDisabled() {
+		// Clear stale cache so re-enabling starts with a fresh prefetch
+		// instead of serving outdated boundaries that cause cache misses.
+		q.clearIfNotEmpty()
 		q.logger.Debug("prefetch skipped, cache disabled")
 		return nil
 	}
@@ -374,6 +391,12 @@ func (q *cachedQueueReader) prefetch() error {
 	if err != nil {
 		q.logger.Error("prefetch failed", tag.Error(err))
 		return fmt.Errorf("prefetch failed: %w", err)
+	}
+
+	if q.isDisabled() {
+		q.logger.Info("prefetch result discarded, mode switched to disabled during prefetch")
+		q.pendingInjectBuffer = q.pendingInjectBuffer[:0]
+		return nil
 	}
 
 	// Upper bound changed while we held the lock (e.g. a concurrent Inject
@@ -566,6 +589,9 @@ func (q *cachedQueueReader) UpdateReadLevel(readLevel persistence.HistoryTaskKey
 // tasks are dropped. No-op when the cache is off.
 func (q *cachedQueueReader) Inject(tasks []persistence.Task) {
 	if q.isDisabled() {
+		// Clear stale cache so re-enabling starts with a fresh prefetch
+		// instead of serving outdated boundaries that cause cache misses.
+		q.clearIfNotEmpty()
 		return
 	}
 

--- a/service/history/queuev2/queue_reader_cached_test.go
+++ b/service/history/queuev2/queue_reader_cached_test.go
@@ -159,6 +159,43 @@ func TestCachedQueueReader_Modes(t *testing.T) {
 	}
 }
 
+func TestCachedQueueReader_IsEmpty(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name      string
+		initLower persistence.HistoryTaskKey
+		initUpper persistence.HistoryTaskKey
+		want      bool
+	}{
+		{
+			name:      "empty when upper bound is minimum",
+			initLower: persistence.MinimumHistoryTaskKey,
+			initUpper: persistence.MinimumHistoryTaskKey,
+			want:      true,
+		},
+		{
+			name:      "not empty when upper bound is set",
+			initLower: newTimeKey(now),
+			initUpper: newTimeKey(now.Add(time.Hour)),
+			want:      false,
+		},
+		{
+			name:      "not empty when only upper bound is set",
+			initLower: persistence.MinimumHistoryTaskKey,
+			initUpper: newTimeKey(now.Add(time.Hour)),
+			want:      false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			r, _ := setupMocksForCachedQueueReader(t, ctrl)
+			setBounds(r, tc.initLower, tc.initUpper)
+			assert.Equal(t, tc.want, r.IsEmpty())
+		})
+	}
+}
+
 func TestCachedQueueReader_UpdateReadLevel(t *testing.T) {
 	now := time.Now()
 	tests := []struct {
@@ -249,13 +286,16 @@ func TestCachedQueueReader_Inject(t *testing.T) {
 		wantBufferLen      int
 	}{
 		{
-			name:  "disabled skips all",
+			name:  "disabled clears stale cache",
 			tasks: []persistence.Task{inside},
 			optsOverride: func(o *cachedQueueReaderOptions) {
 				o.Mode = dynamicproperties.GetStringPropertyFn("disabled")
 			},
-			setupMocks: func(*MockInMemQueue) {},
-			wantUpper:  upper,
+			setupMocks: func(queue *MockInMemQueue) {
+				queue.EXPECT().Clear()
+				queue.EXPECT().Len().Return(0).AnyTimes()
+			},
+			wantUpper: persistence.MinimumHistoryTaskKey,
 		},
 		{
 			name:  "task inside window accepted",
@@ -1324,7 +1364,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 		wantUpper    persistence.HistoryTaskKey
 	}{
 		{
-			name: "disabled: no-op, bounds unchanged",
+			name: "disabled: no-op when cache empty",
 			optsOverride: func(o *cachedQueueReaderOptions) {
 				o.Mode = dynamicproperties.GetStringPropertyFn("disabled")
 			},
@@ -1333,6 +1373,20 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedQueueReader) {},
 			wantLower:  persistence.MinimumHistoryTaskKey,
 			wantUpper:  persistence.MinimumHistoryTaskKey,
+		},
+		{
+			name: "disabled: clears stale cache when not empty",
+			optsOverride: func(o *cachedQueueReaderOptions) {
+				o.Mode = dynamicproperties.GetStringPropertyFn("disabled")
+			},
+			initLower: someLower,
+			initUpper: someUpper,
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *cachedQueueReader) {
+				queue.EXPECT().Clear()
+				queue.EXPECT().Len().Return(0).AnyTimes()
+			},
+			wantLower: persistence.MinimumHistoryTaskKey,
+			wantUpper: persistence.MinimumHistoryTaskKey,
 		},
 		{
 			name:      "cache full: skips DB fetch, bounds unchanged",
@@ -1486,6 +1540,28 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 			wantLower: someLower,
 			wantUpper: maxKey,
 		},
+		{
+			name:      "mode switched to disabled during in-flight fetch discards results and buffer",
+			initLower: someLower,
+			initUpper: someUpper,
+			initBuffer: []persistence.Task{
+				newTask(99, someUpper.GetScheduledTime().Add(time.Minute)),
+			},
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, r *cachedQueueReader) {
+				queue.EXPECT().Len().Return(0).AnyTimes()
+				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, _ *GetTaskRequest) (*GetTaskResponse, error) {
+						r.options.Mode = dynamicproperties.GetStringPropertyFn("disabled")
+						return &GetTaskResponse{
+							Tasks:    []persistence.Task{t1, t2},
+							Progress: &GetTaskProgress{NextTaskKey: maxKey},
+						}, nil
+					},
+				)
+			},
+			wantLower: someLower,
+			wantUpper: someUpper,
+		},
 	}
 
 	for _, tc := range tests {
@@ -1512,6 +1588,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 			r.mu.RLock()
 			gotLower := r.inclusiveLowerBound
 			gotUpper := r.exclusiveUpperBound
+			gotBufferLen := len(r.pendingInjectBuffer)
 			r.mu.RUnlock()
 
 			if tc.wantErr {
@@ -1521,6 +1598,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 			}
 			assert.True(t, gotLower.Equal(tc.wantLower), "lower: got %v want %v", gotLower, tc.wantLower)
 			assert.True(t, gotUpper.Equal(tc.wantUpper), "upper: got %v want %v", gotUpper, tc.wantUpper)
+			assert.Equal(t, 0, gotBufferLen, "pending inject buffer should be empty after prefetch")
 		})
 	}
 }


### PR DESCRIPTION
**What changed?**

Added cache cleanup when `timerProcessorCachedQueueReaderMode` switches to disabled, and guards against in-flight prefetch writing stale data after the mode change. Added `IsEmpty()` and `clearIfNotEmpty()` helpers.

**Why?**

When the mode transitions from shadow/enabled → disabled → shadow/enabled, the cache retained stale boundaries and tasks from before the disable. During the disabled window, `Inject()` dropped new tasks without clearing existing cache state, and `prefetch()` skipped fetching without clearing either. When the mode switched back to shadow, the shadow comparison found mismatches between stale cached data and fresh DB results, producing spurious "shadow comparison mismatch" warnings.

Three fixes:
- `Inject()` calls `clearIfNotEmpty()` when disabled to wipe stale cache state. This is the key path — tasks enter the cache only through injection, so clearing here ensures no stale data survives a mode transition.
- `prefetch()` calls `clearIfNotEmpty()` at the start when disabled, catching mode changes even without inject traffic.
- `prefetch()` checks `isDisabled()` after the DB call completes under the write lock, discarding fetched results and clearing the pending inject buffer if the mode switched to disabled mid-flight. Without this, both the fetched tasks and buffered inject tasks could re-populate the cache after it should be empty.

#7953

**How did you test it?**

```bash
go test -race -run "TestCachedQueueReader_IsEmpty|TestCachedQueueReader_Inject|TestCachedQueueReader_Prefetch" ./service/history/queuev2/...
go test -race ./service/history/queuev2/...
```

New and updated test cases:
- `TestCachedQueueReader_IsEmpty` — 3 cases: empty (bounds at minimum), not empty (both bounds set), not empty (only upper set)
- Inject "disabled clears stale cache" — verifies `queue.Clear()` is called and bounds reset when cache has data
- Inject "disabled with no cached data is no-op" — verifies no `Clear()` when bounds are already at minimum
- Prefetch "disabled: no-op when cache empty" — no clear when already empty
- Prefetch "disabled: clears stale cache when not empty" — clears and resets bounds
- Prefetch "mode switched to disabled during in-flight fetch discards results and buffer" — verifies fetched tasks are not written, pending inject buffer is cleared, and bounds stay unchanged

**Potential risks**

Low. `clearIfNotEmpty()` adds a RLock check on every disabled `Inject()`/`prefetch()` call, but the guard avoids redundant `Clear()` calls. The in-flight prefetch guard is inside the existing write lock scope.

**Release notes**

N/A — bugfix for internal cache consistency during dynamic config mode transitions.

**Documentation Changes**

N/A