### PR TITLE
fix(queuev2): clear CachedQueueReader cache on rangeID change

### DIFF
--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -333,10 +333,10 @@ func (q *cachedQueueReader) isRangeIDChanged() bool {
 	return q.isRangeIDChangedLocked()
 }
 
-// clearIfRangeIDChanged clears the cache if the shard's rangeID has changed,
+// fallbackIfRangeIDChanged clears the cache if the shard's rangeID has changed,
 // e.g. when a shard moved away and was re-acquired by the same host.
 // Returns true if the cache was cleared.
-func (q *cachedQueueReader) clearIfRangeIDChanged() bool {
+func (q *cachedQueueReader) fallbackIfRangeIDChanged() bool {
 	if !q.isRangeIDChanged() {
 		return false
 	}
@@ -678,7 +678,8 @@ func (q *cachedQueueReader) GetTask(ctx context.Context, req *GetTaskRequest) (*
 		return q.base.GetTask(ctx, req)
 	}
 
-	if q.clearIfRangeIDChanged() {
+	if q.fallbackIfRangeIDChanged() {
+		q.logger.Info("GetTask falling back to base reader after rangeID change")
 		return q.base.GetTask(ctx, req)
 	}
 
@@ -746,11 +747,11 @@ func (q *cachedQueueReader) GetTask(ctx context.Context, req *GetTaskRequest) (*
 // inject notifications make cache/DB comparison unreliable for look-ahead.
 func (q *cachedQueueReader) LookAHead(ctx context.Context, req *LookAHeadRequest) (*LookAHeadResponse, error) {
 	if q.isDisabled() || q.isShadow() {
-		q.logger.Debug("fail back to original look-ahead, cache is disabled or shadow mode")
 		return q.base.LookAHead(ctx, req)
 	}
 
-	if q.clearIfRangeIDChanged() {
+	if q.fallbackIfRangeIDChanged() {
+		q.logger.Info("LookAHead falling back to base reader after rangeID change")
 		return q.base.LookAHead(ctx, req)
 	}
 

--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -345,19 +345,19 @@ func (q *cachedQueueReader) fallbackIfRangeIDChanged() bool {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
-	currentRangeID := q.shard.GetRangeID()
-	prevRangeID := q.lastRangeID
-	if currentRangeID == prevRangeID {
+	if !q.isRangeIDChangedLocked() {
 		return false
 	}
 
-	q.lastRangeID = currentRangeID
+	newRangeID := q.shard.GetRangeID()
+	prevRangeID := q.lastRangeID
+	q.lastRangeID = newRangeID
 
-	if currentRangeID == prevRangeID+1 {
+	if newRangeID == prevRangeID+1 {
 		// Same host reacquired the shard. Cache still valid.
 		q.logger.Info("rangeID changed on same host, cache not cleared",
 			tag.Dynamic("previousRangeID", prevRangeID),
-			tag.Dynamic("currentRangeID", currentRangeID),
+			tag.Dynamic("currentRangeID", newRangeID),
 		)
 		return false
 	}
@@ -365,7 +365,7 @@ func (q *cachedQueueReader) fallbackIfRangeIDChanged() bool {
 	// rangeID changed by more than 1: possible stale cache.
 	q.logger.Info("rangeID changed, clearing cache",
 		tag.Dynamic("previousRangeID", prevRangeID),
-		tag.Dynamic("currentRangeID", currentRangeID),
+		tag.Dynamic("currentRangeID", newRangeID),
 	)
 	q.clearLocked()
 	return true

--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -333,9 +333,10 @@ func (q *cachedQueueReader) isRangeIDChanged() bool {
 	return q.isRangeIDChangedLocked()
 }
 
-// fallbackIfRangeIDChanged clears the cache if the shard's rangeID has changed,
-// e.g. when a shard moved away and was re-acquired by the same host.
-// Returns true if the cache was cleared.
+// fallbackIfRangeIDChanged clears cache if rangeID changed by more than 1
+// (shard moved away and was re-acquired). A change of exactly 1 means the same
+// host reacquired the shard — cache remains valid.
+// Returns true if cache was cleared.
 func (q *cachedQueueReader) fallbackIfRangeIDChanged() bool {
 	if !q.isRangeIDChanged() {
 		return false
@@ -344,16 +345,29 @@ func (q *cachedQueueReader) fallbackIfRangeIDChanged() bool {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
-	if !q.isRangeIDChangedLocked() {
+	currentRangeID := q.shard.GetRangeID()
+	prevRangeID := q.lastRangeID
+	if currentRangeID == prevRangeID {
 		return false
 	}
 
+	q.lastRangeID = currentRangeID
+
+	if currentRangeID == prevRangeID+1 {
+		// Same host reacquired the shard. Cache still valid.
+		q.logger.Info("rangeID changed on same host, cache not cleared",
+			tag.Dynamic("previousRangeID", prevRangeID),
+			tag.Dynamic("currentRangeID", currentRangeID),
+		)
+		return false
+	}
+
+	// rangeID changed by more than 1: possible stale cache.
 	q.logger.Info("rangeID changed, clearing cache",
-		tag.Dynamic("previousRangeID", q.lastRangeID),
-		tag.Dynamic("currentRangeID", q.shard.GetRangeID()),
+		tag.Dynamic("previousRangeID", prevRangeID),
+		tag.Dynamic("currentRangeID", currentRangeID),
 	)
 	q.clearLocked()
-	q.lastRangeID = q.shard.GetRangeID()
 	return true
 }
 

--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -357,7 +357,7 @@ func (q *cachedQueueReader) fallbackIfRangeIDChanged() bool {
 		// Same host reacquired the shard. Cache still valid.
 		q.logger.Info("rangeID changed on same host, cache not cleared",
 			tag.Dynamic("previousRangeID", prevRangeID),
-			tag.Dynamic("currentRangeID", newRangeID),
+			tag.Dynamic("newRangeID", newRangeID),
 		)
 		return false
 	}
@@ -365,7 +365,7 @@ func (q *cachedQueueReader) fallbackIfRangeIDChanged() bool {
 	// rangeID changed by more than 1: possible stale cache.
 	q.logger.Info("rangeID changed, clearing cache",
 		tag.Dynamic("previousRangeID", prevRangeID),
-		tag.Dynamic("currentRangeID", newRangeID),
+		tag.Dynamic("newRangeID", newRangeID),
 	)
 	q.clearLocked()
 	return true

--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -139,6 +139,11 @@ type cachedQueueReader struct {
 	// senders never block; duplicate signals are dropped, the loop reads current
 	// state on each wake.
 	prefetchCh chan struct{}
+
+	// lastRangeID is the shard rangeID observed when the cache was last valid.
+	// A change means the shard was re-acquired and the cache may be stale.
+	// Protected by mu.
+	lastRangeID int64
 }
 
 func newCachedQueueReader(
@@ -190,6 +195,7 @@ func newCachedQueueReaderWithOptions(
 		inclusiveLowerBound: persistence.MinimumHistoryTaskKey,
 		exclusiveUpperBound: persistence.MinimumHistoryTaskKey,
 		prefetchCh:          make(chan struct{}, 1),
+		lastRangeID:         shard.GetRangeID(),
 		ctx:                 ctx,
 		cancel:              cancel,
 	}
@@ -301,11 +307,54 @@ func (q *cachedQueueReader) Clear() {
 		tag.Dynamic("cacheState", q.getState()),
 	)
 
+	q.clearLocked()
+}
+
+// clearLocked wipes all cached state. Caller must hold q.mu for writing.
+func (q *cachedQueueReader) clearLocked() {
 	q.queue.Clear()
 	q.pendingInjectBuffer = q.pendingInjectBuffer[:0]
 	q.prefetchTargetUpper = persistence.MinimumHistoryTaskKey
 	q.updateInclusiveLowerBound(persistence.MinimumHistoryTaskKey)
 	q.updateExclusiveUpperBound(persistence.MinimumHistoryTaskKey)
+}
+
+// isRangeIDChangedLocked reports whether the shard's current rangeID differs
+// from the last observed value. Caller must hold q.mu (read or write).
+func (q *cachedQueueReader) isRangeIDChangedLocked() bool {
+	return q.shard.GetRangeID() != q.lastRangeID
+}
+
+// isRangeIDChanged reports whether the shard's current rangeID differs
+// from the last observed value.
+func (q *cachedQueueReader) isRangeIDChanged() bool {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return q.isRangeIDChangedLocked()
+}
+
+// clearIfRangeIDChanged clears the cache if the shard's rangeID has changed,
+// e.g. when a shard moved away and was re-acquired by the same host.
+// Returns true if the cache was cleared.
+func (q *cachedQueueReader) clearIfRangeIDChanged() bool {
+	if !q.isRangeIDChanged() {
+		return false
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if !q.isRangeIDChangedLocked() {
+		return false
+	}
+
+	q.logger.Info("rangeID changed, clearing cache",
+		tag.Dynamic("previousRangeID", q.lastRangeID),
+		tag.Dynamic("currentRangeID", q.shard.GetRangeID()),
+	)
+	q.clearLocked()
+	q.lastRangeID = q.shard.GetRangeID()
+	return true
 }
 
 // prefetch fetches one page of tasks into the look-ahead window. Returns nil
@@ -629,6 +678,10 @@ func (q *cachedQueueReader) GetTask(ctx context.Context, req *GetTaskRequest) (*
 		return q.base.GetTask(ctx, req)
 	}
 
+	if q.clearIfRangeIDChanged() {
+		return q.base.GetTask(ctx, req)
+	}
+
 	inclusiveMinTaskKey := req.Progress.Range.InclusiveMinTaskKey
 	exclusiveMaxTaskKey := req.Progress.Range.ExclusiveMaxTaskKey
 
@@ -694,6 +747,10 @@ func (q *cachedQueueReader) GetTask(ctx context.Context, req *GetTaskRequest) (*
 func (q *cachedQueueReader) LookAHead(ctx context.Context, req *LookAHeadRequest) (*LookAHeadResponse, error) {
 	if q.isDisabled() || q.isShadow() {
 		q.logger.Debug("fail back to original look-ahead, cache is disabled or shadow mode")
+		return q.base.LookAHead(ctx, req)
+	}
+
+	if q.clearIfRangeIDChanged() {
 		return q.base.LookAHead(ctx, req)
 	}
 

--- a/service/history/queuev2/queue_reader_cached_test.go
+++ b/service/history/queuev2/queue_reader_cached_test.go
@@ -1805,4 +1805,3 @@ func TestCachedQueueReader_IsToBufferTask(t *testing.T) {
 		})
 	}
 }
-

--- a/service/history/queuev2/queue_reader_cached_test.go
+++ b/service/history/queuev2/queue_reader_cached_test.go
@@ -483,7 +483,7 @@ func TestCachedQueueReader_GetTask(t *testing.T) {
 		lower       persistence.HistoryTaskKey
 		upper       persistence.HistoryTaskKey
 		req         *GetTaskRequest
-		setupMocks  func(base *MockQueueReader, queue *MockInMemQueue)
+		setupMocks  func(base *MockQueueReader, queue *MockInMemQueue, shard *shard.MockContext)
 		wantErr     bool
 		wantResp    *GetTaskResponse
 	}{
@@ -496,7 +496,7 @@ func TestCachedQueueReader_GetTask(t *testing.T) {
 				Predicate: NewUniversalPredicate(),
 				PageSize:  10,
 			},
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *shard.MockContext) {
 				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).Return(&GetTaskResponse{
 					Progress: newProgress(lower, upper),
 				}, nil)
@@ -515,7 +515,7 @@ func TestCachedQueueReader_GetTask(t *testing.T) {
 				Predicate: NewUniversalPredicate(),
 				PageSize:  10,
 			},
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *shard.MockContext) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).Return(&GetTaskResponse{
 					Progress: &GetTaskProgress{
@@ -541,7 +541,7 @@ func TestCachedQueueReader_GetTask(t *testing.T) {
 				Predicate: NewUniversalPredicate(),
 				PageSize:  10,
 			},
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *shard.MockContext) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).Return(nil, assert.AnError)
 			},
@@ -556,7 +556,7 @@ func TestCachedQueueReader_GetTask(t *testing.T) {
 				Predicate: NewUniversalPredicate(),
 				PageSize:  10,
 			},
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *shard.MockContext) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				queue.EXPECT().GetTasks(lower, upper, gomock.Any(), 10).
 					Return([]persistence.Task{t1, t2}, upper)
@@ -587,7 +587,7 @@ func TestCachedQueueReader_GetTask(t *testing.T) {
 				Predicate: NewUniversalPredicate(),
 				PageSize:  10,
 			},
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *shard.MockContext) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				queue.EXPECT().GetTasks(cacheStart, rangeMax, gomock.Any(), 10).
 					Return([]persistence.Task{cacheTask}, rangeMax)
@@ -618,7 +618,7 @@ func TestCachedQueueReader_GetTask(t *testing.T) {
 				Predicate: NewUniversalPredicate(),
 				PageSize:  10,
 			},
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *shard.MockContext) {
 				// no queue.Len(): early return before acquiring lock
 				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).Return(&GetTaskResponse{
 					Progress: &GetTaskProgress{
@@ -644,7 +644,7 @@ func TestCachedQueueReader_GetTask(t *testing.T) {
 				Predicate: NewUniversalPredicate(),
 				PageSize:  10,
 			},
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *shard.MockContext) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				queue.EXPECT().GetTasks(lower, upper, gomock.Any(), 10).
 					Return(nil, upper) // no tasks; nextTaskKey = upper
@@ -669,7 +669,7 @@ func TestCachedQueueReader_GetTask(t *testing.T) {
 				Predicate: NewUniversalPredicate(),
 				PageSize:  10,
 			},
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *shard.MockContext) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).Return(&GetTaskResponse{
 					Progress: &GetTaskProgress{
@@ -696,7 +696,7 @@ func TestCachedQueueReader_GetTask(t *testing.T) {
 				Predicate: NewUniversalPredicate(),
 				PageSize:  10,
 			},
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *shard.MockContext) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).Return(&GetTaskResponse{
 					Progress: newProgress(lower, upper),
@@ -707,7 +707,7 @@ func TestCachedQueueReader_GetTask(t *testing.T) {
 			},
 		},
 		{
-			name:        "rangeID changed: clears cache and falls back to base",
+			name:        "rangeID changed by >1: clears cache and falls back to base",
 			mode:        "enabled",
 			lastRangeID: 1,
 			lower:       lower, upper: upper,
@@ -716,7 +716,7 @@ func TestCachedQueueReader_GetTask(t *testing.T) {
 				Predicate: NewUniversalPredicate(),
 				PageSize:  10,
 			},
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *shard.MockContext) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				queue.EXPECT().Clear()
 				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).Return(&GetTaskResponse{
@@ -725,6 +725,29 @@ func TestCachedQueueReader_GetTask(t *testing.T) {
 			},
 			wantResp: &GetTaskResponse{
 				Progress: newProgress(upper, rangeMax),
+			},
+		},
+		{
+			// lastRangeID=-1, shard returns 0: 0 == -1+1 → same-host reacquisition, no fallback.
+			// Cache bounds are empty (MinimumHistoryTaskKey) → cache miss → base.GetTask.
+			// Absence of queue.Clear() expectation proves no cache clear occurred.
+			name:        "rangeID changed by 1: same-host reacquisition, no fallback",
+			mode:        "enabled",
+			lastRangeID: -1,
+			lower:       persistence.MinimumHistoryTaskKey, upper: persistence.MinimumHistoryTaskKey,
+			req: &GetTaskRequest{
+				Progress:  newProgress(lower, upper),
+				Predicate: NewUniversalPredicate(),
+				PageSize:  10,
+			},
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *shard.MockContext) {
+				queue.EXPECT().Len().Return(0).AnyTimes()
+				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).Return(&GetTaskResponse{
+					Progress: newProgress(lower, upper),
+				}, nil)
+			},
+			wantResp: &GetTaskResponse{
+				Progress: newProgress(lower, upper),
 			},
 		},
 	}
@@ -738,7 +761,7 @@ func TestCachedQueueReader_GetTask(t *testing.T) {
 			base, queue := deps.mockBase, deps.mockQueue
 			setBounds(r, tc.lower, tc.upper)
 			r.lastRangeID = tc.lastRangeID
-			tc.setupMocks(base, queue)
+			tc.setupMocks(base, queue, deps.mockShard)
 
 			resp, err := r.GetTask(context.Background(), tc.req)
 
@@ -1192,7 +1215,7 @@ func TestCachedQueueReader_LookAHead(t *testing.T) {
 		initLower   persistence.HistoryTaskKey
 		initUpper   persistence.HistoryTaskKey
 		minKey      persistence.HistoryTaskKey
-		setupMocks  func(base *MockQueueReader, queue *MockInMemQueue)
+		setupMocks  func(base *MockQueueReader, queue *MockInMemQueue, shard *shard.MockContext)
 		wantErr     bool
 		wantResp    *LookAHeadResponse
 	}{
@@ -1202,7 +1225,7 @@ func TestCachedQueueReader_LookAHead(t *testing.T) {
 			initLower: persistence.MinimumHistoryTaskKey,
 			initUpper: persistence.MinimumHistoryTaskKey,
 			minKey:    lower,
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *shard.MockContext) {
 				// disabled returns before acquiring the lock, so no queue.Len()
 				base.EXPECT().LookAHead(gomock.Any(), gomock.Any()).Return(&LookAHeadResponse{}, nil)
 			},
@@ -1214,7 +1237,7 @@ func TestCachedQueueReader_LookAHead(t *testing.T) {
 			initLower: persistence.MinimumHistoryTaskKey,
 			initUpper: persistence.MinimumHistoryTaskKey,
 			minKey:    lower,
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *shard.MockContext) {
 				// disabled returns before acquiring the lock, so no queue.Len()
 				base.EXPECT().LookAHead(gomock.Any(), gomock.Any()).Return(nil, assert.AnError)
 			},
@@ -1228,7 +1251,7 @@ func TestCachedQueueReader_LookAHead(t *testing.T) {
 			initLower: lower,
 			initUpper: upper,
 			minKey:    lower,
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *shard.MockContext) {
 				// returns before acquiring the lock, so no queue.Len()
 				base.EXPECT().LookAHead(gomock.Any(), gomock.Any()).Return(&LookAHeadResponse{Task: task1}, nil)
 			},
@@ -1240,7 +1263,7 @@ func TestCachedQueueReader_LookAHead(t *testing.T) {
 			initLower: newTimeKey(now.Add(time.Minute)),
 			initUpper: upper,
 			minKey:    lower, // lower < initLower → miss
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *shard.MockContext) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				base.EXPECT().LookAHead(gomock.Any(), gomock.Any()).Return(&LookAHeadResponse{}, nil)
 			},
@@ -1252,7 +1275,7 @@ func TestCachedQueueReader_LookAHead(t *testing.T) {
 			initLower: lower,
 			initUpper: upper,
 			minKey:    upper, // upper is exclusive → isTaskCovered false → miss
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *shard.MockContext) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				base.EXPECT().LookAHead(gomock.Any(), gomock.Any()).Return(&LookAHeadResponse{}, nil)
 			},
@@ -1264,7 +1287,7 @@ func TestCachedQueueReader_LookAHead(t *testing.T) {
 			initLower: lower,
 			initUpper: upper,
 			minKey:    lower,
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *shard.MockContext) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				queue.EXPECT().LookAHead(lower).Return(task1)
 			},
@@ -1279,7 +1302,7 @@ func TestCachedQueueReader_LookAHead(t *testing.T) {
 			initLower: lower,
 			initUpper: upper,
 			minKey:    lower,
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *shard.MockContext) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				queue.EXPECT().LookAHead(lower).Return(nil)
 			},
@@ -1288,18 +1311,35 @@ func TestCachedQueueReader_LookAHead(t *testing.T) {
 			},
 		},
 		{
-			name:        "rangeID changed: clears cache and falls back to base",
+			name:        "rangeID changed by >1: clears cache and falls back to base",
 			mode:        "enabled",
 			lastRangeID: 1,
 			initLower:   lower,
 			initUpper:   upper,
 			minKey:      lower,
-			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue) {
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *shard.MockContext) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				queue.EXPECT().Clear()
 				base.EXPECT().LookAHead(gomock.Any(), gomock.Any()).Return(&LookAHeadResponse{
 					LookAheadMaxTime: upper.GetScheduledTime(),
 				}, nil)
+			},
+			wantResp: &LookAHeadResponse{
+				LookAheadMaxTime: upper.GetScheduledTime(),
+			},
+		},
+		{
+			// lastRangeID=-1, shard returns 0: 0 == -1+1 → same-host reacquisition, no fallback.
+			// Absence of queue.Clear() expectation proves no cache clear occurred.
+			name:        "rangeID changed by 1: same-host reacquisition, no fallback",
+			mode:        "enabled",
+			lastRangeID: -1,
+			initLower:   lower,
+			initUpper:   upper,
+			minKey:      lower,
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue, _ *shard.MockContext) {
+				queue.EXPECT().Len().Return(0).AnyTimes()
+				queue.EXPECT().LookAHead(lower).Return(nil)
 			},
 			wantResp: &LookAHeadResponse{
 				LookAheadMaxTime: upper.GetScheduledTime(),
@@ -1315,7 +1355,7 @@ func TestCachedQueueReader_LookAHead(t *testing.T) {
 			base, queue := deps.mockBase, deps.mockQueue
 			setBounds(r, tc.initLower, tc.initUpper)
 			r.lastRangeID = tc.lastRangeID
-			tc.setupMocks(base, queue)
+			tc.setupMocks(base, queue, deps.mockShard)
 
 			resp, err := r.LookAHead(context.Background(), &LookAHeadRequest{InclusiveMinTaskKey: tc.minKey})
 

--- a/service/history/queuev2/queue_reader_cached_test.go
+++ b/service/history/queuev2/queue_reader_cached_test.go
@@ -477,14 +477,15 @@ func TestCachedQueueReader_GetTask(t *testing.T) {
 	)
 
 	tests := []struct {
-		name       string
-		mode       string
-		lower      persistence.HistoryTaskKey
-		upper      persistence.HistoryTaskKey
-		req        *GetTaskRequest
-		setupMocks func(base *MockQueueReader, queue *MockInMemQueue)
-		wantErr    bool
-		wantResp   *GetTaskResponse
+		name        string
+		mode        string
+		lastRangeID int64
+		lower       persistence.HistoryTaskKey
+		upper       persistence.HistoryTaskKey
+		req         *GetTaskRequest
+		setupMocks  func(base *MockQueueReader, queue *MockInMemQueue)
+		wantErr     bool
+		wantResp    *GetTaskResponse
 	}{
 		{
 			name:  "disabled delegates to base",
@@ -705,6 +706,27 @@ func TestCachedQueueReader_GetTask(t *testing.T) {
 				Progress: newProgress(lower, upper),
 			},
 		},
+		{
+			name:        "rangeID changed: clears cache and falls back to base",
+			mode:        "enabled",
+			lastRangeID: 1,
+			lower:       lower, upper: upper,
+			req: &GetTaskRequest{
+				Progress:  newProgress(lower, rangeMax),
+				Predicate: NewUniversalPredicate(),
+				PageSize:  10,
+			},
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue) {
+				queue.EXPECT().Len().Return(0).AnyTimes()
+				queue.EXPECT().Clear()
+				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).Return(&GetTaskResponse{
+					Progress: newProgress(upper, rangeMax),
+				}, nil)
+			},
+			wantResp: &GetTaskResponse{
+				Progress: newProgress(upper, rangeMax),
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -715,6 +737,7 @@ func TestCachedQueueReader_GetTask(t *testing.T) {
 			})
 			base, queue := deps.mockBase, deps.mockQueue
 			setBounds(r, tc.lower, tc.upper)
+			r.lastRangeID = tc.lastRangeID
 			tc.setupMocks(base, queue)
 
 			resp, err := r.GetTask(context.Background(), tc.req)
@@ -1163,14 +1186,15 @@ func TestCachedQueueReader_LookAHead(t *testing.T) {
 	task1 := newTask(1, now.Add(10*time.Minute))
 
 	tests := []struct {
-		name       string
-		mode       string
-		initLower  persistence.HistoryTaskKey
-		initUpper  persistence.HistoryTaskKey
-		minKey     persistence.HistoryTaskKey
-		setupMocks func(base *MockQueueReader, queue *MockInMemQueue)
-		wantErr    bool
-		wantResp   *LookAHeadResponse
+		name        string
+		mode        string
+		lastRangeID int64
+		initLower   persistence.HistoryTaskKey
+		initUpper   persistence.HistoryTaskKey
+		minKey      persistence.HistoryTaskKey
+		setupMocks  func(base *MockQueueReader, queue *MockInMemQueue)
+		wantErr     bool
+		wantResp    *LookAHeadResponse
 	}{
 		{
 			name:      "disabled falls back to DB",
@@ -1263,6 +1287,24 @@ func TestCachedQueueReader_LookAHead(t *testing.T) {
 				LookAheadMaxTime: upper.GetScheduledTime(),
 			},
 		},
+		{
+			name:        "rangeID changed: clears cache and falls back to base",
+			mode:        "enabled",
+			lastRangeID: 1,
+			initLower:   lower,
+			initUpper:   upper,
+			minKey:      lower,
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue) {
+				queue.EXPECT().Len().Return(0).AnyTimes()
+				queue.EXPECT().Clear()
+				base.EXPECT().LookAHead(gomock.Any(), gomock.Any()).Return(&LookAHeadResponse{
+					LookAheadMaxTime: upper.GetScheduledTime(),
+				}, nil)
+			},
+			wantResp: &LookAHeadResponse{
+				LookAheadMaxTime: upper.GetScheduledTime(),
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1272,6 +1314,7 @@ func TestCachedQueueReader_LookAHead(t *testing.T) {
 			})
 			base, queue := deps.mockBase, deps.mockQueue
 			setBounds(r, tc.initLower, tc.initUpper)
+			r.lastRangeID = tc.lastRangeID
 			tc.setupMocks(base, queue)
 
 			resp, err := r.LookAHead(context.Background(), &LookAHeadRequest{InclusiveMinTaskKey: tc.minKey})
@@ -1763,108 +1806,3 @@ func TestCachedQueueReader_IsToBufferTask(t *testing.T) {
 	}
 }
 
-func TestCachedQueueReader_RangeIDChange(t *testing.T) {
-	now := time.Now()
-	lower := newTimeKey(now)
-	upper := newTimeKey(now.Add(time.Hour))
-	rangeMax := newTimeKey(now.Add(2 * time.Hour))
-
-	t.Run("GetTask clears cache and falls back to base on rangeID change", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockShard := shard.NewMockContext(ctrl)
-		mockShard.EXPECT().GetConfig().Return(&config.Config{RangeSizeBits: 20}).AnyTimes()
-
-		rangeIDCall := mockShard.EXPECT().GetRangeID().Return(int64(1))
-		mockShard.EXPECT().GetRangeID().Return(int64(2)).After(rangeIDCall).AnyTimes()
-
-		mockBase := NewMockQueueReader(ctrl)
-		mockQueue := NewMockInMemQueue(ctrl)
-
-		r := newCachedQueueReaderWithOptions(
-			mockBase, mockQueue, mockShard,
-			clock.NewMockedTimeSource(),
-			testlogger.New(t),
-			metrics.NoopScope,
-			testOptions(),
-		)
-		setBounds(r, lower, upper)
-
-		req := &GetTaskRequest{
-			Progress:  newProgress(lower, rangeMax),
-			Predicate: NewUniversalPredicate(),
-			PageSize:  10,
-		}
-
-		baseResp := &GetTaskResponse{Progress: newProgress(upper, rangeMax)}
-		mockQueue.EXPECT().Len().Return(0).AnyTimes()
-		mockQueue.EXPECT().Clear()
-		mockBase.EXPECT().GetTask(gomock.Any(), req).Return(baseResp, nil)
-
-		resp, err := r.GetTask(context.Background(), req)
-		require.NoError(t, err)
-		assert.Equal(t, baseResp, resp)
-
-		r.mu.RLock()
-		defer r.mu.RUnlock()
-		assert.True(t, r.exclusiveUpperBound.Equal(persistence.MinimumHistoryTaskKey))
-		assert.True(t, r.inclusiveLowerBound.Equal(persistence.MinimumHistoryTaskKey))
-		assert.Equal(t, int64(2), r.lastRangeID)
-	})
-
-	t.Run("GetTask serves from cache when rangeID unchanged", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		r, deps := setupMocksForCachedQueueReader(t, ctrl)
-		setBounds(r, lower, upper)
-
-		req := &GetTaskRequest{
-			Progress:  newProgress(lower, upper),
-			Predicate: NewUniversalPredicate(),
-			PageSize:  10,
-		}
-
-		task := newTask(1, now.Add(30*time.Minute))
-		deps.mockQueue.EXPECT().Len().Return(0).AnyTimes()
-		deps.mockQueue.EXPECT().GetTasks(lower, upper, gomock.Any(), 10).Return([]persistence.Task{task}, upper)
-
-		resp, err := r.GetTask(context.Background(), req)
-		require.NoError(t, err)
-		assert.Equal(t, []persistence.Task{task}, resp.Tasks)
-	})
-
-	t.Run("LookAHead clears cache on rangeID change", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockShard := shard.NewMockContext(ctrl)
-		mockShard.EXPECT().GetConfig().Return(&config.Config{RangeSizeBits: 20}).AnyTimes()
-
-		rangeIDCall := mockShard.EXPECT().GetRangeID().Return(int64(1))
-		mockShard.EXPECT().GetRangeID().Return(int64(2)).After(rangeIDCall).AnyTimes()
-
-		mockBase := NewMockQueueReader(ctrl)
-		mockQueue := NewMockInMemQueue(ctrl)
-
-		r := newCachedQueueReaderWithOptions(
-			mockBase, mockQueue, mockShard,
-			clock.NewMockedTimeSource(),
-			testlogger.New(t),
-			metrics.NoopScope,
-			testOptions(),
-		)
-		setBounds(r, lower, upper)
-
-		req := &LookAHeadRequest{InclusiveMinTaskKey: lower}
-		baseResp := &LookAHeadResponse{LookAheadMaxTime: now.Add(time.Hour)}
-
-		mockQueue.EXPECT().Len().Return(0).AnyTimes()
-		mockQueue.EXPECT().Clear()
-		mockBase.EXPECT().LookAHead(gomock.Any(), req).Return(baseResp, nil)
-
-		resp, err := r.LookAHead(context.Background(), req)
-		require.NoError(t, err)
-		assert.Equal(t, baseResp, resp)
-
-		r.mu.RLock()
-		defer r.mu.RUnlock()
-		assert.True(t, r.exclusiveUpperBound.Equal(persistence.MinimumHistoryTaskKey))
-		assert.Equal(t, int64(2), r.lastRangeID)
-	})
-}

--- a/service/history/queuev2/queue_reader_cached_test.go
+++ b/service/history/queuev2/queue_reader_cached_test.go
@@ -1762,3 +1762,109 @@ func TestCachedQueueReader_IsToBufferTask(t *testing.T) {
 		})
 	}
 }
+
+func TestCachedQueueReader_RangeIDChange(t *testing.T) {
+	now := time.Now()
+	lower := newTimeKey(now)
+	upper := newTimeKey(now.Add(time.Hour))
+	rangeMax := newTimeKey(now.Add(2 * time.Hour))
+
+	t.Run("GetTask clears cache and falls back to base on rangeID change", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockShard := shard.NewMockContext(ctrl)
+		mockShard.EXPECT().GetConfig().Return(&config.Config{RangeSizeBits: 20}).AnyTimes()
+
+		rangeIDCall := mockShard.EXPECT().GetRangeID().Return(int64(1))
+		mockShard.EXPECT().GetRangeID().Return(int64(2)).After(rangeIDCall).AnyTimes()
+
+		mockBase := NewMockQueueReader(ctrl)
+		mockQueue := NewMockInMemQueue(ctrl)
+
+		r := newCachedQueueReaderWithOptions(
+			mockBase, mockQueue, mockShard,
+			clock.NewMockedTimeSource(),
+			testlogger.New(t),
+			metrics.NoopScope,
+			testOptions(),
+		)
+		setBounds(r, lower, upper)
+
+		req := &GetTaskRequest{
+			Progress:  newProgress(lower, rangeMax),
+			Predicate: NewUniversalPredicate(),
+			PageSize:  10,
+		}
+
+		baseResp := &GetTaskResponse{Progress: newProgress(upper, rangeMax)}
+		mockQueue.EXPECT().Len().Return(0).AnyTimes()
+		mockQueue.EXPECT().Clear()
+		mockBase.EXPECT().GetTask(gomock.Any(), req).Return(baseResp, nil)
+
+		resp, err := r.GetTask(context.Background(), req)
+		require.NoError(t, err)
+		assert.Equal(t, baseResp, resp)
+
+		r.mu.RLock()
+		defer r.mu.RUnlock()
+		assert.True(t, r.exclusiveUpperBound.Equal(persistence.MinimumHistoryTaskKey))
+		assert.True(t, r.inclusiveLowerBound.Equal(persistence.MinimumHistoryTaskKey))
+		assert.Equal(t, int64(2), r.lastRangeID)
+	})
+
+	t.Run("GetTask serves from cache when rangeID unchanged", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		r, deps := setupMocksForCachedQueueReader(t, ctrl)
+		setBounds(r, lower, upper)
+
+		req := &GetTaskRequest{
+			Progress:  newProgress(lower, upper),
+			Predicate: NewUniversalPredicate(),
+			PageSize:  10,
+		}
+
+		task := newTask(1, now.Add(30*time.Minute))
+		deps.mockQueue.EXPECT().Len().Return(0).AnyTimes()
+		deps.mockQueue.EXPECT().GetTasks(lower, upper, gomock.Any(), 10).Return([]persistence.Task{task}, upper)
+
+		resp, err := r.GetTask(context.Background(), req)
+		require.NoError(t, err)
+		assert.Equal(t, []persistence.Task{task}, resp.Tasks)
+	})
+
+	t.Run("LookAHead clears cache on rangeID change", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockShard := shard.NewMockContext(ctrl)
+		mockShard.EXPECT().GetConfig().Return(&config.Config{RangeSizeBits: 20}).AnyTimes()
+
+		rangeIDCall := mockShard.EXPECT().GetRangeID().Return(int64(1))
+		mockShard.EXPECT().GetRangeID().Return(int64(2)).After(rangeIDCall).AnyTimes()
+
+		mockBase := NewMockQueueReader(ctrl)
+		mockQueue := NewMockInMemQueue(ctrl)
+
+		r := newCachedQueueReaderWithOptions(
+			mockBase, mockQueue, mockShard,
+			clock.NewMockedTimeSource(),
+			testlogger.New(t),
+			metrics.NoopScope,
+			testOptions(),
+		)
+		setBounds(r, lower, upper)
+
+		req := &LookAHeadRequest{InclusiveMinTaskKey: lower}
+		baseResp := &LookAHeadResponse{LookAheadMaxTime: now.Add(time.Hour)}
+
+		mockQueue.EXPECT().Len().Return(0).AnyTimes()
+		mockQueue.EXPECT().Clear()
+		mockBase.EXPECT().LookAHead(gomock.Any(), req).Return(baseResp, nil)
+
+		resp, err := r.LookAHead(context.Background(), req)
+		require.NoError(t, err)
+		assert.Equal(t, baseResp, resp)
+
+		r.mu.RLock()
+		defer r.mu.RUnlock()
+		assert.True(t, r.exclusiveUpperBound.Equal(persistence.MinimumHistoryTaskKey))
+		assert.Equal(t, int64(2), r.lastRangeID)
+	})
+}


### PR DESCRIPTION
**What changed?**

Added rangeID change detection to `CachedQueueReader`. When a shard is re-acquired by the same host, the rangeID changes but the cache was not cleared, potentially serving stale data. Now `GetTask()` and `LookAHead()` check for rangeID changes and clear the cache before falling back to the base reader.

**Why?**

When shard ownership moves away and back to the same host, the rangeID is incremented but the in-memory cache persists with stale data from the previous ownership epoch. This could cause the queue reader to serve outdated tasks. The fix detects rangeID changes on the read path and invalidates the cache.

The implementation uses an RLock fast-path with double-check locking pattern: an RLock check on every read (cheap, no contention), upgrading to a write lock only when the rangeID actually changes. This avoids serializing all reads behind a write lock.

#7953 

**How did you test it?**

```bash
go test -race -run TestCachedQueueReader ./service/history/queuev2/...
```

Added `TestCachedQueueReader_RangeIDChange` with three subtests:
- `GetTask clears cache and falls back to base on rangeID change`
- `GetTask serves from cache when rangeID unchanged`
- `LookAHead clears cache on rangeID change`

**Potential risks**

Low risk. The RLock fast-path adds minimal overhead to the read path. Write lock is only acquired when rangeID actually changes, which is a rare event (shard re-acquisition).

**Release notes**

N/A — internal bug fix for cache consistency during shard movement.

**Documentation Changes**

N/A