### PR TITLE
chore(graceful failover): remove logs and revert default interval

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -5860,7 +5860,7 @@ var DurationKeys = map[DurationKey]DynamicDuration{
 	NotifyFailoverMarkerInterval: {
 		KeyName:      "history.NotifyFailoverMarkerInterval",
 		Description:  "NotifyFailoverMarkerInterval is determines the frequency to notify failover marker",
-		DefaultValue: time.Second,
+		DefaultValue: time.Second * 5,
 	},
 	ActivityMaxScheduleToStartTimeoutForRetry: {
 		KeyName:      "history.activityMaxScheduleToStartTimeoutForRetry",

--- a/common/reconciliation/invariant/types.go
+++ b/common/reconciliation/invariant/types.go
@@ -60,6 +60,12 @@ const (
 	// TimerInvalid checks for timers scheduled for non-existent or closed workflows
 	TimerInvalid Name = "TimerInvalid"
 
+	// HistoryInvalid checks that the full history is readable and not corrupted
+	HistoryInvalid Name = "history_invalid"
+
+	// MismatchedRecords checks that current and concrete execution records agree on close status
+	MismatchedRecords Name = "mismatched_records"
+
 	// CollectionMutableState is the collection of invariants relating to mutable state
 	CollectionMutableState Collection = 0
 	// CollectionHistory is the collection  of invariants relating to history

--- a/service/history/failover/coordinator.go
+++ b/service/history/failover/coordinator.go
@@ -99,10 +99,11 @@ type (
 	}
 
 	failoverRecord struct {
-		failoverVersion int64
-		shards          map[int32]struct{}
-		lastUpdatedTime time.Time
-		firstSeenTime   time.Time
+		failoverVersion         int64
+		shards                  map[int32]struct{}
+		lastUpdatedTime         time.Time
+		firstSeenTime           time.Time
+		firstMarkerCreationTime int64
 	}
 )
 
@@ -291,14 +292,18 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 	if _, ok := c.recorder[domainID]; !ok {
 		// initialize the failover record
 		c.recorder[marker.GetDomainID()] = &failoverRecord{
-			failoverVersion: marker.GetFailoverVersion(),
-			shards:          make(map[int32]struct{}),
-			firstSeenTime:   c.timeSource.Now(),
+			failoverVersion:         marker.GetFailoverVersion(),
+			shards:                  make(map[int32]struct{}),
+			firstSeenTime:           c.timeSource.Now(),
+			firstMarkerCreationTime: marker.GetCreationTime(),
 		}
 	}
 
 	record := c.recorder[domainID]
 	record.lastUpdatedTime = c.timeSource.Now()
+	if marker.GetCreationTime() < record.firstMarkerCreationTime {
+		record.firstMarkerCreationTime = marker.GetCreationTime()
+	}
 	for _, shardID := range request.shardIDs {
 		record.shards[shardID] = struct{}{}
 	}
@@ -316,6 +321,7 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 
 	if len(record.shards) == c.config.NumberOfShards {
 		firstSeenTime := record.firstSeenTime
+		firstMarkerCreationTime := record.firstMarkerCreationTime
 		cleanStart := c.timeSource.Now()
 		updated, err := domain.CleanPendingActiveState(
 			c.domainManager,
@@ -351,8 +357,9 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 		}
 
 		now := c.timeSource.Now()
-		// use the last marker to calculate the failover duration
-		failoverDuration := now.Sub(time.Unix(0, marker.GetCreationTime()))
+		// use the earliest marker creation time across all shards to capture the
+		// full failover duration; the last marker would systematically undercount
+		failoverDuration := now.Sub(time.Unix(0, firstMarkerCreationTime))
 		c.scope.Tagged(
 			metrics.DomainTag(domainName),
 		).RecordTimer(
@@ -368,9 +375,9 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 		c.logger.Info("Updated domain from pending-active to active",
 			tag.WorkflowDomainName(domainName),
 			tag.FailoverVersion(marker.FailoverVersion),
-			tag.Duration(failoverDuration),
-			tag.Dynamic("marker-pipeline-duration", now.Sub(firstSeenTime)),
-			tag.Dynamic("clean-pending-active-duration", cleanDuration),
+			tag.Dynamic("failover-duration-seconds", failoverDuration.Seconds()),
+			tag.Dynamic("marker-pipeline-duration-seconds", now.Sub(firstSeenTime).Seconds()),
+			tag.Dynamic("clean-pending-active-duration-seconds", cleanDuration.Seconds()),
 		)
 	} else {
 		c.scope.Tagged(

--- a/service/history/failover/coordinator.go
+++ b/service/history/failover/coordinator.go
@@ -292,17 +292,18 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 	if _, ok := c.recorder[domainID]; !ok {
 		// initialize the failover record
 		c.recorder[marker.GetDomainID()] = &failoverRecord{
-			failoverVersion:         marker.GetFailoverVersion(),
-			shards:                  make(map[int32]struct{}),
-			firstSeenTime:           c.timeSource.Now(),
-			firstMarkerCreationTime: marker.GetCreationTime(),
+			failoverVersion: marker.GetFailoverVersion(),
+			shards:          make(map[int32]struct{}),
+			firstSeenTime:   c.timeSource.Now(),
 		}
 	}
 
 	record := c.recorder[domainID]
 	record.lastUpdatedTime = c.timeSource.Now()
-	if marker.GetCreationTime() < record.firstMarkerCreationTime {
-		record.firstMarkerCreationTime = marker.GetCreationTime()
+	// track the earliest valid CreationTime across all markers for accurate latency;
+	// skip non-positive values so a single bad marker can't poison the minimum
+	if ct := marker.GetCreationTime(); ct > 0 && (record.firstMarkerCreationTime == 0 || ct < record.firstMarkerCreationTime) {
+		record.firstMarkerCreationTime = ct
 	}
 	for _, shardID := range request.shardIDs {
 		record.shards[shardID] = struct{}{}

--- a/service/history/failover/coordinator.go
+++ b/service/history/failover/coordinator.go
@@ -184,11 +184,6 @@ func (c *coordinatorImpl) ReceiveFailoverMarkers(
 	marker *types.FailoverMarkerAttributes,
 ) {
 
-	c.logger.Info("Failover marker received from notify RPC",
-		tag.WorkflowDomainID(marker.GetDomainID()),
-		tag.FailoverVersion(marker.GetFailoverVersion()),
-		tag.Number(int64(len(shardIDs))),
-	)
 	c.receiveChan <- &receiveRequest{
 		shardIDs: shardIDs,
 		marker:   marker,
@@ -244,28 +239,6 @@ func (c *coordinatorImpl) notifyFailoverMarkerLoop() {
 	defer timer.Stop()
 	requestByMarker := make(map[types.FailoverMarkerAttributes]*receiveRequest)
 
-	flush := func() {
-		if len(requestByMarker) == 0 {
-			return
-		}
-		markerCount := len(requestByMarker)
-		var shardCount int
-		for _, req := range requestByMarker {
-			shardCount += len(req.shardIDs)
-		}
-		flushStart := c.timeSource.Now()
-		err := c.notifyRemoteCoordinator(requestByMarker)
-		flushDuration := c.timeSource.Now().Sub(flushStart)
-		if err == nil {
-			c.logger.Info("Flushed pending failover markers to active coordinator",
-				tag.Number(int64(markerCount)),
-				tag.Counter(shardCount),
-				tag.Dynamic("flush-duration", flushDuration),
-			)
-			requestByMarker = make(map[types.FailoverMarkerAttributes]*receiveRequest)
-		}
-	}
-
 	for {
 		select {
 		case <-c.shutdownChan:
@@ -275,7 +248,9 @@ func (c *coordinatorImpl) notifyFailoverMarkerLoop() {
 			// The receiver side will de-dup the shard IDs. See: handleFailoverMarkers
 			aggregateNotificationRequests(notificationReq, requestByMarker)
 		case <-timer.C:
-			flush()
+			if err := c.notifyRemoteCoordinator(requestByMarker); err == nil {
+				requestByMarker = make(map[types.FailoverMarkerAttributes]*receiveRequest)
+			}
 			timer.Reset(backoff.JitDuration(
 				c.config.NotifyFailoverMarkerInterval(),
 				c.config.NotifyFailoverMarkerTimerJitterCoefficient(),
@@ -313,18 +288,17 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 		}
 	}
 
-	now := c.timeSource.Now()
 	if _, ok := c.recorder[domainID]; !ok {
 		// initialize the failover record
 		c.recorder[marker.GetDomainID()] = &failoverRecord{
 			failoverVersion: marker.GetFailoverVersion(),
 			shards:          make(map[int32]struct{}),
-			firstSeenTime:   now,
+			firstSeenTime:   c.timeSource.Now(),
 		}
 	}
 
 	record := c.recorder[domainID]
-	record.lastUpdatedTime = now
+	record.lastUpdatedTime = c.timeSource.Now()
 	for _, shardID := range request.shardIDs {
 		record.shards[shardID] = struct{}{}
 	}
@@ -341,6 +315,7 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 	}
 
 	if len(record.shards) == c.config.NumberOfShards {
+		firstSeenTime := record.firstSeenTime
 		cleanStart := c.timeSource.Now()
 		updated, err := domain.CleanPendingActiveState(
 			c.domainManager,
@@ -357,7 +332,6 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 			c.scope.IncCounter(metrics.CadenceFailures)
 			return
 		}
-		firstSeenTime := record.firstSeenTime
 		delete(c.recorder, domainID)
 		// reset the gauge so it reflects the current (empty) pending state for this domain
 		// rather than the last partial-count value, which would otherwise linger forever
@@ -379,7 +353,6 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 		now := c.timeSource.Now()
 		// use the last marker to calculate the failover duration
 		failoverDuration := now.Sub(time.Unix(0, marker.GetCreationTime()))
-		markerPipelineDuration := now.Sub(firstSeenTime)
 		c.scope.Tagged(
 			metrics.DomainTag(domainName),
 		).RecordTimer(
@@ -396,7 +369,7 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 			tag.WorkflowDomainName(domainName),
 			tag.FailoverVersion(marker.FailoverVersion),
 			tag.Duration(failoverDuration),
-			tag.Dynamic("marker-pipeline-duration", markerPipelineDuration),
+			tag.Dynamic("marker-pipeline-duration", now.Sub(firstSeenTime)),
 			tag.Dynamic("clean-pending-active-duration", cleanDuration),
 		)
 	} else {
@@ -405,13 +378,6 @@ func (c *coordinatorImpl) handleFailoverMarkers(
 		).UpdateGauge(
 			metrics.FailoverMarkerCount,
 			float64(len(record.shards)),
-		)
-		c.logger.Info("Accumulated failover marker shards",
-			tag.WorkflowDomainName(domainName),
-			tag.WorkflowDomainID(domainID),
-			tag.FailoverVersion(marker.GetFailoverVersion()),
-			tag.Counter(len(record.shards)),
-			tag.Number(int64(c.config.NumberOfShards)),
 		)
 	}
 }

--- a/service/history/replication/task_executor.go
+++ b/service/history/replication/task_executor.go
@@ -338,12 +338,6 @@ func (e *taskExecutorImpl) handleFailoverReplicationTask(
 		return ErrEmptyFailoverMarkerAttributes
 	}
 	failoverAttributes.CreationTime = task.CreationTime
-	e.logger.Info("Failover marker handed to standby executor",
-		tag.ShardID(e.shard.GetShardID()),
-		tag.WorkflowDomainID(failoverAttributes.GetDomainID()),
-		tag.FailoverVersion(failoverAttributes.GetFailoverVersion()),
-		tag.Dynamic("execute-lag", time.Since(time.Unix(0, task.GetCreationTime()))),
-	)
 	return e.shard.AddingPendingFailoverMarker(failoverAttributes)
 }
 

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -326,16 +326,7 @@ func (p *taskProcessorImpl) processResponse(response *types.ReplicationMessages)
 	ctx := context.Background()
 	for _, replicationTask := range response.ReplicationTasks {
 		isFailoverMarker := replicationTask.GetTaskType() == types.ReplicationTaskTypeFailoverMarker
-		if isFailoverMarker {
-			if attr := replicationTask.GetFailoverMarkerAttributes(); attr != nil {
-				p.logger.Info("Failover marker arrived at standby replication processor",
-					tag.ShardID(p.shard.GetShardID()),
-					tag.WorkflowDomainID(attr.GetDomainID()),
-					tag.FailoverVersion(attr.GetFailoverVersion()),
-					tag.Dynamic("arrival-lag", time.Since(time.Unix(0, replicationTask.GetCreationTime()))),
-				)
-			}
-		} else {
+		if !isFailoverMarker {
 			// failover markers bypass rate limiting: bounded volume (one per shard
 			// per failover), shard-level (no workflow lock), and cheap to execute.
 			// throttling them behind history replication needlessly delays the


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Removed logs to track failover markers during graceful failover and reverted default interval from 1s to 5s

**Why?**
Logs are noisy and not necessary anymore. 1s interval by default is too frequent.

**How did you test it?**
go test -race -count=1 -run TestCoordinatorSuite ./service/history/failover/...
go test -race -count=1 -run TestTaskProcessorSuite ./service/history/replication/...
go test -race -count=1 -run TestTaskExecutor ./service/history/replication/...

**Potential risks**
No risk, only removing logs

**Release notes**
N/A

**Documentation Changes**
N/A
