### PR TITLE
fix: flaky TestContextCancellation test

### DIFF
--- a/cmd/tools/releaser/internal/console/console_test.go
+++ b/cmd/tools/releaser/internal/console/console_test.go
@@ -133,7 +133,7 @@ func TestContextCancellation(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		reader := strings.NewReader("y\n") // This won't be read due to cancellation
+		reader := newBlockingReader()
 		writer := &bytes.Buffer{}
 		manager := NewManager(reader, writer)
 


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Used a blocking reader instead of a buffered strings.NewReader("y\n") in the "context cancelled before input" test.
https://github.com/cadence-workflow/cadence/issues/8220

**Why?**
Both ctx.Done() and inputChan were ready simultaneously in the select, and Go picks randomly — sometimes inputChan wins, returning nil error instead of the expected context.Canceled.

**How did you test it?**
go test -race -run "TestContextCancellation/context_cancelled_before_input" -count=2000 ./cmd/tools/releaser/internal/console/...

**Potential risks**
No risk, just a test fix

**Release notes**
N/A

**Documentation Changes**
N/A
