### PR TITLE
fix(config): add scheduler search attributes and enable scheduler in ES/Pinot dynamic configs

### DIFF
--- a/config/dynamicconfig/development_es.yaml
+++ b/config/dynamicconfig/development_es.yaml
@@ -43,11 +43,21 @@ frontend.validSearchAttributes:
       ExecutionStatus: 2
       CronSchedule: 1
       ScheduledExecutionTime: 2
+      CadenceScheduleID: 1
+      CadenceScheduleTime: 5
+      CadenceScheduleIsBackfill: 4
+      CadenceScheduleState: 1
+      CadenceScheduleCron: 1
+      CadenceScheduleWorkflowType: 1
+      CadenceScheduleBackfillID: 1
 system.minRetentionDays:
     - value: 0
 history.EnableConsistentQueryByDomain:
 - value: true
   constraints: {}
 frontend.enableActiveClusterSelectionPolicyInStartWorkflow:
+- value: true
+  constraints: {}
+worker.enableScheduler:
 - value: true
   constraints: {}

--- a/config/dynamicconfig/development_pinot.yaml
+++ b/config/dynamicconfig/development_pinot.yaml
@@ -41,8 +41,18 @@ frontend.validSearchAttributes:
       Passed: 4
       ShardID: 2
       IsDeleted: 4
+      CadenceScheduleID: 1
+      CadenceScheduleTime: 5
+      CadenceScheduleIsBackfill: 4
+      CadenceScheduleState: 1
+      CadenceScheduleCron: 1
+      CadenceScheduleWorkflowType: 1
+      CadenceScheduleBackfillID: 1
 system.minRetentionDays:
     - value: 0
 history.EnableConsistentQueryByDomain:
+- value: true
+  constraints: {}
+worker.enableScheduler:
 - value: true
   constraints: {}

--- a/config/dynamicconfig/development_queuev2_cached.yaml
+++ b/config/dynamicconfig/development_queuev2_cached.yaml
@@ -37,6 +37,7 @@ frontend.validSearchAttributes:
     CadenceScheduleState: 1
     CadenceScheduleCron: 1
     CadenceScheduleWorkflowType: 1
+    CadenceScheduleBackfillID: 1
     CloseStatus: 2
     CloseTime: 2
     CustomBoolField: 4
@@ -83,6 +84,9 @@ matching.enableClientAutoConfig:
 - value: true
 frontend.enableActiveClusterSelectionPolicyInStartWorkflow:
 - value: true
+worker.enableScheduler:
+- value: true
+  constraints: {}
 history.enableCleanupOrphanedHistoryBranchOnWorkflowCreation:
 - value: true
 


### PR DESCRIPTION
**What changed?**

Added missing `CadenceSchedule*` search attributes to `frontend.validSearchAttributes` and enabled `worker.enableScheduler` in:
- `config/dynamicconfig/development_es.yaml`
- `config/dynamicconfig/development_pinot.yaml`
- `config/dynamicconfig/development_queuev2_cached.yaml` (also adds the missing `CadenceScheduleBackfillID`)

**Why?**

Without `worker.enableScheduler: true`, the scheduler worker never polls the `cadence-scheduler` task list, leaving scheduler workflows stuck with a pending decision task, `UpsertSearchAttributes` is never called. Without the `CadenceSchedule*` entries in `validSearchAttributes`, even if `UpsertSearchAttributes` is called, the frontend silently rejects those attributes and they are never indexed in Elasticsearch/Pinot. The result is that `ListSchedules` returns empty `cron_expression` and `workflow_type` for all entries on ES/Pinot-backed clusters using these dev configs.

`development.yaml` (basic visibility) already has both settings; the ES and Pinot variants were simply never updated when scheduler support was added.

**How did you test it?**

Reproduced locally using the cadence-web docker-compose ES stack (`docker-compose-backend-services.yml`). Before the fix, `schedule list` returned empty `cron_expression` and `workflow_type`. After applying the fixes and restarting the cadence container, `schedule list` correctly shows the cron expression and workflow type for all schedule entries.

**Potential risks**

None. These are development/local config files only, not production configs. Enabling the scheduler worker and whitelisting the search attributes matches what `development.yaml` already does.

**Release notes**

N/A

**Documentation Changes**

N/A