### PR TITLE
fix(scheduler): dedupe pending backfill by BackfillID on idempotent retry

### DIFF
--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -77,6 +77,11 @@ const (
 	// Reason tag values for scheduler_backfill_rejected_count_per_domain.
 	BackfillRejectedReasonInvalidRange = "invalid_range"
 	BackfillRejectedReasonQueueFull    = "queue_full"
+	// BackfillRejectedReasonDuplicateID is emitted when a backfill signal
+	// arrives with a non-empty BackfillID that matches an already-pending
+	// backfill. The signal is absorbed for idempotent-retry safety rather
+	// than enqueued a second time.
+	BackfillRejectedReasonDuplicateID = "duplicate_id"
 
 	// MaxBufferedFiresSystemLimit caps the BUFFER overlap policy queue regardless
 	// of buffer_limit (including buffer_limit=0 meaning unlimited). It bounds the

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -487,14 +487,10 @@ func handleBackfill(logger *zap.Logger, scope tally.Scope, sig BackfillSignal, s
 	}
 	for _, existing := range state.PendingBackfills {
 		if sig.BackfillID != "" && existing.BackfillID == sig.BackfillID {
-			// Idempotent retry of a still-queued backfill: same BackfillID is
-			// already pending, so absorb the duplicate signal rather than
-			// enqueue a second copy. This protects RPC-level retries that
-			// arrive before the original starts draining. It does NOT protect
-			// retries that arrive after the original has already finished and
-			// been removed from PendingBackfills; those will fire the range
-			// again. If stronger idempotency is needed, track completed
-			// BackfillIDs separately.
+			// Drop the duplicate: BackfillID already matches a pending
+			// request, so a second copy would fire the range twice. Match is
+			// only checked against state.PendingBackfills, so a retry that
+			// lands after the original has drained is not detected here.
 			scope.Tagged(map[string]string{ReasonTag: BackfillRejectedReasonDuplicateID}).
 				Counter(SchedulerBackfillRejectedCountPerDomain).Inc(1)
 			logger.Info("ignoring duplicate backfill: BackfillID matches a pending request",

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -399,9 +399,31 @@ func handleUnpause(logger *zap.Logger, sig UnpauseSignal, state *SchedulerWorkfl
 	return true
 }
 
+// invalidSchedulePolicyCombo mirrors the rejection rule enforced by
+// validateSchedulePolicies in the frontend handler: SKIP_NEW + CATCH_UP_ALL is
+// nonsensical because every caught-up fire would be skipped on arrival as an
+// overlap with the previous run. Kept in-package so the workflow does not have
+// to import service/frontend.
+func invalidSchedulePolicyCombo(p *types.SchedulePolicies) bool {
+	return p.OverlapPolicy == types.ScheduleOverlapPolicySkipNew &&
+		p.CatchUpPolicy == types.ScheduleCatchUpPolicyAll
+}
+
 func handleUpdate(logger *zap.Logger, sig UpdateSignal, input *SchedulerWorkflowInput, state *SchedulerWorkflowState) bool {
 	if sig.Spec == nil && sig.Action == nil && sig.Policies == nil && sig.SearchAttributes == nil {
 		logger.Info("ignoring empty update signal")
+		return false
+	}
+	// Defense in depth: the frontend validates SchedulePolicies before sending
+	// the update signal, but a signal sent directly (e.g. via `cadence cli signal`)
+	// could still carry a combination the ERD declares invalid. Reject the whole
+	// signal rather than mutate input.Policies into an unfireable state and then
+	// silently apply partial spec/action changes around it.
+	if sig.Policies != nil && invalidSchedulePolicyCombo(sig.Policies) {
+		logger.Error("ignoring update signal with invalid policy combination",
+			zap.String("overlapPolicy", sig.Policies.OverlapPolicy.String()),
+			zap.String("catchUpPolicy", sig.Policies.CatchUpPolicy.String()),
+		)
 		return false
 	}
 	changed := false
@@ -486,6 +508,17 @@ func handleBackfill(logger *zap.Logger, scope tally.Scope, sig BackfillSignal, s
 		return false
 	}
 	for _, existing := range state.PendingBackfills {
+		if sig.BackfillID != "" && existing.BackfillID == sig.BackfillID {
+			// Idempotent retry: a backfill with the same non-empty BackfillID is
+			// already queued. Absorb the duplicate so the user can safely retry
+			// BackfillSchedule on transient RPC errors without doubling the fires.
+			scope.Tagged(map[string]string{ReasonTag: BackfillRejectedReasonDuplicateID}).
+				Counter(SchedulerBackfillRejectedCountPerDomain).Inc(1)
+			logger.Info("ignoring duplicate backfill: BackfillID matches a pending request",
+				zap.String("backfillId", sig.BackfillID),
+			)
+			return false
+		}
 		if sig.StartTime.Before(existing.EndTime) && sig.EndTime.After(existing.StartTime) {
 			logger.Warn("backfill window overlaps with pending backfill, fires for overlapping times will be deduplicated",
 				zap.String("newBackfillId", sig.BackfillID),

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -399,31 +399,9 @@ func handleUnpause(logger *zap.Logger, sig UnpauseSignal, state *SchedulerWorkfl
 	return true
 }
 
-// invalidSchedulePolicyCombo mirrors the rejection rule enforced by
-// validateSchedulePolicies in the frontend handler: SKIP_NEW + CATCH_UP_ALL is
-// nonsensical because every caught-up fire would be skipped on arrival as an
-// overlap with the previous run. Kept in-package so the workflow does not have
-// to import service/frontend.
-func invalidSchedulePolicyCombo(p *types.SchedulePolicies) bool {
-	return p.OverlapPolicy == types.ScheduleOverlapPolicySkipNew &&
-		p.CatchUpPolicy == types.ScheduleCatchUpPolicyAll
-}
-
 func handleUpdate(logger *zap.Logger, sig UpdateSignal, input *SchedulerWorkflowInput, state *SchedulerWorkflowState) bool {
 	if sig.Spec == nil && sig.Action == nil && sig.Policies == nil && sig.SearchAttributes == nil {
 		logger.Info("ignoring empty update signal")
-		return false
-	}
-	// Defense in depth: the frontend validates SchedulePolicies before sending
-	// the update signal, but a signal sent directly (e.g. via `cadence cli signal`)
-	// could still carry a combination the ERD declares invalid. Reject the whole
-	// signal rather than mutate input.Policies into an unfireable state and then
-	// silently apply partial spec/action changes around it.
-	if sig.Policies != nil && invalidSchedulePolicyCombo(sig.Policies) {
-		logger.Error("ignoring update signal with invalid policy combination",
-			zap.String("overlapPolicy", sig.Policies.OverlapPolicy.String()),
-			zap.String("catchUpPolicy", sig.Policies.CatchUpPolicy.String()),
-		)
 		return false
 	}
 	changed := false
@@ -509,9 +487,14 @@ func handleBackfill(logger *zap.Logger, scope tally.Scope, sig BackfillSignal, s
 	}
 	for _, existing := range state.PendingBackfills {
 		if sig.BackfillID != "" && existing.BackfillID == sig.BackfillID {
-			// Idempotent retry: a backfill with the same non-empty BackfillID is
-			// already queued. Absorb the duplicate so the user can safely retry
-			// BackfillSchedule on transient RPC errors without doubling the fires.
+			// Idempotent retry of a still-queued backfill: same BackfillID is
+			// already pending, so absorb the duplicate signal rather than
+			// enqueue a second copy. This protects RPC-level retries that
+			// arrive before the original starts draining. It does NOT protect
+			// retries that arrive after the original has already finished and
+			// been removed from PendingBackfills; those will fire the range
+			// again. If stronger idempotency is needed, track completed
+			// BackfillIDs separately.
 			scope.Tagged(map[string]string{ReasonTag: BackfillRejectedReasonDuplicateID}).
 				Counter(SchedulerBackfillRejectedCountPerDomain).Inc(1)
 			logger.Info("ignoring duplicate backfill: BackfillID matches a pending request",

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -702,39 +702,6 @@ func TestHandleUpdate(t *testing.T) {
 			wantPol:     types.ScheduleOverlapPolicySkipNew,
 			wantChanged: true,
 		},
-		{
-			// Defense in depth: even if the frontend validator is bypassed
-			// (e.g. a direct signal from `cadence cli`), the workflow must
-			// not adopt an unfireable SKIP_NEW + CATCH_UP_ALL combination.
-			name: "invalid policy combo (SKIP_NEW + CATCH_UP_ALL) is rejected, input unchanged",
-			sig: UpdateSignal{
-				Policies: &types.SchedulePolicies{
-					OverlapPolicy: types.ScheduleOverlapPolicySkipNew,
-					CatchUpPolicy: types.ScheduleCatchUpPolicyAll,
-				},
-			},
-			wantCron:    "0 * * * *",
-			wantWF:      "old-workflow",
-			wantPol:     types.ScheduleOverlapPolicySkipNew,
-			wantChanged: false,
-		},
-		{
-			// An invalid policy combo on a multi-field signal should drop the
-			// whole signal, not partially apply spec/action around the bad policy.
-			name: "invalid policy combo rejects whole signal, spec and action unchanged",
-			sig: UpdateSignal{
-				Spec:   &types.ScheduleSpec{CronExpression: "*/5 * * * *"},
-				Action: &types.ScheduleAction{StartWorkflow: &types.StartWorkflowAction{WorkflowType: &types.WorkflowType{Name: "new-workflow"}}},
-				Policies: &types.SchedulePolicies{
-					OverlapPolicy: types.ScheduleOverlapPolicySkipNew,
-					CatchUpPolicy: types.ScheduleCatchUpPolicyAll,
-				},
-			},
-			wantCron:    "0 * * * *",
-			wantWF:      "old-workflow",
-			wantPol:     types.ScheduleOverlapPolicySkipNew,
-			wantChanged: false,
-		},
 	}
 
 	for _, tt := range tests {

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -702,6 +702,39 @@ func TestHandleUpdate(t *testing.T) {
 			wantPol:     types.ScheduleOverlapPolicySkipNew,
 			wantChanged: true,
 		},
+		{
+			// Defense in depth: even if the frontend validator is bypassed
+			// (e.g. a direct signal from `cadence cli`), the workflow must
+			// not adopt an unfireable SKIP_NEW + CATCH_UP_ALL combination.
+			name: "invalid policy combo (SKIP_NEW + CATCH_UP_ALL) is rejected, input unchanged",
+			sig: UpdateSignal{
+				Policies: &types.SchedulePolicies{
+					OverlapPolicy: types.ScheduleOverlapPolicySkipNew,
+					CatchUpPolicy: types.ScheduleCatchUpPolicyAll,
+				},
+			},
+			wantCron:    "0 * * * *",
+			wantWF:      "old-workflow",
+			wantPol:     types.ScheduleOverlapPolicySkipNew,
+			wantChanged: false,
+		},
+		{
+			// An invalid policy combo on a multi-field signal should drop the
+			// whole signal, not partially apply spec/action around the bad policy.
+			name: "invalid policy combo rejects whole signal, spec and action unchanged",
+			sig: UpdateSignal{
+				Spec:   &types.ScheduleSpec{CronExpression: "*/5 * * * *"},
+				Action: &types.ScheduleAction{StartWorkflow: &types.StartWorkflowAction{WorkflowType: &types.WorkflowType{Name: "new-workflow"}}},
+				Policies: &types.SchedulePolicies{
+					OverlapPolicy: types.ScheduleOverlapPolicySkipNew,
+					CatchUpPolicy: types.ScheduleCatchUpPolicyAll,
+				},
+			},
+			wantCron:    "0 * * * *",
+			wantWF:      "old-workflow",
+			wantPol:     types.ScheduleOverlapPolicySkipNew,
+			wantChanged: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -866,6 +899,54 @@ func TestHandleBackfill(t *testing.T) {
 			assert.Equal(t, int64(1), c.Value())
 		})
 	}
+
+	t.Run("duplicate BackfillID is absorbed as idempotent retry", func(t *testing.T) {
+		state := &SchedulerWorkflowState{
+			PendingBackfills: []BackfillRequest{
+				{
+					StartTime:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+					EndTime:    time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+					BackfillID: "bf-dup",
+				},
+			},
+		}
+		scope := tally.NewTestScope("", nil)
+		// Same BackfillID, even with a different time range, must not enqueue a
+		// second copy: BackfillSchedule is meant to be retry-safe by ID.
+		sig := BackfillSignal{
+			StartTime:  time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+			EndTime:    time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC),
+			BackfillID: "bf-dup",
+		}
+		got := handleBackfill(testLogger, scope, sig, state)
+		assert.False(t, got)
+		assert.Len(t, state.PendingBackfills, 1)
+		assert.Equal(t, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), state.PendingBackfills[0].StartTime)
+
+		c, ok := findCounter(scope.Snapshot().Counters(), SchedulerBackfillRejectedCountPerDomain,
+			map[string]string{ReasonTag: BackfillRejectedReasonDuplicateID})
+		require.True(t, ok)
+		assert.Equal(t, int64(1), c.Value())
+	})
+
+	t.Run("empty BackfillID does not collide with another empty BackfillID", func(t *testing.T) {
+		state := &SchedulerWorkflowState{
+			PendingBackfills: []BackfillRequest{
+				{
+					StartTime: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+					EndTime:   time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+				},
+			},
+		}
+		scope := tally.NewTestScope("", nil)
+		sig := BackfillSignal{
+			StartTime: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+			EndTime:   time.Date(2026, 2, 2, 0, 0, 0, 0, time.UTC),
+		}
+		got := handleBackfill(testLogger, scope, sig, state)
+		assert.True(t, got)
+		assert.Len(t, state.PendingBackfills, 2)
+	})
 }
 
 func TestEffectiveFireOverlap(t *testing.T) {


### PR DESCRIPTION
**What changed?**

- `handleBackfill` now absorbs a backfill signal whose non-empty `BackfillID` matches an already-pending `BackfillRequest` instead of appending a duplicate. The rejection is counted in `scheduler_backfill_rejected_count_per_domain{reason=duplicate_id}`.

**Why?**

`BackfillSchedule` is intended to be retry-safe via `BackfillID`. Previously, retrying the same backfill on a transient RPC error would append a second `BackfillRequest` to `state.PendingBackfills`, causing the same time range to fire twice with identical search attributes. Treating a duplicate `BackfillID` against a still-pending entry as a no-op preserves retry safety in the common case.

Scope note: deduplication is only checked against entries that are still in `state.PendingBackfills`. A retry that arrives after the original has already finished and been removed from the queue will fire the range a second time. Stronger end-to-end idempotency would require tracking recently-completed `BackfillID`s and is not part of this change.

**How did you test it?**
```
go test -race ./service/worker/scheduler/...
make pr GEN_DIR=service/worker/scheduler
```
**Potential risks**

Low. The added behavior is a pure rejection path: a previously-accepted duplicate signal is now logged at info level and dropped. The metric on the rejection path gives operators visibility into duplicates. 

**Documentation Changes**

N/A