### PR TITLE
feat(active-active): Add SQLite support for Cluster Selection Policy

### DIFF
--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -1576,156 +1576,6 @@ func (s *ExecutionManagerSuite) TestGetWorkflow() {
 	s.assertChecksumsEqual(csum, state.Checksum)
 }
 
-// TestGetActiveClusterSelectionPolicy test
-func (s *ExecutionManagerSuite) TestGetActiveClusterSelectionPolicy() {
-	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
-	defer cancel()
-
-	domainID := uuid.New()
-	workflowID := "get-active-cluster-selection-policy-test"
-	runID := uuid.New()
-	policy := &types.ActiveClusterSelectionPolicy{
-		ClusterAttribute: &types.ClusterAttribute{Scope: "region", Name: "region1"},
-	}
-
-	decisionScheduleID := int64(rand.Int31())
-	versionHistory := p.NewVersionHistory([]byte{}, []*p.VersionHistoryItem{
-		{
-			EventID: decisionScheduleID,
-			Version: constants.EmptyVersion,
-		},
-	})
-	versionHistories := p.NewVersionHistories(versionHistory)
-	createReq := &p.CreateWorkflowExecutionRequest{
-		RangeID: s.ShardInfo.RangeID,
-		NewWorkflowSnapshot: p.WorkflowSnapshot{
-			ExecutionInfo: &p.WorkflowExecutionInfo{
-				CreateRequestID:              uuid.New(),
-				DomainID:                     domainID,
-				WorkflowID:                   workflowID,
-				RunID:                        runID,
-				FirstExecutionRunID:          runID,
-				TaskList:                     "tasklist",
-				WorkflowTypeName:             "wf-type",
-				WorkflowTimeout:              20,
-				DecisionStartToCloseTimeout:  13,
-				State:                        p.WorkflowStateRunning,
-				CloseStatus:                  p.WorkflowCloseStatusNone,
-				LastFirstEventID:             constants.FirstEventID,
-				NextEventID:                  3,
-				LastProcessedEvent:           0,
-				DecisionScheduleID:           decisionScheduleID,
-				DecisionStartedID:            constants.EmptyEventID,
-				DecisionTimeout:              1,
-				ActiveClusterSelectionPolicy: policy,
-			},
-			ExecutionStats:   &p.ExecutionStats{},
-			VersionHistories: versionHistories,
-		},
-		Mode: p.CreateWorkflowModeBrandNew,
-	}
-	_, err := s.ExecutionManager.CreateWorkflowExecution(ctx, createReq)
-	s.NoError(err)
-
-	got, err := s.ExecutionManager.GetActiveClusterSelectionPolicy(ctx, &p.GetActiveClusterSelectionPolicyRequest{
-		DomainID:   domainID,
-		WorkflowID: workflowID,
-		RunID:      runID,
-	})
-	s.NoError(err)
-	s.Equal(policy, got)
-
-	_, err = s.ExecutionManager.GetActiveClusterSelectionPolicy(ctx, &p.GetActiveClusterSelectionPolicyRequest{
-		DomainID:   domainID,
-		WorkflowID: workflowID,
-		RunID:      uuid.New(),
-	})
-	s.Error(err)
-	s.IsType(&types.EntityNotExistsError{}, err)
-}
-
-// TestDeleteActiveClusterSelectionPolicy test
-func (s *ExecutionManagerSuite) TestDeleteActiveClusterSelectionPolicy() {
-	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
-	defer cancel()
-
-	domainID := uuid.New()
-	workflowID := "delete-active-cluster-selection-policy-test"
-	runID := uuid.New()
-	policy := &types.ActiveClusterSelectionPolicy{
-		ClusterAttribute: &types.ClusterAttribute{Scope: "region", Name: "region1"},
-	}
-
-	decisionScheduleID := int64(rand.Int31())
-	versionHistory := p.NewVersionHistory([]byte{}, []*p.VersionHistoryItem{
-		{
-			EventID: decisionScheduleID,
-			Version: constants.EmptyVersion,
-		},
-	})
-	versionHistories := p.NewVersionHistories(versionHistory)
-	createReq := &p.CreateWorkflowExecutionRequest{
-		RangeID: s.ShardInfo.RangeID,
-		NewWorkflowSnapshot: p.WorkflowSnapshot{
-			ExecutionInfo: &p.WorkflowExecutionInfo{
-				CreateRequestID:              uuid.New(),
-				DomainID:                     domainID,
-				WorkflowID:                   workflowID,
-				RunID:                        runID,
-				FirstExecutionRunID:          runID,
-				TaskList:                     "tasklist",
-				WorkflowTypeName:             "wf-type",
-				WorkflowTimeout:              20,
-				DecisionStartToCloseTimeout:  13,
-				State:                        p.WorkflowStateRunning,
-				CloseStatus:                  p.WorkflowCloseStatusNone,
-				LastFirstEventID:             constants.FirstEventID,
-				NextEventID:                  3,
-				LastProcessedEvent:           0,
-				DecisionScheduleID:           decisionScheduleID,
-				DecisionStartedID:            constants.EmptyEventID,
-				DecisionTimeout:              1,
-				ActiveClusterSelectionPolicy: policy,
-			},
-			ExecutionStats:   &p.ExecutionStats{},
-			VersionHistories: versionHistories,
-		},
-		Mode: p.CreateWorkflowModeBrandNew,
-	}
-	_, err := s.ExecutionManager.CreateWorkflowExecution(ctx, createReq)
-	s.NoError(err)
-
-	got, err := s.ExecutionManager.GetActiveClusterSelectionPolicy(ctx, &p.GetActiveClusterSelectionPolicyRequest{
-		DomainID:   domainID,
-		WorkflowID: workflowID,
-		RunID:      runID,
-	})
-	s.NoError(err)
-	s.Equal(policy, got)
-
-	err = s.ExecutionManager.DeleteActiveClusterSelectionPolicy(ctx, &p.DeleteActiveClusterSelectionPolicyRequest{
-		DomainID:   domainID,
-		WorkflowID: workflowID,
-		RunID:      runID,
-	})
-	s.NoError(err)
-
-	_, err = s.ExecutionManager.GetActiveClusterSelectionPolicy(ctx, &p.GetActiveClusterSelectionPolicyRequest{
-		DomainID:   domainID,
-		WorkflowID: workflowID,
-		RunID:      runID,
-	})
-	s.Error(err)
-	s.IsType(&types.EntityNotExistsError{}, err)
-
-	err = s.ExecutionManager.DeleteActiveClusterSelectionPolicy(ctx, &p.DeleteActiveClusterSelectionPolicyRequest{
-		DomainID:   domainID,
-		WorkflowID: workflowID,
-		RunID:      runID,
-	})
-	s.NoError(err)
-}
-
 // TestUpdateWorkflow test
 func (s *ExecutionManagerSuite) TestUpdateWorkflow() {
 	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
@@ -6157,6 +6007,156 @@ func (s *ExecutionManagerSuite) TestWorkflowTimerTaskTracking() {
 		DomainID:   domainID,
 		WorkflowID: workflowExecution.WorkflowID,
 		RunID:      workflowExecution.RunID,
+	})
+	s.NoError(err)
+}
+
+// TestGetActiveClusterSelectionPolicy test
+func (s *ExecutionManagerSuite) TestGetActiveClusterSelectionPolicy() {
+	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
+	defer cancel()
+
+	domainID := uuid.New()
+	workflowID := "get-active-cluster-selection-policy-test"
+	runID := uuid.New()
+	policy := &types.ActiveClusterSelectionPolicy{
+		ClusterAttribute: &types.ClusterAttribute{Scope: "region", Name: "region1"},
+	}
+
+	decisionScheduleID := int64(rand.Int31())
+	versionHistory := p.NewVersionHistory([]byte{}, []*p.VersionHistoryItem{
+		{
+			EventID: decisionScheduleID,
+			Version: constants.EmptyVersion,
+		},
+	})
+	versionHistories := p.NewVersionHistories(versionHistory)
+	createReq := &p.CreateWorkflowExecutionRequest{
+		RangeID: s.ShardInfo.RangeID,
+		NewWorkflowSnapshot: p.WorkflowSnapshot{
+			ExecutionInfo: &p.WorkflowExecutionInfo{
+				CreateRequestID:              uuid.New(),
+				DomainID:                     domainID,
+				WorkflowID:                   workflowID,
+				RunID:                        runID,
+				FirstExecutionRunID:          runID,
+				TaskList:                     "tasklist",
+				WorkflowTypeName:             "wf-type",
+				WorkflowTimeout:              20,
+				DecisionStartToCloseTimeout:  13,
+				State:                        p.WorkflowStateRunning,
+				CloseStatus:                  p.WorkflowCloseStatusNone,
+				LastFirstEventID:             constants.FirstEventID,
+				NextEventID:                  3,
+				LastProcessedEvent:           0,
+				DecisionScheduleID:           decisionScheduleID,
+				DecisionStartedID:            constants.EmptyEventID,
+				DecisionTimeout:              1,
+				ActiveClusterSelectionPolicy: policy,
+			},
+			ExecutionStats:   &p.ExecutionStats{},
+			VersionHistories: versionHistories,
+		},
+		Mode: p.CreateWorkflowModeBrandNew,
+	}
+	_, err := s.ExecutionManager.CreateWorkflowExecution(ctx, createReq)
+	s.NoError(err)
+
+	got, err := s.ExecutionManager.GetActiveClusterSelectionPolicy(ctx, &p.GetActiveClusterSelectionPolicyRequest{
+		DomainID:   domainID,
+		WorkflowID: workflowID,
+		RunID:      runID,
+	})
+	s.NoError(err)
+	s.Equal(policy, got)
+
+	_, err = s.ExecutionManager.GetActiveClusterSelectionPolicy(ctx, &p.GetActiveClusterSelectionPolicyRequest{
+		DomainID:   domainID,
+		WorkflowID: workflowID,
+		RunID:      uuid.New(),
+	})
+	s.Error(err)
+	s.IsType(&types.EntityNotExistsError{}, err)
+}
+
+// TestDeleteActiveClusterSelectionPolicy test
+func (s *ExecutionManagerSuite) TestDeleteActiveClusterSelectionPolicy() {
+	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
+	defer cancel()
+
+	domainID := uuid.New()
+	workflowID := "delete-active-cluster-selection-policy-test"
+	runID := uuid.New()
+	policy := &types.ActiveClusterSelectionPolicy{
+		ClusterAttribute: &types.ClusterAttribute{Scope: "region", Name: "region1"},
+	}
+
+	decisionScheduleID := int64(rand.Int31())
+	versionHistory := p.NewVersionHistory([]byte{}, []*p.VersionHistoryItem{
+		{
+			EventID: decisionScheduleID,
+			Version: constants.EmptyVersion,
+		},
+	})
+	versionHistories := p.NewVersionHistories(versionHistory)
+	createReq := &p.CreateWorkflowExecutionRequest{
+		RangeID: s.ShardInfo.RangeID,
+		NewWorkflowSnapshot: p.WorkflowSnapshot{
+			ExecutionInfo: &p.WorkflowExecutionInfo{
+				CreateRequestID:              uuid.New(),
+				DomainID:                     domainID,
+				WorkflowID:                   workflowID,
+				RunID:                        runID,
+				FirstExecutionRunID:          runID,
+				TaskList:                     "tasklist",
+				WorkflowTypeName:             "wf-type",
+				WorkflowTimeout:              20,
+				DecisionStartToCloseTimeout:  13,
+				State:                        p.WorkflowStateRunning,
+				CloseStatus:                  p.WorkflowCloseStatusNone,
+				LastFirstEventID:             constants.FirstEventID,
+				NextEventID:                  3,
+				LastProcessedEvent:           0,
+				DecisionScheduleID:           decisionScheduleID,
+				DecisionStartedID:            constants.EmptyEventID,
+				DecisionTimeout:              1,
+				ActiveClusterSelectionPolicy: policy,
+			},
+			ExecutionStats:   &p.ExecutionStats{},
+			VersionHistories: versionHistories,
+		},
+		Mode: p.CreateWorkflowModeBrandNew,
+	}
+	_, err := s.ExecutionManager.CreateWorkflowExecution(ctx, createReq)
+	s.NoError(err)
+
+	got, err := s.ExecutionManager.GetActiveClusterSelectionPolicy(ctx, &p.GetActiveClusterSelectionPolicyRequest{
+		DomainID:   domainID,
+		WorkflowID: workflowID,
+		RunID:      runID,
+	})
+	s.NoError(err)
+	s.Equal(policy, got)
+
+	err = s.ExecutionManager.DeleteActiveClusterSelectionPolicy(ctx, &p.DeleteActiveClusterSelectionPolicyRequest{
+		DomainID:   domainID,
+		WorkflowID: workflowID,
+		RunID:      runID,
+	})
+	s.NoError(err)
+
+	_, err = s.ExecutionManager.GetActiveClusterSelectionPolicy(ctx, &p.GetActiveClusterSelectionPolicyRequest{
+		DomainID:   domainID,
+		WorkflowID: workflowID,
+		RunID:      runID,
+	})
+	s.Error(err)
+	s.IsType(&types.EntityNotExistsError{}, err)
+
+	err = s.ExecutionManager.DeleteActiveClusterSelectionPolicy(ctx, &p.DeleteActiveClusterSelectionPolicyRequest{
+		DomainID:   domainID,
+		WorkflowID: workflowID,
+		RunID:      runID,
 	})
 	s.NoError(err)
 }

--- a/common/persistence/sql/sqlplugin/sqlite/active_cluster_selection_policy.go
+++ b/common/persistence/sql/sqlplugin/sqlite/active_cluster_selection_policy.go
@@ -27,14 +27,63 @@ import (
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
 )
 
+const (
+	// Insert is silently skipped if a row with the same (shard_id, domain_id, workflow_id, run_id) primary key already exists
+	insertActiveClusterSelectionPolicyQuery = `INSERT OR IGNORE INTO active_cluster_selection_policy
+		(shard_id, domain_id, workflow_id, run_id, data, data_encoding)
+		VALUES (?, ?, ?, ?, ?, ?)`
+
+	getActiveClusterSelectionPolicyQuery = `SELECT shard_id, domain_id, workflow_id, run_id, data, data_encoding
+		FROM active_cluster_selection_policy
+		WHERE shard_id = ? AND domain_id = ? AND workflow_id = ? AND run_id = ?`
+
+	deleteActiveClusterSelectionPolicyQuery = `DELETE FROM active_cluster_selection_policy
+		WHERE shard_id = ? AND domain_id = ? AND workflow_id = ? AND run_id = ?`
+)
+
 func (mdb *DB) InsertIntoActiveClusterSelectionPolicy(ctx context.Context, row *sqlplugin.ActiveClusterSelectionPolicyRow) (sql.Result, error) {
-	return nil, sqlplugin.ErrNotImplemented
+	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(row.ShardID, mdb.GetTotalNumDBShards())
+	return mdb.driver.ExecContext(
+		ctx,
+		dbShardID,
+		insertActiveClusterSelectionPolicyQuery,
+		row.ShardID,
+		row.DomainID,
+		row.WorkflowID,
+		row.RunID,
+		row.Data,
+		row.DataEncoding,
+	)
 }
 
 func (mdb *DB) SelectFromActiveClusterSelectionPolicy(ctx context.Context, filter *sqlplugin.ActiveClusterSelectionPolicyFilter) (*sqlplugin.ActiveClusterSelectionPolicyRow, error) {
-	return nil, sqlplugin.ErrNotImplemented
+	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(filter.ShardID, mdb.GetTotalNumDBShards())
+	var row sqlplugin.ActiveClusterSelectionPolicyRow
+	err := mdb.driver.GetContext(
+		ctx,
+		dbShardID,
+		&row,
+		getActiveClusterSelectionPolicyQuery,
+		filter.ShardID,
+		filter.DomainID,
+		filter.WorkflowID,
+		filter.RunID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
 }
 
 func (mdb *DB) DeleteFromActiveClusterSelectionPolicy(ctx context.Context, filter *sqlplugin.ActiveClusterSelectionPolicyFilter) (sql.Result, error) {
-	return nil, sqlplugin.ErrNotImplemented
+	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(filter.ShardID, mdb.GetTotalNumDBShards())
+	return mdb.driver.ExecContext(
+		ctx,
+		dbShardID,
+		deleteActiveClusterSelectionPolicyQuery,
+		filter.ShardID,
+		filter.DomainID,
+		filter.WorkflowID,
+		filter.RunID,
+	)
 }

--- a/common/persistence/sql/sqlplugin/sqlite/active_cluster_selection_policy_test.go
+++ b/common/persistence/sql/sqlplugin/sqlite/active_cluster_selection_policy_test.go
@@ -36,6 +36,8 @@ import (
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin/mysql"
 )
 
+var errExec = errors.New("boom")
+
 func newTestDB(mockDriver sqldriver.Driver) *DB {
 	return &DB{
 		DB:          mysql.NewDBWithDriver(nil, mockDriver, 1, nil),
@@ -52,10 +54,10 @@ func TestInsertIntoActiveClusterSelectionPolicy(t *testing.T) {
 		name      string
 		row       *sqlplugin.ActiveClusterSelectionPolicyRow
 		mockSetup func(*sqldriver.MockDriver)
-		wantErr   bool
+		wantErr   error
 	}{
 		{
-			name: "successful insert",
+			name: "valid row is inserted without error",
 			row: &sqlplugin.ActiveClusterSelectionPolicyRow{
 				ShardID:      7,
 				DomainID:     domainID,
@@ -94,9 +96,9 @@ func TestInsertIntoActiveClusterSelectionPolicy(t *testing.T) {
 					gomock.Any(),
 					insertActiveClusterSelectionPolicyQuery,
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(nil, errors.New("boom"))
+				).Return(nil, errExec)
 			},
-			wantErr: true,
+			wantErr: errExec,
 		},
 	}
 
@@ -110,8 +112,8 @@ func TestInsertIntoActiveClusterSelectionPolicy(t *testing.T) {
 
 			mdb := newTestDB(mockDriver)
 			_, err := mdb.InsertIntoActiveClusterSelectionPolicy(context.Background(), tc.row)
-			if tc.wantErr {
-				assert.Error(t, err)
+			if tc.wantErr != nil {
+				assert.ErrorIs(t, err, tc.wantErr)
 				return
 			}
 			assert.NoError(t, err)
@@ -131,7 +133,7 @@ func TestSelectFromActiveClusterSelectionPolicy(t *testing.T) {
 		wantErr   error
 	}{
 		{
-			name: "row found",
+			name: "matching row exists, returns the row",
 			filter: &sqlplugin.ActiveClusterSelectionPolicyFilter{
 				ShardID: 7, DomainID: domainID, WorkflowID: "wf-1", RunID: runID,
 			},
@@ -163,7 +165,7 @@ func TestSelectFromActiveClusterSelectionPolicy(t *testing.T) {
 			},
 		},
 		{
-			name: "no rows found propagates sql.ErrNoRows",
+			name: "no matching row, returns sql.ErrNoRows",
 			filter: &sqlplugin.ActiveClusterSelectionPolicyFilter{
 				ShardID: 1, DomainID: domainID, WorkflowID: "wf-1", RunID: runID,
 			},
@@ -206,10 +208,10 @@ func TestDeleteFromActiveClusterSelectionPolicy(t *testing.T) {
 		name      string
 		filter    *sqlplugin.ActiveClusterSelectionPolicyFilter
 		mockSetup func(*sqldriver.MockDriver)
-		wantErr   bool
+		wantErr   error
 	}{
 		{
-			name: "successful delete",
+			name: "matching row is deleted without error",
 			filter: &sqlplugin.ActiveClusterSelectionPolicyFilter{
 				ShardID: 7, DomainID: domainID, WorkflowID: "wf-1", RunID: runID,
 			},
@@ -232,9 +234,9 @@ func TestDeleteFromActiveClusterSelectionPolicy(t *testing.T) {
 					gomock.Any(), gomock.Any(),
 					deleteActiveClusterSelectionPolicyQuery,
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(nil, errors.New("boom"))
+				).Return(nil, errExec)
 			},
-			wantErr: true,
+			wantErr: errExec,
 		},
 	}
 
@@ -248,8 +250,8 @@ func TestDeleteFromActiveClusterSelectionPolicy(t *testing.T) {
 
 			mdb := newTestDB(mockDriver)
 			_, err := mdb.DeleteFromActiveClusterSelectionPolicy(context.Background(), tc.filter)
-			if tc.wantErr {
-				assert.Error(t, err)
+			if tc.wantErr != nil {
+				assert.ErrorIs(t, err, tc.wantErr)
 				return
 			}
 			assert.NoError(t, err)

--- a/common/persistence/sql/sqlplugin/sqlite/active_cluster_selection_policy_test.go
+++ b/common/persistence/sql/sqlplugin/sqlite/active_cluster_selection_policy_test.go
@@ -1,0 +1,258 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/uber/cadence/common/persistence/serialization"
+	"github.com/uber/cadence/common/persistence/sql/sqldriver"
+	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
+	"github.com/uber/cadence/common/persistence/sql/sqlplugin/mysql"
+)
+
+func newTestDB(mockDriver sqldriver.Driver) *DB {
+	return &DB{
+		DB:          mysql.NewDBWithDriver(nil, mockDriver, 1, nil),
+		driver:      mockDriver,
+		numDBShards: 1,
+	}
+}
+
+func TestInsertIntoActiveClusterSelectionPolicy(t *testing.T) {
+	domainID := serialization.UUID(uuid.NewRandom())
+	runID := serialization.UUID(uuid.NewRandom())
+
+	tests := []struct {
+		name      string
+		row       *sqlplugin.ActiveClusterSelectionPolicyRow
+		mockSetup func(*sqldriver.MockDriver)
+		wantErr   bool
+	}{
+		{
+			name: "successful insert",
+			row: &sqlplugin.ActiveClusterSelectionPolicyRow{
+				ShardID:      7,
+				DomainID:     domainID,
+				WorkflowID:   "wf-1",
+				RunID:        runID,
+				Data:         []byte("policy-bytes"),
+				DataEncoding: "thriftrw",
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().ExecContext(
+					gomock.Any(),
+					0,
+					insertActiveClusterSelectionPolicyQuery,
+					7,
+					domainID,
+					"wf-1",
+					runID,
+					[]byte("policy-bytes"),
+					"thriftrw",
+				).Return(nil, nil)
+			},
+		},
+		{
+			name: "exec error is returned",
+			row: &sqlplugin.ActiveClusterSelectionPolicyRow{
+				ShardID:      1,
+				DomainID:     domainID,
+				WorkflowID:   "wf-1",
+				RunID:        runID,
+				Data:         []byte("x"),
+				DataEncoding: "thriftrw",
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().ExecContext(
+					gomock.Any(),
+					gomock.Any(),
+					insertActiveClusterSelectionPolicyQuery,
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil, errors.New("boom"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDriver := sqldriver.NewMockDriver(ctrl)
+			tc.mockSetup(mockDriver)
+
+			mdb := newTestDB(mockDriver)
+			_, err := mdb.InsertIntoActiveClusterSelectionPolicy(context.Background(), tc.row)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestSelectFromActiveClusterSelectionPolicy(t *testing.T) {
+	domainID := serialization.UUID(uuid.NewRandom())
+	runID := serialization.UUID(uuid.NewRandom())
+
+	tests := []struct {
+		name      string
+		filter    *sqlplugin.ActiveClusterSelectionPolicyFilter
+		mockSetup func(*sqldriver.MockDriver)
+		wantRow   *sqlplugin.ActiveClusterSelectionPolicyRow
+		wantErr   error
+	}{
+		{
+			name: "row found",
+			filter: &sqlplugin.ActiveClusterSelectionPolicyFilter{
+				ShardID: 7, DomainID: domainID, WorkflowID: "wf-1", RunID: runID,
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().GetContext(
+					gomock.Any(),
+					0,
+					gomock.Any(),
+					getActiveClusterSelectionPolicyQuery,
+					7, domainID, "wf-1", runID,
+				).DoAndReturn(func(_ context.Context, _ int, dest interface{}, _ string, _ ...interface{}) error {
+					row := dest.(*sqlplugin.ActiveClusterSelectionPolicyRow)
+					row.ShardID = 7
+					row.DomainID = domainID
+					row.WorkflowID = "wf-1"
+					row.RunID = runID
+					row.Data = []byte("policy-bytes")
+					row.DataEncoding = "thriftrw"
+					return nil
+				})
+			},
+			wantRow: &sqlplugin.ActiveClusterSelectionPolicyRow{
+				ShardID:      7,
+				DomainID:     domainID,
+				WorkflowID:   "wf-1",
+				RunID:        runID,
+				Data:         []byte("policy-bytes"),
+				DataEncoding: "thriftrw",
+			},
+		},
+		{
+			name: "no rows found propagates sql.ErrNoRows",
+			filter: &sqlplugin.ActiveClusterSelectionPolicyFilter{
+				ShardID: 1, DomainID: domainID, WorkflowID: "wf-1", RunID: runID,
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().GetContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+					getActiveClusterSelectionPolicyQuery,
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(sql.ErrNoRows)
+			},
+			wantErr: sql.ErrNoRows,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDriver := sqldriver.NewMockDriver(ctrl)
+			tc.mockSetup(mockDriver)
+
+			mdb := newTestDB(mockDriver)
+			got, err := mdb.SelectFromActiveClusterSelectionPolicy(context.Background(), tc.filter)
+			if tc.wantErr != nil {
+				assert.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantRow, got)
+		})
+	}
+}
+
+func TestDeleteFromActiveClusterSelectionPolicy(t *testing.T) {
+	domainID := serialization.UUID(uuid.NewRandom())
+	runID := serialization.UUID(uuid.NewRandom())
+
+	tests := []struct {
+		name      string
+		filter    *sqlplugin.ActiveClusterSelectionPolicyFilter
+		mockSetup func(*sqldriver.MockDriver)
+		wantErr   bool
+	}{
+		{
+			name: "successful delete",
+			filter: &sqlplugin.ActiveClusterSelectionPolicyFilter{
+				ShardID: 7, DomainID: domainID, WorkflowID: "wf-1", RunID: runID,
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().ExecContext(
+					gomock.Any(),
+					0,
+					deleteActiveClusterSelectionPolicyQuery,
+					7, domainID, "wf-1", runID,
+				).Return(nil, nil)
+			},
+		},
+		{
+			name: "exec error is returned",
+			filter: &sqlplugin.ActiveClusterSelectionPolicyFilter{
+				ShardID: 1, DomainID: domainID, WorkflowID: "wf-1", RunID: runID,
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().ExecContext(
+					gomock.Any(), gomock.Any(),
+					deleteActiveClusterSelectionPolicyQuery,
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil, errors.New("boom"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDriver := sqldriver.NewMockDriver(ctrl)
+			tc.mockSetup(mockDriver)
+
+			mdb := newTestDB(mockDriver)
+			_, err := mdb.DeleteFromActiveClusterSelectionPolicy(context.Background(), tc.filter)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/common/persistence/sql/sqlplugin/sqlite/sqlite_persistence_test.go
+++ b/common/persistence/sql/sqlplugin/sqlite/sqlite_persistence_test.go
@@ -74,14 +74,6 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionWithWorkflowRequestsD
 	s.T().Skip("skip the test until we store workflow_request in sqlite")
 }
 
-func (s *ExecutionManagerSuite) TestGetActiveClusterSelectionPolicy() {
-	s.T().Skip("skip the test until we support ActiveClusterSelectionPolicy in sqlite")
-}
-
-func (s *ExecutionManagerSuite) TestDeleteActiveClusterSelectionPolicy() {
-	s.T().Skip("skip the test until we support ActiveClusterSelectionPolicy in sqlite")
-}
-
 func TestSQLiteExecutionManagerSuite(t *testing.T) {
 	s := new(ExecutionManagerSuite)
 	option := GetTestClusterOption()

--- a/schema/sqlite/cadence/schema.sql
+++ b/schema/sqlite/cadence/schema.sql
@@ -317,3 +317,15 @@ CREATE TABLE domain_audit_log
     comment               VARCHAR(255) NOT NULL DEFAULT '',
     PRIMARY KEY (domain_id, operation_type, created_time, event_id)
 );
+
+CREATE TABLE active_cluster_selection_policy
+(
+    shard_id      INT          NOT NULL,
+    domain_id     BINARY(16)   NOT NULL,
+    workflow_id   VARCHAR(255) NOT NULL,
+    run_id        BINARY(16)   NOT NULL,
+    --
+    data          MEDIUMBLOB   NOT NULL,
+    data_encoding VARCHAR(16)  NOT NULL,
+    PRIMARY KEY (shard_id, domain_id, workflow_id, run_id)
+);

--- a/schema/sqlite/cadence/versioned/v0.3/active_cluster_selection_policy.sql
+++ b/schema/sqlite/cadence/versioned/v0.3/active_cluster_selection_policy.sql
@@ -1,0 +1,10 @@
+CREATE TABLE active_cluster_selection_policy (
+    shard_id      INT          NOT NULL,
+    domain_id     BINARY(16)   NOT NULL,
+    workflow_id   VARCHAR(255) NOT NULL,
+    run_id        BINARY(16)   NOT NULL,
+    --
+    data          MEDIUMBLOB   NOT NULL,
+    data_encoding VARCHAR(16)  NOT NULL,
+    PRIMARY KEY (shard_id, domain_id, workflow_id, run_id)
+);

--- a/schema/sqlite/cadence/versioned/v0.3/manifest.json
+++ b/schema/sqlite/cadence/versioned/v0.3/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.3",
+  "MinCompatibleVersion": "0.3",
+  "Description": "Add active_cluster_selection_policy table for active-active domain workflows",
+  "SchemaUpdateCqlFiles": [
+    "active_cluster_selection_policy.sql"
+  ]
+}

--- a/schema/sqlite/version.go
+++ b/schema/sqlite/version.go
@@ -23,7 +23,7 @@ package sqlite
 // NOTE: whenever there is a new data base schema update, plz update the following versions
 
 // Version is the SQLite database release version
-const Version = "0.2"
+const Version = "0.3"
 
 // VisibilityVersion is the SQLite visibility database release version
 const VisibilityVersion = "0.1"

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -142,7 +142,7 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDirFromEmbeddings() {
 	s.NoError(err)
 	ans, err = readSchemaDir(fsys, "0.1", "")
 	s.NoError(err)
-	s.Equal([]string{"v0.2"}, ans)
+	s.Equal([]string{"v0.2", "v0.3"}, ans)
 
 	fsys, err = fs.Sub(sqlite.SchemaFS, "visibility/versioned")
 	s.NoError(err)


### PR DESCRIPTION
**Detailed Description**
- Added active_cluster_selection_policy table in SQLite database
- Implemented CRUD methods for SQLite database updates (insert, select, delete)

Fixes: #7599 

**Impact Analysis**
- **Backward Compatibility**: Only adds table - doesn't change existing tables
- **Forward Compatibility**: Older versions simply do not provide sqlite support 

**Testing Plan**
- **Unit Tests**: `go test ./common/persistence/sql/sqlplugin/sqlite/ -run ActiveClusterSelectionPolicy`
- **Persistence Tests**: `go test ./common/persistence/sql/sqlplugin/sqlite/ -run 'TestSQLiteExecutionManagerSuite/.*ActiveClusterSelectionPolicy'`
- **Integration Tests**: [Do we have integration test covering the change?]
- **Compatibility Tests**: [Have we done tests to test the backward and forward compatibility?]

**Rollout Plan**
- What is the rollout plan? 
- Does the order of deployment matter?
- Is it safe to rollback? Does the order of rollback matter?
- Is there a kill switch to mitigate the impact immediately?

## Release notes

Add SQLite support to Active Cluster Selection Policy

## Documentation Changes
N/A