### PR TITLE
fix(scheduler): pass CodeUnavailable through metered handler for mid-ContinueAsNew

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2277,6 +2277,7 @@ const (
 	CadenceErrLimitExceededCounter
 	CadenceErrContextTimeoutCounter
 	CadenceErrGRPCConnectionClosingCounter
+	CadenceErrServiceUnavailableCounter
 	CadenceErrRetryTaskCounter
 	CadenceErrBadBinaryCounter
 	CadenceErrClientVersionNotSupportedCounter
@@ -3223,6 +3224,7 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 		CadenceErrLimitExceededCounter:                               {metricName: "cadence_errors_limit_exceeded", metricType: Counter},
 		CadenceErrContextTimeoutCounter:                              {metricName: "cadence_errors_context_timeout", metricType: Counter},
 		CadenceErrGRPCConnectionClosingCounter:                       {metricName: "cadence_errors_grpc_connection_closing", metricType: Counter},
+		CadenceErrServiceUnavailableCounter:                          {metricName: "cadence_errors_service_unavailable", metricType: Counter},
 		CadenceErrRetryTaskCounter:                                   {metricName: "cadence_errors_retry_task", metricType: Counter},
 		CadenceErrBadBinaryCounter:                                   {metricName: "cadence_errors_bad_binary", metricType: Counter},
 		CadenceErrClientVersionNotSupportedCounter:                   {metricName: "cadence_errors_client_version_not_supported", metricType: Counter},

--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -293,9 +293,8 @@ func (wh *WorkflowHandler) DescribeSchedule(
 	}
 	if info.CloseStatus != nil {
 		if *info.CloseStatus == types.WorkflowExecutionCloseStatusContinuedAsNew {
-			return nil, &types.ServiceBusyError{
-				Message: fmt.Sprintf("schedule %q in domain %q: scheduler mid-ContinueAsNew, retry", scheduleID, domainName),
-			}
+			return nil, yarpcerrors.Newf(yarpcerrors.CodeUnavailable,
+				"schedule %q in domain %q: scheduler mid-ContinueAsNew, retry", scheduleID, domainName)
 		}
 		return nil, &types.InternalServiceError{
 			Message: fmt.Sprintf(
@@ -319,9 +318,8 @@ func (wh *WorkflowHandler) DescribeSchedule(
 		if queryResp.QueryRejected.CloseStatus != nil {
 			closeStatus = queryResp.QueryRejected.CloseStatus.String()
 			if *queryResp.QueryRejected.CloseStatus == types.WorkflowExecutionCloseStatusContinuedAsNew {
-				return nil, &types.ServiceBusyError{
-					Message: fmt.Sprintf("schedule %q in domain %q: scheduler mid-ContinueAsNew, retry", scheduleID, domainName),
-				}
+				return nil, yarpcerrors.Newf(yarpcerrors.CodeUnavailable,
+					"schedule %q in domain %q: scheduler mid-ContinueAsNew, retry", scheduleID, domainName)
 			}
 		}
 		return nil, &types.InternalServiceError{

--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -293,10 +293,9 @@ func (wh *WorkflowHandler) DescribeSchedule(
 	}
 	if info.CloseStatus != nil {
 		if *info.CloseStatus == types.WorkflowExecutionCloseStatusContinuedAsNew {
-			return nil, yarpcerrors.Newf(yarpcerrors.CodeUnavailable,
-				"schedule %q in domain %q: scheduler mid-ContinueAsNew, retry",
-				scheduleID, domainName,
-			)
+			return nil, &types.ServiceBusyError{
+				Message: fmt.Sprintf("schedule %q in domain %q: scheduler mid-ContinueAsNew, retry", scheduleID, domainName),
+			}
 		}
 		return nil, &types.InternalServiceError{
 			Message: fmt.Sprintf(
@@ -320,10 +319,9 @@ func (wh *WorkflowHandler) DescribeSchedule(
 		if queryResp.QueryRejected.CloseStatus != nil {
 			closeStatus = queryResp.QueryRejected.CloseStatus.String()
 			if *queryResp.QueryRejected.CloseStatus == types.WorkflowExecutionCloseStatusContinuedAsNew {
-				return nil, yarpcerrors.Newf(yarpcerrors.CodeUnavailable,
-					"schedule %q in domain %q: scheduler mid-ContinueAsNew, retry",
-					scheduleID, domainName,
-				)
+				return nil, &types.ServiceBusyError{
+					Message: fmt.Sprintf("schedule %q in domain %q: scheduler mid-ContinueAsNew, retry", scheduleID, domainName),
+				}
 			}
 		}
 		return nil, &types.InternalServiceError{

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -575,8 +575,7 @@ func TestDescribeSchedule(t *testing.T) {
 			wantErr: false,
 		},
 		// If the close status stays CONTINUED_AS_NEW past the retry budget, the
-		// scheduler is stuck mid-transition; return ServiceBusyError so the
-		// middleware maps it to RESOURCE_EXHAUSTED and clients retry.
+		// scheduler is stuck mid-transition; return CodeUnavailable so clients retry.
 		"scheduler mid-ContinueAsNew - retry budget exhausted": {
 			request: validRequest,
 			mockFn: func(f *scheduleTestFixture) {
@@ -590,9 +589,9 @@ func TestDescribeSchedule(t *testing.T) {
 			},
 			wantErr: true,
 			checkErr: func(t *testing.T, err error) {
-				var sbe *types.ServiceBusyError
-				assert.ErrorAs(t, err, &sbe)
-				assert.Contains(t, sbe.Message, "mid-ContinueAsNew")
+				assert.True(t, yarpcerrors.IsStatus(err))
+				assert.Equal(t, yarpcerrors.CodeUnavailable, yarpcerrors.FromError(err).Code())
+				assert.Contains(t, yarpcerrors.FromError(err).Message(), "mid-ContinueAsNew")
 			},
 		},
 		// A freshly started scheduler run has not yet processed its first decision
@@ -742,9 +741,9 @@ func TestDescribeSchedule(t *testing.T) {
 			},
 		},
 		// If the scheduler does ContinueAsNew between the DWE probe and the query,
-		// the query is rejected with CONTINUED_AS_NEW. Return ServiceBusyError so
-		// the middleware maps it to RESOURCE_EXHAUSTED and the client retries.
-		"scheduler ContinueAsNew between DWE and Query - return ServiceBusyError": {
+		// the query is rejected with CONTINUED_AS_NEW. Return CodeUnavailable so
+		// the client retries — the new run will be queryable momentarily.
+		"scheduler ContinueAsNew between DWE and Query - return Unavailable": {
 			request: validRequest,
 			mockFn: func(f *scheduleTestFixture) {
 				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
@@ -762,9 +761,9 @@ func TestDescribeSchedule(t *testing.T) {
 			},
 			wantErr: true,
 			checkErr: func(t *testing.T, err error) {
-				var sbe *types.ServiceBusyError
-				assert.ErrorAs(t, err, &sbe)
-				assert.Contains(t, sbe.Message, "mid-ContinueAsNew")
+				assert.True(t, yarpcerrors.IsStatus(err))
+				assert.Equal(t, yarpcerrors.CodeUnavailable, yarpcerrors.FromError(err).Code())
+				assert.Contains(t, yarpcerrors.FromError(err).Message(), "mid-ContinueAsNew")
 			},
 		},
 		"success": {

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -575,7 +575,8 @@ func TestDescribeSchedule(t *testing.T) {
 			wantErr: false,
 		},
 		// If the close status stays CONTINUED_AS_NEW past the retry budget, the
-		// scheduler is stuck mid-transition; return Unavailable so clients retry.
+		// scheduler is stuck mid-transition; return ServiceBusyError so the
+		// middleware maps it to RESOURCE_EXHAUSTED and clients retry.
 		"scheduler mid-ContinueAsNew - retry budget exhausted": {
 			request: validRequest,
 			mockFn: func(f *scheduleTestFixture) {
@@ -589,9 +590,9 @@ func TestDescribeSchedule(t *testing.T) {
 			},
 			wantErr: true,
 			checkErr: func(t *testing.T, err error) {
-				assert.True(t, yarpcerrors.IsStatus(err))
-				assert.Equal(t, yarpcerrors.CodeUnavailable, yarpcerrors.FromError(err).Code())
-				assert.Contains(t, yarpcerrors.FromError(err).Message(), "mid-ContinueAsNew")
+				var sbe *types.ServiceBusyError
+				assert.ErrorAs(t, err, &sbe)
+				assert.Contains(t, sbe.Message, "mid-ContinueAsNew")
 			},
 		},
 		// A freshly started scheduler run has not yet processed its first decision
@@ -741,9 +742,9 @@ func TestDescribeSchedule(t *testing.T) {
 			},
 		},
 		// If the scheduler does ContinueAsNew between the DWE probe and the query,
-		// the query is rejected with CONTINUED_AS_NEW. Return Unavailable so the
-		// client retries — the new run will be queryable momentarily.
-		"scheduler ContinueAsNew between DWE and Query - return Unavailable": {
+		// the query is rejected with CONTINUED_AS_NEW. Return ServiceBusyError so
+		// the middleware maps it to RESOURCE_EXHAUSTED and the client retries.
+		"scheduler ContinueAsNew between DWE and Query - return ServiceBusyError": {
 			request: validRequest,
 			mockFn: func(f *scheduleTestFixture) {
 				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
@@ -761,9 +762,9 @@ func TestDescribeSchedule(t *testing.T) {
 			},
 			wantErr: true,
 			checkErr: func(t *testing.T, err error) {
-				assert.True(t, yarpcerrors.IsStatus(err))
-				assert.Equal(t, yarpcerrors.CodeUnavailable, yarpcerrors.FromError(err).Code())
-				assert.Contains(t, yarpcerrors.FromError(err).Message(), "mid-ContinueAsNew")
+				var sbe *types.ServiceBusyError
+				assert.ErrorAs(t, err, &sbe)
+				assert.Contains(t, sbe.Message, "mid-ContinueAsNew")
 			},
 		},
 		"success": {

--- a/service/frontend/wrappers/metered/metered.go
+++ b/service/frontend/wrappers/metered/metered.go
@@ -96,6 +96,8 @@ func (h *apiHandler) handleErr(err error, scope metrics.Scope, logger log.Logger
 			return err
 		}
 		if err.Code() == yarpcerrors.CodeUnavailable {
+			logger.Error("Frontend request failed with service unavailable", tag.Error(err))
+			scope.IncCounter(metrics.CadenceErrServiceUnavailableCounter)
 			return err
 		}
 	}

--- a/service/frontend/wrappers/metered/metered.go
+++ b/service/frontend/wrappers/metered/metered.go
@@ -95,6 +95,9 @@ func (h *apiHandler) handleErr(err error, scope metrics.Scope, logger log.Logger
 			logger.Warn(constants.GRPCConnectionClosingError, tag.Error(err))
 			return err
 		}
+		if err.Code() == yarpcerrors.CodeUnavailable {
+			return err
+		}
 	}
 	if errors.Is(err, context.DeadlineExceeded) {
 		logger.Error("Frontend request timedout", tag.Error(err))

--- a/service/frontend/wrappers/metered/metered.go
+++ b/service/frontend/wrappers/metered/metered.go
@@ -96,7 +96,6 @@ func (h *apiHandler) handleErr(err error, scope metrics.Scope, logger log.Logger
 			return err
 		}
 		if err.Code() == yarpcerrors.CodeUnavailable {
-			scope.IncCounter(metrics.CadenceErrServiceBusyCounter)
 			return err
 		}
 	}

--- a/service/frontend/wrappers/metered/metered.go
+++ b/service/frontend/wrappers/metered/metered.go
@@ -96,6 +96,7 @@ func (h *apiHandler) handleErr(err error, scope metrics.Scope, logger log.Logger
 			return err
 		}
 		if err.Code() == yarpcerrors.CodeUnavailable {
+			scope.IncCounter(metrics.CadenceErrServiceBusyCounter)
 			return err
 		}
 	}


### PR DESCRIPTION
## Problem

When the scheduler workflow is mid-ContinueAsNew, `DescribeSchedule` returns a `yarpcerrors.CodeUnavailable` status to signal the caller to retry. However, the metered handler's `handleErr` switch only passes through `CodeDeadlineExceeded` and `CodeCancelled` from `*yarpcerrors.Status`; `CodeUnavailable` fell to the catch-all `frontendInternalServiceError` wrapper, which wraps it in a plain `fmt.Errorf`. This strips the yarpc status, and the error arrives at clients as `StatusCode.UNKNOWN` instead of `UNAVAILABLE`.

## Fix

Two coordinated changes:

**`metered.go`** add a `CodeUnavailable` passthrough alongside the existing `CodeDeadlineExceeded` and `CodeCancelled` cases. `UNAVAILABLE` means "momentarily unavailable, retry" and is already in the Python client's `RETRYABLE_CODES` set; it just never reached the client because metered was eating it.

**`handler_schedule.go`** use `yarpcerrors.Newf(yarpcerrors.CodeUnavailable, ...)` for both mid-ContinueAsNew sites. This is semantically correct: `UNAVAILABLE` = transient, retry. `ServiceBusyError` / `RESOURCE_EXHAUSTED` = rate limiting / overload, which is the wrong signal here.

## Testing

All 21 `TestDescribeSchedule` subtests pass. All `metered` package tests pass.

End-to-end: running `describe_schedule` against a live server no longer fails with `"cadence internal uncategorized error"` when the scheduler is mid-ContinueAsNew; the client receives a retryable `UNAVAILABLE` status.