### PR TITLE
feat(batcher): Surface RPS and Concurrency params to heartbeat

### DIFF
--- a/service/worker/batcher/entities.go
+++ b/service/worker/batcher/entities.go
@@ -110,6 +110,13 @@ type HeartBeatDetails struct {
 	SuccessCount int
 	// Number of workflows that give up due to errors.
 	ErrorCount int
+	// RPS is the rate limit currently in effect for the running activity.
+	// Surfaced in the heartbeat so the UI can display the live, signal-tuned value.
+	RPS int
+	// Concurrency is the number of task processors currently in effect for the
+	// running activity. Surfaced in the heartbeat so the UI can display the
+	// live, signal-tuned value.
+	Concurrency int
 }
 
 type taskDetail struct {

--- a/service/worker/batcher/workflow_v2.go
+++ b/service/worker/batcher/workflow_v2.go
@@ -182,6 +182,11 @@ func batchActivityV2(ctx context.Context, params BatchParams) (HeartBeatDetails,
 		hbd.TotalEstimate = resp.GetCount()
 	}
 
+	// Reflect the params in effect for this activity invocation so the
+	// signal-tuned RPS/Concurrency are surfaced in every heartbeat.
+	hbd.RPS = params.RPS
+	hbd.Concurrency = params.Concurrency
+
 	rateLimiter := rate.NewLimiter(rate.Limit(params.RPS), params.RPS)
 	taskCh := make(chan taskDetail, params.PageSize)
 	respCh := make(chan error, params.PageSize)

--- a/service/worker/batcher/workflow_v2_test.go
+++ b/service/worker/batcher/workflow_v2_test.go
@@ -280,6 +280,8 @@ func TestBatchActivityV2_UsesProgress(t *testing.T) {
 	assert.Equal(t, 3, result.SuccessCount, "should add new success to progress")
 	assert.Equal(t, 2, result.CurrentPage, "should increment from progress page")
 	assert.Equal(t, int64(4), result.TotalEstimate, "should preserve TotalEstimate from progress")
+	assert.Equal(t, 5, result.RPS, "should surface the active RPS in heartbeat details")
+	assert.Equal(t, 5, result.Concurrency, "should surface the active Concurrency in heartbeat details")
 }
 
 func TestBatchActivityV2_EmptyPageDoesNotIncrementCurrentPage(t *testing.T) {


### PR DESCRIPTION
**What changed?**
RPS and Concurrency params of the batcher jobs surface to heartbeat

**Why?**
Since batcher workflow now able to update RPS and Concurrency via signal (and UI - RPS only), it is needed in the hbd object so the UI can get the latest value.

**How did you test it?**
locally - ran few workflows with different params and updates.