### PR TITLE
chore(matching): set "Task list manager state changed" logs to info level

### DIFF
--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -327,7 +327,7 @@ func (e *matchingEngineImpl) getOrCreateTaskListManager(ctx context.Context, tas
 		tag.WorkflowDomainID(taskList.GetDomainID()),
 	)
 
-	logger.Debug("Task list manager state changed", tag.LifeCycleStarting)
+	logger.Info("Task list manager state changed", tag.LifeCycleStarting)
 	params := tasklist.ManagerParams{
 		DomainCache:     e.domainCache,
 		Logger:          e.logger,
@@ -360,7 +360,7 @@ func (e *matchingEngineImpl) getOrCreateTaskListManager(ctx context.Context, tas
 		return nil, err
 	}
 
-	logger.Debug("Task list manager state changed", tag.LifeCycleStarted)
+	logger.Info("Task list manager state changed", tag.LifeCycleStarted)
 	event.Log(event.E{
 		TaskListName: taskList.GetName(),
 		TaskListKind: &taskListKind,

--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -332,7 +332,7 @@ func (c *taskListManagerImpl) Stop() {
 	c.taskReader.Stop()
 	c.matcher.DisconnectBlockedPollers()
 	c.stopWG.Wait()
-	c.logger.Debug("Task list manager state changed", tag.LifeCycleStopped)
+	c.logger.Info("Task list manager state changed", tag.LifeCycleStopped)
 }
 
 func (c *taskListManagerImpl) handleErr(err error) error {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
This PR sets tasklist manager lifecycle logs back to info logs. 
reverting this PR - https://github.com/cadence-workflow/cadence/pull/7903 

**Why?**
These logs are useful when debugging the issues with tasklists, to understand the state of the tasklist at the specific time. 

**How did you test it?**
go test -race -run . ./service/matching/handler/
go test -race -run TestTaskListManager ./service/matching/tasklist/

**Potential risks**
No risks because we are returning the old state of logs

**Release notes**
N/A

**Documentation Changes**
N/A
