### PR TITLE
fix: flaky TestNotifyPendingFailoverMarker test

### DIFF
--- a/service/history/failover/marker_notifier_test.go
+++ b/service/history/failover/marker_notifier_test.go
@@ -148,7 +148,7 @@ func (s *markerNotifierSuite) TestNotifyPendingFailoverMarker() {
 	s.coordinator.EXPECT().NotifyFailoverMarkers(
 		int32(s.mockShard.GetShardID()),
 		tasks,
-	).Do(
+	).AnyTimes().Do(
 		func(
 			shardID int32,
 			markers []*types.FailoverMarkerAttributes,


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Set the number of times of the mock to AnyTimes.

https://github.com/cadence-workflow/cadence/issues/8148

**Why?**
Times was not set and it was defaulting to Times(1) which caused the flakiness.

**How did you test it?**
Tested locally with 200 counts

go test -race -run TestMarkerNotifierSuite/TestNotifyPendingFailoverMarker -count=200 ./service/history/failover/...

**Potential risks**
No risk, just a flaky test fix

**Release notes**
N/A

**Documentation Changes**
N/A
