### PR TITLE
test: Speed up TestSignalWithStartWorkflow_IDReusePolicy

### DIFF
--- a/host/signal_workflow_test.go
+++ b/host/signal_workflow_test.go
@@ -1546,6 +1546,11 @@ func (s *IntegrationSuite) TestSignalWithStartWorkflow_IDReusePolicy() {
 	_, err := poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
+	// Run the activity instead of waiting for it to time out
+	err = poller.PollAndProcessActivityTask(false)
+	s.Logger.Info("PollAndProcessActivityTask", tag.Error(err))
+	s.Nil(err)
+
 	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Avoid relying on activity timeouts.


**Why?**
Similar to https://github.com/cadence-workflow/cadence/pull/8290 , but a slightly different snippit.

**How did you test it?**
Running the tests.

**Potential risks**
Low. It's unlikely this introduces flakiness as the test relies on the completion of this workflow.

**Release notes**


**Documentation Changes**

