### PR TITLE
chore(graceful failover): improve timeout logging message

### DIFF
--- a/common/domain/failover_watcher.go
+++ b/common/domain/failover_watcher.go
@@ -180,11 +180,12 @@ func (p *failoverWatcherImpl) handleFailoverTimeout(
 			p.logger.Error("Failed to resolve source cluster for graceful failover", tag.WorkflowDomainID(domainID), tag.WorkflowDomainName(domain.GetInfo().Name), tag.Error(err))
 			sourceCluster = "unknown"
 		}
-		p.logger.Info("Graceful failover completed",
+		p.logger.Warn("Graceful failover force-completed by watcher: failover timeout exceeded before all shards reported",
 			tag.WorkflowDomainID(domainID),
 			tag.WorkflowDomainName(domain.GetInfo().Name),
 			tag.PrevActiveCluster(sourceCluster),
 			tag.ActiveClusterName(domain.GetReplicationConfig().ActiveClusterName),
+			tag.Dynamic("failover-end-time", time.Unix(0, *failoverEndTime)),
 		)
 		p.scope.Tagged(metrics.DomainTag(domain.GetInfo().Name)).IncCounter(metrics.GracefulFailoverFailure)
 	}


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Changed graceful failover timed out log from info to warn and improved message to indicate that the failover completion was due to timeout

https://github.com/cadence-workflow/cadence/issues/8138

**Why?**
The expectation is that under normal circumstances and after proper tuning, the failover happens within the timeout window. Also it's important to make sure that the user knows that the reason for the end of the graceful failover was due to the timeout

**How did you test it?**
Tested locally by running xdc setup and executing a failover with short timeout and running existing unit tests

go test -race -run TestFailoverWatcher ./common/domain/...

**Potential risks**
No risk, only a log level and message change

**Release notes**
N/A

**Documentation Changes**
N/A
