### PR TITLE
fix(scheduler): use CreateTime as catchup watermark floor for never-fired schedules

### DIFF
--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -857,6 +857,13 @@ func catchUpWatermark(state *SchedulerWorkflowState) time.Time {
 	if state.LastRunTime.After(watermark) {
 		watermark = state.LastRunTime
 	}
+	// When the schedule has never fired, both LastProcessedTime and LastRunTime are zero.
+	// Starting from epoch causes computeMissedFireTimes to find thousands of ancient fires,
+	// all outside the catch-up window, so no catch-up fires are dispatched. Use CreateTime
+	// as the floor so catch-up only considers fires that could have been missed since creation.
+	if !state.CreateTime.IsZero() && state.CreateTime.After(watermark) {
+		watermark = state.CreateTime
+	}
 	return watermark
 }
 

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1990,32 +1990,42 @@ func TestCatchUpWatermark(t *testing.T) {
 	t0 := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 	tests := []struct {
 		name              string
+		createTime        time.Time
 		lastProcessedTime time.Time
 		lastRunTime       time.Time
 		want              time.Time
 	}{
 		{
-			name: "both zero -> zero",
+			name: "all zero -> zero",
 			want: time.Time{},
 		},
 		{
+			name:       "never fired, CreateTime set -> CreateTime (prevents epoch watermark)",
+			createTime: t0,
+			want:       t0,
+		},
+		{
 			name:        "only LastRunTime set (no catch-up has run yet) -> LastRunTime",
+			createTime:  t0.Add(-time.Hour),
 			lastRunTime: t0,
 			want:        t0,
 		},
 		{
 			name:              "only LastProcessedTime set (catch-up ran but no live fires since) -> LastProcessedTime",
+			createTime:        t0.Add(-time.Hour),
 			lastProcessedTime: t0,
 			want:              t0,
 		},
 		{
 			name:              "live fires happened after catch-up -> LastRunTime is newer",
+			createTime:        t0.Add(-time.Hour),
 			lastProcessedTime: t0,
 			lastRunTime:       t0.Add(time.Hour),
 			want:              t0.Add(time.Hour),
 		},
 		{
 			name:              "catch-up ran after a quiet period (LastProcessedTime newer)",
+			createTime:        t0.Add(-time.Hour),
 			lastProcessedTime: t0.Add(time.Hour),
 			lastRunTime:       t0,
 			want:              t0.Add(time.Hour),
@@ -2024,6 +2034,7 @@ func TestCatchUpWatermark(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := catchUpWatermark(&SchedulerWorkflowState{
+				CreateTime:        tt.createTime,
 				LastProcessedTime: tt.lastProcessedTime,
 				LastRunTime:       tt.lastRunTime,
 			})


### PR DESCRIPTION
## What changed

`catchUpWatermark` now includes `state.CreateTime` as a lower bound alongside `LastProcessedTime` and `LastRunTime`.

## Why

When a schedule is created and immediately paused (or never fires before the first catch-up pass), both `LastProcessedTime` and `LastRunTime` are zero. `catchUpWatermark` returned the epoch, so `computeMissedFireTimes` found 1000 ancient fire times, all beyond the 365-day catch-up window and skipped every one. Result: zero catch-up fires dispatched regardless of policy (`One` or `All`).

## How tested

- `TestCatchUpWatermark` extended with a `CreateTime`-only case (never-fired schedule); all 6 cases pass.
- E2E: created a 1-min cron, paused for 130s (`All` policy) and 70s (`One` policy). Before fix: 0 catch-up fires. After fix: correct fires dispatched on unpause.

## Risk
Low. Only affects schedules that have never fired. Any schedule with a prior fire has non-zero `LastRunTime` or `LastProcessedTime`, so the `CreateTime` branch is never taken for those.