### PR TITLE
fix: add new histogram bucket which can cover up to 1million counts

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -3307,7 +3307,7 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 		HistorySize:                                                  {metricName: "history_size", metricType: Timer},
 		HistorySizeHistogram:                                         {metricName: "history_size_counts", metricType: Histogram, intExponentialBuckets: Mid8B16MB},
 		HistoryCount:                                                 {metricName: "history_count", metricType: Timer},
-		HistoryCountHistogram:                                        {metricName: "history_count_counts", metricType: Histogram, intExponentialBuckets: Mid1To16k},
+		HistoryCountHistogram:                                        {metricName: "history_count_counts", metricType: Histogram, intExponentialBuckets: Mid1To50k},
 		EventBlobSizeExceedLimit:                                     {metricName: "blob_size_exceed_limit", metricType: Counter},
 		EventBlobSize:                                                {metricName: "event_blob_size", metricType: Timer},
 		EventBlobSizeHistogram:                                       {metricName: "event_blob_size_counts", metricType: Histogram, intExponentialBuckets: Mid8B16MB},

--- a/common/metrics/histograms.go
+++ b/common/metrics/histograms.go
@@ -66,6 +66,11 @@ var (
 	// due to float->duration truncation, which Prometheus rejects.
 	Mid1To16k = IntSubsettableHistogram(makeSubsettableHistogram(2, 8, 16384, 64))
 
+	// Mid1To50k is a histogram for medium counters, like workflow history event counts.
+	//
+	// This targets single-digits through ~50k, covering the default history count warning limit.
+	Mid1To50k = IntSubsettableHistogram(makeSubsettableHistogram(2, 8, 65536, 68))
+
 	// Mid8B16MB is a histogram for byte sizes, like mutable state or history blob sizes.
 	//
 	// This targets a few bytes through ~16MB, covering typical workflow execution sizes.

--- a/common/metrics/histograms_test.go
+++ b/common/metrics/histograms_test.go
@@ -151,9 +151,30 @@ func TestHistogramValues(t *testing.T) {
 [524288]
 `)
 	})
+	t.Run("mid_to_50k_ints", func(t *testing.T) {
+		checkHistogram(t, Mid1To50k, `
+[0]
+[8 9 11 13]
+[16 19 22 26]
+[32 38 45 53]
+[64 76 90 107]
+[128 152 181 215]
+[256 304 362 430]
+[512 608 724 861]
+[1024 1217 1448 1722]
+[2048 2435 2896 3444]
+[4096 4870 5792 6888]
+[8192 9741 11585 13777]
+[16384 19483 23170 27554]
+[32768 38967 46340 55108]
+[65536 77935 92681 110217]
+[131072 155871 185363 220435]
+[262144 311743 370727 440871]
+[524288 623487 741455 881743]
+[1048576]
+`)
+	})
 }
-
-// most histograms should pass this check, but fuzzy comparison is fine if needed for extreme cases.
 func checkHistogram[T any](t *testing.T, h histogrammy[T], expected string) {
 	var buf strings.Builder
 	h.print(func(s string, a ...any) {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Current the count upper limit for the buckets is about 16k however we allow 50k history events, adding a new bucket which covers up to 1m

**Why?**
new metrics bucket is needed to cover larger range

**How did you test it?**
go test -race -run TestHistogramValues ./common/metrics/...

**Potential risks**
NO

**Release notes**


**Documentation Changes**

