### PR TITLE
fix: flaky TestRegisterDomainRequestFuzz test

### DIFF
--- a/common/types/mapper/proto/api_test.go
+++ b/common/types/mapper/proto/api_test.go
@@ -449,14 +449,24 @@ func TestRegisterDomainRequestFuzz(t *testing.T) {
 		testutils.EnsureFuzzCoverage(t, []string{
 			"nil", "empty", "filled",
 		}, func(t *testing.T, f *fuzz.Fuzzer) string {
-			// Configure fuzzer to generate valid enum values and reasonable day ranges
 			fuzzer := f.Funcs(
 				func(e *types.ArchivalStatus, c fuzz.Continue) {
-					*e = types.ArchivalStatus(c.Intn(2)) // 0-1 are valid values (Disabled=0, Enabled=1)
+					*e = types.ArchivalStatus(c.Intn(2))
 				},
 				func(days *int32, c fuzz.Continue) {
-					// Generate reasonable retention period values to avoid precision loss in conversion
-					*days = int32(c.Intn(10000)) // 0-9999 days is reasonable range
+					*days = int32(c.Intn(10000))
+				},
+				func(r **types.RegisterDomainRequest, c fuzz.Continue) {
+					switch c.Intn(3) {
+					case 0:
+						*r = nil
+					case 1:
+						*r = &types.RegisterDomainRequest{}
+					default:
+						var v types.RegisterDomainRequest
+						c.Fuzz(&v)
+						*r = &v
+					}
 				},
 			).NilChance(0.3)
 


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Added a custom fuzz func for RegisterDomainRequest that explicitly generates nil, empty, and filled cases with equal probability.

https://github.com/cadence-workflow/cadence/issues/8189

**Why?**
Previously, the "empty" case relied on the fuzzer randomly producing empty strings for multiple non-pointer fields simultaneously, which was statistically near-impossible and caused flaky failures.

**How did you test it?**
Updated test and ran with 1000 count

go test -race -run TestRegisterDomainRequestFuzz -count=1000 ./common/types/mapper/proto/...

**Potential risks**
No risk. Flaky test fix.

**Release notes**
N/A

**Documentation Changes**
N/A
