### PR TITLE
test: Reduce timeout on necessary poll request

### DIFF
--- a/host/query_workflow_test.go
+++ b/host/query_workflow_test.go
@@ -121,7 +121,11 @@ func (s *IntegrationSuite) TestQueryWorkflow_Sticky() {
 
 	// Make a request with stick tasklist to refresh the stickiness, otherwise we won't be able to add
 	// decisions to the sticky tasklist
-	ctx, cancel := createContext()
+	// Matching rejects tasks for a sticky TaskList if it has never seen a poller before
+	// We need to do a "quick poll" so that it has seen us, and the only way to guarantee it observed the request
+	// is for this request to time out and receive no task in response. If we go shorter than 2s matching will reject
+	// this request.
+	ctx, cancel := context.WithTimeout(s.T().Context(), time.Second*5)
 	defer cancel()
 	resp, err := poller.Engine.PollForDecisionTask(ctx, &types.PollForDecisionTaskRequest{
 		Domain:   poller.Domain,


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
This test relies on a sticky poller to have polled the TaskList. Wait for a few seconds instead of ~70s.

**Why?**
Speed up integration tests

**How did you test it?**
Ran tests locally

**Potential risks**
Could introduce flakiness if somehow we're unable to execute the request within a few seconds in a test environment. 

**Release notes**


**Documentation Changes**

