### PR TITLE
fix(schedule): remove forced gRPC transport from schedule commands

### DIFF
--- a/tools/cli/schedule_commands.go
+++ b/tools/cli/schedule_commands.go
@@ -38,11 +38,6 @@ type scheduleCLIImpl struct {
 }
 
 func withScheduleClient(c *cli.Context, cb func(sc *scheduleCLIImpl) error) error {
-	if c.String(FlagTransport) != grpcTransport {
-		if err := c.Set(FlagTransport, grpcTransport); err != nil {
-			return commoncli.Problem("Schedule commands require gRPC transport but failed to set it", err)
-		}
-	}
 	client, err := initializeFrontendClient(c)
 	if err != nil {
 		return err


### PR DESCRIPTION
## What changed

Removed the `withScheduleClient` block that forced gRPC transport for all schedule CLI commands regardless of what `--transport` the user passed.

## Why

Schedule commands were originally added before the Thrift IDL and mapper existed for schedule types.

That reason no longer applies. The Thrift mapper now covers every schedule type end-to-end, including fields added since: `PauseOnFailure`, `ConcurrencyLimit`, `BufferLimit`, `WorkflowIDPrefix`, and `OngoingBackfills`. The Thrift wrapper routes all 8 schedule operations through the same internal handler.

Keeping the forced gRPC was:
- Inconsistent: every other CLI command respects the user's `--transport` flag
- Potentially breaking: users on clusters that only expose TChannel (port 7933) could not use schedule commands even though the server supports them over Thrift
- Factually wrong: the error message said "Schedule commands require gRPC transport" which is no longer true

## Behavior change

| | Before | After |
|---|---|---|
| `cadence schedule ...` (no flags) | gRPC, port **7833** (forced) | TChannel, port **7933** (CLI default) |
| `cadence --transport grpc schedule ...` | gRPC, port 7833 | gRPC, port 7833 |
| `cadence --transport tchannel schedule ...` | gRPC, port 7833 (overridden) | TChannel, port 7933 |

Users who relied on the auto-switch without specifying `--transport` will now hit TChannel instead of gRPC. Both transports work correctly, the Thrift mapper is complete and tested.

## Testing

All 18 `TestScheduleCLI_*` tests pass. The tests inject the mock frontend client directly, so they exercise the schedule command logic independently of transport.