### PR TITLE
fix: flaky test in queue/transfer_queue_processor_test

### DIFF
--- a/service/history/queue/transfer_queue_processor_test.go
+++ b/service/history/queue/transfer_queue_processor_test.go
@@ -83,6 +83,11 @@ func TestTransferQueueProcessor_StartStop(t *testing.T) {
 	ctrl, processor := setupTransferQueueProcessor(t, nil)
 	defer ctrl.Finish()
 
+	mockShard := processor.shard.(*shard.TestContext)
+	mockShard.Resource.ExecutionMgr.On("RangeCompleteHistoryTask", mock.Anything, mock.Anything).
+		Return(&persistence.RangeCompleteHistoryTaskResponse{}, nil).Maybe()
+	mockShard.Resource.ShardMgr.On("UpdateShard", mock.Anything, mock.Anything).Return(nil).Maybe()
+
 	assert.Equal(t, common.DaemonStatusInitialized, processor.status)
 
 	processor.Start()
@@ -104,6 +109,11 @@ func TestTransferQueueProcessor_StartNotGracefulStop(t *testing.T) {
 
 	ctrl, processor := setupTransferQueueProcessor(t, cfg)
 	defer ctrl.Finish()
+
+	mockShard := processor.shard.(*shard.TestContext)
+	mockShard.Resource.ExecutionMgr.On("RangeCompleteHistoryTask", mock.Anything, mock.Anything).
+		Return(&persistence.RangeCompleteHistoryTaskResponse{}, nil).Maybe()
+	mockShard.Resource.ShardMgr.On("UpdateShard", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	assert.Equal(t, common.DaemonStatusInitialized, processor.status)
 	processor.Start()
@@ -209,6 +219,9 @@ func TestTransferQueueProcessor_FailoverDomain(t *testing.T) {
 					},
 				}
 				mockShard.GetExecutionManager().(*mocks.ExecutionManager).On("GetHistoryTasks", mock.Anything, mock.Anything).Return(response, nil).Once()
+				mockShard.Resource.ExecutionMgr.On("RangeCompleteHistoryTask", mock.Anything, mock.Anything).
+					Return(&persistence.RangeCompleteHistoryTaskResponse{}, nil).Maybe()
+				mockShard.Resource.ShardMgr.On("UpdateShard", mock.Anything, mock.Anything).Return(nil).Maybe()
 			},
 			processorStarted: true,
 		},
@@ -263,6 +276,11 @@ func TestTransferQueueProcessor_HandleAction(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl, processor := setupTransferQueueProcessor(t, nil)
 			defer ctrl.Finish()
+
+			mockShard := processor.shard.(*shard.TestContext)
+			mockShard.Resource.ExecutionMgr.On("RangeCompleteHistoryTask", mock.Anything, mock.Anything).
+				Return(&persistence.RangeCompleteHistoryTaskResponse{}, nil).Maybe()
+			mockShard.Resource.ShardMgr.On("UpdateShard", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 			defer processor.Stop()
 			processor.Start()
@@ -349,8 +367,16 @@ func TestTransferQueueProcessor_completeTransfer(t *testing.T) {
 
 			tt.mockSetup(processor.shard.(*shard.TestContext))
 
-			defer processor.Stop()
-			processor.Start()
+			processor.activeQueueProcessor.Start()
+			for _, standbyQueueProcessor := range processor.standbyQueueProcessors {
+				standbyQueueProcessor.Start()
+			}
+			defer func() {
+				processor.activeQueueProcessor.Stop()
+				for _, standbyQueueProcessor := range processor.standbyQueueProcessors {
+					standbyQueueProcessor.Stop()
+				}
+			}()
 
 			err := processor.completeTransfer()
 


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Replaced processor.Start()/Stop() with starting only the sub-processors (activeQueueProcessor, standbyQueueProcessors). This avoids spawning the background completeTransferLoop that races with the direct completeTransfer() call.

Added .Maybe() mocks for RangeCompleteHistoryTask and UpdateShard since these tests legitimately call processor.Start() and the background loop may fire before Stop().

**Why?**
The background completeTransferLoop goroutine (spawned by processor.Start()) raced with tests, calling RangeCompleteHistoryTask and UpdateShard without mock expectations.

**How did you test it?**
go test -race -run "TestTransferQueueProcessor_StartStop" ./service/history/queue/...
go test -race -run "TestTransferQueueProcessor_StartNotGracefulStop" ./service/history/queue/...
go test -race -run "TestTransferQueueProcessor_FailoverDomain" ./service/history/queue/...
go test -race -run "TestTransferQueueProcessor_HandleAction" ./service/history/queue/...
go test -race -run "TestTransferQueueProcessor_completeTransfer" ./service/history/queue/...

**Potential risks**
No risk, just test changes.

**Release notes**
N/A

**Documentation Changes**
N/A
