### PR TITLE
test: Shutdown workers first when completing integration tests

### DIFF
--- a/host/onebox.go
+++ b/host/onebox.go
@@ -427,6 +427,15 @@ func (c *cadenceImpl) Stop() {
 	if c.enableWorker() {
 		serviceCount++
 	}
+	if c.workerConfig.EnableReplicator {
+		c.replicator.Stop()
+	}
+	if c.workerConfig.EnableArchiver {
+		c.clientWorker.Stop()
+	}
+	if c.workerConfig.EnableScheduler {
+		c.schedulerWorkerManager.Stop()
+	}
 
 	c.shutdownWG.Add(serviceCount)
 	c.frontendService.Stop()
@@ -437,12 +446,6 @@ func (c *cadenceImpl) Stop() {
 		matchingService.Stop()
 	}
 
-	if c.workerConfig.EnableReplicator {
-		c.replicator.Stop()
-	}
-	if c.workerConfig.EnableArchiver {
-		c.clientWorker.Stop()
-	}
 	close(c.shutdownCh)
 	c.shutdownWG.Wait()
 }
@@ -1010,7 +1013,6 @@ func (c *cadenceImpl) startWorker(hosts map[string][]membership.HostInfo, startW
 	var schedulerDomainCache cache.DomainCache
 	if c.workerConfig.EnableScheduler {
 		schedulerDomainCache = c.startSchedulerWorkerManager(params, service)
-		defer c.schedulerWorkerManager.Stop()
 		defer schedulerDomainCache.Stop()
 	}
 


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
When creating a test cluster for an integration test we start services in the order:
- history
- matching
- frontend
- worker

When stopping the test cluster we shut them down in the order:
- frontend
- history
- matching
- worker

Shutting down worker last significantly slows down the shutdown process. When the yarpc dispatcher is shut down it has a clever orderly shutdown process, where it stops accepting new requests but still waits for all currently in flight requests to finish. If those requests are long-poll requests from the Worker, such as Polling for the schedules feature, it requires the request to time out before it proceeds with the shutdown. For the base `integration_test_cluster.yaml` that has schedules enabled, this adds a 60s delay after the test suite completes.

This should be impactful beyond schedules, although in practice we only see a 60s decrease in sqlite execution time.

**Why?**

Make integration tests faster .

**How did you test it?**

Ran integration tests locally, raising this PR will run them more exhaustively.

**Potential risks**

Tests may somehow rely on this behavior

**Release notes**


**Documentation Changes**

