### PR TITLE
fix(history): drain is flaky on shutdown

### DIFF
--- a/service/history/queue/timer_queue_processor.go
+++ b/service/history/queue/timer_queue_processor.go
@@ -350,6 +350,21 @@ func (t *timerQueueProcessor) FailoverDomain(domainIDs map[string]struct{}) {
 }
 
 func (t *timerQueueProcessor) HandleAction(ctx context.Context, clusterName string, action *Action) (*ActionResult, error) {
+	// External callers abort if the processor is shutting down so they don't block
+	// indefinitely once the processing pumps stop accepting work.
+	return t.handleAction(ctx, clusterName, action, t.shutdownChan)
+}
+
+// handleAction routes the action to the proper queue processor and waits for the result.
+// abortCh, when non-nil, makes the call return errProcessorShutdown if it is signaled
+// before the result arrives.
+//
+// The drain path passes a nil abortCh so the action is awaited to completion: during
+// graceful shutdown the queue processors are intentionally kept running until drain
+// returns, so the result is guaranteed to arrive (bounded by ctx). This avoids racing
+// the already-closed shutdownChan, which would otherwise nondeterministically abort the
+// completeTimer issued during drain.
+func (t *timerQueueProcessor) handleAction(ctx context.Context, clusterName string, action *Action, abortCh <-chan struct{}) (*ActionResult, error) {
 	var resultNotificationCh chan actionResultNotification
 	var added bool
 	if clusterName == t.currentClusterName {
@@ -379,7 +394,7 @@ func (t *timerQueueProcessor) HandleAction(ctx context.Context, clusterName stri
 	select {
 	case resultNotification := <-resultNotificationCh:
 		return resultNotification.result, resultNotification.err
-	case <-t.shutdownChan:
+	case <-abortCh:
 		return nil, errProcessorShutdown
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -398,16 +413,20 @@ func (t *timerQueueProcessor) UnlockTaskProcessing() {
 
 func (t *timerQueueProcessor) drain() {
 	if !t.shard.GetConfig().QueueProcessorEnableGracefulSyncShutdown() {
-		if err := t.completeTimer(context.Background()); err != nil {
+		// non-graceful: pumps are already stopped, so completeTimer returns early
+		if err := t.completeTimer(context.Background(), nil); err != nil {
 			t.logger.Error("Failed to complete timer task during drain", tag.Error(err))
 		}
 		return
 	}
 
-	// when graceful shutdown is enabled for queue processor, use a context with timeout
+	// When graceful shutdown is enabled the queue processors are still running at this
+	// point (they are stopped only after drain returns), so pass a nil abort channel to
+	// deterministically wait for the GetState results instead of racing the already-closed
+	// shutdownChan. The timeout context bounds the wait in case a pump is unresponsive.
 	ctx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
 	defer cancel()
-	if err := t.completeTimer(ctx); err != nil {
+	if err := t.completeTimer(ctx, nil); err != nil {
 		t.logger.Error("Failed to complete timer task during drain", tag.Error(err))
 	}
 }
@@ -435,7 +454,8 @@ func (t *timerQueueProcessor) completeTimerLoop() {
 			return
 		case <-completeTimer.C:
 			for attempt := 0; attempt < t.config.TimerProcessorCompleteTimerFailureRetryCount(); attempt++ {
-				err := t.completeTimer(context.Background())
+				// periodic completion aborts promptly if a shutdown is signaled
+				err := t.completeTimer(context.Background(), t.shutdownChan)
 				if err == nil {
 					break
 				}
@@ -470,9 +490,9 @@ func (t *timerQueueProcessor) completeTimerLoop() {
 	}
 }
 
-func (t *timerQueueProcessor) completeTimer(ctx context.Context) error {
+func (t *timerQueueProcessor) completeTimer(ctx context.Context, abortCh <-chan struct{}) error {
 	newAckLevel := maximumTimerTaskKey
-	actionResult, err := t.HandleAction(ctx, t.currentClusterName, NewGetStateAction())
+	actionResult, err := t.handleAction(ctx, t.currentClusterName, NewGetStateAction(), abortCh)
 	if err != nil {
 		return err
 	}
@@ -481,7 +501,7 @@ func (t *timerQueueProcessor) completeTimer(ctx context.Context) error {
 	}
 
 	for standbyClusterName := range t.standbyQueueProcessors {
-		actionResult, err := t.HandleAction(ctx, standbyClusterName, NewGetStateAction())
+		actionResult, err := t.handleAction(ctx, standbyClusterName, NewGetStateAction(), abortCh)
 		if err != nil {
 			return err
 		}

--- a/service/history/queue/timer_queue_processor_test.go
+++ b/service/history/queue/timer_queue_processor_test.go
@@ -27,8 +27,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"go.uber.org/mock/gomock"
 
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/reconciliation/invariant"
 	hcommon "github.com/uber/cadence/service/history/common"
@@ -39,6 +42,55 @@ import (
 	"github.com/uber/cadence/service/history/task"
 	"github.com/uber/cadence/service/worker/archiver"
 )
+
+func TestTimerQueueProcessor_StartStop_DrainCompletesTimer(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ackTime := time.Now().Truncate(time.Millisecond)
+	clusterAckTime := ackTime.Add(time.Hour)
+
+	mockShard := shard.NewTestContext(
+		t,
+		ctrl,
+		&persistence.ShardInfo{
+			ShardID:       10,
+			RangeID:       1,
+			TimerAckLevel: ackTime,
+			// per-cluster ack levels are ahead of the processor's initial ackLevel
+			// (TimerAckLevel), so the graceful-shutdown drain deterministically advances
+			// the ack level once.
+			ClusterTimerAckLevel: map[string]time.Time{
+				constants.TestClusterMetadata.GetCurrentClusterName(): clusterAckTime,
+				"standby": clusterAckTime,
+			},
+		},
+		config.NewForTest(),
+	)
+
+	processor := NewTimerQueueProcessor(
+		mockShard,
+		task.NewMockProcessor(ctrl),
+		execution.NewCache(mockShard),
+		archiver.NewMockClient(ctrl),
+		invariant.NewMockInvariant(ctrl),
+	).(*timerQueueProcessor)
+
+	mockShard.Resource.ExecutionMgr.On("RangeCompleteHistoryTask", mock.Anything, mock.Anything).
+		Return(&persistence.RangeCompleteHistoryTaskResponse{}, nil).Once()
+	mockShard.GetShardManager().(*mocks.ShardManager).On("UpdateShard", mock.Anything, mock.Anything).
+		Return(nil).Once()
+
+	assert.Equal(t, common.DaemonStatusInitialized, processor.status)
+	processor.Start()
+	assert.Equal(t, common.DaemonStatusStarted, processor.status)
+
+	processor.Stop()
+	assert.Equal(t, common.DaemonStatusStopped, processor.status)
+
+	mockShard.Resource.ExecutionMgr.AssertExpectations(t)
+	mockShard.Resource.ShardMgr.AssertExpectations(t)
+}
 
 func setupTimerQueueProcessor(t *testing.T) (*gomock.Controller, *timerQueueProcessor) {
 	t.Helper()

--- a/service/history/queue/transfer_queue_processor.go
+++ b/service/history/queue/transfer_queue_processor.go
@@ -319,6 +319,26 @@ func (t *transferQueueProcessor) HandleAction(
 	clusterName string,
 	action *Action,
 ) (*ActionResult, error) {
+	// External callers abort if the processor is shutting down so they don't block
+	// indefinitely once the processing pumps stop accepting work.
+	return t.handleAction(ctx, clusterName, action, t.shutdownChan)
+}
+
+// handleAction routes the action to the proper queue processor and waits for the result.
+// abortCh, when non-nil, makes the call return errProcessorShutdown if it is signaled
+// before the result arrives.
+//
+// The drain path passes a nil abortCh so the action is awaited to completion: during
+// graceful shutdown the queue processors are intentionally kept running until drain
+// returns, so the result is guaranteed to arrive (bounded by ctx). This avoids racing
+// the already-closed shutdownChan, which would otherwise nondeterministically abort the
+// completeTransfer issued during drain.
+func (t *transferQueueProcessor) handleAction(
+	ctx context.Context,
+	clusterName string,
+	action *Action,
+	abortCh <-chan struct{},
+) (*ActionResult, error) {
 	var resultNotificationCh chan actionResultNotification
 	var added bool
 	if clusterName == t.currentClusterName {
@@ -348,7 +368,7 @@ func (t *transferQueueProcessor) HandleAction(
 	select {
 	case resultNotification := <-resultNotificationCh:
 		return resultNotification.result, resultNotification.err
-	case <-t.shutdownChan:
+	case <-abortCh:
 		return nil, errProcessorShutdown
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -366,8 +386,16 @@ func (t *transferQueueProcessor) UnlockTaskProcessing() {
 }
 
 func (t *transferQueueProcessor) drain() {
-	// before shutdown, make sure the ack level is up to date
-	if err := t.completeTransfer(); err != nil {
+	// Before shutdown, make sure the ack level is up to date.
+	//
+	// The active/standby queue processors are still running at this point (they are
+	// stopped only after drain returns), so pass a nil abort channel to deterministically
+	// wait for the GetState results instead of racing the already-closed shutdownChan.
+	// The timeout context bounds the wait in case a pump is unresponsive. In the
+	// non-graceful path the pumps are already stopped, so completeTransfer returns early.
+	ctx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
+	defer cancel()
+	if err := t.completeTransfer(ctx, nil); err != nil {
 		t.logger.Error("Failed to complete transfer task during shutdown", tag.Error(err))
 	}
 }
@@ -396,7 +424,8 @@ func (t *transferQueueProcessor) completeTransferLoop() {
 			return
 		case <-completeTimer.C:
 			for attempt := 0; attempt < t.config.TransferProcessorCompleteTransferFailureRetryCount(); attempt++ {
-				err := t.completeTransfer()
+				// periodic completion aborts promptly if a shutdown is signaled
+				err := t.completeTransfer(context.Background(), t.shutdownChan)
 				if err == nil {
 					break
 				}
@@ -431,9 +460,9 @@ func (t *transferQueueProcessor) completeTransferLoop() {
 	}
 }
 
-func (t *transferQueueProcessor) completeTransfer() error {
+func (t *transferQueueProcessor) completeTransfer(ctx context.Context, abortCh <-chan struct{}) error {
 	newAckLevel := maximumTransferTaskKey
-	actionResult, err := t.HandleAction(context.Background(), t.currentClusterName, NewGetStateAction())
+	actionResult, err := t.handleAction(ctx, t.currentClusterName, NewGetStateAction(), abortCh)
 	if err != nil {
 		return err
 	}
@@ -442,7 +471,7 @@ func (t *transferQueueProcessor) completeTransfer() error {
 	}
 
 	for standbyClusterName := range t.standbyQueueProcessors {
-		actionResult, err := t.HandleAction(context.Background(), standbyClusterName, NewGetStateAction())
+		actionResult, err := t.handleAction(ctx, standbyClusterName, NewGetStateAction(), abortCh)
 		if err != nil {
 			return err
 		}
@@ -479,7 +508,7 @@ func (t *transferQueueProcessor) completeTransfer() error {
 		// we're switching from exclusive begin/end to inclusive min/exclusive max,
 		// so we need to adjust the taskID, for example, if the original range is (1, 10],
 		// the new range should be [2, 11), so we add 1 to both the min and max taskID
-		resp, err := t.shard.GetExecutionManager().RangeCompleteHistoryTask(context.Background(), &persistence.RangeCompleteHistoryTaskRequest{
+		resp, err := t.shard.GetExecutionManager().RangeCompleteHistoryTask(ctx, &persistence.RangeCompleteHistoryTaskRequest{
 			TaskCategory:        persistence.HistoryTaskCategoryTransfer,
 			InclusiveMinTaskKey: persistence.NewImmediateTaskKey(t.ackLevel + 1),
 			ExclusiveMaxTaskKey: persistence.NewImmediateTaskKey(newAckLevelTaskID + 1),

--- a/service/history/queue/transfer_queue_processor_test.go
+++ b/service/history/queue/transfer_queue_processor_test.go
@@ -79,9 +79,32 @@ func setupTransferQueueProcessor(t *testing.T, cfg *config.Config) (*gomock.Cont
 	).(*transferQueueProcessor)
 }
 
+// expectGracefulDrainCompletesTransfer registers (and asserts) the persistence
+// expectations for the completeTransfer that the processor deterministically runs when
+// it drains on graceful shutdown.
+//
+// The test shard sets ClusterTransferAckLevel to {current: 3, standby: 2} while a
+// freshly constructed processor starts with ackLevel 0, so completeTransfer computes a
+// newAckLevelTaskID of 2 and advances the ack level exactly once: one RangeCompleteHistoryTask
+// (a single page, since TasksCompleted is 0) followed by one UpdateShard. During graceful
+// shutdown the queue processors stay running until drain returns, so this is deterministic.
+func expectGracefulDrainCompletesTransfer(t *testing.T, mockShard *shard.TestContext) {
+	mockShard.Resource.ExecutionMgr.On("RangeCompleteHistoryTask", mock.Anything, mock.Anything).
+		Return(&persistence.RangeCompleteHistoryTaskResponse{}, nil).Once()
+	mockShard.GetShardManager().(*mocks.ShardManager).On("UpdateShard", mock.Anything, mock.Anything).
+		Return(nil).Once()
+	t.Cleanup(func() {
+		mockShard.Resource.ExecutionMgr.AssertExpectations(t)
+		mockShard.Resource.ShardMgr.AssertExpectations(t)
+	})
+}
+
 func TestTransferQueueProcessor_StartStop(t *testing.T) {
 	ctrl, processor := setupTransferQueueProcessor(t, nil)
 	defer ctrl.Finish()
+
+	// graceful Stop drains the processor, which deterministically completes the transfer
+	expectGracefulDrainCompletesTransfer(t, processor.shard.(*shard.TestContext))
 
 	assert.Equal(t, common.DaemonStatusInitialized, processor.status)
 
@@ -104,6 +127,10 @@ func TestTransferQueueProcessor_StartNotGracefulStop(t *testing.T) {
 
 	ctrl, processor := setupTransferQueueProcessor(t, cfg)
 	defer ctrl.Finish()
+
+	// non-graceful Stop stops the pumps before draining, so completeTransfer returns
+	// early and issues no persistence calls. No RangeCompleteHistoryTask/UpdateShard
+	// mocks are registered, so any such call would fail the test.
 
 	assert.Equal(t, common.DaemonStatusInitialized, processor.status)
 	processor.Start()
@@ -264,6 +291,9 @@ func TestTransferQueueProcessor_HandleAction(t *testing.T) {
 			ctrl, processor := setupTransferQueueProcessor(t, nil)
 			defer ctrl.Finish()
 
+			// graceful Stop drains the processor, which deterministically completes the transfer
+			expectGracefulDrainCompletesTransfer(t, processor.shard.(*shard.TestContext))
+
 			defer processor.Stop()
 			processor.Start()
 
@@ -325,8 +355,10 @@ func TestTransferQueueProcessor_completeTransfer(t *testing.T) {
 		"error - ackLevel < newAckLevelTaskID - RangeCompleteTransferTask error": {
 			ackLevel: 1,
 			mockSetup: func(mockShard *shard.TestContext) {
+				// ackLevel stays below the target after the error, so the deferred graceful
+				// Stop drains and calls completeTransfer again; allow both invocations.
 				mockShard.Resource.ExecutionMgr.On("RangeCompleteHistoryTask", mock.Anything, mock.Anything).
-					Return(&persistence.RangeCompleteHistoryTaskResponse{}, assert.AnError).Once()
+					Return(&persistence.RangeCompleteHistoryTaskResponse{}, assert.AnError)
 			},
 			err: assert.AnError,
 		},
@@ -352,7 +384,7 @@ func TestTransferQueueProcessor_completeTransfer(t *testing.T) {
 			defer processor.Stop()
 			processor.Start()
 
-			err := processor.completeTransfer()
+			err := processor.completeTransfer(context.Background(), nil)
 
 			if tt.err != nil {
 				assert.Error(t, err)


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

Allow draining to complete before shutdown the queue processor

**Why?**
During shutdown, this is what happens to history queue processors

shutdownChan closed -> drain -> HandleAction (race between shutdown channel and in-flight result)

**How did you test it?**

Unit Test (with stress 50 runs)

**Potential risks**

Shutdown may take longer to wait for the task to complete. 

**Release notes**


**Documentation Changes**

