### PR TITLE
fix(scheduler): populate createTime, lastUpdateTime, and pauseInfo.pausedAt in DescribeSchedule

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -352,6 +352,7 @@ func (wh *WorkflowHandler) DescribeSchedule(
 				return &types.SchedulePauseInfo{
 					Reason:   desc.PauseReason,
 					PausedBy: desc.PausedBy,
+					PausedAt: desc.PausedAt,
 				}
 			}(),
 		},
@@ -361,6 +362,8 @@ func (wh *WorkflowHandler) DescribeSchedule(
 			TotalRuns:        desc.TotalRuns,
 			MissedRuns:       desc.MissedRuns,
 			SkippedRuns:      desc.SkippedRuns,
+			CreateTime:       desc.CreatedAt,
+			LastUpdateTime:   desc.LastUpdatedAt,
 			OngoingBackfills: ongoingBackfillsForResponse(desc.OngoingBackfills),
 		},
 		Memo:             desc.Memo,

--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -193,6 +193,7 @@ func (wh *WorkflowHandler) CreateSchedule(
 		return nil, err
 	}
 
+	now := time.Now()
 	workflowInput := scheduler.SchedulerWorkflowInput{
 		Domain:           domainName,
 		ScheduleID:       scheduleID,
@@ -200,6 +201,10 @@ func (wh *WorkflowHandler) CreateSchedule(
 		Action:           *request.GetAction(),
 		SearchAttributes: request.GetSearchAttributes(),
 		Memo:             request.GetMemo(),
+		State: scheduler.SchedulerWorkflowState{
+			CreatedAt:     now,
+			LastUpdatedAt: now,
+		},
 	}
 	if request.GetPolicies() != nil {
 		workflowInput.Policies = *request.GetPolicies()

--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -191,6 +191,9 @@ type SchedulerWorkflowState struct {
 	// processMissedRunsAt prefers this over input.Policies.CatchUpPolicy for the first
 	// catch-up pass after an unpause, then clears it. Invalid (zero) means no override.
 	UnpauseCatchUpPolicy types.ScheduleCatchUpPolicy `json:"unpauseCatchUpPolicy,omitempty"`
+	CreatedAt            time.Time                   `json:"createdAt,omitempty"`
+	LastUpdatedAt        time.Time                   `json:"lastUpdatedAt,omitempty"`
+	PausedAt             time.Time                   `json:"pausedAt,omitempty"`
 }
 
 // BufferedFire is a schedule fire queued for sequential execution by the BUFFER
@@ -287,6 +290,9 @@ type ScheduleDescription struct {
 	// OngoingBackfills mirrors SchedulerWorkflowState.PendingBackfills at the
 	// time of the describe query.
 	OngoingBackfills []types.BackfillInfo `json:"ongoingBackfills,omitempty"`
+	CreatedAt        time.Time            `json:"createdAt,omitempty"`
+	LastUpdatedAt    time.Time            `json:"lastUpdatedAt,omitempty"`
+	PausedAt         time.Time            `json:"pausedAt,omitempty"`
 }
 
 // TriggerSource identifies what caused a schedule fire, used to differentiate

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -65,6 +65,10 @@ func SchedulerWorkflow(ctx workflow.Context, input SchedulerWorkflowInput) error
 
 	state := &input.State
 
+	if state.CreatedAt.IsZero() {
+		state.CreatedAt = workflow.Now(ctx)
+	}
+
 	err := workflow.SetQueryHandler(ctx, QueryTypeDescribe, func() (*ScheduleDescription, error) {
 		return buildScheduleDescription(&input, state), nil
 	})
@@ -229,7 +233,7 @@ func applyAllInputs(
 		var sig PauseSignal
 		c.Receive(ctx, &sig)
 		scope.Tagged(map[string]string{SignalTypeTag: signalTypeTagPause}).Counter(SchedulerSignalReceivedCountPerDomain).Inc(1)
-		if handlePause(logger, sig, state) {
+		if handlePause(logger, sig, state, workflow.Now(ctx)) {
 			stateChanged = true
 		}
 	})
@@ -247,7 +251,7 @@ func applyAllInputs(
 		var sig UpdateSignal
 		c.Receive(ctx, &sig)
 		scope.Tagged(map[string]string{SignalTypeTag: signalTypeTagUpdate}).Counter(SchedulerSignalReceivedCountPerDomain).Inc(1)
-		if handleUpdate(logger, sig, input, state) {
+		if handleUpdate(logger, sig, input, state, workflow.Now(ctx)) {
 			stateChanged = true
 		}
 	})
@@ -269,7 +273,7 @@ func applyAllInputs(
 
 	selector.Select(ctx)
 
-	if drainBufferedSignals(logger, scope, chs, state, input) {
+	if drainBufferedSignals(ctx, logger, scope, chs, state, input) {
 		stateChanged = true
 	}
 
@@ -280,6 +284,7 @@ func applyAllInputs(
 // Delete signals are checked first to prevent signal loss across ContinueAsNew boundaries.
 // Returns true if a state-changing signal was found.
 func drainBufferedSignals(
+	ctx workflow.Context,
 	logger *zap.Logger,
 	scope tally.Scope,
 	chs signalChannels,
@@ -299,7 +304,7 @@ func drainBufferedSignals(
 			break
 		}
 		scope.Tagged(map[string]string{SignalTypeTag: signalTypeTagPause}).Counter(SchedulerSignalReceivedCountPerDomain).Inc(1)
-		if handlePause(logger, sig, state) {
+		if handlePause(logger, sig, state, workflow.Now(ctx)) {
 			stateChanged = true
 		}
 	}
@@ -319,7 +324,7 @@ func drainBufferedSignals(
 			break
 		}
 		scope.Tagged(map[string]string{SignalTypeTag: signalTypeTagUpdate}).Counter(SchedulerSignalReceivedCountPerDomain).Inc(1)
-		if handleUpdate(logger, sig, input, state) {
+		if handleUpdate(logger, sig, input, state, workflow.Now(ctx)) {
 			stateChanged = true
 		}
 	}
@@ -372,7 +377,7 @@ func buildScheduleSearchAttributes(input *SchedulerWorkflowInput, state *Schedul
 	return sa
 }
 
-func handlePause(logger *zap.Logger, sig PauseSignal, state *SchedulerWorkflowState) bool {
+func handlePause(logger *zap.Logger, sig PauseSignal, state *SchedulerWorkflowState, now time.Time) bool {
 	if state.Paused {
 		logger.Info("ignoring pause signal, schedule is already paused")
 		return false
@@ -380,6 +385,7 @@ func handlePause(logger *zap.Logger, sig PauseSignal, state *SchedulerWorkflowSt
 	state.Paused = true
 	state.PauseReason = sig.Reason
 	state.PausedBy = sig.PausedBy
+	state.PausedAt = now
 	logger.Info("schedule paused", zap.String("reason", sig.Reason), zap.String("pausedBy", sig.PausedBy))
 	return true
 }
@@ -392,6 +398,7 @@ func handleUnpause(logger *zap.Logger, sig UnpauseSignal, state *SchedulerWorkfl
 	state.Paused = false
 	state.PauseReason = ""
 	state.PausedBy = ""
+	state.PausedAt = time.Time{}
 	if sig.CatchUpPolicy != types.ScheduleCatchUpPolicyInvalid {
 		state.UnpauseCatchUpPolicy = sig.CatchUpPolicy
 	}
@@ -399,7 +406,7 @@ func handleUnpause(logger *zap.Logger, sig UnpauseSignal, state *SchedulerWorkfl
 	return true
 }
 
-func handleUpdate(logger *zap.Logger, sig UpdateSignal, input *SchedulerWorkflowInput, state *SchedulerWorkflowState) bool {
+func handleUpdate(logger *zap.Logger, sig UpdateSignal, input *SchedulerWorkflowInput, state *SchedulerWorkflowState, now time.Time) bool {
 	if sig.Spec == nil && sig.Action == nil && sig.Policies == nil && sig.SearchAttributes == nil {
 		logger.Info("ignoring empty update signal")
 		return false
@@ -460,6 +467,7 @@ func handleUpdate(logger *zap.Logger, sig UpdateSignal, input *SchedulerWorkflow
 		changed = true
 	}
 	if changed {
+		state.LastUpdatedAt = now
 		logger.Info("schedule updated")
 	}
 	return changed
@@ -1078,6 +1086,9 @@ func buildScheduleDescription(input *SchedulerWorkflowInput, state *SchedulerWor
 		Memo:             input.Memo,
 		SearchAttributes: input.SearchAttributes,
 		OngoingBackfills: ongoing,
+		CreatedAt:        state.CreatedAt,
+		LastUpdatedAt:    state.LastUpdatedAt,
+		PausedAt:         state.PausedAt,
 	}
 }
 

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -65,10 +65,6 @@ func SchedulerWorkflow(ctx workflow.Context, input SchedulerWorkflowInput) error
 
 	state := &input.State
 
-	if state.CreatedAt.IsZero() {
-		state.CreatedAt = workflow.Now(ctx)
-	}
-
 	err := workflow.SetQueryHandler(ctx, QueryTypeDescribe, func() (*ScheduleDescription, error) {
 		return buildScheduleDescription(&input, state), nil
 	})

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -507,6 +507,28 @@ func TestBuildScheduleDescription(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "schedule with timestamps",
+			input: SchedulerWorkflowInput{ScheduleID: "sched-ts", Domain: "test-domain"},
+			state: SchedulerWorkflowState{
+				CreatedAt:     time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+				LastUpdatedAt: time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC),
+				Paused:        true,
+				PauseReason:   "test",
+				PausedBy:      "admin",
+				PausedAt:      time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC),
+			},
+			want: &ScheduleDescription{
+				ScheduleID:    "sched-ts",
+				Domain:        "test-domain",
+				Paused:        true,
+				PauseReason:   "test",
+				PausedBy:      "admin",
+				CreatedAt:     time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+				LastUpdatedAt: time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC),
+				PausedAt:      time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -556,14 +578,18 @@ func TestHandlePause(t *testing.T) {
 		},
 	}
 
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			state := tt.initial
-			changed := handlePause(testLogger, tt.sig, &state)
+			changed := handlePause(testLogger, tt.sig, &state, now)
 			assert.Equal(t, tt.wantChanged, changed)
 			assert.Equal(t, tt.wantPaused, state.Paused)
 			assert.Equal(t, tt.wantReason, state.PauseReason)
 			assert.Equal(t, tt.wantPausedBy, state.PausedBy)
+			if tt.wantChanged {
+				assert.Equal(t, now, state.PausedAt)
+			}
 		})
 	}
 }
@@ -581,7 +607,7 @@ func TestHandleUnpause(t *testing.T) {
 	}{
 		{
 			name:         "unpause from paused",
-			initial:      SchedulerWorkflowState{Paused: true, PauseReason: "maintenance", PausedBy: "admin"},
+			initial:      SchedulerWorkflowState{Paused: true, PauseReason: "maintenance", PausedBy: "admin", PausedAt: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)},
 			sig:          UnpauseSignal{Reason: "maintenance done"},
 			wantPaused:   false,
 			wantReason:   "",
@@ -599,7 +625,7 @@ func TestHandleUnpause(t *testing.T) {
 		},
 		{
 			name:                     "unpause with CatchUpPolicyOne stores override in state",
-			initial:                  SchedulerWorkflowState{Paused: true},
+			initial:                  SchedulerWorkflowState{Paused: true, PausedAt: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)},
 			sig:                      UnpauseSignal{Reason: "resume", CatchUpPolicy: types.ScheduleCatchUpPolicyOne},
 			wantPaused:               false,
 			wantChanged:              true,
@@ -607,7 +633,7 @@ func TestHandleUnpause(t *testing.T) {
 		},
 		{
 			name:                     "unpause with CatchUpPolicySkip stores override in state",
-			initial:                  SchedulerWorkflowState{Paused: true},
+			initial:                  SchedulerWorkflowState{Paused: true, PausedAt: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)},
 			sig:                      UnpauseSignal{Reason: "resume", CatchUpPolicy: types.ScheduleCatchUpPolicySkip},
 			wantPaused:               false,
 			wantChanged:              true,
@@ -615,7 +641,7 @@ func TestHandleUnpause(t *testing.T) {
 		},
 		{
 			name:                     "unpause with Invalid policy does not set override",
-			initial:                  SchedulerWorkflowState{Paused: true},
+			initial:                  SchedulerWorkflowState{Paused: true, PausedAt: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)},
 			sig:                      UnpauseSignal{Reason: "resume", CatchUpPolicy: types.ScheduleCatchUpPolicyInvalid},
 			wantPaused:               false,
 			wantChanged:              true,
@@ -632,6 +658,9 @@ func TestHandleUnpause(t *testing.T) {
 			assert.Equal(t, tt.wantReason, state.PauseReason)
 			assert.Equal(t, tt.wantPausedBy, state.PausedBy)
 			assert.Equal(t, tt.wantUnpauseCatchUpPolicy, state.UnpauseCatchUpPolicy)
+			if tt.wantChanged {
+				assert.True(t, state.PausedAt.IsZero(), "PausedAt should be cleared on unpause")
+			}
 		})
 	}
 }
@@ -745,17 +774,23 @@ func TestHandleUpdate(t *testing.T) {
 		},
 	}
 
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			input := original
 			state := &SchedulerWorkflowState{}
-			changed := handleUpdate(testLogger, tt.sig, &input, state)
+			changed := handleUpdate(testLogger, tt.sig, &input, state, now)
 			assert.Equal(t, tt.wantChanged, changed)
 			assert.Equal(t, tt.wantCron, input.Spec.CronExpression)
 			assert.Equal(t, tt.wantWF, input.Action.StartWorkflow.WorkflowType.Name)
 			assert.Equal(t, tt.wantPol, input.Policies.OverlapPolicy)
 			if tt.sig.SearchAttributes != nil {
 				assert.Equal(t, tt.sig.SearchAttributes, input.SearchAttributes)
+			}
+			if tt.wantChanged {
+				assert.Equal(t, now, state.LastUpdatedAt)
+			} else {
+				assert.True(t, state.LastUpdatedAt.IsZero())
 			}
 		})
 	}
@@ -770,7 +805,7 @@ func TestHandleUpdate(t *testing.T) {
 		}
 		changed := handleUpdate(testLogger, UpdateSignal{
 			Spec: &types.ScheduleSpec{CronExpression: "*/5 * * * *"},
-		}, &input, state)
+		}, &input, state, now)
 		assert.True(t, changed)
 		assert.Equal(t, "*/5 * * * *", input.Spec.CronExpression)
 		assert.Empty(t, state.PendingBackfills)
@@ -785,7 +820,7 @@ func TestHandleUpdate(t *testing.T) {
 		}
 		changed := handleUpdate(testLogger, UpdateSignal{
 			Action: &types.ScheduleAction{StartWorkflow: &types.StartWorkflowAction{WorkflowType: &types.WorkflowType{Name: "new-workflow"}}},
-		}, &input, state)
+		}, &input, state, now)
 		assert.True(t, changed)
 		assert.Len(t, state.PendingBackfills, 1)
 	})
@@ -799,7 +834,7 @@ func TestHandleUpdate(t *testing.T) {
 		}
 		changed := handleUpdate(testLogger, UpdateSignal{
 			Spec: &types.ScheduleSpec{CronExpression: "not-a-cron"},
-		}, &input, state)
+		}, &input, state, now)
 		assert.False(t, changed)
 		assert.Len(t, state.PendingBackfills, 1)
 	})
@@ -2062,7 +2097,7 @@ func TestHandleUpdate_RunningWorkflowsClearedOnOverlapPolicyChange(t *testing.T)
 				},
 			}
 
-			changed := handleUpdate(testLogger, sig, input, state)
+			changed := handleUpdate(testLogger, sig, input, state, time.Now())
 
 			assert.True(t, changed, "policy update signal should report state as changed")
 			if tt.wantNil {
@@ -2134,7 +2169,7 @@ func TestHandleUpdate_BufferedFiresClearedOnOverlapPolicyChange(t *testing.T) {
 				Policies: &types.SchedulePolicies{OverlapPolicy: tt.toOverlap},
 			}
 
-			changed := handleUpdate(testLogger, sig, input, state)
+			changed := handleUpdate(testLogger, sig, input, state, time.Now())
 
 			assert.True(t, changed, "policy change should always report as changed")
 			assert.Equal(t, tt.toOverlap, input.Policies.OverlapPolicy)


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Added CreatedAt, LastUpdatedAt, PausedAt fields to SchedulerWorkflowState (persisted across ContinueAsNew) and ScheduleDescription (query response).
- Set CreatedAt once on first workflow execution using workflow.Now(ctx).
- Set PausedAt on pause, cleared on unpause.
- Set LastUpdatedAt on each successful UpdateSchedule signal.
- Wired these through buildScheduleDescription and the frontend handler into the DescribeScheduleResponse.

**Why?**

- DescribeSchedule returned 0001-01-01T00:00:00Z for createTime, lastUpdateTime, and pauseInfo.pausedAt. The API types already defined these fields, but the scheduler workflow never tracked or populated them.

**How did you test it?**
- Added a "schedule with timestamps" case to TestBuildScheduleDescription.
- Updated TestHandlePause to assert PausedAt is set to now.
- Updated TestHandleUnpause to assert PausedAt is cleared to zero.
- Updated TestHandleUpdate to assert LastUpdatedAt is set when changed, zero when not.
- All existing tests updated for new function signatures.
- go test -race ./service/worker/scheduler/... — pass.
- go test -race ./service/frontend/api/... — pass.
- make build — pass.

**Potential risks**
- Existing schedules: CreatedAt will be zero until the next ContinueAsNew, at which point it picks up workflow.Now(ctx). This means CreateTime reflects "first execution after this deploy" for pre-existing schedules, not the original creation time. Similarly, PausedAt will be zero for schedules already paused before deploy until the next pause signal. This is fine since schedule is not released yet
- Workflow state size: Three additional time.Time fields (~30 bytes JSON each) in the ContinueAsNew payload. Negligible impact.
- Non-determinism: All timestamps use workflow.Now(ctx) (deterministic workflow clock), so replay safety is preserved.


**Release notes**
DescribeSchedule now returns accurate createTime, lastUpdateTime, and pauseInfo.pausedAt timestamps. Previously these fields were always zero-valued.

**Documentation Changes**
N/A
