### PR TITLE
fix(schedule): return Unavailable for CONTINUED_AS_NEW scheduler close status

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -278,8 +278,8 @@ func (wh *WorkflowHandler) DescribeSchedule(
 	if info.CloseStatus != nil {
 		if *info.CloseStatus == types.WorkflowExecutionCloseStatusContinuedAsNew {
 			return nil, yarpcerrors.Newf(yarpcerrors.CodeUnavailable,
-				"schedule %q in domain %q is not operational: scheduler workflow ended with status %s",
-				scheduleID, domainName, info.CloseStatus.String(),
+				"schedule %q in domain %q: scheduler mid-ContinueAsNew, retry",
+				scheduleID, domainName,
 			)
 		}
 		return nil, &types.InternalServiceError{
@@ -305,8 +305,8 @@ func (wh *WorkflowHandler) DescribeSchedule(
 			closeStatus = queryResp.QueryRejected.CloseStatus.String()
 			if *queryResp.QueryRejected.CloseStatus == types.WorkflowExecutionCloseStatusContinuedAsNew {
 				return nil, yarpcerrors.Newf(yarpcerrors.CodeUnavailable,
-					"schedule %q in domain %q is not operational: scheduler workflow ended with status %s",
-					scheduleID, domainName, closeStatus,
+					"schedule %q in domain %q: scheduler mid-ContinueAsNew, retry",
+					scheduleID, domainName,
 				)
 			}
 		}

--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -276,6 +276,12 @@ func (wh *WorkflowHandler) DescribeSchedule(
 		return nil, err
 	}
 	if info.CloseStatus != nil {
+		if *info.CloseStatus == types.WorkflowExecutionCloseStatusContinuedAsNew {
+			return nil, yarpcerrors.Newf(yarpcerrors.CodeUnavailable,
+				"schedule %q in domain %q is not operational: scheduler workflow ended with status %s",
+				scheduleID, domainName, info.CloseStatus.String(),
+			)
+		}
 		return nil, &types.InternalServiceError{
 			Message: fmt.Sprintf(
 				"schedule %q in domain %q is not operational: scheduler workflow ended with status %s",
@@ -297,6 +303,12 @@ func (wh *WorkflowHandler) DescribeSchedule(
 		closeStatus := "unknown"
 		if queryResp.QueryRejected.CloseStatus != nil {
 			closeStatus = queryResp.QueryRejected.CloseStatus.String()
+			if *queryResp.QueryRejected.CloseStatus == types.WorkflowExecutionCloseStatusContinuedAsNew {
+				return nil, yarpcerrors.Newf(yarpcerrors.CodeUnavailable,
+					"schedule %q in domain %q is not operational: scheduler workflow ended with status %s",
+					scheduleID, domainName, closeStatus,
+				)
+			}
 		}
 		return nil, &types.InternalServiceError{
 			Message: fmt.Sprintf(

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -575,8 +575,7 @@ func TestDescribeSchedule(t *testing.T) {
 			wantErr: false,
 		},
 		// If the close status stays CONTINUED_AS_NEW past the retry budget, the
-		// scheduler is likely stuck mid-transition; surface that as not operational
-		// so an operator can investigate.
+		// scheduler is stuck mid-transition; return Unavailable so clients retry.
 		"scheduler mid-ContinueAsNew - retry budget exhausted": {
 			request: validRequest,
 			mockFn: func(f *scheduleTestFixture) {
@@ -590,9 +589,9 @@ func TestDescribeSchedule(t *testing.T) {
 			},
 			wantErr: true,
 			checkErr: func(t *testing.T, err error) {
-				var internalErr *types.InternalServiceError
-				assert.ErrorAs(t, err, &internalErr)
-				assert.Contains(t, internalErr.Message, "CONTINUED_AS_NEW")
+				assert.True(t, yarpcerrors.IsStatus(err))
+				assert.Equal(t, yarpcerrors.CodeUnavailable, yarpcerrors.FromError(err).Code())
+				assert.Contains(t, yarpcerrors.FromError(err).Message(), "CONTINUED_AS_NEW")
 			},
 		},
 		// A freshly started scheduler run has not yet processed its first decision
@@ -739,6 +738,32 @@ func TestDescribeSchedule(t *testing.T) {
 				var internalErr *types.InternalServiceError
 				assert.ErrorAs(t, err, &internalErr)
 				assert.Contains(t, internalErr.Message, "FAILED")
+			},
+		},
+		// If the scheduler does ContinueAsNew between the DWE probe and the query,
+		// the query is rejected with CONTINUED_AS_NEW. Return Unavailable so the
+		// client retries — the new run will be queryable momentarily.
+		"scheduler ContinueAsNew between DWE and Query - return Unavailable": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+					}, nil)
+				closeStatus := types.WorkflowExecutionCloseStatusContinuedAsNew
+				f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+					Return(&types.HistoryQueryWorkflowResponse{
+						Response: &types.QueryWorkflowResponse{
+							QueryRejected: &types.QueryRejected{CloseStatus: &closeStatus},
+						},
+					}, nil)
+			},
+			wantErr: true,
+			checkErr: func(t *testing.T, err error) {
+				assert.True(t, yarpcerrors.IsStatus(err))
+				assert.Equal(t, yarpcerrors.CodeUnavailable, yarpcerrors.FromError(err).Code())
+				assert.Contains(t, yarpcerrors.FromError(err).Message(), "CONTINUED_AS_NEW")
 			},
 		},
 		"success": {

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -591,7 +591,7 @@ func TestDescribeSchedule(t *testing.T) {
 			checkErr: func(t *testing.T, err error) {
 				assert.True(t, yarpcerrors.IsStatus(err))
 				assert.Equal(t, yarpcerrors.CodeUnavailable, yarpcerrors.FromError(err).Code())
-				assert.Contains(t, yarpcerrors.FromError(err).Message(), "CONTINUED_AS_NEW")
+				assert.Contains(t, yarpcerrors.FromError(err).Message(), "mid-ContinueAsNew")
 			},
 		},
 		// A freshly started scheduler run has not yet processed its first decision
@@ -763,7 +763,7 @@ func TestDescribeSchedule(t *testing.T) {
 			checkErr: func(t *testing.T, err error) {
 				assert.True(t, yarpcerrors.IsStatus(err))
 				assert.Equal(t, yarpcerrors.CodeUnavailable, yarpcerrors.FromError(err).Code())
-				assert.Contains(t, yarpcerrors.FromError(err).Message(), "CONTINUED_AS_NEW")
+				assert.Contains(t, yarpcerrors.FromError(err).Message(), "mid-ContinueAsNew")
 			},
 		},
 		"success": {


### PR DESCRIPTION
## What changed

`DescribeSchedule` can observe `CloseStatus=CONTINUED_AS_NEW` in two places inside `handler_schedule.go`:

1. After `describeSchedulerExecution` exhausts its CONTINUED_AS_NEW retry budget
2. When the scheduler does ContinueAsNew in the window between the DWE probe and the `QueryWorkflow` call

Both previously returned `&types.InternalServiceError{...}`, which maps to gRPC `INTERNAL`.

This PR changes both to return `yarpcerrors.Newf(yarpcerrors.CodeUnavailable, ...)` when the close status is specifically `CONTINUED_AS_NEW`. 
## Why

`CONTINUED_AS_NEW` is always a transient state. The scheduler workflow ContinueAsNews periodically to bound history size, and on every `UpdateSchedule`. A client that receives this error should always retry, there is nothing wrong with the schedule, the new run will be queryable within milliseconds.

`INTERNAL` is the wrong signal because it implies a server-side bug. `UNAVAILABLE` is the correct gRPC status code for "transient, retry" per the gRPC spec.

The practical effect: `UNAVAILABLE` is in the retry allowlist (`RETRYABLE_CODES`) of all three Cadence SDKs (Go, Java, Python). Clients now transparently retry this transient condition through their existing retry interceptors, with zero SDK changes required.

## How did you test it

Added unit test

## Potential risk

**Low.** The change is narrowly scoped:
- Only affects `CONTINUED_AS_NEW` close status.

## Documentation
N/A