### PR TITLE
fix(graceful failover): add timeout to notify failover marker call

### DIFF
--- a/service/history/failover/coordinator.go
+++ b/service/history/failover/coordinator.go
@@ -53,6 +53,7 @@ const (
 	updateDomainRetryCoefficient     = 2.0
 	updateDomainMaxRetry             = 2
 	notifyFailoverMarkerMinInterval  = 500 * time.Millisecond
+	notifyRemoteCoordinatorTimeout   = 5 * time.Second
 )
 
 var (
@@ -436,8 +437,10 @@ func (c *coordinatorImpl) notifyRemoteCoordinator(
 			})
 		}
 
+		rpcCtx, cancel := ctx.WithTimeout(ctx.Background(), notifyRemoteCoordinatorTimeout)
+		defer cancel()
 		err := c.historyClient.NotifyFailoverMarkers(
-			ctx.Background(),
+			rpcCtx,
 			&types.NotifyFailoverMarkersRequest{
 				FailoverMarkerTokens: tokens,
 			},

--- a/service/history/failover/coordinator_test.go
+++ b/service/history/failover/coordinator_test.go
@@ -107,7 +107,7 @@ func (s *coordinatorSuite) TestNotifyFailoverMarkers() {
 	var mu sync.Mutex
 	seenShards := make(map[int32]struct{})
 	s.historyClient.EXPECT().NotifyFailoverMarkers(
-		context.Background(), gomock.Any(),
+		gomock.Any(), gomock.Any(),
 	).DoAndReturn(func(_ context.Context, request *types.NotifyFailoverMarkersRequest, _ ...yarpc.CallOption) error {
 		mu.Lock()
 		defer mu.Unlock()
@@ -160,7 +160,7 @@ func (s *coordinatorSuite) TestNotifyFailoverMarkers_EagerFlush() {
 		CreationTime:    common.Int64Ptr(1),
 	}
 	s.historyClient.EXPECT().NotifyFailoverMarkers(
-		context.Background(), &types.NotifyFailoverMarkersRequest{
+		gomock.Any(), &types.NotifyFailoverMarkersRequest{
 			FailoverMarkerTokens: []*types.FailoverMarkerToken{
 				{
 					ShardIDs:       []int32{1},
@@ -187,7 +187,7 @@ func (s *coordinatorSuite) TestNotifyFailoverMarkers_EagerFlush() {
 
 func (s *coordinatorSuite) TestNotifyRemoteCoordinator_Empty() {
 	requestByMarker := make(map[types.FailoverMarkerAttributes]*receiveRequest)
-	s.historyClient.EXPECT().NotifyFailoverMarkers(context.Background(), gomock.Any()).Times(0)
+	s.historyClient.EXPECT().NotifyFailoverMarkers(gomock.Any(), gomock.Any()).Times(0)
 	err := s.coordinator.notifyRemoteCoordinator(requestByMarker)
 	s.NoError(err)
 }
@@ -206,7 +206,7 @@ func (s *coordinatorSuite) TestNotifyRemoteCoordinator() {
 	}
 
 	s.historyClient.EXPECT().NotifyFailoverMarkers(
-		context.Background(), &types.NotifyFailoverMarkersRequest{
+		gomock.Any(), &types.NotifyFailoverMarkersRequest{
 			FailoverMarkerTokens: []*types.FailoverMarkerToken{
 				{
 					ShardIDs:       []int32{1, 2, 3},
@@ -234,7 +234,7 @@ func (s *coordinatorSuite) TestNotifyRemoteCoordinator_Error() {
 	}
 
 	s.historyClient.EXPECT().NotifyFailoverMarkers(
-		context.Background(), &types.NotifyFailoverMarkersRequest{
+		gomock.Any(), &types.NotifyFailoverMarkersRequest{
 			FailoverMarkerTokens: []*types.FailoverMarkerToken{
 				{
 					ShardIDs:       []int32{1, 2, 3},


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Added context timeout to NotifyFailoverMarkers call

https://github.com/cadence-workflow/cadence/issues/8138

**Why?**
The RPC was issued with context.Background(), so a single hung peer could block the notify loop indefinitely. Because all markers for a host's shards funnel through that one loop, one stuck call silently halted failover-marker propagation until the process restarted. A 5s timeout bounds the blast radius: the call fails fast, the loop continues, and the next tick retries.

**How did you test it?**
Updated tests to relax the input from context background

go test -race -count=1 -run 'TestCoordinatorSuite/(TestNotifyFailoverMarkers|TestNotifyFailoverMarkers_EagerFlush|TestNotifyRemoteCoordinator_Empty|TestNotifyRemoteCoordinator|TestNotifyRemoteCoordinator_Error)' ./service/history/failover/...

**Potential risks**
No risk. This is actually a fix to address the problem added by the latest eager dispatch change.

**Release notes**
N/A

**Documentation Changes**
N/A
