### PR TITLE
fix: add RemoveListener before Destroy in ringpop

### DIFF
--- a/common/peerprovider/ringpopprovider/provider.go
+++ b/common/peerprovider/ringpopprovider/provider.go
@@ -281,6 +281,7 @@ func (r *Provider) Stop() {
 		return
 	}
 
+	r.ringpop.RemoveListener(r)
 	r.ringpop.Destroy()
 }
 


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Add RemoveListener before Destroy so ringpop stops delivering events before the instance is torn down.

https://github.com/cadence-workflow/cadence/issues/8213

**Why?**
Stop called Destroy without first removing the event listener, so ringpop's internal goroutines could still call HandleEvent after the provider was stopped, causing a data race on the logger.

**How did you test it?**
Existing tests pass
go test -race -run TestRingpopProvider -count=10 ./common/peerprovider/ringpopprovider/...

**Potential risks**
Very low risk. RemoveListener just unregisters the callback so ringpop stops delivering events to this provider. Since we're about to Destroy the ringpop instance anyway, dropping events a moment earlier has no functional impact 

**Release notes**
N/A

**Documentation Changes**
N/A
