### PR TITLE
revert(graceful failover): eager flushing of failover markers

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -5860,7 +5860,7 @@ var DurationKeys = map[DurationKey]DynamicDuration{
 	NotifyFailoverMarkerInterval: {
 		KeyName:      "history.NotifyFailoverMarkerInterval",
 		Description:  "NotifyFailoverMarkerInterval is determines the frequency to notify failover marker",
-		DefaultValue: time.Second * 5,
+		DefaultValue: time.Second,
 	},
 	ActivityMaxScheduleToStartTimeoutForRetry: {
 		KeyName:      "history.activityMaxScheduleToStartTimeoutForRetry",

--- a/service/history/failover/coordinator.go
+++ b/service/history/failover/coordinator.go
@@ -52,7 +52,6 @@ const (
 	updateDomainRetryInitialInterval = 50 * time.Millisecond
 	updateDomainRetryCoefficient     = 2.0
 	updateDomainMaxRetry             = 2
-	notifyFailoverMarkerMinInterval  = 500 * time.Millisecond
 	notifyRemoteCoordinatorTimeout   = 5 * time.Second
 )
 
@@ -244,7 +243,6 @@ func (c *coordinatorImpl) notifyFailoverMarkerLoop() {
 	))
 	defer timer.Stop()
 	requestByMarker := make(map[types.FailoverMarkerAttributes]*receiveRequest)
-	var lastFlush time.Time
 
 	flush := func() {
 		if len(requestByMarker) == 0 {
@@ -265,21 +263,7 @@ func (c *coordinatorImpl) notifyFailoverMarkerLoop() {
 				tag.Dynamic("flush-duration", flushDuration),
 			)
 			requestByMarker = make(map[types.FailoverMarkerAttributes]*receiveRequest)
-			lastFlush = c.timeSource.Now()
 		}
-	}
-
-	resetTimer := func() {
-		if !timer.Stop() {
-			select {
-			case <-timer.C:
-			default:
-			}
-		}
-		timer.Reset(backoff.JitDuration(
-			c.config.NotifyFailoverMarkerInterval(),
-			c.config.NotifyFailoverMarkerTimerJitterCoefficient(),
-		))
 	}
 
 	for {
@@ -290,18 +274,6 @@ func (c *coordinatorImpl) notifyFailoverMarkerLoop() {
 			// if a shard movement happens, it is fine to have duplicated shard IDs in the request
 			// The receiver side will de-dup the shard IDs. See: handleFailoverMarkers
 			aggregateNotificationRequests(notificationReq, requestByMarker)
-			if c.timeSource.Now().Sub(lastFlush) >= notifyFailoverMarkerMinInterval {
-				flush()
-				resetTimer()
-			} else {
-				if !timer.Stop() {
-					select {
-					case <-timer.C:
-					default:
-					}
-				}
-				timer.Reset(notifyFailoverMarkerMinInterval - c.timeSource.Now().Sub(lastFlush))
-			}
 		case <-timer.C:
 			flush()
 			timer.Reset(backoff.JitDuration(

--- a/service/history/failover/coordinator_test.go
+++ b/service/history/failover/coordinator_test.go
@@ -141,50 +141,6 @@ func (s *coordinatorSuite) TestNotifyFailoverMarkers() {
 	<-doneCh
 }
 
-func (s *coordinatorSuite) TestNotifyFailoverMarkers_EagerFlush() {
-	s.config.NotifyFailoverMarkerInterval = dynamicproperties.GetDurationPropertyFn(time.Hour)
-	s.coordinator = NewCoordinator(
-		s.mockMetadataManager,
-		s.historyClient,
-		s.mockResource.GetTimeSource(),
-		s.mockResource.GetDomainCache(),
-		s.config,
-		s.mockResource.GetMetricsClient(),
-		s.mockResource.GetLogger(),
-	).(*coordinatorImpl)
-
-	doneCh := make(chan struct{})
-	attributes := &types.FailoverMarkerAttributes{
-		DomainID:        uuid.New(),
-		FailoverVersion: 1,
-		CreationTime:    common.Int64Ptr(1),
-	}
-	s.historyClient.EXPECT().NotifyFailoverMarkers(
-		gomock.Any(), &types.NotifyFailoverMarkersRequest{
-			FailoverMarkerTokens: []*types.FailoverMarkerToken{
-				{
-					ShardIDs:       []int32{1},
-					FailoverMarker: attributes,
-				},
-			},
-		},
-	).DoAndReturn(func(_ context.Context, _ *types.NotifyFailoverMarkersRequest, _ ...yarpc.CallOption) error {
-		close(doneCh)
-		return nil
-	}).Times(1)
-
-	s.coordinator.Start()
-	s.coordinator.NotifyFailoverMarkers(
-		1,
-		[]*types.FailoverMarkerAttributes{attributes},
-	)
-	select {
-	case <-doneCh:
-	case <-time.After(5 * time.Second):
-		s.Fail("eager-flush did not fire within timeout")
-	}
-}
-
 func (s *coordinatorSuite) TestNotifyRemoteCoordinator_Empty() {
 	requestByMarker := make(map[types.FailoverMarkerAttributes]*receiveRequest)
 	s.historyClient.EXPECT().NotifyFailoverMarkers(gomock.Any(), gomock.Any()).Times(0)


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Reverted eager flushing of failover markers and set interval from 5s to 1s
https://github.com/cadence-workflow/cadence/issues/8138

**Why?**
There is a bug in the implementation that's causing the coordinator to not receive all the markers, causing the failover to always wait for the timeout

**How did you test it?**
Unit tests

go test -race -count=1 -run TestCoordinatorSuite ./service/history/failover/

Set 3 clusters and xdc database using:

```
docker compose -f docker/dev/cassandra.yml up -d

make install-schema-xdc

github.com/uber/cadence/cmd/server --zone xdc_cluster0 start
github.com/uber/cadence/cmd/server --zone xdc_cluster1 start
github.com/uber/cadence/cmd/server --zone xdc_cluster2 start

cadence --env development --do test domain register --ac cluster1 --cl cluster0,cluster1,cluster2 --rd 1

cadence --env development --do test domain update --ac cluster0 --ft grace --fts 120
```

**Potential risks**
No risk, fixing an issue that was introduced with eager flushing

**Release notes**
N/A

**Documentation Changes**
N/A
