### PR TITLE
feat(graceful failover): parallelize marker processing per domain

### DIFF
--- a/service/history/failover/coordinator.go
+++ b/service/history/failover/coordinator.go
@@ -251,18 +251,35 @@ func (c *coordinatorImpl) receiveFailoverMarkersLoop() {
 
 func (c *coordinatorImpl) dispatchToWorker(request *receiveRequest) {
 	domainID := request.marker.GetDomainID()
-	w := c.getOrCreateWorker(domainID)
+	for {
+		w := c.getOrCreateWorker(domainID)
 
-	select {
-	case w.receiveChan <- workerMsg{receive: request}:
-	default:
-		// Worker's channel is saturated. Process inline rather than blocking
-		// the dispatcher — blocking would re-serialize every other domain
-		// behind this one slow worker. handleFailoverMarkers takes w.mu, so
-		// state mutations remain serialized per worker. The version-check in
-		// handleFailoverMarkers tolerates this happening out-of-order relative
-		// to any messages still queued for the worker.
-		c.handleFailoverMarkers(w, request)
+		// Re-validate under RLock that w is still the current worker for this
+		// domain before sending. Without this, the worker goroutine could call
+		// tryRemoveWorker (deleting itself from the map and exiting) between
+		// getOrCreateWorker returning and the channel send, leaving the message
+		// sitting in an orphaned buffered channel that no one drains.
+		c.workersLock.RLock()
+		cur, ok := c.workers[domainID]
+		if !ok || cur != w {
+			c.workersLock.RUnlock()
+			continue
+		}
+		select {
+		case w.receiveChan <- workerMsg{receive: request}:
+			c.workersLock.RUnlock()
+			return
+		default:
+			// Worker's channel is saturated. Don't hold workersLock across the
+			// inline call — handleFailoverMarkers may invoke CleanPendingActiveState,
+			// which would block all worker exits and new-worker creates for every
+			// other domain. A saturated channel also means tryRemoveWorker cannot
+			// succeed for this w (len(receiveChan) > 0), so w is guaranteed to
+			// still be the live worker when we call handleFailoverMarkers below.
+			c.workersLock.RUnlock()
+			c.handleFailoverMarkers(w, request)
+			return
+		}
 	}
 }
 

--- a/service/history/failover/coordinator.go
+++ b/service/history/failover/coordinator.go
@@ -47,6 +47,7 @@ import (
 const (
 	notificationChanBufferSize       = 1000
 	receiveChanBufferSize            = 1000
+	workerChanBufferSize             = 512
 	cleanupMarkerInterval            = 30 * time.Minute
 	invalidMarkerDuration            = 1 * time.Hour
 	updateDomainRetryInitialInterval = 50 * time.Millisecond
@@ -76,8 +77,8 @@ type (
 		shutdownChan     chan struct{}
 		retryPolicy      backoff.RetryPolicy
 
-		recorderLock sync.Mutex
-		recorder     map[string]*failoverRecord
+		workersLock sync.RWMutex
+		workers     map[string]*domainWorker
 
 		domainManager persistence.DomainManager
 		historyClient history.Client
@@ -104,6 +105,19 @@ type (
 		lastUpdatedTime time.Time
 		firstSeenTime   time.Time
 	}
+
+	workerMsg struct {
+		receive *receiveRequest
+		cleanup bool
+	}
+
+	domainWorker struct {
+		domainID    string
+		receiveChan chan workerMsg
+
+		mu     sync.Mutex
+		record *failoverRecord
+	}
 )
 
 // NewCoordinator initialize a failover coordinator
@@ -123,7 +137,7 @@ func NewCoordinator(
 
 	return &coordinatorImpl{
 		status:           common.DaemonStatusInitialized,
-		recorder:         make(map[string]*failoverRecord),
+		workers:          make(map[string]*domainWorker),
 		notificationChan: make(chan *notificationRequest, notificationChanBufferSize),
 		receiveChan:      make(chan *receiveRequest, receiveChanBufferSize),
 		shutdownChan:     make(chan struct{}),
@@ -193,22 +207,27 @@ func (c *coordinatorImpl) ReceiveFailoverMarkers(
 func (c *coordinatorImpl) GetFailoverInfo(
 	domainID string,
 ) (*types.GetFailoverInfoResponse, error) {
-	c.recorderLock.Lock()
-	defer c.recorderLock.Unlock()
-
-	record, ok := c.recorder[domainID]
+	c.workersLock.RLock()
+	w, ok := c.workers[domainID]
+	c.workersLock.RUnlock()
 	if !ok {
+		return nil, errRecordNotFound
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.record == nil {
 		return nil, errRecordNotFound
 	}
 
 	var pendingShards []int32
 	for i := 0; i < c.config.NumberOfShards; i++ {
-		if _, ok := record.shards[int32(i)]; !ok {
+		if _, ok := w.record.shards[int32(i)]; !ok {
 			pendingShards = append(pendingShards, int32(i))
 		}
 	}
 	return &types.GetFailoverInfoResponse{
-		CompletedShardCount: int32(len(record.shards)),
+		CompletedShardCount: int32(len(w.record.shards)),
 		PendingShards:       pendingShards,
 	}, nil
 }
@@ -225,7 +244,234 @@ func (c *coordinatorImpl) receiveFailoverMarkersLoop() {
 		case <-ticker.C:
 			c.cleanupInvalidMarkers()
 		case request := <-c.receiveChan:
-			c.handleFailoverMarkers(request)
+			c.dispatchToWorker(request)
+		}
+	}
+}
+
+func (c *coordinatorImpl) dispatchToWorker(request *receiveRequest) {
+	domainID := request.marker.GetDomainID()
+	w := c.getOrCreateWorker(domainID)
+
+	select {
+	case w.receiveChan <- workerMsg{receive: request}:
+	default:
+		// Worker's channel is saturated. Process inline rather than blocking
+		// the dispatcher — blocking would re-serialize every other domain
+		// behind this one slow worker. handleFailoverMarkers takes w.mu, so
+		// state mutations remain serialized per worker. The version-check in
+		// handleFailoverMarkers tolerates this happening out-of-order relative
+		// to any messages still queued for the worker.
+		c.handleFailoverMarkers(w, request)
+	}
+}
+
+func (c *coordinatorImpl) getOrCreateWorker(domainID string) *domainWorker {
+	c.workersLock.RLock()
+	w, ok := c.workers[domainID]
+	c.workersLock.RUnlock()
+	if ok {
+		return w
+	}
+
+	c.workersLock.Lock()
+	defer c.workersLock.Unlock()
+	if w, ok := c.workers[domainID]; ok {
+		return w
+	}
+	w = &domainWorker{
+		domainID:    domainID,
+		receiveChan: make(chan workerMsg, workerChanBufferSize),
+	}
+	c.workers[domainID] = w
+	go c.runDomainWorker(w)
+	return w
+}
+
+func (c *coordinatorImpl) runDomainWorker(w *domainWorker) {
+	for {
+		select {
+		case <-c.shutdownChan:
+			return
+		case msg := <-w.receiveChan:
+			done := false
+			if msg.cleanup {
+				done = true
+			} else {
+				done = c.handleFailoverMarkers(w, msg.receive)
+			}
+			if done && c.tryRemoveWorker(w) {
+				return
+			}
+		}
+	}
+}
+
+// tryRemoveWorker removes the worker from the outer map iff it has no pending
+// messages and no live failover record. Returns true if the worker was removed
+// and the goroutine should exit. Returns false if work arrived after the worker
+// decided to exit (queued message, or a record re-created by an inline dispatch
+// from dispatchToWorker), in which case the worker keeps running.
+func (c *coordinatorImpl) tryRemoveWorker(w *domainWorker) bool {
+	c.workersLock.Lock()
+	defer c.workersLock.Unlock()
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if len(w.receiveChan) > 0 || w.record != nil {
+		return false
+	}
+	delete(c.workers, w.domainID)
+	return true
+}
+
+// handleFailoverMarkers processes a single receiveRequest for one domain.
+// Returns true if the failover record was deleted (worker should attempt exit).
+func (c *coordinatorImpl) handleFailoverMarkers(
+	w *domainWorker,
+	request *receiveRequest,
+) bool {
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	marker := request.marker
+	domainID := marker.GetDomainID()
+	if w.record != nil {
+		// if the local failover version is less than the failover version in the marker,
+		// it means that another failover happened for this domain and the local one should be invalidated
+		if w.record.failoverVersion < marker.GetFailoverVersion() {
+			w.record = nil
+		}
+
+		// if the local failover version is larger than the failover version in the marker,
+		// ignore the incoming marker
+		if w.record != nil && w.record.failoverVersion > marker.GetFailoverVersion() {
+			return false
+		}
+	}
+
+	now := c.timeSource.Now()
+	if w.record == nil {
+		w.record = &failoverRecord{
+			failoverVersion: marker.GetFailoverVersion(),
+			shards:          make(map[int32]struct{}),
+			firstSeenTime:   now,
+		}
+	}
+
+	w.record.lastUpdatedTime = now
+	for _, shardID := range request.shardIDs {
+		w.record.shards[shardID] = struct{}{}
+	}
+
+	domainName, err := c.domainCache.GetDomainName(domainID)
+	if err != nil {
+		c.logger.Error("Coordinator failed to get domain name while recording failover markers from request",
+			tag.WorkflowDomainID(domainID),
+			tag.Error(err),
+		)
+
+		c.scope.Tagged(metrics.DomainTag(domainName)).IncCounter(metrics.CadenceFailures)
+		return false
+	}
+
+	if len(w.record.shards) == c.config.NumberOfShards {
+		cleanStart := c.timeSource.Now()
+		updated, err := domain.CleanPendingActiveState(
+			c.domainManager,
+			domainID,
+			w.record.failoverVersion,
+			c.retryPolicy,
+		)
+		cleanDuration := c.timeSource.Now().Sub(cleanStart)
+		if err != nil {
+			c.logger.Error("Coordinator failed to update domain after receiving failover markers from all shards",
+				tag.WorkflowDomainID(domainID),
+				tag.Error(err),
+			)
+			c.scope.IncCounter(metrics.CadenceFailures)
+			return false
+		}
+		firstSeenTime := w.record.firstSeenTime
+		w.record = nil
+		// reset the gauge so it reflects the current (empty) pending state for this domain
+		// rather than the last partial-count value, which would otherwise linger forever
+		c.scope.Tagged(
+			metrics.DomainTag(domainName),
+		).UpdateGauge(
+			metrics.FailoverMarkerCount,
+			0,
+		)
+
+		if !updated {
+			// another path already cleared the pending-active state — avoid the
+			// misleading "Updated domain from pending-active to active" log and
+			// the bogus GracefulFailoverLatency (which would otherwise report
+			// now - marker.CreationTime on a long-stale marker)
+			return true
+		}
+
+		now := c.timeSource.Now()
+		// use the last marker to calculate the failover duration
+		failoverDuration := now.Sub(time.Unix(0, marker.GetCreationTime()))
+		markerPipelineDuration := now.Sub(firstSeenTime)
+		c.scope.Tagged(
+			metrics.DomainTag(domainName),
+		).RecordTimer(
+			metrics.GracefulFailoverLatency,
+			failoverDuration,
+		)
+		c.scope.Tagged(
+			metrics.DomainTag(domainName),
+		).RecordHistogramDuration(
+			metrics.GracefulFailoverLatencyHistogram,
+			failoverDuration,
+		)
+		c.logger.Info("Updated domain from pending-active to active",
+			tag.WorkflowDomainName(domainName),
+			tag.FailoverVersion(marker.FailoverVersion),
+			tag.Duration(failoverDuration),
+			tag.Dynamic("marker-pipeline-duration", markerPipelineDuration),
+			tag.Dynamic("clean-pending-active-duration", cleanDuration),
+		)
+		return true
+	}
+
+	c.scope.Tagged(
+		metrics.DomainTag(domainName),
+	).UpdateGauge(
+		metrics.FailoverMarkerCount,
+		float64(len(w.record.shards)),
+	)
+	return false
+}
+
+func (c *coordinatorImpl) cleanupInvalidMarkers() {
+	c.workersLock.RLock()
+	expired := make([]*domainWorker, 0)
+	for _, w := range c.workers {
+		w.mu.Lock()
+		stale := w.record != nil && c.timeSource.Now().Sub(w.record.lastUpdatedTime) > invalidMarkerDuration
+		if stale {
+			w.record = nil
+		}
+		empty := w.record == nil
+		w.mu.Unlock()
+		if empty {
+			expired = append(expired, w)
+		}
+	}
+	c.workersLock.RUnlock()
+
+	for _, w := range expired {
+		select {
+		case w.receiveChan <- workerMsg{cleanup: true}:
+		case <-c.shutdownChan:
+			return
+		default:
+			// Worker's channel is full; skip this round. The record is already
+			// cleared, so the worker will reach tryRemoveWorker and exit on
+			// its own once it drains.
 		}
 	}
 }
@@ -289,136 +535,6 @@ func (c *coordinatorImpl) notifyFailoverMarkerLoop() {
 				c.config.NotifyFailoverMarkerInterval(),
 				c.config.NotifyFailoverMarkerTimerJitterCoefficient(),
 			))
-		}
-	}
-}
-
-func (c *coordinatorImpl) handleFailoverMarkers(
-	request *receiveRequest,
-) {
-
-	c.recorderLock.Lock()
-	defer c.recorderLock.Unlock()
-
-	marker := request.marker
-	domainID := marker.GetDomainID()
-	if record, ok := c.recorder[domainID]; ok {
-		// if the local failover version is less than the failover version in the marker,
-		// it means that another failover happened for this domain and the local one should be invalidated
-		if record.failoverVersion < marker.GetFailoverVersion() {
-			delete(c.recorder, domainID)
-		}
-
-		// if the local failover version is larger than the failover version in the marker,
-		// ignore the incoming marker
-		if record.failoverVersion > marker.GetFailoverVersion() {
-			return
-		}
-	}
-
-	now := c.timeSource.Now()
-	if _, ok := c.recorder[domainID]; !ok {
-		// initialize the failover record
-		c.recorder[marker.GetDomainID()] = &failoverRecord{
-			failoverVersion: marker.GetFailoverVersion(),
-			shards:          make(map[int32]struct{}),
-			firstSeenTime:   now,
-		}
-	}
-
-	record := c.recorder[domainID]
-	record.lastUpdatedTime = now
-	for _, shardID := range request.shardIDs {
-		record.shards[shardID] = struct{}{}
-	}
-
-	domainName, err := c.domainCache.GetDomainName(domainID)
-	if err != nil {
-		c.logger.Error("Coordinator failed to get domain name while recording failover markers from request",
-			tag.WorkflowDomainID(domainID),
-			tag.Error(err),
-		)
-
-		c.scope.Tagged(metrics.DomainTag(domainName)).IncCounter(metrics.CadenceFailures)
-		return
-	}
-
-	if len(record.shards) == c.config.NumberOfShards {
-		cleanStart := c.timeSource.Now()
-		updated, err := domain.CleanPendingActiveState(
-			c.domainManager,
-			domainID,
-			record.failoverVersion,
-			c.retryPolicy,
-		)
-		cleanDuration := c.timeSource.Now().Sub(cleanStart)
-		if err != nil {
-			c.logger.Error("Coordinator failed to update domain after receiving failover markers from all shards",
-				tag.WorkflowDomainID(domainID),
-				tag.Error(err),
-			)
-			c.scope.IncCounter(metrics.CadenceFailures)
-			return
-		}
-		firstSeenTime := record.firstSeenTime
-		delete(c.recorder, domainID)
-		// reset the gauge so it reflects the current (empty) pending state for this domain
-		// rather than the last partial-count value, which would otherwise linger forever
-		c.scope.Tagged(
-			metrics.DomainTag(domainName),
-		).UpdateGauge(
-			metrics.FailoverMarkerCount,
-			0,
-		)
-
-		if !updated {
-			// another path already cleared the pending-active state — avoid the
-			// misleading "Updated domain from pending-active to active" log and
-			// the bogus GracefulFailoverLatency (which would otherwise report
-			// now - marker.CreationTime on a long-stale marker)
-			return
-		}
-
-		now := c.timeSource.Now()
-		// use the last marker to calculate the failover duration
-		failoverDuration := now.Sub(time.Unix(0, marker.GetCreationTime()))
-		markerPipelineDuration := now.Sub(firstSeenTime)
-		c.scope.Tagged(
-			metrics.DomainTag(domainName),
-		).RecordTimer(
-			metrics.GracefulFailoverLatency,
-			failoverDuration,
-		)
-		c.scope.Tagged(
-			metrics.DomainTag(domainName),
-		).RecordHistogramDuration(
-			metrics.GracefulFailoverLatencyHistogram,
-			failoverDuration,
-		)
-		c.logger.Info("Updated domain from pending-active to active",
-			tag.WorkflowDomainName(domainName),
-			tag.FailoverVersion(marker.FailoverVersion),
-			tag.Duration(failoverDuration),
-			tag.Dynamic("marker-pipeline-duration", markerPipelineDuration),
-			tag.Dynamic("clean-pending-active-duration", cleanDuration),
-		)
-	} else {
-		c.scope.Tagged(
-			metrics.DomainTag(domainName),
-		).UpdateGauge(
-			metrics.FailoverMarkerCount,
-			float64(len(record.shards)),
-		)
-	}
-}
-
-func (c *coordinatorImpl) cleanupInvalidMarkers() {
-	c.recorderLock.Lock()
-	defer c.recorderLock.Unlock()
-
-	for domainID, record := range c.recorder {
-		if c.timeSource.Now().Sub(record.lastUpdatedTime) > invalidMarkerDuration {
-			delete(c.recorder, domainID)
 		}
 	}
 }

--- a/service/history/failover/coordinator_test.go
+++ b/service/history/failover/coordinator_test.go
@@ -280,6 +280,29 @@ func (s *coordinatorSuite) TestAggregateNotificationRequests() {
 	s.Equal([]int32{3}, requestByMarker[attributes2].shardIDs)
 }
 
+func (s *coordinatorSuite) handle(req *receiveRequest) bool {
+	domainID := req.marker.GetDomainID()
+	w, ok := s.coordinator.workers[domainID]
+	if !ok {
+		w = &domainWorker{
+			domainID:    domainID,
+			receiveChan: make(chan workerMsg, workerChanBufferSize),
+		}
+		s.coordinator.workers[domainID] = w
+	}
+	return s.coordinator.handleFailoverMarkers(w, req)
+}
+
+func (s *coordinatorSuite) record(domainID string) *failoverRecord {
+	w, ok := s.coordinator.workers[domainID]
+	if !ok {
+		return nil
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.record
+}
+
 func (s *coordinatorSuite) TestHandleFailoverMarkers_DeleteExpiredFailoverMarker() {
 	domainID := uuid.New()
 	attributes1 := &types.FailoverMarkerAttributes{
@@ -301,9 +324,12 @@ func (s *coordinatorSuite) TestHandleFailoverMarkers_DeleteExpiredFailoverMarker
 		marker:   attributes2,
 	}
 
-	s.coordinator.handleFailoverMarkers(request1)
-	s.coordinator.handleFailoverMarkers(request2)
-	s.Equal(1, len(s.coordinator.recorder))
+	s.handle(request1)
+	s.handle(request2)
+	rec := s.record(domainID)
+	s.NotNil(rec)
+	s.Equal(int64(2), rec.failoverVersion)
+	s.Len(rec.shards, 1)
 }
 
 func (s *coordinatorSuite) TestHandleFailoverMarkers_IgnoreExpiredFailoverMarker() {
@@ -327,9 +353,12 @@ func (s *coordinatorSuite) TestHandleFailoverMarkers_IgnoreExpiredFailoverMarker
 		marker:   attributes2,
 	}
 
-	s.coordinator.handleFailoverMarkers(request2)
-	s.coordinator.handleFailoverMarkers(request1)
-	s.Equal(1, len(s.coordinator.recorder))
+	s.handle(request2)
+	s.handle(request1)
+	rec := s.record(domainID)
+	s.NotNil(rec)
+	s.Equal(int64(2), rec.failoverVersion)
+	s.Len(rec.shards, 1)
 }
 
 func (s *coordinatorSuite) TestHandleFailoverMarkers_CleanPendingActiveState_Success() {
@@ -400,9 +429,9 @@ func (s *coordinatorSuite) TestHandleFailoverMarkers_CleanPendingActiveState_Suc
 		NotificationVersion:         1,
 	}).Return(nil).Times(1)
 
-	s.coordinator.handleFailoverMarkers(request1)
-	s.coordinator.handleFailoverMarkers(request2)
-	s.Equal(0, len(s.coordinator.recorder))
+	s.handle(request1)
+	s.handle(request2)
+	s.Nil(s.record(domainID))
 }
 
 func (s *coordinatorSuite) TestHandleFailoverMarkers_CleanPendingActiveState_Error() {
@@ -473,9 +502,11 @@ func (s *coordinatorSuite) TestHandleFailoverMarkers_CleanPendingActiveState_Err
 		NotificationVersion:         1,
 	}).Return(fmt.Errorf("test error")).Times(3)
 
-	s.coordinator.handleFailoverMarkers(request1)
-	s.coordinator.handleFailoverMarkers(request2)
-	s.Equal(1, len(s.coordinator.recorder))
+	s.handle(request1)
+	s.handle(request2)
+	rec := s.record(domainID)
+	s.NotNil(rec)
+	s.Len(rec.shards, 2)
 }
 
 func (s *coordinatorSuite) TestHandleFailoverMarkers_CleanPendingActiveState_NoOp() {
@@ -535,9 +566,9 @@ func (s *coordinatorSuite) TestHandleFailoverMarkers_CleanPendingActiveState_NoO
 		NotificationVersion:         1,
 	}, nil).Times(1)
 
-	s.coordinator.handleFailoverMarkers(request1)
-	s.coordinator.handleFailoverMarkers(request2)
-	s.Equal(0, len(s.coordinator.recorder), "recorder entry should be cleared even when CleanPendingActiveState is a no-op")
+	s.handle(request1)
+	s.handle(request2)
+	s.Nil(s.record(domainID), "record should be cleared even when CleanPendingActiveState is a no-op")
 	s.mockMetadataManager.AssertNotCalled(s.T(), "UpdateDomain", mock.Anything, mock.Anything)
 }
 
@@ -554,7 +585,7 @@ func (s *coordinatorSuite) TestGetFailoverInfo_Success() {
 		shardIDs: []int32{1},
 		marker:   attributes,
 	}
-	s.coordinator.handleFailoverMarkers(request)
+	s.handle(request)
 
 	resp, err := s.coordinator.GetFailoverInfo(domainID)
 	s.NoError(err)
@@ -567,4 +598,69 @@ func (s *coordinatorSuite) TestGetFailoverInfo_DomainIDNotFound_Error() {
 	resp, err := s.coordinator.GetFailoverInfo(domainID)
 	s.Nil(resp)
 	s.Error(err)
+}
+
+func (s *coordinatorSuite) TestHandleFailoverMarkers_PerDomainConcurrency() {
+	domainA := uuid.New()
+	domainB := uuid.New()
+
+	infoA := &persistence.DomainInfo{ID: domainA, Status: persistence.DomainStatusRegistered}
+	infoB := &persistence.DomainInfo{ID: domainB, Status: persistence.DomainStatusRegistered}
+	cfg := &persistence.DomainConfig{Retention: 1, EmitMetric: true}
+	repl := &persistence.DomainReplicationConfig{
+		ActiveClusterName: "active",
+		Clusters:          []*persistence.ClusterReplicationConfig{{ClusterName: "active"}},
+	}
+
+	s.mockMetadataManager.On("GetMetadata", mock.Anything).Return(&persistence.GetMetadataResponse{NotificationVersion: 1}, nil)
+	s.mockMetadataManager.On("GetDomain", mock.Anything, &persistence.GetDomainRequest{ID: domainA}).Return(&persistence.GetDomainResponse{
+		Info: infoA, Config: cfg, ReplicationConfig: repl, IsGlobalDomain: true,
+		ConfigVersion: 1, FailoverVersion: 2, FailoverNotificationVersion: 2,
+		FailoverEndTime: common.Int64Ptr(1), NotificationVersion: 1,
+	}, nil).Times(1)
+	s.mockMetadataManager.On("GetDomain", mock.Anything, &persistence.GetDomainRequest{ID: domainB}).Return(&persistence.GetDomainResponse{
+		Info: infoB, Config: cfg, ReplicationConfig: repl, IsGlobalDomain: true,
+		ConfigVersion: 1, FailoverVersion: 2, FailoverNotificationVersion: 2,
+		FailoverEndTime: common.Int64Ptr(1), NotificationVersion: 1,
+	}, nil).Times(1)
+
+	blockA := make(chan struct{})
+	aDone := make(chan struct{})
+	s.mockMetadataManager.On("UpdateDomain", mock.Anything, mock.MatchedBy(func(req *persistence.UpdateDomainRequest) bool {
+		return req.Info.ID == domainA
+	})).Run(func(args mock.Arguments) {
+		<-blockA
+		close(aDone)
+	}).Return(nil).Times(1)
+
+	bDone := make(chan struct{})
+	s.mockMetadataManager.On("UpdateDomain", mock.Anything, mock.MatchedBy(func(req *persistence.UpdateDomainRequest) bool {
+		return req.Info.ID == domainB
+	})).Run(func(args mock.Arguments) { close(bDone) }).Return(nil).Times(1)
+
+	s.coordinator.Start()
+	defer s.coordinator.Stop()
+
+	mkMarker := func(domainID string) *types.FailoverMarkerAttributes {
+		return &types.FailoverMarkerAttributes{
+			DomainID: domainID, FailoverVersion: 2, CreationTime: common.Int64Ptr(1),
+		}
+	}
+	// Two shards each => completion fires on the second marker per domain.
+	s.coordinator.ReceiveFailoverMarkers([]int32{0}, mkMarker(domainA))
+	s.coordinator.ReceiveFailoverMarkers([]int32{1}, mkMarker(domainA))
+	s.coordinator.ReceiveFailoverMarkers([]int32{0}, mkMarker(domainB))
+	s.coordinator.ReceiveFailoverMarkers([]int32{1}, mkMarker(domainB))
+
+	select {
+	case <-bDone:
+	case <-time.After(2 * time.Second):
+		s.Fail("domain B's completion was blocked by domain A's in-flight UpdateDomain")
+	}
+	close(blockA)
+	select {
+	case <-aDone:
+	case <-time.After(2 * time.Second):
+		s.Fail("domain A's UpdateDomain never completed after unblock")
+	}
 }


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Parallelize failover marker processing, moving the handleFailoverMarkers to a go routine and only locking for the domainID

https://github.com/cadence-workflow/cadence/issues/8138

**Why?**
Previously the marker processing was done serially for all domains. If there are multiple domains being failed over at the same time, with a large number of shards, this could significantly increase the failover duration.

**How did you test it?**
Added tests to verify the behavior in parallel

go test -race -count=1 ./service/history/failover/...

Added test
go test -race -run TestCoordinatorSuite/TestHandleFailoverMarkers_PerDomainConcurrency ./service/history/failover/...

Updated tests
go test -race -run 'TestCoordinatorSuite/TestHandleFailoverMarkers' ./service/history/failover/...

High count to test any race conditions or leaks
go test -race -count=300 -run 'TestCoordinatorSuite/TestHandleFailoverMarkers' ./service/history/failover/...

**Potential risks**
It could affect processing of graceful failovers. Will conduct tests locally, on existing deployments, and with multiple domain failovers

**Release notes**
Parallelize failover marker handling per domain to reduce graceful failover latency when multiple domains fail over together

**Documentation Changes**
N/A