### PR TITLE
fix(scheduler): apply 365d default catch_up_window when unset

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -76,20 +76,14 @@ func validateSchedulePolicies(policies *types.SchedulePolicies) error {
 	return nil
 }
 
-// defaultCatchUpWindow bounds how far back the scheduler walks when catching up
-// missed runs after a pause / worker recovery. Chosen to match temporal
-// (CurrentTweakablePolicies.DefaultCatchupWindow = 365 days) so users moving
-// between systems see the same recovery behavior. The IDL comment on
-// SchedulePolicies.catch_up_window already promises a server-applied default
-// when the field is unset; this constant is what that promise resolves to.
+// defaultCatchUpWindow is applied to SchedulePolicies.CatchUpWindow when the
+// field is unset and the configured catch-up policy consults the window.
 const defaultCatchUpWindow = 365 * 24 * time.Hour
 
-// applySchedulePolicyDefaults fills in server-defaulted fields on a
-// user-supplied SchedulePolicies in place. Today the only defaulted field is
-// CatchUpWindow when a catch-up policy that actually consults the window is
-// selected: SKIP and the zero value (Invalid → treated as SKIP downstream)
-// ignore the window, so leaving it 0 in those cases is harmless and we avoid
-// rewriting fields the user did not exercise.
+// applySchedulePolicyDefaults fills in server-defaulted fields on a user-supplied
+// SchedulePolicies in place. CatchUpWindow is set to defaultCatchUpWindow only
+// when CatchUpPolicy is ONE or ALL; SKIP and the zero value do not consult the
+// window.
 func applySchedulePolicyDefaults(policies *types.SchedulePolicies) {
 	if policies == nil {
 		return

--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -76,6 +76,31 @@ func validateSchedulePolicies(policies *types.SchedulePolicies) error {
 	return nil
 }
 
+// defaultCatchUpWindow bounds how far back the scheduler walks when catching up
+// missed runs after a pause / worker recovery. Chosen to match temporal
+// (CurrentTweakablePolicies.DefaultCatchupWindow = 365 days) so users moving
+// between systems see the same recovery behavior. The IDL comment on
+// SchedulePolicies.catch_up_window already promises a server-applied default
+// when the field is unset; this constant is what that promise resolves to.
+const defaultCatchUpWindow = 365 * 24 * time.Hour
+
+// applySchedulePolicyDefaults fills in server-defaulted fields on a
+// user-supplied SchedulePolicies in place. Today the only defaulted field is
+// CatchUpWindow when a catch-up policy that actually consults the window is
+// selected: SKIP and the zero value (Invalid → treated as SKIP downstream)
+// ignore the window, so leaving it 0 in those cases is harmless and we avoid
+// rewriting fields the user did not exercise.
+func applySchedulePolicyDefaults(policies *types.SchedulePolicies) {
+	if policies == nil {
+		return
+	}
+	usesWindow := policies.CatchUpPolicy == types.ScheduleCatchUpPolicyOne ||
+		policies.CatchUpPolicy == types.ScheduleCatchUpPolicyAll
+	if usesWindow && policies.CatchUpWindow == 0 {
+		policies.CatchUpWindow = defaultCatchUpWindow
+	}
+}
+
 // validateScheduleSpecTimeRange rejects a spec whose EndTime is not after its
 // StartTime when both are set. A zero StartTime or EndTime means "unbounded" and
 // is left unchecked. Mirrors the range validation BackfillSchedule performs, and
@@ -172,6 +197,7 @@ func (wh *WorkflowHandler) CreateSchedule(
 	if err := validateSchedulePolicies(request.GetPolicies()); err != nil {
 		return nil, err
 	}
+	applySchedulePolicyDefaults(request.GetPolicies())
 	wh.warnIfBufferLimitExceedsSystemLimit(scheduleID, domainName, request.GetPolicies())
 	if err := validateUserSearchAttributes(request.GetSearchAttributes()); err != nil {
 		return nil, err
@@ -368,6 +394,7 @@ func (wh *WorkflowHandler) UpdateSchedule(
 	if err := validateSchedulePolicies(request.GetPolicies()); err != nil {
 		return nil, err
 	}
+	applySchedulePolicyDefaults(request.GetPolicies())
 	wh.warnIfBufferLimitExceedsSystemLimit(scheduleID, domainName, request.GetPolicies())
 	if spec := request.GetSpec(); spec != nil && spec.GetCronExpression() != "" {
 		if _, err := backoff.ValidateSchedule(spec.GetCronExpression()); err != nil {

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -1628,9 +1628,6 @@ func TestApplySchedulePolicyDefaults(t *testing.T) {
 			wantWindow: 0,
 		},
 		"invalid/uninitialized catch-up policy leaves the window untouched": {
-			// The workflow treats Invalid as Skip, so injecting a window here
-			// would be misleading and would surprise callers who never set a
-			// catch-up policy in the first place.
 			policies:   &types.SchedulePolicies{},
 			wantWindow: 0,
 		},

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -1666,6 +1666,8 @@ func TestApplySchedulePolicyDefaults(t *testing.T) {
 			assert.Equal(t, tt.wantWindow, tt.policies.CatchUpWindow)
 		})
 	}
+}
+
 func TestOngoingBackfillsForResponse(t *testing.T) {
 	t.Run("nil input returns nil", func(t *testing.T) {
 		assert.Nil(t, ongoingBackfillsForResponse(nil))

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -1592,6 +1592,60 @@ func TestValidateSchedulePolicies(t *testing.T) {
 	}
 }
 
+func TestApplySchedulePolicyDefaults(t *testing.T) {
+	tests := map[string]struct {
+		policies     *types.SchedulePolicies
+		wantWindow   time.Duration
+		wantPolicies *types.SchedulePolicies
+	}{
+		"nil policies is a no-op": {
+			policies:     nil,
+			wantPolicies: nil,
+		},
+		"CATCH_UP_ALL with unset window gets default": {
+			policies: &types.SchedulePolicies{
+				CatchUpPolicy: types.ScheduleCatchUpPolicyAll,
+			},
+			wantWindow: defaultCatchUpWindow,
+		},
+		"CATCH_UP_ONE with unset window gets default": {
+			policies: &types.SchedulePolicies{
+				CatchUpPolicy: types.ScheduleCatchUpPolicyOne,
+			},
+			wantWindow: defaultCatchUpWindow,
+		},
+		"explicitly-set window is preserved (not overwritten)": {
+			policies: &types.SchedulePolicies{
+				CatchUpPolicy: types.ScheduleCatchUpPolicyAll,
+				CatchUpWindow: 30 * time.Minute,
+			},
+			wantWindow: 30 * time.Minute,
+		},
+		"SKIP catch-up does not consult the window, so we leave it zero": {
+			policies: &types.SchedulePolicies{
+				CatchUpPolicy: types.ScheduleCatchUpPolicySkip,
+			},
+			wantWindow: 0,
+		},
+		"invalid/uninitialized catch-up policy leaves the window untouched": {
+			// The workflow treats Invalid as Skip, so injecting a window here
+			// would be misleading and would surprise callers who never set a
+			// catch-up policy in the first place.
+			policies:   &types.SchedulePolicies{},
+			wantWindow: 0,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			applySchedulePolicyDefaults(tt.policies)
+			if tt.policies == nil {
+				return
+			}
+			assert.Equal(t, tt.wantWindow, tt.policies.CatchUpWindow)
+		})
+	}
+}
+
 // TestValidateUserSearchAttributes verifies that user-supplied search attribute
 // keys colliding with the scheduler-reserved "CadenceSchedule" prefix are
 // rejected, while other keys (including a lowercase near-miss) are allowed. The


### PR DESCRIPTION
**What changed?**

- New `defaultCatchUpWindow = 365 * 24 * time.Hour` constant.
- New `applySchedulePolicyDefaults` helper that sets `policies.CatchUpWindow` to the default when (and only when) `CatchUpPolicy` is `ONE` or `ALL`. `SKIP` and the zero-value (uninitialized) policy do not consult the window and are left untouched.

**Why?**

A schedule created with `CATCH_UP_ALL` and `CatchUpWindow == 0` caught up every missed run regardless of age, bounded only by the per-execution fire cap. This PR fulfills the IDL contract.

**How did you test it?**

```
go test -race -run Schedule ./service/frontend/api/...
make pr GEN_DIR=service/frontend/api
```

**Potential risks**

Behavior change: schedules previously created with `CATCH_UP_ALL` or `CATCH_UP_ONE` and `CatchUpWindow == 0` were treated as unlimited catch-up; they will now be capped at 365 days of catch-up. Operators who want truly unlimited catch-up must pass an explicit large duration. The workflow side still treats `window <= 0` as unlimited for in-flight state, so behavior of currently-running schedule workflows is unchanged until their next update. 

**Documentation Changes**
N/A