### PR TITLE
test: Reduce the execution time of TestQueryWorkflow_BeforeFirstDecision

### DIFF
--- a/host/query_workflow_test.go
+++ b/host/query_workflow_test.go
@@ -1404,7 +1404,8 @@ func (s *IntegrationSuite) TestQueryWorkflow_BeforeFirstDecision() {
 		RunID:      we.RunID,
 	}
 
-	ctx, cancel = createContext()
+	// This will wait until the context times out, so make it reasonably short
+	ctx, cancel = context.WithTimeout(s.T().Context(), 3*time.Second)
 	defer cancel()
 	// query workflow without any decision task should produce an error
 	_, err := s.Engine.QueryWorkflow(ctx, &types.QueryWorkflowRequest{


### PR DESCRIPTION

<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
History will repeatedly retry the query based on the context's timeout. Reduce the timeout so it runs faster.


**Why?**
Speed up the test

**How did you test it?**
Running it

**Potential risks**
This could increase flakiness if the test environment is unable to process the request at all within a few seconds.

**Release notes**


**Documentation Changes**

