### PR TITLE
chore: Post a welcome comment on all incoming PRs from non-maintainers

### DIFF
--- a/.gitar/rules/assign-maintainer-reviewer.md
+++ b/.gitar/rules/assign-maintainer-reviewer.md
@@ -1,22 +1,67 @@
 ---
 title: Assign Maintainer Reviewer for External Contributors
-description: Automatically assigns a maintainer to review PRs from non-maintainers
+description: Automatically assigns a maintainer and posts a welcome comment when a non-maintainer opens a PR
 when: Pull request is opened
 actions:
-  - Assign reviewer in round-robin rotation
+  - Assign maintainer as assignee in round-robin rotation
+  - Post welcome comment with Slack community details
 ---
 
 # Auto-assign Maintainer Reviewer
 
-When a pull request is opened by someone not listed in `.github/CODEOWNERS`, assign @natemort plus one reviewer from the following list in round-robin rotation:
+## Overview
 
-- @c-warren
-- @fimanishi 
-- @neil-xie
-- @zawadzkidiana
-- @shijiesheng
-- @abhishekj720 
+When a pull request is opened by someone who is not a project maintainer, assign a maintainer as the PR assignee and post a welcome comment pointing the contributor to the community Slack.
 
-You must modify the assignees field on the Pull Request - being a reviewer is not sufficient.
+## Detection Logic
 
-Do not assign a reviewer if the PR author is already a maintainer listed in CODEOWNERS.
+### Step 1: Identify the PR author
+
+Get the GitHub username of the person who opened the pull request.
+
+### Step 2: Build the maintainer list from MAINTAINERS.md
+
+Read `MAINTAINERS.md`. Extract all GitHub usernames by parsing the GitHub profile URLs in the format `https://github.com/<username>` — these appear in both the **TSC** and **Maintainers** sections. The full list of maintainers is the union of both sections.
+
+### Step 3: Check if the author is a maintainer
+
+Compare the PR author's username (case-insensitively) against the extracted maintainer list.
+
+**If the author is a maintainer → skip this rule entirely. Take no action.**
+
+### Step 4: Assign a maintainer (for non-maintainer PRs only)
+
+Perform **both** of the following:
+
+1. **Always assign `@natemort`** as an assignee on the pull request.
+2. **Assign one additional reviewer** from the rotation list below, selected by taking `(PR number) mod 6` to determine the index (0-based):
+
+   - 0 → @c-warren
+   - 1 → @fimanishi
+   - 2 → @neil-xie
+   - 3 → @zawadzkidiana
+   - 4 → @shijiesheng
+   - 5 → @abhishekj720
+
+**Important:** You must set the `assignees` field on the pull request, not just the `reviewers` field. Both `@natemort` and the rotation pick must appear as assignees.
+
+### Step 5: Post a welcome comment (for non-maintainer PRs only)
+
+Post the following comment on the pull request, substituting the PR author's GitHub username for `{author}`:
+
+---
+
+Hi @{author}, thanks for your contribution! A maintainer has been assigned to review your PR.
+
+While you wait, consider joining our community on the **CNCF Slack** — the `#cadence-contributors` channel is the best place to ask questions, get help unblocking test runs, and connect directly with maintainers to help accelerate your review.
+
+👉 [Join the CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf) · [Getting started guide](https://cadenceworkflow.io/community/how-to-contribute/getting-started#join-the-community)
+
+---
+
+## Skip Conditions
+
+Skip this rule entirely (no assignment, no comment) when **either** of these is true:
+
+- The PR author's GitHub username appears in `MAINTAINERS.md` (TSC or Maintainers section)
+- The pull request was opened by a bot account


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

Updates our gitar rule to add a welcome comment when a non-maintainer creates a pull request. 

**Why?**

Running tests are blocked for non-maintainers, which can be frustrating. This gives them an outlet (slack) to contact a cadence maintainer to help with the review of their PR. Additionally, it should assign a specific person for them to reach out to. 

**How did you test it?**

This is untested. 

**Potential risks**

None

**Release notes**

None

**Documentation Changes**

None