### PR TITLE
feat(scheduler): expose ongoing backfill progress in DescribeSchedule

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -132,6 +132,24 @@ func validateUserSearchAttributes(sa *types.SearchAttributes) error {
 	return nil
 }
 
+// ongoingBackfillsForResponse converts the scheduler workflow's snapshot of
+// pending backfills into the public BackfillInfo list returned via
+// DescribeScheduleResponse. Returns nil (not empty slice) when there are no
+// backfills, so json.Marshal of the response keeps the field absent rather
+// than emitting an empty array — matches the pattern used by Memo /
+// SearchAttributes elsewhere in the handler.
+func ongoingBackfillsForResponse(in []types.BackfillInfo) []*types.BackfillInfo {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]*types.BackfillInfo, 0, len(in))
+	for i := range in {
+		bf := in[i]
+		out = append(out, &bf)
+	}
+	return out
+}
+
 func (wh *WorkflowHandler) CreateSchedule(
 	ctx context.Context,
 	request *types.CreateScheduleRequest,
@@ -332,11 +350,12 @@ func (wh *WorkflowHandler) DescribeSchedule(
 			}(),
 		},
 		Info: &types.ScheduleInfo{
-			LastRunTime: desc.LastRunTime,
-			NextRunTime: desc.NextRunTime,
-			TotalRuns:   desc.TotalRuns,
-			MissedRuns:  desc.MissedRuns,
-			SkippedRuns: desc.SkippedRuns,
+			LastRunTime:      desc.LastRunTime,
+			NextRunTime:      desc.NextRunTime,
+			TotalRuns:        desc.TotalRuns,
+			MissedRuns:       desc.MissedRuns,
+			SkippedRuns:      desc.SkippedRuns,
+			OngoingBackfills: ongoingBackfillsForResponse(desc.OngoingBackfills),
 		},
 		Memo:             desc.Memo,
 		SearchAttributes: desc.SearchAttributes,

--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -133,11 +133,9 @@ func validateUserSearchAttributes(sa *types.SearchAttributes) error {
 }
 
 // ongoingBackfillsForResponse converts the scheduler workflow's snapshot of
-// pending backfills into the public BackfillInfo list returned via
-// DescribeScheduleResponse. Returns nil (not empty slice) when there are no
-// backfills, so json.Marshal of the response keeps the field absent rather
-// than emitting an empty array — matches the pattern used by Memo /
-// SearchAttributes elsewhere in the handler.
+// pending backfills into the BackfillInfo pointer slice carried in
+// DescribeScheduleResponse. Returns nil (not an empty slice) when there are
+// no backfills so the marshalled response omits the field.
 func ongoingBackfillsForResponse(in []types.BackfillInfo) []*types.BackfillInfo {
 	if len(in) == 0 {
 		return nil

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -1592,6 +1592,40 @@ func TestValidateSchedulePolicies(t *testing.T) {
 	}
 }
 
+func TestOngoingBackfillsForResponse(t *testing.T) {
+	t.Run("nil input returns nil", func(t *testing.T) {
+		assert.Nil(t, ongoingBackfillsForResponse(nil))
+	})
+	t.Run("empty input returns nil", func(t *testing.T) {
+		assert.Nil(t, ongoingBackfillsForResponse([]types.BackfillInfo{}))
+	})
+	t.Run("non-empty input is mapped one-to-one and copies each entry", func(t *testing.T) {
+		in := []types.BackfillInfo{
+			{
+				BackfillID:    "bf-a",
+				StartTime:     time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+				EndTime:       time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC),
+				RunsTotal:     24,
+				RunsCompleted: 5,
+			},
+			{
+				BackfillID: "bf-b",
+				StartTime:  time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+				EndTime:    time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC),
+			},
+		}
+		out := ongoingBackfillsForResponse(in)
+		require.Len(t, out, 2)
+		assert.Equal(t, in[0], *out[0])
+		assert.Equal(t, in[1], *out[1])
+
+		// Each pointer must refer to an independent copy so a later mutation
+		// of the response slice does not race against scheduler-workflow state.
+		out[0].RunsCompleted = 99
+		assert.Equal(t, int32(5), in[0].RunsCompleted, "mutating out must not affect in")
+	})
+}
+
 // TestValidateUserSearchAttributes verifies that user-supplied search attribute
 // keys colliding with the scheduler-reserved "CadenceSchedule" prefix are
 // rejected, while other keys (including a lowercase near-miss) are allowed. The

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -131,6 +131,15 @@ const (
 	maxDrainFiresPerExecution        = 10
 	maxPendingBackfills              = 10
 
+	// maxBackfillRunsTotalCount caps the cron-walk used to populate
+	// BackfillRequest.RunsTotal at enqueue. A per-second cron over a year
+	// would otherwise produce ~31M fires of counting work in the workflow
+	// signal handler; capping at 100k keeps the cost bounded and covers the
+	// vast majority of real backfills (typical: a few hundred fires). When
+	// a range exceeds the cap, RunsTotal is recorded as 0 to signal
+	// "unknown" rather than a misleading bounded count.
+	maxBackfillRunsTotalCount = 100000
+
 	localActivityScheduleToCloseTimeout = 60 * time.Second
 	localActivityMaxRetries             = 3
 	localActivityRetryInitialInterval   = time.Second
@@ -210,6 +219,22 @@ type BackfillRequest struct {
 	EndTime       time.Time                   `json:"endTime"`
 	OverlapPolicy types.ScheduleOverlapPolicy `json:"overlapPolicy"`
 	BackfillID    string                      `json:"backfillId,omitempty"`
+	// RunsTotal is the number of cron fires within (StartTime, EndTime] at the
+	// time the backfill was enqueued. It does NOT track spec changes
+	// mid-backfill, because a spec change clears all pending backfills (see
+	// handleUpdate). 0 means "unknown" — set when the count would exceed
+	// maxBackfillRunsTotalCount, which happens for very-frequent crons over
+	// very long ranges. Consumers surfacing a progress percentage should
+	// ignore entries with RunsTotal == 0.
+	RunsTotal int32 `json:"runsTotal,omitempty"`
+	// RunsCompleted is the number of fires from this backfill the scheduler
+	// has finished considering. A fire counts the moment it leaves
+	// processBackfills — whether it actually started, was skipped under the
+	// overlap policy, or was deferred into the BUFFER queue. This matches
+	// how SchedulerWorkflowState.TotalRuns / SkippedRuns are updated and lets
+	// the backfill drop out of PendingBackfills the moment processing is done,
+	// not whenever the BUFFER queue happens to drain.
+	RunsCompleted int32 `json:"runsCompleted,omitempty"`
 }
 
 // PauseSignal is the payload sent with a pause signal.
@@ -258,6 +283,11 @@ type ScheduleDescription struct {
 	SkippedRuns      int64                   `json:"skippedRuns"`
 	Memo             *types.Memo             `json:"memo,omitempty"`
 	SearchAttributes *types.SearchAttributes `json:"searchAttributes,omitempty"`
+	// OngoingBackfills mirrors SchedulerWorkflowState.PendingBackfills at the
+	// time of the describe query. Each entry is reported as a BackfillInfo
+	// (id, range, progress) so the frontend can surface it as
+	// ScheduleInfo.OngoingBackfills without a separate query path.
+	OngoingBackfills []types.BackfillInfo `json:"ongoingBackfills,omitempty"`
 }
 
 // TriggerSource identifies what caused a schedule fire, used to differentiate

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -131,13 +131,9 @@ const (
 	maxDrainFiresPerExecution        = 10
 	maxPendingBackfills              = 10
 
-	// maxBackfillRunsTotalCount caps the cron-walk used to populate
-	// BackfillRequest.RunsTotal at enqueue. A per-second cron over a year
-	// would otherwise produce ~31M fires of counting work in the workflow
-	// signal handler; capping at 100k keeps the cost bounded and covers the
-	// vast majority of real backfills (typical: a few hundred fires). When
-	// a range exceeds the cap, RunsTotal is recorded as 0 to signal
-	// "unknown" rather than a misleading bounded count.
+	// maxBackfillRunsTotalCount caps the cron walk that populates
+	// BackfillRequest.RunsTotal. When a backfill range produces more fires
+	// than this, RunsTotal is set to the cap as a lower bound.
 	maxBackfillRunsTotalCount = 100000
 
 	localActivityScheduleToCloseTimeout = 60 * time.Second
@@ -220,21 +216,21 @@ type BackfillRequest struct {
 	OverlapPolicy types.ScheduleOverlapPolicy `json:"overlapPolicy"`
 	BackfillID    string                      `json:"backfillId,omitempty"`
 	// RunsTotal is the number of cron fires within (StartTime, EndTime] at the
-	// time the backfill was enqueued. It does NOT track spec changes
-	// mid-backfill, because a spec change clears all pending backfills (see
-	// handleUpdate). 0 means "unknown" — set when the count would exceed
-	// maxBackfillRunsTotalCount, which happens for very-frequent crons over
-	// very long ranges. Consumers surfacing a progress percentage should
-	// ignore entries with RunsTotal == 0.
+	// time the backfill was first processed. Populated lazily by processBackfills
+	// using the workflow's currently parsed cron. When the range exceeds
+	// maxBackfillRunsTotalCount, RunsTotal is set to that cap as a lower bound;
+	// consumers may observe RunsCompleted approach or exceed RunsTotal before
+	// the backfill finishes draining.
 	RunsTotal int32 `json:"runsTotal,omitempty"`
-	// RunsCompleted is the number of fires from this backfill the scheduler
-	// has finished considering. A fire counts the moment it leaves
-	// processBackfills — whether it actually started, was skipped under the
-	// overlap policy, or was deferred into the BUFFER queue. This matches
-	// how SchedulerWorkflowState.TotalRuns / SkippedRuns are updated and lets
-	// the backfill drop out of PendingBackfills the moment processing is done,
-	// not whenever the BUFFER queue happens to drain.
+	// RunsCompleted is the number of fires from this backfill that
+	// processBackfills has handed off to processScheduleFire — counted whether
+	// the fire started, was skipped under the overlap policy, or was deferred
+	// into the BUFFER queue.
 	RunsCompleted int32 `json:"runsCompleted,omitempty"`
+	// RunsTotalComputed records whether RunsTotal has been populated, so
+	// processBackfills does not re-walk the cron on every batch and an empty
+	// range (RunsTotal == 0) is not confused with "not yet computed".
+	RunsTotalComputed bool `json:"runsTotalComputed,omitempty"`
 }
 
 // PauseSignal is the payload sent with a pause signal.
@@ -284,9 +280,7 @@ type ScheduleDescription struct {
 	Memo             *types.Memo             `json:"memo,omitempty"`
 	SearchAttributes *types.SearchAttributes `json:"searchAttributes,omitempty"`
 	// OngoingBackfills mirrors SchedulerWorkflowState.PendingBackfills at the
-	// time of the describe query. Each entry is reported as a BackfillInfo
-	// (id, range, progress) so the frontend can surface it as
-	// ScheduleInfo.OngoingBackfills without a separate query path.
+	// time of the describe query.
 	OngoingBackfills []types.BackfillInfo `json:"ongoingBackfills,omitempty"`
 }
 

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -943,34 +943,42 @@ func processMissedRunsAt(ctx workflow.Context, logger *zap.Logger, scope tally.S
 // Like processMissedRuns, it caps fires per execution and returns true
 // if more work remains (signalling the caller to ContinueAsNew).
 func processBackfills(ctx workflow.Context, logger *zap.Logger, scope tally.Scope, sched cron.Schedule, input *SchedulerWorkflowInput, state *SchedulerWorkflowState) bool {
-	// Backfills respect the pause state: an explicit user request to replay a time
-	// range should not fire workflows while the schedule is paused. The pending
-	// backfills are preserved in state and will execute once the schedule is unpaused.
-	if state.Paused || len(state.PendingBackfills) == 0 {
+	if len(state.PendingBackfills) == 0 {
+		return false
+	}
+
+	// Populate RunsTotal for any queued backfill that hasn't been counted
+	// yet. Done outside the pause short-circuit so DescribeSchedule reports
+	// accurate progress for queued work on a paused schedule instead of 0/0.
+	// Uses the cron parsed at the top of this workflow execution, so a
+	// same-batch UpdateSchedule that changed the cron does not leave us
+	// counting against the stale expression.
+	for i := range state.PendingBackfills {
+		bf := &state.PendingBackfills[i]
+		if bf.RunsTotalComputed {
+			continue
+		}
+		total, truncated := countCronFires(sched, bf.StartTime.Add(-time.Second), bf.EndTime, input.Spec, maxBackfillRunsTotalCount)
+		if truncated {
+			// Range exceeds the count cap; report the cap as a lower bound
+			// rather than overload 0 as "unknown".
+			bf.RunsTotal = int32(maxBackfillRunsTotalCount)
+		} else {
+			bf.RunsTotal = int32(total)
+		}
+		bf.RunsTotalComputed = true
+	}
+
+	// Backfills respect the pause state: an explicit user request to replay
+	// a time range should not fire workflows while the schedule is paused.
+	// The pending backfills are preserved and will execute on unpause.
+	if state.Paused {
 		return false
 	}
 
 	fired := 0
 	for len(state.PendingBackfills) > 0 {
 		bf := &state.PendingBackfills[0]
-
-		// RunsTotal is computed lazily on first contact. Doing it here (not in
-		// handleBackfill) uses the cron schedule re-parsed at the top of this
-		// workflow execution, so a same-batch UpdateSchedule that changed the
-		// cron does not leave us counting against the stale expression.
-		if !bf.RunsTotalComputed {
-			total, truncated := countCronFires(sched, bf.StartTime.Add(-time.Second), bf.EndTime, input.Spec, maxBackfillRunsTotalCount)
-			if truncated {
-				// The range exceeds the count cap; report the cap as a lower
-				// bound rather than overload 0 as "unknown". Callers comparing
-				// RunsCompleted against RunsTotal may see RunsCompleted reach
-				// or exceed this value before the backfill finishes draining.
-				bf.RunsTotal = int32(maxBackfillRunsTotalCount)
-			} else {
-				bf.RunsTotal = int32(total)
-			}
-			bf.RunsTotalComputed = true
-		}
 
 		fires := computeMissedFireTimes(sched, bf.StartTime.Add(-time.Second), bf.EndTime, input.Spec)
 

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -147,7 +147,7 @@ func SchedulerWorkflow(ctx workflow.Context, input SchedulerWorkflowInput) error
 		}
 
 		previousPaused := state.Paused
-		changed, timerFired := applyAllInputs(ctx, logger, scope, timerFuture, chs, state, &input)
+		changed, timerFired := applyAllInputs(ctx, logger, scope, sched, timerFuture, chs, state, &input)
 
 		if timerCancel != nil {
 			timerCancel()
@@ -207,6 +207,7 @@ func applyAllInputs(
 	ctx workflow.Context,
 	logger *zap.Logger,
 	scope tally.Scope,
+	sched cron.Schedule,
 	timerFuture workflow.Future,
 	chs signalChannels,
 	state *SchedulerWorkflowState,
@@ -256,7 +257,7 @@ func applyAllInputs(
 		var sig BackfillSignal
 		c.Receive(ctx, &sig)
 		scope.Tagged(map[string]string{SignalTypeTag: signalTypeTagBackfill}).Counter(SchedulerSignalReceivedCountPerDomain).Inc(1)
-		if handleBackfill(logger, scope, sig, state) {
+		if handleBackfill(logger, scope, sched, input, sig, state) {
 			stateChanged = true
 		}
 	})
@@ -269,7 +270,7 @@ func applyAllInputs(
 
 	selector.Select(ctx)
 
-	if drainBufferedSignals(logger, scope, chs, state, input) {
+	if drainBufferedSignals(logger, scope, sched, chs, state, input) {
 		stateChanged = true
 	}
 
@@ -282,6 +283,7 @@ func applyAllInputs(
 func drainBufferedSignals(
 	logger *zap.Logger,
 	scope tally.Scope,
+	sched cron.Schedule,
 	chs signalChannels,
 	state *SchedulerWorkflowState,
 	input *SchedulerWorkflowInput,
@@ -329,7 +331,7 @@ func drainBufferedSignals(
 			break
 		}
 		scope.Tagged(map[string]string{SignalTypeTag: signalTypeTagBackfill}).Counter(SchedulerSignalReceivedCountPerDomain).Inc(1)
-		if handleBackfill(logger, scope, sig, state) {
+		if handleBackfill(logger, scope, sched, input, sig, state) {
 			stateChanged = true
 		}
 	}
@@ -465,7 +467,7 @@ func handleUpdate(logger *zap.Logger, sig UpdateSignal, input *SchedulerWorkflow
 	return changed
 }
 
-func handleBackfill(logger *zap.Logger, scope tally.Scope, sig BackfillSignal, state *SchedulerWorkflowState) bool {
+func handleBackfill(logger *zap.Logger, scope tally.Scope, sched cron.Schedule, input *SchedulerWorkflowInput, sig BackfillSignal, state *SchedulerWorkflowState) bool {
 	if !sig.EndTime.After(sig.StartTime) {
 		scope.Tagged(map[string]string{ReasonTag: BackfillRejectedReasonInvalidRange}).
 			Counter(SchedulerBackfillRejectedCountPerDomain).Inc(1)
@@ -495,17 +497,33 @@ func handleBackfill(logger *zap.Logger, scope tally.Scope, sig BackfillSignal, s
 			)
 		}
 	}
+	// Compute RunsTotal up front so DescribeSchedule can show progress as the
+	// backfill drains. handleBackfill runs inside the workflow loop, so this
+	// walk is deterministic — passing a stable cron.Schedule / spec snapshot.
+	// Match processBackfills' fire boundary: (StartTime, EndTime].
+	runsTotal, truncated := countCronFires(sched, sig.StartTime.Add(-time.Second), sig.EndTime, input.Spec, maxBackfillRunsTotalCount)
+	if truncated {
+		// Don't surface a misleadingly bounded count for huge ranges; report
+		// "unknown" via 0 so consumers know the percentage is meaningless.
+		logger.Info("backfill range exceeds RunsTotal count cap, reporting unknown total",
+			zap.String("backfillId", sig.BackfillID),
+			zap.Int("cap", maxBackfillRunsTotalCount),
+		)
+		runsTotal = 0
+	}
 	state.PendingBackfills = append(state.PendingBackfills, BackfillRequest{
 		StartTime:     sig.StartTime,
 		EndTime:       sig.EndTime,
 		OverlapPolicy: sig.OverlapPolicy,
 		BackfillID:    sig.BackfillID,
+		RunsTotal:     int32(runsTotal),
 	})
 	logger.Info("backfill queued",
 		zap.Time("startTime", sig.StartTime),
 		zap.Time("endTime", sig.EndTime),
 		zap.String("overlapPolicy", sig.OverlapPolicy.String()),
 		zap.String("backfillId", sig.BackfillID),
+		zap.Int("runsTotal", runsTotal),
 		zap.Int("pendingCount", len(state.PendingBackfills)),
 	)
 	return true
@@ -769,6 +787,26 @@ func computeMissedFireTimes(sched cron.Schedule, lastRun, now time.Time, spec ty
 	return missedFiresResult{times: missed, truncated: true}
 }
 
+// countCronFires returns the number of cron fire times in (start, end],
+// without materializing the fires. Used to populate BackfillRequest.RunsTotal
+// at signal-handle time when we only need the count, not the times.
+// Caps the walk at `limit`; the second return value is true when the range
+// would have produced more than `limit` fires (caller treats the count as
+// unknown in that case).
+func countCronFires(sched cron.Schedule, start, end time.Time, spec types.ScheduleSpec, limit int) (int, bool) {
+	count := 0
+	t := start
+	for count < limit {
+		next := computeNextRunTime(sched, t, spec)
+		if next.IsZero() || next.After(end) {
+			return count, false
+		}
+		count++
+		t = next
+	}
+	return count, true
+}
+
 // missedRunPolicyResult is the output of applyMissedRunPolicy.
 type missedRunPolicyResult struct {
 	toFire  []time.Time // fire times to execute, in order
@@ -953,6 +991,12 @@ func processBackfills(ctx workflow.Context, logger *zap.Logger, scope tally.Scop
 			overlap := effectiveFireOverlap(TriggerSourceBackfill, bf.OverlapPolicy, input.Policies.OverlapPolicy)
 			processScheduleFire(ctx, logger, scope, input, state, t, TriggerSourceBackfill, overlap, bf.BackfillID)
 			fired++
+			// RunsCompleted advances on every fire that leaves processScheduleFire,
+			// regardless of whether it actually started, was skipped under the
+			// overlap policy, or was queued into the BUFFER. Anything else would
+			// pin the backfill in OngoingBackfills indefinitely whenever the
+			// schedule's overlap policy holds runs back from starting.
+			bf.RunsCompleted++
 		}
 
 		if fires.truncated {
@@ -972,6 +1016,8 @@ func processBackfills(ctx workflow.Context, logger *zap.Logger, scope tally.Scop
 		logger.Info("backfill completed",
 			zap.String("backfillId", bf.BackfillID),
 			zap.Int("firedTotal", fired),
+			zap.Int32("runsCompleted", bf.RunsCompleted),
+			zap.Int32("runsTotal", bf.RunsTotal),
 		)
 		state.PendingBackfills = state.PendingBackfills[1:]
 	}
@@ -986,6 +1032,19 @@ func processBackfills(ctx workflow.Context, logger *zap.Logger, scope tally.Scop
 // buildScheduleDescription creates a snapshot of the current schedule
 // configuration and runtime state for the describe query handler.
 func buildScheduleDescription(input *SchedulerWorkflowInput, state *SchedulerWorkflowState) *ScheduleDescription {
+	var ongoing []types.BackfillInfo
+	if len(state.PendingBackfills) > 0 {
+		ongoing = make([]types.BackfillInfo, 0, len(state.PendingBackfills))
+		for _, bf := range state.PendingBackfills {
+			ongoing = append(ongoing, types.BackfillInfo{
+				BackfillID:    bf.BackfillID,
+				StartTime:     bf.StartTime,
+				EndTime:       bf.EndTime,
+				RunsTotal:     bf.RunsTotal,
+				RunsCompleted: bf.RunsCompleted,
+			})
+		}
+	}
 	return &ScheduleDescription{
 		ScheduleID:       input.ScheduleID,
 		Domain:           input.Domain,
@@ -1002,6 +1061,7 @@ func buildScheduleDescription(input *SchedulerWorkflowInput, state *SchedulerWor
 		SkippedRuns:      state.SkippedRuns,
 		Memo:             input.Memo,
 		SearchAttributes: input.SearchAttributes,
+		OngoingBackfills: ongoing,
 	}
 }
 

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -147,7 +147,7 @@ func SchedulerWorkflow(ctx workflow.Context, input SchedulerWorkflowInput) error
 		}
 
 		previousPaused := state.Paused
-		changed, timerFired := applyAllInputs(ctx, logger, scope, sched, timerFuture, chs, state, &input)
+		changed, timerFired := applyAllInputs(ctx, logger, scope, timerFuture, chs, state, &input)
 
 		if timerCancel != nil {
 			timerCancel()
@@ -207,7 +207,6 @@ func applyAllInputs(
 	ctx workflow.Context,
 	logger *zap.Logger,
 	scope tally.Scope,
-	sched cron.Schedule,
 	timerFuture workflow.Future,
 	chs signalChannels,
 	state *SchedulerWorkflowState,
@@ -257,7 +256,7 @@ func applyAllInputs(
 		var sig BackfillSignal
 		c.Receive(ctx, &sig)
 		scope.Tagged(map[string]string{SignalTypeTag: signalTypeTagBackfill}).Counter(SchedulerSignalReceivedCountPerDomain).Inc(1)
-		if handleBackfill(logger, scope, sched, input, sig, state) {
+		if handleBackfill(logger, scope, sig, state) {
 			stateChanged = true
 		}
 	})
@@ -270,7 +269,7 @@ func applyAllInputs(
 
 	selector.Select(ctx)
 
-	if drainBufferedSignals(logger, scope, sched, chs, state, input) {
+	if drainBufferedSignals(logger, scope, chs, state, input) {
 		stateChanged = true
 	}
 
@@ -283,7 +282,6 @@ func applyAllInputs(
 func drainBufferedSignals(
 	logger *zap.Logger,
 	scope tally.Scope,
-	sched cron.Schedule,
 	chs signalChannels,
 	state *SchedulerWorkflowState,
 	input *SchedulerWorkflowInput,
@@ -331,7 +329,7 @@ func drainBufferedSignals(
 			break
 		}
 		scope.Tagged(map[string]string{SignalTypeTag: signalTypeTagBackfill}).Counter(SchedulerSignalReceivedCountPerDomain).Inc(1)
-		if handleBackfill(logger, scope, sched, input, sig, state) {
+		if handleBackfill(logger, scope, sig, state) {
 			stateChanged = true
 		}
 	}
@@ -467,7 +465,7 @@ func handleUpdate(logger *zap.Logger, sig UpdateSignal, input *SchedulerWorkflow
 	return changed
 }
 
-func handleBackfill(logger *zap.Logger, scope tally.Scope, sched cron.Schedule, input *SchedulerWorkflowInput, sig BackfillSignal, state *SchedulerWorkflowState) bool {
+func handleBackfill(logger *zap.Logger, scope tally.Scope, sig BackfillSignal, state *SchedulerWorkflowState) bool {
 	if !sig.EndTime.After(sig.StartTime) {
 		scope.Tagged(map[string]string{ReasonTag: BackfillRejectedReasonInvalidRange}).
 			Counter(SchedulerBackfillRejectedCountPerDomain).Inc(1)
@@ -497,33 +495,17 @@ func handleBackfill(logger *zap.Logger, scope tally.Scope, sched cron.Schedule, 
 			)
 		}
 	}
-	// Compute RunsTotal up front so DescribeSchedule can show progress as the
-	// backfill drains. handleBackfill runs inside the workflow loop, so this
-	// walk is deterministic — passing a stable cron.Schedule / spec snapshot.
-	// Match processBackfills' fire boundary: (StartTime, EndTime].
-	runsTotal, truncated := countCronFires(sched, sig.StartTime.Add(-time.Second), sig.EndTime, input.Spec, maxBackfillRunsTotalCount)
-	if truncated {
-		// Don't surface a misleadingly bounded count for huge ranges; report
-		// "unknown" via 0 so consumers know the percentage is meaningless.
-		logger.Info("backfill range exceeds RunsTotal count cap, reporting unknown total",
-			zap.String("backfillId", sig.BackfillID),
-			zap.Int("cap", maxBackfillRunsTotalCount),
-		)
-		runsTotal = 0
-	}
 	state.PendingBackfills = append(state.PendingBackfills, BackfillRequest{
 		StartTime:     sig.StartTime,
 		EndTime:       sig.EndTime,
 		OverlapPolicy: sig.OverlapPolicy,
 		BackfillID:    sig.BackfillID,
-		RunsTotal:     int32(runsTotal),
 	})
 	logger.Info("backfill queued",
 		zap.Time("startTime", sig.StartTime),
 		zap.Time("endTime", sig.EndTime),
 		zap.String("overlapPolicy", sig.OverlapPolicy.String()),
 		zap.String("backfillId", sig.BackfillID),
-		zap.Int("runsTotal", runsTotal),
 		zap.Int("pendingCount", len(state.PendingBackfills)),
 	)
 	return true
@@ -787,12 +769,9 @@ func computeMissedFireTimes(sched cron.Schedule, lastRun, now time.Time, spec ty
 	return missedFiresResult{times: missed, truncated: true}
 }
 
-// countCronFires returns the number of cron fire times in (start, end],
-// without materializing the fires. Used to populate BackfillRequest.RunsTotal
-// at signal-handle time when we only need the count, not the times.
-// Caps the walk at `limit`; the second return value is true when the range
-// would have produced more than `limit` fires (caller treats the count as
-// unknown in that case).
+// countCronFires returns the number of cron fire times in (start, end] without
+// materializing them, capped at limit. The second return value is true when
+// the range would have produced more fires than the cap.
 func countCronFires(sched cron.Schedule, start, end time.Time, spec types.ScheduleSpec, limit int) (int, bool) {
 	count := 0
 	t := start
@@ -975,6 +954,24 @@ func processBackfills(ctx workflow.Context, logger *zap.Logger, scope tally.Scop
 	for len(state.PendingBackfills) > 0 {
 		bf := &state.PendingBackfills[0]
 
+		// RunsTotal is computed lazily on first contact. Doing it here (not in
+		// handleBackfill) uses the cron schedule re-parsed at the top of this
+		// workflow execution, so a same-batch UpdateSchedule that changed the
+		// cron does not leave us counting against the stale expression.
+		if !bf.RunsTotalComputed {
+			total, truncated := countCronFires(sched, bf.StartTime.Add(-time.Second), bf.EndTime, input.Spec, maxBackfillRunsTotalCount)
+			if truncated {
+				// The range exceeds the count cap; report the cap as a lower
+				// bound rather than overload 0 as "unknown". Callers comparing
+				// RunsCompleted against RunsTotal may see RunsCompleted reach
+				// or exceed this value before the backfill finishes draining.
+				bf.RunsTotal = int32(maxBackfillRunsTotalCount)
+			} else {
+				bf.RunsTotal = int32(total)
+			}
+			bf.RunsTotalComputed = true
+		}
+
 		fires := computeMissedFireTimes(sched, bf.StartTime.Add(-time.Second), bf.EndTime, input.Spec)
 
 		for _, t := range fires.times {
@@ -991,11 +988,10 @@ func processBackfills(ctx workflow.Context, logger *zap.Logger, scope tally.Scop
 			overlap := effectiveFireOverlap(TriggerSourceBackfill, bf.OverlapPolicy, input.Policies.OverlapPolicy)
 			processScheduleFire(ctx, logger, scope, input, state, t, TriggerSourceBackfill, overlap, bf.BackfillID)
 			fired++
-			// RunsCompleted advances on every fire that leaves processScheduleFire,
-			// regardless of whether it actually started, was skipped under the
-			// overlap policy, or was queued into the BUFFER. Anything else would
-			// pin the backfill in OngoingBackfills indefinitely whenever the
-			// schedule's overlap policy holds runs back from starting.
+			// Count any fire handed off to processScheduleFire, whether it
+			// started, was skipped under the overlap policy, or was queued
+			// into the BUFFER. Counting only "started" would pin a
+			// BUFFER-deferred backfill in OngoingBackfills indefinitely.
 			bf.RunsCompleted++
 		}
 

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1003,12 +1003,17 @@ func TestProcessBackfillsRespectsPause(t *testing.T) {
 			},
 		},
 	}
-	// processBackfills should short-circuit without touching PendingBackfills
 	scope := tally.NewTestScope("", nil)
 	moreWork := processBackfills(nil, testLogger, scope, sched, input, state)
-	assert.False(t, moreWork, "paused schedule should not process backfills")
-	assert.Len(t, state.PendingBackfills, 1, "pending backfills should be preserved while paused")
-	assert.Empty(t, scope.Snapshot().Counters(), "no metrics should be emitted when paused")
+	assert.False(t, moreWork, "paused schedule should not fire backfills")
+	require.Len(t, state.PendingBackfills, 1, "pending backfills preserved while paused")
+	assert.Empty(t, scope.Snapshot().Counters(), "no fire metrics emitted when paused")
+	// RunsTotal must still be populated so DescribeSchedule does not report
+	// the queued backfill as 0/0 (which by contract means an empty range).
+	// Hourly cron over (10:00-1s, 13:00] → fires at 10, 11, 12, 13 = 4.
+	assert.True(t, state.PendingBackfills[0].RunsTotalComputed)
+	assert.Equal(t, int32(4), state.PendingBackfills[0].RunsTotal)
+	assert.Equal(t, int32(0), state.PendingBackfills[0].RunsCompleted)
 }
 
 func TestProcessBackfillsFiredMetric(t *testing.T) {

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -466,6 +466,47 @@ func TestBuildScheduleDescription(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Describe must surface PendingBackfills as OngoingBackfills so
+			// callers can show progress; this is what fills the new
+			// ScheduleInfo.OngoingBackfills field on DescribeScheduleResponse.
+			name:  "schedule with pending backfills exposes ongoing backfills",
+			input: SchedulerWorkflowInput{ScheduleID: "sched-bf", Domain: "dev"},
+			state: SchedulerWorkflowState{
+				PendingBackfills: []BackfillRequest{
+					{
+						BackfillID:    "bf-a",
+						StartTime:     time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+						EndTime:       time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC),
+						RunsTotal:     24,
+						RunsCompleted: 5,
+					},
+					{
+						BackfillID: "bf-b",
+						StartTime:  time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+						EndTime:    time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+			want: &ScheduleDescription{
+				ScheduleID: "sched-bf",
+				Domain:     "dev",
+				OngoingBackfills: []types.BackfillInfo{
+					{
+						BackfillID:    "bf-a",
+						StartTime:     time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+						EndTime:       time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC),
+						RunsTotal:     24,
+						RunsCompleted: 5,
+					},
+					{
+						BackfillID: "bf-b",
+						StartTime:  time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+						EndTime:    time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -850,7 +891,10 @@ func TestHandleBackfill(t *testing.T) {
 				})
 			}
 			scope := tally.NewTestScope("", nil)
-			got := handleBackfill(testLogger, scope, tt.sig, state)
+			// Hourly cron: a 1-day range = 24 fires for counting RunsTotal.
+			sched := mustParseCron(t, "0 * * * *")
+			input := &SchedulerWorkflowInput{Spec: types.ScheduleSpec{CronExpression: "0 * * * *"}}
+			got := handleBackfill(testLogger, scope, sched, input, tt.sig, state)
 			assert.Equal(t, tt.wantQueued, got)
 			assert.Equal(t, tt.wantPendingLen, len(state.PendingBackfills))
 
@@ -864,6 +908,67 @@ func TestHandleBackfill(t *testing.T) {
 				map[string]string{ReasonTag: tt.wantRejectReason})
 			require.True(t, ok)
 			assert.Equal(t, int64(1), c.Value())
+		})
+	}
+
+	t.Run("RunsTotal computed from cron walk", func(t *testing.T) {
+		state := &SchedulerWorkflowState{}
+		scope := tally.NewTestScope("", nil)
+		// Hourly cron over a 24-hour window. The cron walk uses (start-1s, end]
+		// (matching processBackfills' fire enumeration), so the 00:00 fire at
+		// each end of the window is included — 25 fires total.
+		sched := mustParseCron(t, "0 * * * *")
+		input := &SchedulerWorkflowInput{Spec: types.ScheduleSpec{CronExpression: "0 * * * *"}}
+		sig := BackfillSignal{
+			StartTime:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			EndTime:    time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+			BackfillID: "bf-counted",
+		}
+		got := handleBackfill(testLogger, scope, sched, input, sig, state)
+		require.True(t, got)
+		require.Len(t, state.PendingBackfills, 1)
+		assert.Equal(t, int32(25), state.PendingBackfills[0].RunsTotal)
+		assert.Equal(t, int32(0), state.PendingBackfills[0].RunsCompleted)
+	})
+}
+
+func TestCountCronFires(t *testing.T) {
+	hourly := mustParseCron(t, "0 * * * *")
+	spec := types.ScheduleSpec{CronExpression: "0 * * * *"}
+
+	tests := map[string]struct {
+		start, end time.Time
+		limit      int
+		wantCount  int
+		wantTrunc  bool
+	}{
+		"hourly cron over 24h inclusive fits under cap": {
+			start:     time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Add(-time.Second),
+			end:       time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+			limit:     100,
+			wantCount: 25,
+			wantTrunc: false,
+		},
+		"empty range returns zero": {
+			start:     time.Date(2026, 1, 1, 0, 0, 0, 30, time.UTC),
+			end:       time.Date(2026, 1, 1, 0, 30, 0, 0, time.UTC),
+			limit:     100,
+			wantCount: 0,
+			wantTrunc: false,
+		},
+		"limit truncates a long range": {
+			start:     time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Add(-time.Second),
+			end:       time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+			limit:     10,
+			wantCount: 10,
+			wantTrunc: true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			count, truncated := countCronFires(hourly, tt.start, tt.end, spec, tt.limit)
+			assert.Equal(t, tt.wantCount, count)
+			assert.Equal(t, tt.wantTrunc, truncated)
 		})
 	}
 }
@@ -954,6 +1059,36 @@ func TestProcessBackfillsFiredMetric(t *testing.T) {
 	c, ok := findCounter(scope.Snapshot().Counters(), SchedulerBackfillFiredCountPerDomain, map[string]string{})
 	require.True(t, ok, "backfill fired metric should be emitted")
 	assert.Equal(t, int64(3), c.Value(), "expected 3 fires: 10:00, 11:00, 12:00")
+}
+
+// TestProcessBackfillsTracksRunsCompleted verifies that RunsCompleted advances
+// on every fire processBackfills hands off (which is what
+// DescribeSchedule.OngoingBackfills surfaces as progress). The backfill must
+// have more fires than maxBackfillFiresPerExecution so it remains in
+// PendingBackfills after one call and we can read the partial counter.
+func TestProcessBackfillsTracksRunsCompleted(t *testing.T) {
+	sched := mustParseCron(t, "0 * * * *")
+	// Hourly cron over 24h-inclusive → 25 fires. maxBackfillFiresPerExecution
+	// is 10, so the first call processes 10 and leaves 15 behind.
+	input := &SchedulerWorkflowInput{
+		Spec: types.ScheduleSpec{CronExpression: "0 * * * *"},
+	}
+	state := &SchedulerWorkflowState{
+		PendingBackfills: []BackfillRequest{
+			{
+				StartTime:  time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC),
+				EndTime:    time.Date(2026, 1, 16, 0, 0, 0, 0, time.UTC),
+				BackfillID: "bf-partial",
+				RunsTotal:  25,
+			},
+		},
+	}
+	scope := tally.NewTestScope("", nil)
+	moreWork := processBackfills(nil, testLogger, scope, sched, input, state)
+	assert.True(t, moreWork, "backfill should signal more work after hitting per-execution cap")
+	require.Len(t, state.PendingBackfills, 1, "partial backfill should remain in state")
+	assert.Equal(t, int32(maxBackfillFiresPerExecution), state.PendingBackfills[0].RunsCompleted)
+	assert.Equal(t, int32(25), state.PendingBackfills[0].RunsTotal, "RunsTotal should not change as fires drain")
 }
 
 func TestBackfillFireComputation(t *testing.T) {

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -891,10 +891,7 @@ func TestHandleBackfill(t *testing.T) {
 				})
 			}
 			scope := tally.NewTestScope("", nil)
-			// Hourly cron: a 1-day range = 24 fires for counting RunsTotal.
-			sched := mustParseCron(t, "0 * * * *")
-			input := &SchedulerWorkflowInput{Spec: types.ScheduleSpec{CronExpression: "0 * * * *"}}
-			got := handleBackfill(testLogger, scope, sched, input, tt.sig, state)
+			got := handleBackfill(testLogger, scope, tt.sig, state)
 			assert.Equal(t, tt.wantQueued, got)
 			assert.Equal(t, tt.wantPendingLen, len(state.PendingBackfills))
 
@@ -910,26 +907,6 @@ func TestHandleBackfill(t *testing.T) {
 			assert.Equal(t, int64(1), c.Value())
 		})
 	}
-
-	t.Run("RunsTotal computed from cron walk", func(t *testing.T) {
-		state := &SchedulerWorkflowState{}
-		scope := tally.NewTestScope("", nil)
-		// Hourly cron over a 24-hour window. The cron walk uses (start-1s, end]
-		// (matching processBackfills' fire enumeration), so the 00:00 fire at
-		// each end of the window is included — 25 fires total.
-		sched := mustParseCron(t, "0 * * * *")
-		input := &SchedulerWorkflowInput{Spec: types.ScheduleSpec{CronExpression: "0 * * * *"}}
-		sig := BackfillSignal{
-			StartTime:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
-			EndTime:    time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
-			BackfillID: "bf-counted",
-		}
-		got := handleBackfill(testLogger, scope, sched, input, sig, state)
-		require.True(t, got)
-		require.Len(t, state.PendingBackfills, 1)
-		assert.Equal(t, int32(25), state.PendingBackfills[0].RunsTotal)
-		assert.Equal(t, int32(0), state.PendingBackfills[0].RunsCompleted)
-	})
 }
 
 func TestCountCronFires(t *testing.T) {
@@ -1062,10 +1039,8 @@ func TestProcessBackfillsFiredMetric(t *testing.T) {
 }
 
 // TestProcessBackfillsTracksRunsCompleted verifies that RunsCompleted advances
-// on every fire processBackfills hands off (which is what
-// DescribeSchedule.OngoingBackfills surfaces as progress). The backfill must
-// have more fires than maxBackfillFiresPerExecution so it remains in
-// PendingBackfills after one call and we can read the partial counter.
+// on every fire handed off by processBackfills, and that RunsTotal is computed
+// once on the first batch and preserved across subsequent batches.
 func TestProcessBackfillsTracksRunsCompleted(t *testing.T) {
 	sched := mustParseCron(t, "0 * * * *")
 	// Hourly cron over 24h-inclusive → 25 fires. maxBackfillFiresPerExecution
@@ -1079,7 +1054,6 @@ func TestProcessBackfillsTracksRunsCompleted(t *testing.T) {
 				StartTime:  time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC),
 				EndTime:    time.Date(2026, 1, 16, 0, 0, 0, 0, time.UTC),
 				BackfillID: "bf-partial",
-				RunsTotal:  25,
 			},
 		},
 	}
@@ -1088,7 +1062,66 @@ func TestProcessBackfillsTracksRunsCompleted(t *testing.T) {
 	assert.True(t, moreWork, "backfill should signal more work after hitting per-execution cap")
 	require.Len(t, state.PendingBackfills, 1, "partial backfill should remain in state")
 	assert.Equal(t, int32(maxBackfillFiresPerExecution), state.PendingBackfills[0].RunsCompleted)
-	assert.Equal(t, int32(25), state.PendingBackfills[0].RunsTotal, "RunsTotal should not change as fires drain")
+	assert.Equal(t, int32(25), state.PendingBackfills[0].RunsTotal, "RunsTotal computed lazily on first batch")
+	assert.True(t, state.PendingBackfills[0].RunsTotalComputed)
+}
+
+// TestProcessBackfillsRunsTotalTruncated covers a range that exceeds the count
+// cap: RunsTotal is set to the cap as a lower bound, not 0.
+func TestProcessBackfillsRunsTotalTruncated(t *testing.T) {
+	// Per-minute cron over 100 days = 144000 fires, above the
+	// maxBackfillRunsTotalCount (100000) cap.
+	sched := mustParseCron(t, "* * * * *")
+	input := &SchedulerWorkflowInput{
+		Spec: types.ScheduleSpec{CronExpression: "* * * * *"},
+	}
+	state := &SchedulerWorkflowState{
+		PendingBackfills: []BackfillRequest{
+			{
+				StartTime:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+				EndTime:    time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC),
+				BackfillID: "bf-huge",
+			},
+		},
+	}
+	scope := tally.NewTestScope("", nil)
+	_ = processBackfills(nil, testLogger, scope, sched, input, state)
+	require.Len(t, state.PendingBackfills, 1)
+	assert.Equal(t, int32(maxBackfillRunsTotalCount), state.PendingBackfills[0].RunsTotal,
+		"truncated count should report the cap as a lower bound, not 0")
+	assert.True(t, state.PendingBackfills[0].RunsTotalComputed)
+}
+
+// TestProcessBackfillsLazyRunsTotalIgnoresStaleSched simulates a same-batch
+// UpdateSchedule changing the cron between backfill enqueue and processing.
+// RunsTotal must reflect the cron passed into processBackfills (the freshly
+// re-parsed one), not the cron that was in effect when handleBackfill ran.
+func TestProcessBackfillsLazyRunsTotalUsesProcessSched(t *testing.T) {
+	// Backfill enqueued with no RunsTotal computed yet. processBackfills now
+	// receives an hourly cron; we expect RunsTotal to come from that, not from
+	// some other cron a hypothetical caller might have used at enqueue time.
+	hourly := mustParseCron(t, "0 * * * *")
+	input := &SchedulerWorkflowInput{
+		Spec: types.ScheduleSpec{CronExpression: "0 * * * *"},
+	}
+	state := &SchedulerWorkflowState{
+		PendingBackfills: []BackfillRequest{
+			{
+				StartTime:  time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC),
+				EndTime:    time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC),
+				BackfillID: "bf-fresh-sched",
+			},
+		},
+	}
+	scope := tally.NewTestScope("", nil)
+	_ = processBackfills(nil, testLogger, scope, hourly, input, state)
+	// 3 fires for hourly cron over [10:00, 12:00]: 10:00, 11:00, 12:00.
+	// Backfill drains in one call (under the per-execution cap), so it has
+	// been removed; check the firing metric reflects the count instead.
+	assert.Empty(t, state.PendingBackfills)
+	c, ok := findCounter(scope.Snapshot().Counters(), SchedulerBackfillFiredCountPerDomain, map[string]string{})
+	require.True(t, ok)
+	assert.Equal(t, int64(3), c.Value())
 }
 
 func TestBackfillFireComputation(t *testing.T) {

--- a/tools/cli/schedule_commands.go
+++ b/tools/cli/schedule_commands.go
@@ -483,5 +483,20 @@ func printDescribeSchedule(resp *types.DescribeScheduleResponse) {
 		if !info.NextRunTime.IsZero() {
 			fmt.Printf("  Next Run:         %s\n", info.NextRunTime.Format(time.RFC3339))
 		}
+		if len(info.OngoingBackfills) > 0 {
+			fmt.Printf("  Ongoing Backfills:\n")
+			for _, bf := range info.OngoingBackfills {
+				if bf == nil {
+					continue
+				}
+				fmt.Printf("    - id: %s [%s, %s] progress: %d/%d\n",
+					bf.BackfillID,
+					bf.StartTime.Format(time.RFC3339),
+					bf.EndTime.Format(time.RFC3339),
+					bf.RunsCompleted,
+					bf.RunsTotal,
+				)
+			}
+		}
 	}
 }

--- a/tools/cli/schedule_commands_test.go
+++ b/tools/cli/schedule_commands_test.go
@@ -21,10 +21,16 @@
 package cli
 
 import (
+	"bytes"
 	"flag"
+	"io"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 	"go.uber.org/mock/gomock"
 
@@ -180,6 +186,74 @@ func TestScheduleCLI_DescribeSchedule(t *testing.T) {
 	sc := &scheduleCLIImpl{frontendClient: mockClient}
 	err := sc.DescribeSchedule(c)
 	assert.NoError(t, err)
+}
+
+func TestPrintDescribeSchedule_OngoingBackfills(t *testing.T) {
+	resp := &types.DescribeScheduleResponse{
+		Spec:     &types.ScheduleSpec{CronExpression: "0 * * * *"},
+		Action:   &types.ScheduleAction{StartWorkflow: &types.StartWorkflowAction{WorkflowType: &types.WorkflowType{Name: "wf"}}},
+		Policies: &types.SchedulePolicies{},
+		State:    &types.ScheduleState{},
+		Info: &types.ScheduleInfo{
+			TotalRuns: 4,
+			OngoingBackfills: []*types.BackfillInfo{
+				{
+					BackfillID:    "bf-a",
+					StartTime:     time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+					EndTime:       time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC),
+					RunsTotal:     24,
+					RunsCompleted: 7,
+				},
+				nil, // nil entries must be tolerated
+				{
+					BackfillID:    "bf-b",
+					StartTime:     time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+					EndTime:       time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC),
+					RunsTotal:     12,
+					RunsCompleted: 12,
+				},
+			},
+		},
+	}
+
+	out := captureStdout(t, func() { printDescribeSchedule(resp) })
+	assert.Contains(t, out, "Ongoing Backfills:")
+	assert.Contains(t, out, "id: bf-a")
+	assert.Contains(t, out, "progress: 7/24")
+	assert.Contains(t, out, "id: bf-b")
+	assert.Contains(t, out, "progress: 12/12")
+}
+
+func TestPrintDescribeSchedule_NoOngoingBackfills(t *testing.T) {
+	resp := &types.DescribeScheduleResponse{
+		Spec:     &types.ScheduleSpec{CronExpression: "0 * * * *"},
+		Action:   &types.ScheduleAction{StartWorkflow: &types.StartWorkflowAction{WorkflowType: &types.WorkflowType{Name: "wf"}}},
+		Policies: &types.SchedulePolicies{},
+		State:    &types.ScheduleState{},
+		Info:     &types.ScheduleInfo{TotalRuns: 4},
+	}
+
+	out := captureStdout(t, func() { printDescribeSchedule(resp) })
+	assert.NotContains(t, out, "Ongoing Backfills")
+}
+
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns
+// what fn wrote. Used to assert against printDescribeSchedule output.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+	require.NoError(t, w.Close())
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	return strings.TrimRight(buf.String(), "\n")
 }
 
 func TestScheduleCLI_PauseSchedule(t *testing.T) {


### PR DESCRIPTION
**What changed?**

- `BackfillRequest` gains `RunsTotal`, `RunsCompleted`, and `RunsTotalComputed`. `processBackfills` computes `RunsTotal` lazily on first contact and increments `RunsCompleted` for every fire it hands off. `buildScheduleDescription` exposes pending backfills as `OngoingBackfills`.
- `DescribeSchedule` populates `Info.OngoingBackfills` from the workflow description via `ongoingBackfillsForResponse`.
- `printDescribeSchedule` renders ongoing backfills with progress.

**Why?**

The scheduler tracked `PendingBackfills` internally but never surfaced them, so operators could not see whether a backfill was in flight or how far along it was. This PR wires the existing fields end-to-end and renders them in the CLI.

`RunsTotal` is computed inside `processBackfills` (not at signal-handle time) so it always uses the cron that was re-parsed at the top of the current workflow execution, avoiding a stale-cron window when an `UpdateSchedule` and a `BackfillSchedule` are batched together. When the range exceeds `maxBackfillRunsTotalCount`, `RunsTotal` is set to the cap as a lower bound; `RunsTotal == 0` therefore unambiguously means an empty range.

`RunsCompleted` increments on every fire that leaves `processBackfills`, regardless of whether it started, was skipped under the overlap policy, or was deferred into the BUFFER queue. Counting only "started" would leave a BUFFER-bound backfill stuck in `OngoingBackfills`.

**How did you test it?**

```
go test -race ./service/worker/scheduler/... ./service/frontend/api/... ./tools/cli/...
make pr GEN_DIR=service/worker/scheduler
```

**Potential risks**

Backwards-compat: `BackfillRequest.RunsTotal`, `RunsCompleted` and `RunsTotalComputed` use `omitempty`. Backfills already persisted from older scheduler runs deserialize with all three at 0, so their first `processBackfills` call after this lands populates `RunsTotal` correctly. No IDL, schema, or feature-flag change.

**Documentation Changes**

N/A