### PR TITLE
fix(history): gate notify-tasks-dropped log on CQR shadow mode

### DIFF
--- a/service/history/shard/notify_task.go
+++ b/service/history/shard/notify_task.go
@@ -67,10 +67,7 @@ func (s *contextImpl) notifyTasksFromCreateWorkflowExecution(
 		s.notifyTasksFromSnapshot(&request.NewWorkflowSnapshot, persistenceError)
 		return
 	}
-	s.logger.Info("notify tasks dropped due to persistence error",
-		tag.Error(err),
-		tag.Dynamic("droppedTaskIDs", taskIDsFromSnapshot(&request.NewWorkflowSnapshot)),
-	)
+	s.logNotifyTaskDroppedOnPersistenceError(err, taskIDsFromSnapshot(&request.NewWorkflowSnapshot))
 }
 
 // notifyTasksFromUpdateWorkflowExecution sends task notifications for an UpdateWorkflowExecution operation.
@@ -84,13 +81,10 @@ func (s *contextImpl) notifyTasksFromUpdateWorkflowExecution(
 		s.notifyTasksFromSnapshot(request.NewWorkflowSnapshot, persistenceError)
 		return
 	}
-	s.logger.Info("notify tasks dropped due to persistence error",
-		tag.Error(err),
-		tag.Dynamic("droppedTaskIDs", slices.Concat(
-			taskIDsFromMutation(&request.UpdateWorkflowMutation),
-			taskIDsFromSnapshot(request.NewWorkflowSnapshot),
-		)),
-	)
+	s.logNotifyTaskDroppedOnPersistenceError(err, slices.Concat(
+		taskIDsFromMutation(&request.UpdateWorkflowMutation),
+		taskIDsFromSnapshot(request.NewWorkflowSnapshot),
+	))
 }
 
 // notifyTasksFromConflictResolveWorkflowExecution sends task notifications for a ConflictResolveWorkflowExecution operation.
@@ -105,13 +99,23 @@ func (s *contextImpl) notifyTasksFromConflictResolveWorkflowExecution(
 		s.notifyTasksFromMutation(request.CurrentWorkflowMutation, persistenceError)
 		return
 	}
+	s.logNotifyTaskDroppedOnPersistenceError(err, slices.Concat(
+		taskIDsFromSnapshot(&request.ResetWorkflowSnapshot),
+		taskIDsFromSnapshot(request.NewWorkflowSnapshot),
+		taskIDsFromMutation(request.CurrentWorkflowMutation),
+	))
+}
+
+// logNotifyTaskDroppedOnPersistenceError logs dropped task IDs when the cached queue reader
+// is in shadow mode. In shadow mode the cache is validated against the DB, so dropped tasks
+// produce observable mismatches that are worth tracking. In other modes the log is noise.
+func (s *contextImpl) logNotifyTaskDroppedOnPersistenceError(err error, droppedTaskIDs []int64) {
+	if s.config.TimerProcessorCachedQueueReaderMode() != "shadow" {
+		return
+	}
 	s.logger.Info("notify tasks dropped due to persistence error",
 		tag.Error(err),
-		tag.Dynamic("droppedTaskIDs", slices.Concat(
-			taskIDsFromSnapshot(&request.ResetWorkflowSnapshot),
-			taskIDsFromSnapshot(request.NewWorkflowSnapshot),
-			taskIDsFromMutation(request.CurrentWorkflowMutation),
-		)),
+		tag.Dynamic("droppedTaskIDs", droppedTaskIDs),
 	)
 }
 


### PR DESCRIPTION
**What changed?**

Extracted `logNotifyTaskDroppedOnPersistenceError` helper on `contextImpl` in `service/history/shard/notify_task.go`. Replaced three inline `logger.Info` calls (in `notifyTasksFromCreateWorkflowExecution`, `notifyTasksFromUpdateWorkflowExecution`, `notifyTasksFromConflictResolveWorkflowExecution`) with calls to this helper. The helper early-returns unless `TimerProcessorCachedQueueReaderMode == "shadow"`.

**Why?**

The `"notify tasks dropped due to persistence error"` log fired on every definitive persistence failure regardless of configuration. This log is only meaningful when the cached queue reader is in shadow mode: shadow mode validates cache against DB, so dropped tasks produce observable cache-vs-DB mismatches worth tracking. In `enabled` or `disabled` mode the log adds noise without actionable signal.

The helper follows the same pattern as `logMarkerRegressionIfOnActiveCluster` — typed params, single shared method, early-return guard at the top.

#7953 

**How did you test it?**

```
make build
go test -race ./service/history/shard/...
```

**Potential risks**

N/A — log-only change. No behavior change to task processing or notification logic.

**Release notes**

N/A

**Documentation Changes**

N/A