### PR TITLE
fix(queuev2): downgrade false-positive ownership change log to Info

### DIFF
--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -835,6 +835,13 @@ func (q *cachedQueueReader) getTaskRangeID(taskID int64) int64 {
 // reportShadowComparison logs the result of a shadow comparison.
 func (q *cachedQueueReader) reportShadowComparison(result findMismatchesInShadowResult, logTags []tag.Tag) {
 
+	// Compute min ownerChangedRangeID before capping for logging, so the
+	// Info-vs-Warn decision uses the full set rather than a truncated slice.
+	var minOwnerChangedRangeID int64
+	if len(result.OwnerChangedRangeIDs) > 0 {
+		minOwnerChangedRangeID = slices.Min(result.OwnerChangedRangeIDs)
+	}
+
 	// Cap the number of mismatched task keys logged to avoid excessively large logs
 	result.MissedInCacheTasks = capShadowMismatchSlice(result.MissedInCacheTasks)
 	result.IncorrectTimeTasks = capShadowMismatchSlice(result.IncorrectTimeTasks)
@@ -848,7 +855,7 @@ func (q *cachedQueueReader) reportShadowComparison(result findMismatchesInShadow
 		// When currentRangeID is less than all ownerChangedRangeIDs, the tasks were created
 		// by a newer shard owner. This host has already lost ownership and will be stopped soon,
 		// so it's expected to see tasks from the new owner that aren't in its cache.
-		if result.CurrentRangeID < slices.Min(result.OwnerChangedRangeIDs) {
+		if result.CurrentRangeID < minOwnerChangedRangeID {
 			q.logger.Info("shard ownership already transferred, new owner created tasks not in cache", logTags...)
 		} else {
 			q.logger.Warn("possible shard ownership change, missed tasks are created in another range", logTags...)

--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -845,7 +845,14 @@ func (q *cachedQueueReader) reportShadowComparison(result findMismatchesInShadow
 	logTags = append(logTags, tag.Dynamic("shadowMismatch", result))
 
 	if len(result.OwnerChangedTasks) > 0 {
-		q.logger.Warn("possible shard ownership change, missed tasks are created in another range", logTags...)
+		// When currentRangeID is less than all ownerChangedRangeIDs, the tasks were created
+		// by a newer shard owner. This host has already lost ownership and will be stopped soon,
+		// so it's expected to see tasks from the new owner that aren't in its cache.
+		if result.CurrentRangeID < slices.Min(result.OwnerChangedRangeIDs) {
+			q.logger.Info("shard ownership already transferred, new owner created tasks not in cache", logTags...)
+		} else {
+			q.logger.Warn("possible shard ownership change, missed tasks are created in another range", logTags...)
+		}
 	}
 	if !result.HasMismatches {
 		q.logger.Debug("shadow comparison matched", logTags...)


### PR DESCRIPTION
**What changed?**

Downgraded the "possible shard ownership change" warning log to Info when the current host's rangeID is lower than all owner-changed rangeIDs.

**Why?**

The shadow comparison logs `"possible shard ownership change, missed tasks are created in another range"` as a Warn whenever tasks with a different rangeID are found. In most cases, this fires on old hosts that have already lost shard ownership — they see tasks created by the new owner (higher rangeID) and warn about them, but these are not actionable.

When `currentRangeID < min(ownerChangedRangeIDs)`, all mismatched tasks were created by a newer owner. The old host is lagging behind and will be stopped soon. This is expected behavior, not worth a warning.

The Warn is preserved when `currentRangeID >= some ownerChangedRangeID`, which indicates a genuinely concerning scenario (tasks from an older or same-generation owner).

**How did you test it?**

```bash
go build ./service/history/queuev2/...
go test -race -count=1 ./service/history/queuev2/...
make pr GEN_DIR=service/history
```

**Potential risks**

N/A — log level change only, no behavioral change. The Warn path is preserved for genuine ownership issues.

**Release notes**

Reduced false-positive warning logs in queue v2 shadow comparison. Old hosts that already lost shard ownership now log at Info level instead of Warn when seeing tasks created by the new owner.

**Documentation Changes**

N/A