### PR TITLE
test: Fix integration tests inadvertently relying on activity timeout

### DIFF
--- a/host/cancel_workflow_test.go
+++ b/host/cancel_workflow_test.go
@@ -327,8 +327,9 @@ func (s *IntegrationSuite) TestRequestCancelWorkflowDecisionExecution() {
 	s.Logger.Info("foreign PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
-	err = foreignPoller.PollAndProcessActivityTask(false)
-	s.Logger.Info("foreign PollAndProcessActivityTask", tag.Error(err))
+	// Complete the activity so the next decision is scheduled
+	err = poller.PollAndProcessActivityTask(false)
+	s.Logger.Info("PollAndProcessActivityTask", tag.Error(err))
 	s.Nil(err)
 
 	// Cancel the foreign workflow with this decision request.
@@ -337,7 +338,7 @@ func (s *IntegrationSuite) TestRequestCancelWorkflowDecisionExecution() {
 	s.Nil(err)
 
 	cancellationSent := false
-	intiatedEventID := 10
+	intiatedEventID := 11
 CheckHistoryLoopForCancelSent:
 	for i := 1; i < 10; i++ {
 		ctx, cancel := createContext()
@@ -505,13 +506,18 @@ func (s *IntegrationSuite) TestRequestCancelWorkflowDecisionExecution_UnKnownTar
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
+	// Complete the activity so the next decision is scheduled
+	err = poller.PollAndProcessActivityTask(false)
+	s.Logger.Info("PollAndProcessActivityTask", tag.Error(err))
+	s.Nil(err)
+
 	// Cancel the foreign workflow with this decision request.
 	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
 	cancellationSentFailed := false
-	intiatedEventID := 10
+	intiatedEventID := 11
 CheckHistoryLoopForCancelSent:
 	for i := 1; i < 10; i++ {
 		ctx, cancel := createContext()

--- a/host/signal_workflow_test.go
+++ b/host/signal_workflow_test.go
@@ -545,8 +545,9 @@ func (s *IntegrationSuite) TestSignalExternalWorkflowDecision() {
 	s.Logger.Info("foreign PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
-	err = foreignPoller.PollAndProcessActivityTask(false)
-	s.Logger.Info("foreign PollAndProcessActivityTask", tag.Error(err))
+	// Run the activity in the original workflow. Its completion triggers the next decision, which signals the foreign workflow.
+	err = poller.PollAndProcessActivityTask(false)
+	s.Logger.Info("PollAndProcessActivityTask", tag.Error(err))
 	s.Nil(err)
 
 	// Signal the foreign workflow with this decision request.
@@ -556,7 +557,7 @@ func (s *IntegrationSuite) TestSignalExternalWorkflowDecision() {
 
 	// in source workflow
 	signalSent := false
-	intiatedEventID := 10
+	intiatedEventID := 11
 CheckHistoryLoopForSignalSent:
 	for i := 1; i < 10; i++ {
 		ctx, cancel := createContext()
@@ -852,8 +853,9 @@ func (s *IntegrationSuite) TestSignalExternalWorkflowDecision_WithoutRunID() {
 	s.Logger.Info("foreign PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
-	err = foreignPoller.PollAndProcessActivityTask(false)
-	s.Logger.Info("foreign PollAndProcessActivityTask", tag.Error(err))
+	// Complete the activity so the next decision is scheduled
+	err = poller.PollAndProcessActivityTask(false)
+	s.Logger.Info("PollAndProcessActivityTask", tag.Error(err))
 	s.Nil(err)
 
 	// Signal the foreign workflow with this decision request.
@@ -863,7 +865,7 @@ func (s *IntegrationSuite) TestSignalExternalWorkflowDecision_WithoutRunID() {
 
 	// in source workflow
 	signalSent := false
-	intiatedEventID := 10
+	intiatedEventID := 11
 CheckHistoryLoopForSignalSent:
 	for i := 1; i < 10; i++ {
 		ctx, cancel := createContext()
@@ -1000,13 +1002,18 @@ func (s *IntegrationSuite) TestSignalExternalWorkflowDecision_UnKnownTarget() {
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
+	// Complete the activity so the next decision is scheduled
+	err = poller.PollAndProcessActivityTask(false)
+	s.Logger.Info("PollAndProcessActivityTask", tag.Error(err))
+	s.Nil(err)
+
 	// Signal the foreign workflow with this decision request.
 	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
 	signalSentFailed := false
-	intiatedEventID := 10
+	intiatedEventID := 11
 CheckHistoryLoopForCancelSent:
 	for i := 1; i < 10; i++ {
 		ctx, cancel := createContext()
@@ -1131,13 +1138,18 @@ func (s *IntegrationSuite) TestSignalExternalWorkflowDecision_SignalSelf() {
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
+	// Complete the activity so the next decision is scheduled
+	err = poller.PollAndProcessActivityTask(false)
+	s.Logger.Info("PollAndProcessActivityTask", tag.Error(err))
+	s.Nil(err)
+
 	// Signal the foreign workflow with this decision request.
 	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
 	signalSentFailed := false
-	intiatedEventID := 10
+	intiatedEventID := 11
 CheckHistoryLoopForCancelSent:
 	for i := 1; i < 10; i++ {
 		ctx, cancel := createContext()


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
These tests all have the same copy+pasted error that relies on an activity timeout before the next decision is dispatched (they run the activity from the workflow that doesn't care about it). As a result, each test takes 10s when it should take almost none.

Fix the tests and increment the expected event ID, as the history is going from (ActivityScheduled, ActivityTimedOut) to (ActivityScheduled, ActivityStarted, ActivityCompleted).

It would be better to rewrite these tests, but that's complex and time consuming while this provides an immediate improvement.

**Why?**
Speed up integration tests

**How did you test it?**
Running the tests

**Potential risks**
Low. These tests aren't timing based, so running faster shouldn't impact them.

**Release notes**


**Documentation Changes**

