### PR TITLE
chore(reconciliation): clean up invariant package inconsistencies

### DIFF
--- a/common/reconciliation/invariant/inactive_domain_exists.go
+++ b/common/reconciliation/invariant/inactive_domain_exists.go
@@ -76,7 +76,7 @@ func (idc *inactiveDomainExists) Check(
 		return CheckResult{
 			CheckResultType: CheckResultTypeCorrupted,
 			InvariantName:   idc.Name(),
-			Info:            "failed check: domain is not active",
+			Info:            "domain is not active",
 			InfoDetails:     "The domain has been deprecated or deleted",
 		}
 	}

--- a/common/reconciliation/invariant/open_current_execution.go
+++ b/common/reconciliation/invariant/open_current_execution.go
@@ -165,7 +165,7 @@ func ExecutionStillOpen(
 ) (bool, error) {
 	domainName, err := dc.GetDomainName(exec.DomainID)
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 	req := &persistence.GetWorkflowExecutionRequest{
 		DomainID: exec.DomainID,

--- a/common/reconciliation/invariant/stale_workflow.go
+++ b/common/reconciliation/invariant/stale_workflow.go
@@ -41,11 +41,6 @@ import (
 const (
 	// how long to allow things to be beyond when they should have been fully cleaned up, for safety purposes
 	retentionSafetyMargin = time.Hour * 24 * 10
-
-	// time.DateOnly, introduced in go1.20
-	//
-	// deprecated: use time.DateOnly when able
-	dateOnly = "2006-01-02"
 )
 
 // sane time ranges for workflows.
@@ -212,8 +207,8 @@ func (c *staleWorkflowCheck) CheckAge(workflow *persistence.GetWorkflowExecution
 			zap.String("rid", info.RunID),
 			zap.String("domain_name", domainName),
 			zap.String("domain_id", info.DomainID),
-			zap.String("started_at", info.StartTimestamp.Format(dateOnly)),
-			zap.String("expected_cleanup_at", expected.Format(dateOnly)),
+			zap.String("started_at", info.StartTimestamp.Format(time.DateOnly)),
+			zap.String("expected_cleanup_at", expected.Format(time.DateOnly)),
 			zap.String("state", state), // may simplify log processing
 		)
 	}
@@ -308,7 +303,7 @@ func (c *staleWorkflowCheck) checkRunningAge(workflow *persistence.GetWorkflowEx
 			CheckResultType: CheckResultTypeCorrupted,
 			InvariantName:   c.Name(),
 			Info:            "stale running workflow",
-			InfoDetails:     fmt.Sprintf("running workflow should have timed out by %v and been cleaned up by %v, but it still exists", timesOutAt.Format(dateOnly), cleansUpAt.Format(dateOnly)),
+			InfoDetails:     fmt.Sprintf("running workflow should have timed out by %v and been cleaned up by %v, but it still exists", timesOutAt.Format(time.DateOnly), cleansUpAt.Format(time.DateOnly)),
 		}
 	}
 	return false, cleansUpAt, CheckResult{
@@ -363,7 +358,7 @@ func (c *staleWorkflowCheck) checkClosedAge(workflow *persistence.GetWorkflowExe
 			CheckResultType: CheckResultTypeCorrupted,
 			InvariantName:   c.Name(),
 			Info:            "completed workflow exists beyond retention window",
-			InfoDetails:     fmt.Sprintf("completed workflow exists beyond retention window, should have disappeared by %v", closed.Add(maxLifespan).Format(dateOnly)),
+			InfoDetails:     fmt.Sprintf("completed workflow exists beyond retention window, should have disappeared by %v", closed.Add(maxLifespan).Format(time.DateOnly)),
 		}
 	}
 
@@ -372,7 +367,7 @@ func (c *staleWorkflowCheck) checkClosedAge(workflow *persistence.GetWorkflowExe
 		CheckResultType: CheckResultTypeHealthy,
 		InvariantName:   c.Name(),
 		Info:            "completed workflow still within retention + 10-day buffer",
-		InfoDetails:     fmt.Sprintf("completed workflow still within retention + 10-day buffer, closed %v and allowed to exist until %v", closed, closed.Add(maxLifespan).Format(dateOnly)),
+		InfoDetails:     fmt.Sprintf("completed workflow still within retention + 10-day buffer, closed %v and allowed to exist until %v", closed, closed.Add(maxLifespan).Format(time.DateOnly)),
 	}
 
 }

--- a/common/reconciliation/invariant/stale_workflow_test.go
+++ b/common/reconciliation/invariant/stale_workflow_test.go
@@ -446,7 +446,7 @@ func TestStillRunning(t *testing.T) {
 		// should be cleaned up because it's simply too old to reasonably exist
 		t.Logf("result: %#v", result)
 		assert.Equal(t, CheckResultTypeCorrupted, result.CheckResultType, "result should be corrupted, as it has expired")
-		assert.True(t, pastExpiration, "workflow should be past expiration, created: %v, retention days: %v + %v safety, now: %v", created.Format(dateOnly), testRetentionDays, retentionSafetyMargin, time.Now().Format(dateOnly))
+		assert.True(t, pastExpiration, "workflow should be past expiration, created: %v, retention days: %v + %v safety, now: %v", created.Format(time.DateOnly), testRetentionDays, retentionSafetyMargin, time.Now().Format(time.DateOnly))
 	})
 	t.Run("bad-running-and-backoff-and-corrupt", func(t *testing.T) {
 		// created 2 days before retention margin
@@ -460,7 +460,7 @@ func TestStillRunning(t *testing.T) {
 		// should be cleaned up because it's simply too old to reasonably exist
 		t.Logf("result: %#v", result)
 		assert.Equal(t, CheckResultTypeCorrupted, result.CheckResultType, "result should be corrupted, as it has expired")
-		assert.True(t, pastExpiration, "workflow should be past expiration, created: %v, backoff: %v, retention days: %v + %v safety, now: %v", created.Format(dateOnly), oneDay, testRetentionDays, retentionSafetyMargin, time.Now().Format(dateOnly))
+		assert.True(t, pastExpiration, "workflow should be past expiration, created: %v, backoff: %v, retention days: %v + %v safety, now: %v", created.Format(time.DateOnly), oneDay, testRetentionDays, retentionSafetyMargin, time.Now().Format(time.DateOnly))
 
 	})
 }

--- a/common/reconciliation/invariant/timer_invalid.go
+++ b/common/reconciliation/invariant/timer_invalid.go
@@ -31,25 +31,23 @@ import (
 	"github.com/uber/cadence/common/types"
 )
 
-const TimerInvalidName = "TimerInvalid"
-
-type TimerInvalid struct {
+type timerInvalid struct {
 	pr    persistence.Retryer
 	cache cache.DomainCache
 }
 
-// NewTimerInvalid returns a new history exists invariant
+// NewTimerInvalid returns a new timer invalid invariant
 func NewTimerInvalid(
 	pr persistence.Retryer, cache cache.DomainCache,
 ) Invariant {
-	return &TimerInvalid{
+	return &timerInvalid{
 		pr:    pr,
 		cache: cache,
 	}
 }
 
 // Check checks if timer is scheduled for open execution
-func (h *TimerInvalid) Check(
+func (h *timerInvalid) Check(
 	ctx context.Context,
 	e interface{},
 ) CheckResult {
@@ -118,7 +116,7 @@ func (h *TimerInvalid) Check(
 }
 
 // Fix will delete invalid timer
-func (h *TimerInvalid) Fix(
+func (h *timerInvalid) Fix(
 	ctx context.Context,
 	e interface{},
 ) FixResult {
@@ -167,6 +165,6 @@ func (h *TimerInvalid) Fix(
 	}
 }
 
-func (h *TimerInvalid) Name() Name {
-	return TimerInvalidName
+func (h *timerInvalid) Name() Name {
+	return TimerInvalid
 }

--- a/common/reconciliation/invariant/timer_invalid_test.go
+++ b/common/reconciliation/invariant/timer_invalid_test.go
@@ -155,7 +155,9 @@ func (ts *TimerInvalidTest) TestCheck() {
 			)
 			ctx := context.Background()
 			if tc.ctxExpired {
-				ctx, _ = context.WithDeadline(ctx, time.Now())
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithDeadline(ctx, time.Now())
+				defer cancel()
 			}
 			result := i.Check(ctx, tc.entity)
 			ts.Equal(tc.expectedResult, result)
@@ -283,7 +285,9 @@ func (ts *TimerInvalidTest) TestFix() {
 			)
 			ctx := context.Background()
 			if tc.ctxExpired {
-				ctx, _ = context.WithDeadline(ctx, time.Now())
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithDeadline(ctx, time.Now())
+				defer cancel()
 			}
 			result := i.Fix(ctx, tc.entity)
 			ts.Equal(tc.expectedResult, result)

--- a/common/reconciliation/invariant/types.go
+++ b/common/reconciliation/invariant/types.go
@@ -57,6 +57,9 @@ const (
 	// implying a failed cleanup / lost timers / etc of some kind.
 	StaleWorkflow Name = "stale_workflow"
 
+	// TimerInvalid checks for timers scheduled for non-existent or closed workflows
+	TimerInvalid Name = "TimerInvalid"
+
 	// CollectionMutableState is the collection of invariants relating to mutable state
 	CollectionMutableState Collection = 0
 	// CollectionHistory is the collection  of invariants relating to history

--- a/service/worker/scanner/timers/timers.go
+++ b/service/worker/scanner/timers/timers.go
@@ -109,7 +109,7 @@ func timerCustomConfig(_ shardscanner.FixerContext) shardscanner.CustomScannerCo
 	// currently this is not read anywhere because "fixer enabled"
 	// means "run this one invariant's fixes".
 	return map[string]string{
-		invariant.TimerInvalidName: "true",
+		string(invariant.TimerInvalid): "true",
 	}
 }
 


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Cleaned up small inconsistencies in the reconciliation invariant package found during audit:

- Fix ExecutionStillOpen silently swallowing domain cache errors (returned false, nil instead of false, err)
- Unexport TimerInvalid struct and move its name constant to types.go to match all other invariants
- Fix copy-paste comment on NewTimerInvalid (said "history exists")
- Replace deprecated dateOnly constant with time.DateOnly (Go 1.20+)
- Fix misleading "failed check" wording in InactiveDomainExists corruption result
- Fix go vet context leak warnings in timer_invalid_test.go

**Why?**
This package is being used but we have plans to improve it, covering more cases and using more broadly. Initial cleanup to prepare the codebase for the new work. Mostly focus on existing inconsistencies, error swallowing and incorrect messages

**How did you test it?**
Unit tests

go test ./common/reconciliation/... ./service/worker/scanner/timers/...

**Potential risks**
Low risk. The main risk is returning the error on domain cache errors, but today we are treating them as healthy errors when they could not be. So we are actually improving the check

**Release notes**
N/A

**Documentation Changes**
N/A
