### PR TITLE
test: Reduce time of TestQueryWorkflow_Consistent_NewDecisionTask_Sticky

### DIFF
--- a/host/query_workflow_test.go
+++ b/host/query_workflow_test.go
@@ -1222,7 +1222,7 @@ func (s *IntegrationSuite) TestQueryWorkflow_Consistent_NewDecisionTask_Sticky()
 
 	// Make a request with stick tasklist to refresh the stickiness, otherwise we won't be able to add
 	// decisions to the sticky tasklist
-	ctx, cancel := createContext()
+	ctx, cancel := context.WithTimeout(s.T().Context(), time.Second*5)
 	defer cancel()
 	resp, err := poller.Engine.PollForDecisionTask(ctx, &types.PollForDecisionTaskRequest{
 		Domain:   poller.Domain,


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
This test is quite complicated and generally questionable, so there's likely room to optimize it further. By replacing a long poll that's guaranteed to time out with a shorter poll we can reduce the execution time, regardless of everything else.

**Why?**
Speed up tests

**How did you test it?**
Running the test

**Potential risks**
This test is quite complicated and timing based. It's possible it becomes flaky, although that seems unlikely due to this being at the start of the test.

**Release notes**


**Documentation Changes**

