### PR TITLE
fix(queuev2): treat ConditionFailedError as possibly successful for task notifications

### DIFF
--- a/service/history/common/errors.go
+++ b/service/history/common/errors.go
@@ -35,7 +35,6 @@ func IsOperationPossiblySuccessfulError(err error) bool {
 		*types.WorkflowExecutionAlreadyStartedError,
 		*persistence.WorkflowExecutionAlreadyStartedError,
 		*persistence.CurrentWorkflowConditionFailedError,
-		*persistence.ConditionFailedError,
 		*types.ServiceBusyError,
 		*types.LimitExceededError,
 		*persistence.ShardOwnershipLostError:

--- a/service/history/common/errors_test.go
+++ b/service/history/common/errors_test.go
@@ -40,7 +40,7 @@ func TestIsOperationPossiblySuccessfulError(t *testing.T) {
 		{"WorkflowExecutionAlreadyStartedError (types)", &types.WorkflowExecutionAlreadyStartedError{}, false},
 		{"WorkflowExecutionAlreadyStartedError (persistence)", &persistence.WorkflowExecutionAlreadyStartedError{}, false},
 		{"CurrentWorkflowConditionFailedError", &persistence.CurrentWorkflowConditionFailedError{}, false},
-		{"ConditionFailedError", &persistence.ConditionFailedError{}, false},
+		{"ConditionFailedError", &persistence.ConditionFailedError{}, true},
 		{"ServiceBusyError", &types.ServiceBusyError{}, false},
 		{"LimitExceededError", &types.LimitExceededError{}, false},
 		{"ShardOwnershipLostError", &persistence.ShardOwnershipLostError{}, false},

--- a/service/history/execution/context_test.go
+++ b/service/history/execution/context_test.go
@@ -58,7 +58,7 @@ func TestIsOperationPossiblySuccessfulError(t *testing.T) {
 	assert.False(t, isOperationPossiblySuccessfulError(&types.WorkflowExecutionAlreadyStartedError{}))
 	assert.False(t, isOperationPossiblySuccessfulError(&persistence.WorkflowExecutionAlreadyStartedError{}))
 	assert.False(t, isOperationPossiblySuccessfulError(&persistence.CurrentWorkflowConditionFailedError{}))
-	assert.False(t, isOperationPossiblySuccessfulError(&persistence.ConditionFailedError{}))
+	assert.True(t, isOperationPossiblySuccessfulError(&persistence.ConditionFailedError{}))
 	assert.False(t, isOperationPossiblySuccessfulError(&types.ServiceBusyError{}))
 	assert.False(t, isOperationPossiblySuccessfulError(&types.LimitExceededError{}))
 	assert.False(t, isOperationPossiblySuccessfulError(&persistence.ShardOwnershipLostError{}))

--- a/service/history/shard/notify_task_test.go
+++ b/service/history/shard/notify_task_test.go
@@ -42,7 +42,7 @@ func TestIsOperationPossiblySuccessfulError(t *testing.T) {
 		{"WorkflowExecutionAlreadyStartedError (types)", &types.WorkflowExecutionAlreadyStartedError{}, false},
 		{"WorkflowExecutionAlreadyStartedError (persistence)", &persistence.WorkflowExecutionAlreadyStartedError{}, false},
 		{"CurrentWorkflowConditionFailedError", &persistence.CurrentWorkflowConditionFailedError{}, false},
-		{"ConditionFailedError", &persistence.ConditionFailedError{}, false},
+		{"ConditionFailedError", &persistence.ConditionFailedError{}, true},
 		{"ServiceBusyError", &types.ServiceBusyError{}, false},
 		{"LimitExceededError", &types.LimitExceededError{}, false},
 		{"ShardOwnershipLostError", &persistence.ShardOwnershipLostError{}, false},


### PR DESCRIPTION
**What changed?**

Removed `*persistence.ConditionFailedError` from the definitive-failure list in `IsOperationPossiblySuccessfulError`, so it now falls through as "possibly successful."

**Why?**

Previously, `ConditionFailedError` was classified as a definitive failure, causing `isNotifyTaskNeeded` to return `(false, false)` and drop all task notifications ("notify tasks dropped due to persistence error"). However, tasks are written to the DB before the execution record condition check runs, so they exist despite the error. Shadow mode confirmed tasks present in DB with no corresponding cache injection.

With this fix, `ConditionFailedError` is treated as "possibly successful," so tasks propagate to `NotifyNewTask` with `persistenceError=true`. This triggers a cache `Clear()` followed by a re-fetch from DB, picking up the already-persisted tasks.

**How did you test it?**

```bash
go test -race -count=1 ./service/history/common/...
go test -race -count=1 ./service/history/shard/...
go test -race -count=1 ./service/history/execution/...
go test -race -count=1 ./service/history/queuev2/...
```

All tests pass, including updated expectations for `ConditionFailedError` in three test files.

**Potential risks**

This changes behavior for `ConditionFailedError` across both callers of `IsOperationPossiblySuccessfulError`:
- `shard/notify_task.go` — tasks now notify instead of being dropped
- `execution/context.go` — tasks now notify with `persistenceError=true` instead of being silently skipped

The execution layer's `IsConflictError` still catches `ConflictError`-wrapped `ConditionFailedError`, so conflict resolution paths are unaffected.

Cache `Clear()` on persistence error is more conservative than direct `Inject()` — correctness is preserved via DB re-fetch.

**Release notes**

Fixed a bug where `ConditionFailedError` during workflow persistence caused queuev2 task notifications to be dropped, leading to missed task processing despite tasks being present in the database.

**Documentation Changes**

N/A