### PR TITLE
chore(graceful failover): skip wait and ratelimitting for failover markers

### DIFF
--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -231,7 +231,9 @@ Loop:
 				tag.Counter(len(response.GetReplicationTasks())),
 			)
 
-			p.taskProcessingStartWait()
+			if !batchContainsFailoverMarker(response) {
+				p.taskProcessingStartWait()
+			}
 			p.processResponse(response)
 		case <-p.done:
 			return
@@ -325,7 +327,8 @@ func (p *taskProcessorImpl) processResponse(response *types.ReplicationMessages)
 	batchRequestStartTime := time.Now()
 	ctx := context.Background()
 	for _, replicationTask := range response.ReplicationTasks {
-		if replicationTask.GetTaskType() == types.ReplicationTaskTypeFailoverMarker {
+		isFailoverMarker := replicationTask.GetTaskType() == types.ReplicationTaskTypeFailoverMarker
+		if isFailoverMarker {
 			if attr := replicationTask.GetFailoverMarkerAttributes(); attr != nil {
 				p.logger.Info("Failover marker arrived at standby replication processor",
 					tag.ShardID(p.shard.GetShardID()),
@@ -334,10 +337,15 @@ func (p *taskProcessorImpl) processResponse(response *types.ReplicationMessages)
 					tag.Dynamic("arrival-lag", time.Since(time.Unix(0, replicationTask.GetCreationTime()))),
 				)
 			}
+		} else {
+			// failover markers bypass rate limiting: bounded volume (one per shard
+			// per failover), shard-level (no workflow lock), and cheap to execute.
+			// throttling them behind history replication needlessly delays the
+			// completion of graceful failover.
+			// TODO: move to MultiStageRateLimiter
+			_ = p.hostRateLimiter.Wait(ctx)
+			_ = p.shardRateLimiter.Wait(ctx)
 		}
-		// TODO: move to MultiStageRateLimiter
-		_ = p.hostRateLimiter.Wait(ctx)
-		_ = p.shardRateLimiter.Wait(ctx)
 		err := p.processSingleTask(replicationTask)
 		if err != nil {
 			// Encounter error and skip updating ack levels
@@ -762,6 +770,18 @@ func (p *taskProcessorImpl) taskProcessingStartWait() {
 		p.config.ReplicationTaskProcessorStartWait(shardID),
 		p.config.ReplicationTaskProcessorStartWaitJitterCoefficient(shardID),
 	))
+}
+
+// batchContainsFailoverMarker returns true if any task in the response batch is
+// a FailoverMarker. Failover markers gate graceful-failover completion, so
+// batches that carry them skip the per-batch start wait to minimize tail latency.
+func batchContainsFailoverMarker(response *types.ReplicationMessages) bool {
+	for _, task := range response.GetReplicationTasks() {
+		if task.GetTaskType() == types.ReplicationTaskTypeFailoverMarker {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *taskProcessorImpl) isShuttingDown() bool {

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -231,9 +231,7 @@ Loop:
 				tag.Counter(len(response.GetReplicationTasks())),
 			)
 
-			if !batchContainsFailoverMarker(response) {
-				p.taskProcessingStartWait()
-			}
+			p.taskProcessingStartWait(response.GetReplicationTasks())
 			p.processResponse(response)
 		case <-p.done:
 			return
@@ -764,24 +762,23 @@ func (p *taskProcessorImpl) updateFailureMetric(scope metrics.ScopeIdx, err erro
 	}
 }
 
-func (p *taskProcessorImpl) taskProcessingStartWait() {
+func (p *taskProcessorImpl) taskProcessingStartWait(tasks []*types.ReplicationTask) {
 	shardID := p.shard.GetShardID()
-	time.Sleep(backoff.JitDuration(
-		p.config.ReplicationTaskProcessorStartWait(shardID),
-		p.config.ReplicationTaskProcessorStartWaitJitterCoefficient(shardID),
-	))
-}
-
-// batchContainsFailoverMarker returns true if any task in the response batch is
-// a FailoverMarker. Failover markers gate graceful-failover completion, so
-// batches that carry them skip the per-batch start wait to minimize tail latency.
-func batchContainsFailoverMarker(response *types.ReplicationMessages) bool {
-	for _, task := range response.GetReplicationTasks() {
+	wait := p.config.ReplicationTaskProcessorStartWait(shardID)
+	if wait <= 0 {
+		return
+	}
+	// failover markers gate graceful-failover completion — skip the per-batch
+	// wait when one is in flight to minimize tail latency.
+	for _, task := range tasks {
 		if task.GetTaskType() == types.ReplicationTaskTypeFailoverMarker {
-			return true
+			return
 		}
 	}
-	return false
+	time.Sleep(backoff.JitDuration(
+		wait,
+		p.config.ReplicationTaskProcessorStartWaitJitterCoefficient(shardID),
+	))
 }
 
 func (p *taskProcessorImpl) isShuttingDown() bool {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Added skip to rate limit for failover markers. Skip delay if failover marker is in batch.

https://github.com/cadence-workflow/cadence/issues/8138

**Why?**
Failover markers have bounded volume (one per shard per failover), shard-level (no workflow lock), and cheap to execute. Throttling them behind history replication needlessly delays the completion of graceful failover.

**How did you test it?**
go test -race -count=1 ./service/history/failover/... ./service/history/replication/...

**Potential risks**
No risk. Delay is set to 0 by default.

**Release notes**
N/A

**Documentation Changes**
N/A
