### PR TITLE
feat(graceful failover): eager coordinator notification

### DIFF
--- a/service/history/failover/coordinator.go
+++ b/service/history/failover/coordinator.go
@@ -274,6 +274,14 @@ func (c *coordinatorImpl) notifyFailoverMarkerLoop() {
 			if c.timeSource.Now().Sub(lastFlush) >= notifyFailoverMarkerMinInterval {
 				flush()
 				resetTimer()
+			} else {
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(notifyFailoverMarkerMinInterval - c.timeSource.Now().Sub(lastFlush))
 			}
 		case <-timer.C:
 			flush()

--- a/service/history/failover/coordinator.go
+++ b/service/history/failover/coordinator.go
@@ -52,6 +52,7 @@ const (
 	updateDomainRetryInitialInterval = 50 * time.Millisecond
 	updateDomainRetryCoefficient     = 2.0
 	updateDomainMaxRetry             = 2
+	notifyFailoverMarkerMinInterval  = 500 * time.Millisecond
 )
 
 var (
@@ -237,6 +238,30 @@ func (c *coordinatorImpl) notifyFailoverMarkerLoop() {
 	))
 	defer timer.Stop()
 	requestByMarker := make(map[types.FailoverMarkerAttributes]*receiveRequest)
+	var lastFlush time.Time
+
+	flush := func() {
+		if len(requestByMarker) == 0 {
+			return
+		}
+		if err := c.notifyRemoteCoordinator(requestByMarker); err == nil {
+			requestByMarker = make(map[types.FailoverMarkerAttributes]*receiveRequest)
+			lastFlush = c.timeSource.Now()
+		}
+	}
+
+	resetTimer := func() {
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer.Reset(backoff.JitDuration(
+			c.config.NotifyFailoverMarkerInterval(),
+			c.config.NotifyFailoverMarkerTimerJitterCoefficient(),
+		))
+	}
 
 	for {
 		select {
@@ -246,10 +271,12 @@ func (c *coordinatorImpl) notifyFailoverMarkerLoop() {
 			// if a shard movement happens, it is fine to have duplicated shard IDs in the request
 			// The receiver side will de-dup the shard IDs. See: handleFailoverMarkers
 			aggregateNotificationRequests(notificationReq, requestByMarker)
-		case <-timer.C:
-			if err := c.notifyRemoteCoordinator(requestByMarker); err == nil {
-				requestByMarker = make(map[types.FailoverMarkerAttributes]*receiveRequest)
+			if c.timeSource.Now().Sub(lastFlush) >= notifyFailoverMarkerMinInterval {
+				flush()
+				resetTimer()
 			}
+		case <-timer.C:
+			flush()
 			timer.Reset(backoff.JitDuration(
 				c.config.NotifyFailoverMarkerInterval(),
 				c.config.NotifyFailoverMarkerTimerJitterCoefficient(),

--- a/service/history/failover/coordinator_test.go
+++ b/service/history/failover/coordinator_test.go
@@ -25,6 +25,7 @@ package failover
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -102,19 +103,31 @@ func (s *coordinatorSuite) TestNotifyFailoverMarkers() {
 		FailoverVersion: 1,
 		CreationTime:    common.Int64Ptr(1),
 	}
+
+	var mu sync.Mutex
+	seenShards := make(map[int32]struct{})
 	s.historyClient.EXPECT().NotifyFailoverMarkers(
-		context.Background(), &types.NotifyFailoverMarkersRequest{
-			FailoverMarkerTokens: []*types.FailoverMarkerToken{
-				{
-					ShardIDs:       []int32{1, 2},
-					FailoverMarker: attributes,
-				},
-			},
-		},
-	).DoAndReturn(func(ctx context.Context, request *types.NotifyFailoverMarkersRequest, opts ...yarpc.CallOption) error {
-		close(doneCh)
+		context.Background(), gomock.Any(),
+	).DoAndReturn(func(_ context.Context, request *types.NotifyFailoverMarkersRequest, _ ...yarpc.CallOption) error {
+		mu.Lock()
+		defer mu.Unlock()
+		s.Len(request.FailoverMarkerTokens, 1)
+		token := request.FailoverMarkerTokens[0]
+		s.Equal(attributes, token.FailoverMarker)
+		for _, shardID := range token.ShardIDs {
+			seenShards[shardID] = struct{}{}
+		}
+		if _, ok := seenShards[1]; ok {
+			if _, ok := seenShards[2]; ok {
+				select {
+				case <-doneCh:
+				default:
+					close(doneCh)
+				}
+			}
+		}
 		return nil
-	}).Times(1)
+	}).MinTimes(1)
 
 	s.coordinator.NotifyFailoverMarkers(
 		1,
@@ -126,6 +139,50 @@ func (s *coordinatorSuite) TestNotifyFailoverMarkers() {
 	)
 	s.coordinator.Start()
 	<-doneCh
+}
+
+func (s *coordinatorSuite) TestNotifyFailoverMarkers_EagerFlush() {
+	s.config.NotifyFailoverMarkerInterval = dynamicproperties.GetDurationPropertyFn(time.Hour)
+	s.coordinator = NewCoordinator(
+		s.mockMetadataManager,
+		s.historyClient,
+		s.mockResource.GetTimeSource(),
+		s.mockResource.GetDomainCache(),
+		s.config,
+		s.mockResource.GetMetricsClient(),
+		s.mockResource.GetLogger(),
+	).(*coordinatorImpl)
+
+	doneCh := make(chan struct{})
+	attributes := &types.FailoverMarkerAttributes{
+		DomainID:        uuid.New(),
+		FailoverVersion: 1,
+		CreationTime:    common.Int64Ptr(1),
+	}
+	s.historyClient.EXPECT().NotifyFailoverMarkers(
+		context.Background(), &types.NotifyFailoverMarkersRequest{
+			FailoverMarkerTokens: []*types.FailoverMarkerToken{
+				{
+					ShardIDs:       []int32{1},
+					FailoverMarker: attributes,
+				},
+			},
+		},
+	).DoAndReturn(func(_ context.Context, _ *types.NotifyFailoverMarkersRequest, _ ...yarpc.CallOption) error {
+		close(doneCh)
+		return nil
+	}).Times(1)
+
+	s.coordinator.Start()
+	s.coordinator.NotifyFailoverMarkers(
+		1,
+		[]*types.FailoverMarkerAttributes{attributes},
+	)
+	select {
+	case <-doneCh:
+	case <-time.After(5 * time.Second):
+		s.Fail("eager-flush did not fire within timeout")
+	}
 }
 
 func (s *coordinatorSuite) TestNotifyRemoteCoordinator_Empty() {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Eagerly notify remote coordinator on failover markers arrival

https://github.com/cadence-workflow/cadence/issues/8138

**Why?**
Marker notification relied on the loop and the NotifyFailoverMarkerInterval. During a graceful failover we want to minimize its duration to complete as soon as possible. Under normal circumstances a high interval make sense.

**How did you test it?**
go test -race -count=1 -run TestCoordinatorSuite ./service/history/failover/...

go test -race -count=1 -run 'TestCoordinatorSuite/TestNotifyFailoverMarkers$' ./service/history/failover/...

go test -race -count=1 -run 'TestCoordinatorSuite/TestNotifyFailoverMarkers_EagerFlush' ./service/history/failover/...

**Potential risks**
Risks are increasing the number of rpc calls. Number of shards are bounded and so are the failover markers. Multiple  failovers at the same time justify even more the lower possible interval.

**Release notes**
N/A

**Documentation Changes**
N/A
