### PR TITLE
fix(metrics): Fix Cluster Metadata Empty Metric Name

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2572,6 +2572,13 @@ const (
 	// cluster forwarding policy metrics
 	ClusterForwardingPolicyRequests
 
+	// cluster metadata metrics
+	ClusterMetadataFailureToResolveCounter
+	ClusterMetadataGettingMinFailoverVersionCounter
+	ClusterMetadataGettingFailoverVersionCounter
+	ClusterMetadataResolvingFailoverVersionCounter
+	ClusterMetadataResolvingMinFailoverVersionCounter
+
 	RingResolverError
 
 	// WorkflowExecutionHistoryAccess tracks the access to the workflow history
@@ -2670,12 +2677,6 @@ const (
 	QueueValidatorInvalidLoadCounter
 	QueueValidatorValidationCounter
 	QueueValidatorValidationFailure
-
-	ClusterMetadataFailureToResolveCounter
-	ClusterMetadataGettingMinFailoverVersionCounter
-	ClusterMetadataGettingFailoverVersionCounter
-	ClusterMetadataResolvingFailoverVersionCounter
-	ClusterMetadataResolvingMinFailoverVersionCounter
 
 	ActivityE2ELatency
 	ActivityE2ELatencyHistogram
@@ -3546,6 +3547,12 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 
 		ClusterForwardingPolicyRequests: {metricName: "cluster_forwarding_policy_requests", metricType: Counter},
 
+		ClusterMetadataFailureToResolveCounter:            {metricName: "failed_to_resolve_failover_version", metricType: Counter},
+		ClusterMetadataGettingMinFailoverVersionCounter:   {metricName: "getting_min_failover_version_counter", metricType: Counter},
+		ClusterMetadataGettingFailoverVersionCounter:      {metricName: "getting_failover_version_counter", metricType: Counter},
+		ClusterMetadataResolvingFailoverVersionCounter:    {metricName: "resolving_failover_version_counter", metricType: Counter},
+		ClusterMetadataResolvingMinFailoverVersionCounter: {metricName: "resolving_min_failover_version_counter", metricType: Counter},
+
 		RingResolverError: {metricName: "ring_resolver_error", metricType: Counter},
 
 		WorkflowExecutionHistoryAccess: {metricName: "workflow_execution_history_access", metricType: Gauge},
@@ -3645,11 +3652,6 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 		QueueValidatorInvalidLoadCounter:                              {metricName: "queue_validator_invalid_load_counter", metricType: Counter},
 		QueueValidatorValidationCounter:                               {metricName: "queue_validator_validation_counter", metricType: Counter},
 		QueueValidatorValidationFailure:                               {metricName: "queue_validator_validation_error", metricType: Counter},
-		ClusterMetadataFailureToResolveCounter:                        {metricName: "failed_to_resolve_failover_version", metricType: Counter},
-		ClusterMetadataGettingMinFailoverVersionCounter:               {metricName: "getting_min_failover_version_counter", metricType: Counter},
-		ClusterMetadataGettingFailoverVersionCounter:                  {metricName: "getting_failover_version_counter", metricType: Counter},
-		ClusterMetadataResolvingFailoverVersionCounter:                {metricName: "resolving_failover_version_counter", metricType: Counter},
-		ClusterMetadataResolvingMinFailoverVersionCounter:             {metricName: "resolving_min_failover_version_counter", metricType: Counter},
 		ActivityE2ELatency:                                            {metricName: "activity_end_to_end_latency", metricType: Timer},
 		ActivityE2ELatencyHistogram:                                   {metricName: "activity_end_to_end_latency_ns", metricType: Histogram, exponentialBuckets: Mid1ms24h},
 		ActivityLostCounter:                                           {metricName: "activity_lost", metricType: Counter},


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Moved the shared `ClusterMetadata*` metric constants and definitions from History-specific metrics to Common metrics.
RegisterDomain in Frontend can emit ClusterMetadataGettingMinFailoverVersionCounter with a real Prometheus metric name instead of fqName: "".
Prometheus reporter warnings for this normal domain registration path go away.
The metric is no longer silently broken or dropped because of a service/metric-definition mismatch.
Observability for failover version generation becomes consistent across Frontend, History, Matching, and Worker.
The fix preserves the existing metric names, so dashboards/alerts using those names should not need changes.

**Why?**
Cluster metadata is used by multiple services, including the Frontend. During `RegisterDomain`, Frontend can emit cluster metadata metrics, but those metric IDs were only defined for History, causing Prometheus to see an empty metric name (`fqName: ""`)

**How did you test it?**
before the fix:
1. Start Cadence with Prometheus enabled, the normal dev backend running:
```
 ./cadence-server --zone prometheus start
 ```
2. Register a domain: 
```
./cadence --do samples-domain domain register  
```

3. Watch the server logs for warnings like: 

```
{"level":"warn","msg":"error in prometheus reporter","error":"descriptor Desc{fqName: \"\", help: \" counter\", constLabels: {}, variableLabels: [cadence_service operation]} is invalid: \"\" is not a valid metric name","logging-call-at":"metrics.go:151"}
```
The warning is triggered on a normal domain registration path, creates noisy prometheus reporter errors, and can hide real observability issues by making metric emission look broken.

**Potential risks**
Low. Metric names are unchanged; only their definition ownership moved so all service metrics clients can resolve them.

**Release notes**


**Documentation Changes**

