### PR TITLE
chore(graceful failover): add more logging to identify bottlenecks

### DIFF
--- a/service/history/failover/coordinator.go
+++ b/service/history/failover/coordinator.go
@@ -101,6 +101,7 @@ type (
 		failoverVersion int64
 		shards          map[int32]struct{}
 		lastUpdatedTime time.Time
+		firstSeenTime   time.Time
 	}
 )
 
@@ -280,16 +281,18 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 		}
 	}
 
+	now := c.timeSource.Now()
 	if _, ok := c.recorder[domainID]; !ok {
 		// initialize the failover record
 		c.recorder[marker.GetDomainID()] = &failoverRecord{
 			failoverVersion: marker.GetFailoverVersion(),
 			shards:          make(map[int32]struct{}),
+			firstSeenTime:   now,
 		}
 	}
 
 	record := c.recorder[domainID]
-	record.lastUpdatedTime = c.timeSource.Now()
+	record.lastUpdatedTime = now
 	for _, shardID := range request.shardIDs {
 		record.shards[shardID] = struct{}{}
 	}
@@ -306,12 +309,14 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 	}
 
 	if len(record.shards) == c.config.NumberOfShards {
+		cleanStart := c.timeSource.Now()
 		updated, err := domain.CleanPendingActiveState(
 			c.domainManager,
 			domainID,
 			record.failoverVersion,
 			c.retryPolicy,
 		)
+		cleanDuration := c.timeSource.Now().Sub(cleanStart)
 		if err != nil {
 			c.logger.Error("Coordinator failed to update domain after receiving failover markers from all shards",
 				tag.WorkflowDomainID(domainID),
@@ -320,6 +325,7 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 			c.scope.IncCounter(metrics.CadenceFailures)
 			return
 		}
+		firstSeenTime := record.firstSeenTime
 		delete(c.recorder, domainID)
 		// reset the gauge so it reflects the current (empty) pending state for this domain
 		// rather than the last partial-count value, which would otherwise linger forever
@@ -341,6 +347,7 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 		now := c.timeSource.Now()
 		// use the last marker to calculate the failover duration
 		failoverDuration := now.Sub(time.Unix(0, marker.GetCreationTime()))
+		markerPipelineDuration := now.Sub(firstSeenTime)
 		c.scope.Tagged(
 			metrics.DomainTag(domainName),
 		).RecordTimer(
@@ -357,6 +364,8 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 			tag.WorkflowDomainName(domainName),
 			tag.FailoverVersion(marker.FailoverVersion),
 			tag.Duration(failoverDuration),
+			tag.Dynamic("marker-pipeline-duration", markerPipelineDuration),
+			tag.Dynamic("clean-pending-active-duration", cleanDuration),
 		)
 	} else {
 		c.scope.Tagged(

--- a/service/history/replication/task_executor.go
+++ b/service/history/replication/task_executor.go
@@ -338,6 +338,12 @@ func (e *taskExecutorImpl) handleFailoverReplicationTask(
 		return ErrEmptyFailoverMarkerAttributes
 	}
 	failoverAttributes.CreationTime = task.CreationTime
+	e.logger.Info("Failover marker handed to standby executor",
+		tag.ShardID(e.shard.GetShardID()),
+		tag.WorkflowDomainID(failoverAttributes.GetDomainID()),
+		tag.FailoverVersion(failoverAttributes.GetFailoverVersion()),
+		tag.Dynamic("execute-lag", time.Since(time.Unix(0, task.GetCreationTime()))),
+	)
 	return e.shard.AddingPendingFailoverMarker(failoverAttributes)
 }
 

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -325,6 +325,16 @@ func (p *taskProcessorImpl) processResponse(response *types.ReplicationMessages)
 	batchRequestStartTime := time.Now()
 	ctx := context.Background()
 	for _, replicationTask := range response.ReplicationTasks {
+		if replicationTask.GetTaskType() == types.ReplicationTaskTypeFailoverMarker {
+			if attr := replicationTask.GetFailoverMarkerAttributes(); attr != nil {
+				p.logger.Info("Failover marker arrived at standby replication processor",
+					tag.ShardID(p.shard.GetShardID()),
+					tag.WorkflowDomainID(attr.GetDomainID()),
+					tag.FailoverVersion(attr.GetFailoverVersion()),
+					tag.Dynamic("arrival-lag", time.Since(time.Unix(0, replicationTask.GetCreationTime()))),
+				)
+			}
+		}
 		// TODO: move to MultiStageRateLimiter
 		_ = p.hostRateLimiter.Wait(ctx)
 		_ = p.shardRateLimiter.Wait(ctx)


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Added first seen marker time and clean pending state duration to graceful failover completion log. Added logs when markers arrive at the task processor and executor.

https://github.com/cadence-workflow/cadence/issues/8138

**Why?**
Improving visibility on arrival times for markers at different points to identify possible bottlenecks or areas for improvements.

**How did you test it?**
No test updates required, only logs added. Existing tests still pass.

go test -race -count=1 ./service/history/failover/... ./service/history/replication/...

**Potential risks**
No risks. We emit 2 * number of shards per graceful failover logs. It's acceptable for now as we continue to improve graceful failover. May convert that to debug later.

**Release notes**
N/A

**Documentation Changes**
N/A
