### PR TITLE
chore: Add limit to history size logs for easier customer diagnosis

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -368,6 +368,11 @@ func WorkflowHistorySize(historySize int) Tag {
 	return newInt("wf-history-size", historySize)
 }
 
+// WorkflowHistorySizeLimit returns tag for HistorySizeLimit
+func WorkflowHistorySizeLimit(historySize int) Tag {
+	return newInt("wf-history-size-limit", historySize)
+}
+
 // WorkflowHistorySizeBytes returns tag for HistorySizeBytes
 func WorkflowHistorySizeBytes(historySizeBytes int) Tag {
 	return newInt("wf-history-size-bytes", historySizeBytes)
@@ -376,6 +381,11 @@ func WorkflowHistorySizeBytes(historySizeBytes int) Tag {
 // WorkflowEventCount returns tag for EventCount
 func WorkflowEventCount(eventCount int) Tag {
 	return newInt("wf-event-count", eventCount)
+}
+
+// WorkflowEventCountLimit returns tag for EventCountLimit
+func WorkflowEventCountLimit(eventCount int) Tag {
+	return newInt("wf-event-count-limit", eventCount)
 }
 
 func WorkflowEventType(eventType string) Tag {

--- a/service/history/decision/checker.go
+++ b/service/history/decision/checker.go
@@ -175,7 +175,10 @@ func (c *workflowSizeChecker) failWorkflowSizeExceedsLimit() (bool, error) {
 			tag.WorkflowID(executionInfo.WorkflowID),
 			tag.WorkflowRunID(executionInfo.RunID),
 			tag.WorkflowHistorySize(historySize),
-			tag.WorkflowEventCount(historyCount))
+			tag.WorkflowHistorySizeLimit(c.historySizeLimitError),
+			tag.WorkflowEventCount(historyCount),
+			tag.WorkflowEventCountLimit(c.historyCountLimitError),
+		)
 
 		attributes := &types.FailWorkflowExecutionDecisionAttributes{
 			Reason:  common.StringPtr(common.FailureReasonSizeExceedsLimit),
@@ -196,7 +199,10 @@ func (c *workflowSizeChecker) failWorkflowSizeExceedsLimit() (bool, error) {
 			tag.WorkflowID(executionInfo.WorkflowID),
 			tag.WorkflowRunID(executionInfo.RunID),
 			tag.WorkflowHistorySize(historySize),
-			tag.WorkflowEventCount(historyCount))
+			tag.WorkflowEventCount(historyCount),
+			tag.WorkflowHistorySizeLimit(c.historySizeLimitWarn),
+			tag.WorkflowEventCountLimit(c.historyCountLimitWarn),
+		)
 		return false, nil
 	}
 


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

Logs the limit alongside the current value for when the history limit is approaching or exceeding the limit. 

**Why?**

The existing logs give no way for the user to know how close they are to the limit (when warned), or what the limit they exceeded was. This will give them an easy way to know the limit they breached when they receive the error. 

**How did you test it?**

Logging change, so untested. 🚀 🙏 

**Potential risks**

None. 

**Release notes**

None.

**Documentation Changes**

None. 