### PR TITLE
test: Fail test suites with slow tests

### DIFF
--- a/host/activity_test.go
+++ b/host/activity_test.go
@@ -167,7 +167,7 @@ func (s *IntegrationSuite) TestActivityHeartBeatWorkflow_Success() {
 	}
 }
 
-func (s *IntegrationSuite) TestActivityHeartbeatDetailsDuringRetry() {
+func (s *IntegrationSuite) TestActivityHeartbeatDetailsDuringRetry_SLOW() {
 	id := "integration-heartbeat-details-retry-test"
 	wt := "integration-heartbeat-details-retry-type"
 	tl := "integration-heartbeat-details-retry-tasklist"
@@ -347,7 +347,7 @@ func (s *IntegrationSuite) TestActivityHeartbeatDetailsDuringRetry() {
 	s.Equal(3, activityExecutedCount)
 }
 
-func (s *IntegrationSuite) TestActivityRetry() {
+func (s *IntegrationSuite) TestActivityRetry_SLOW() {
 	id := "integration-activity-retry-test"
 	wt := "integration-activity-retry-type"
 	tl := "integration-activity-retry-tasklist"
@@ -672,7 +672,7 @@ func (s *IntegrationSuite) TestActivityHeartBeatWorkflow_Timeout() {
 	s.True(workflowComplete)
 }
 
-func (s *IntegrationSuite) TestActivityTimeouts() {
+func (s *IntegrationSuite) TestActivityTimeouts_SLOW() {
 	id := "integration-activity-timeout-test"
 	wt := "integration-activity-timeout-test-type"
 	tl := "integration-activity-timeout-test-tasklist"
@@ -918,7 +918,7 @@ func (s *IntegrationSuite) TestActivityTimeouts() {
 	s.False(workflowFailed)
 }
 
-func (s *IntegrationSuite) TestActivityHeartbeatTimeouts() {
+func (s *IntegrationSuite) TestActivityHeartbeatTimeouts_SLOW() {
 	id := "integration-activity-heartbeat-timeout-test"
 	wt := "integration-activity-heartbeat-timeout-test-type"
 	tl := "integration-activity-heartbeat-timeout-test-tasklist"

--- a/host/archival_test.go
+++ b/host/archival_test.go
@@ -102,7 +102,7 @@ func (s *IntegrationSuite) TestArchival_ArchiverWorker() {
 	s.True(s.isMutableStateDeleted(domainID, execution))
 }
 
-func (s *IntegrationSuite) TestVisibilityArchival() {
+func (s *IntegrationSuite) TestVisibilityArchival_SLOW() {
 	s.True(s.TestCluster.archiverBase.metadata.GetVisibilityConfig().ClusterConfiguredForArchival())
 
 	domainID := s.getDomainID(s.ArchivalDomainName)

--- a/host/async_wf_test.go
+++ b/host/async_wf_test.go
@@ -130,7 +130,7 @@ func (s *AsyncWFIntegrationSuite) TearDownSuite() {
 	s.TearDownBaseSuite()
 }
 
-func (s *AsyncWFIntegrationSuite) TestStartWorkflowExecutionAsync() {
+func (s *AsyncWFIntegrationSuite) TestStartWorkflowExecutionAsync_SLOW() {
 	tests := []struct {
 		name             string
 		wantStartFailure bool

--- a/host/client_integration_test.go
+++ b/host/client_integration_test.go
@@ -99,6 +99,7 @@ func (s *ClientIntegrationSuite) SetupSuite() {
 }
 
 func (s *ClientIntegrationSuite) TearDownSuite() {
+	s.worker.Stop()
 	s.TearDownBaseSuite()
 }
 
@@ -381,7 +382,7 @@ func (s *ClientIntegrationSuite) TestClientDataConverter_WithChild() {
 	s.Equal(2, d.NumOfCallFromData)
 }
 
-func (s *ClientIntegrationSuite) Test_StickyWorkerRestartDecisionTask() {
+func (s *ClientIntegrationSuite) Test_StickyWorkerRestartDecisionTask_SLOW() {
 	testCases := []struct {
 		name       string
 		waitTime   time.Duration

--- a/host/continue_as_new_test.go
+++ b/host/continue_as_new_test.go
@@ -354,7 +354,7 @@ func (s *IntegrationSuite) TestWorkflowContinueAsNew_TaskID() {
 	}
 }
 
-func (s *IntegrationSuite) TestChildWorkflowWithContinueAsNew() {
+func (s *IntegrationSuite) TestChildWorkflowWithContinueAsNew_SLOW() {
 	parentID := "integration-child-workflow-with-continue-as-new-test-parent"
 	childID := "integration-child-workflow-with-continue-as-new-test-child"
 	wtParent := "integration-child-workflow-with-continue-as-new-test-parent-type"

--- a/host/cron_integration_test.go
+++ b/host/cron_integration_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/uber/cadence/common/types"
 )
 
-func (s *IntegrationSuite) TestCronWorkflowWithOverlapPolicy() {
+func (s *IntegrationSuite) TestCronWorkflowWithOverlapPolicy_SLOW() {
 	id := "integration-wf-cron-overlap-test"
 	wt := "integration-wf-cron-overlap-type"
 	tl := "integration-wf-cron-overlap-tasklist"
@@ -166,7 +166,7 @@ func (s *IntegrationSuite) TestCronWorkflowWithOverlapPolicy() {
 	}
 }
 
-func (s *IntegrationSuite) TestCronWorkflowOverlapBehavior() {
+func (s *IntegrationSuite) TestCronWorkflowOverlapBehavior_SLOW() {
 	id := "integration-wf-cron-overlap-behavior-test"
 	wt := "integration-wf-cron-overlap-behavior-type"
 	tl := "integration-wf-cron-overlap-behavior-tasklist"

--- a/host/decision_test.go
+++ b/host/decision_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/uber/cadence/common/types"
 )
 
-func (s *IntegrationSuite) TestDecisionHeartbeatingWithEmptyResult() {
+func (s *IntegrationSuite) TestDecisionHeartbeatingWithEmptyResult_SLOW() {
 	id := uuid.New()
 	wt := "integration-workflow-decision-heartbeating-local-activities"
 	tl := id

--- a/host/elastic_search_test.go
+++ b/host/elastic_search_test.go
@@ -272,7 +272,7 @@ func (s *ElasticSearchIntegrationSuite) TestListWorkflow_ExecutionTime() {
 	s.testHelperForReadOnce(we.GetRunID(), query, false, false)
 }
 
-func (s *ElasticSearchIntegrationSuite) TestListWorkflow_SearchAttribute() {
+func (s *ElasticSearchIntegrationSuite) TestListWorkflow_SearchAttribute_SLOW() {
 	id := "es-integration-list-workflow-by-search-attr-test"
 	wt := "es-integration-list-workflow-by-search-attr-test-type"
 	tl := "es-integration-list-workflow-by-search-attr-test-tasklist"
@@ -354,7 +354,7 @@ func (s *ElasticSearchIntegrationSuite) TestListWorkflow_SearchAttribute() {
 	s.Equal(expectedSearchAttributes, descResp.WorkflowExecutionInfo.GetSearchAttributes())
 }
 
-func (s *ElasticSearchIntegrationSuite) TestListWorkflow_PageToken() {
+func (s *ElasticSearchIntegrationSuite) TestListWorkflow_PageToken_SLOW() {
 	id := "es-integration-list-workflow-token-test"
 	wt := "es-integration-list-workflow-token-test-type"
 	tl := "es-integration-list-workflow-token-test-tasklist"
@@ -366,7 +366,7 @@ func (s *ElasticSearchIntegrationSuite) TestListWorkflow_PageToken() {
 	s.testListWorkflowHelper(numOfWorkflows, pageSize, request, id, wt, false)
 }
 
-func (s *ElasticSearchIntegrationSuite) TestListWorkflow_SearchAfter() {
+func (s *ElasticSearchIntegrationSuite) TestListWorkflow_SearchAfter_SLOW() {
 	id := "es-integration-list-workflow-searchAfter-test"
 	wt := "es-integration-list-workflow-searchAfter-test-type"
 	tl := "es-integration-list-workflow-searchAfter-test-tasklist"
@@ -378,7 +378,7 @@ func (s *ElasticSearchIntegrationSuite) TestListWorkflow_SearchAfter() {
 	s.testListWorkflowHelper(numOfWorkflows, pageSize, request, id, wt, false)
 }
 
-func (s *ElasticSearchIntegrationSuite) TestListWorkflow_OrQuery() {
+func (s *ElasticSearchIntegrationSuite) TestListWorkflow_OrQuery_SLOW() {
 	id := "es-integration-list-workflow-or-query-test"
 	wt := "es-integration-list-workflow-or-query-test-type"
 	tl := "es-integration-list-workflow-or-query-test-tasklist"
@@ -498,7 +498,7 @@ func (s *ElasticSearchIntegrationSuite) TestListWorkflow_OrQuery() {
 }
 
 // To test last page search trigger max window size error
-func (s *ElasticSearchIntegrationSuite) TestListWorkflow_MaxWindowSize() {
+func (s *ElasticSearchIntegrationSuite) TestListWorkflow_MaxWindowSize_SLOW() {
 	id := "es-integration-list-workflow-max-window-size-test"
 	wt := "es-integration-list-workflow-max-window-size-test-type"
 	tl := "es-integration-list-workflow-max-window-size-test-tasklist"
@@ -549,7 +549,7 @@ func (s *ElasticSearchIntegrationSuite) TestListWorkflow_MaxWindowSize() {
 	s.True(len(resp.GetNextPageToken()) == 0)
 }
 
-func (s *ElasticSearchIntegrationSuite) TestListWorkflow_OrderBy() {
+func (s *ElasticSearchIntegrationSuite) TestListWorkflow_OrderBy_SLOW() {
 	id := "es-integration-list-workflow-order-by-test"
 	wt := "es-integration-list-workflow-order-by-test-type"
 	tl := "es-integration-list-workflow-order-by-test-tasklist"
@@ -876,7 +876,7 @@ func (s *ElasticSearchIntegrationSuite) TestScanWorkflow_SearchAttribute() {
 	s.testHelperForReadOnce(we.GetRunID(), query, true, false)
 }
 
-func (s *ElasticSearchIntegrationSuite) TestScanWorkflow_PageToken() {
+func (s *ElasticSearchIntegrationSuite) TestScanWorkflow_PageToken_SLOW() {
 	id := "es-integration-scan-workflow-token-test"
 	wt := "es-integration-scan-workflow-token-test-type"
 	tl := "es-integration-scan-workflow-token-test-tasklist"
@@ -995,7 +995,7 @@ func (s *ElasticSearchIntegrationSuite) createActiveActiveStartWorkflowExecution
 	return request
 }
 
-func (s *ElasticSearchIntegrationSuite) TestUpsertWorkflowExecution() {
+func (s *ElasticSearchIntegrationSuite) TestUpsertWorkflowExecution_SLOW() {
 	id := "es-integration-upsert-workflow-test"
 	wt := "es-integration-upsert-workflow-test-type"
 	tl := "es-integration-upsert-workflow-test-tasklist"

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -594,7 +594,7 @@ func (s *IntegrationSuite) TestSequentialWorkflow() {
 	)
 }
 
-func (s *IntegrationSuite) TestDelayStartWorkflow() {
+func (s *IntegrationSuite) TestDelayStartWorkflow_SLOW() {
 	startWorkflowTS := time.Now()
 	RunSequentialWorkflow(
 		s,
@@ -887,7 +887,7 @@ func (s *IntegrationSuite) TestCompleteDecisionTaskAndCreateNewOne() {
 	s.Equal(types.EventTypeDecisionTaskStarted, newTask.DecisionTask.History.Events[3].GetEventType())
 }
 
-func (s *IntegrationSuite) TestDecisionAndActivityTimeoutsWorkflow() {
+func (s *IntegrationSuite) TestDecisionAndActivityTimeoutsWorkflow_SLOW() {
 	id := "integration-timeouts-workflow-test"
 	wt := "integration-timeouts-workflow-test-type"
 	tl := "integration-timeouts-workflow-test-tasklist"
@@ -1014,7 +1014,7 @@ func (s *IntegrationSuite) TestDecisionAndActivityTimeoutsWorkflow() {
 	s.True(workflowComplete)
 }
 
-func (s *IntegrationSuite) TestWorkflowRetry() {
+func (s *IntegrationSuite) TestWorkflowRetry_SLOW() {
 	id := "integration-wf-retry-test"
 	wt := "integration-wf-retry-type"
 	tl := "integration-wf-retry-tasklist"
@@ -1276,7 +1276,7 @@ func (s *IntegrationSuite) TestWorkflowRetryFailures() {
 
 }
 
-func (s *IntegrationSuite) TestCronWorkflow() {
+func (s *IntegrationSuite) TestCronWorkflow_SLOW() {
 	id := "integration-wf-cron-test"
 	wt := "integration-wf-cron-type"
 	tl := "integration-wf-cron-tasklist"
@@ -1504,7 +1504,7 @@ func (s *IntegrationSuite) TestCronWorkflow() {
 	}
 }
 
-func (s *IntegrationSuite) TestCronWorkflowTimeout() {
+func (s *IntegrationSuite) TestCronWorkflowTimeout_SLOW() {
 	id := "integration-wf-cron-timeout-test"
 	wt := "integration-wf-cron-timeout-type"
 	tl := "integration-wf-cron-timeout-tasklist"
@@ -1627,7 +1627,7 @@ func (s *IntegrationSuite) TestCronWorkflowTimeout() {
 	s.NoError(terminateErr)
 }
 
-func (s *IntegrationSuite) TestSequential_UserTimers() {
+func (s *IntegrationSuite) TestSequential_UserTimers_SLOW() {
 	id := "integration-sequential-user-timers-test"
 	wt := "integration-sequential-user-timers-test-type"
 	tl := "integration-sequential-user-timers-test-tasklist"
@@ -2434,7 +2434,7 @@ func (s *IntegrationSuite) TestChildWorkflowExecution() {
 	s.Equal([]byte("Child Done."), completedAttributes.Result)
 }
 
-func (s *IntegrationSuite) TestCronChildWorkflowExecution() {
+func (s *IntegrationSuite) TestCronChildWorkflowExecution_SLOW() {
 	parentID := "integration-cron-child-workflow-test-parent"
 	childID := "integration-cron-child-workflow-test-child"
 	wtParent := "integration-cron-child-workflow-test-parent-type"
@@ -4264,7 +4264,7 @@ func (s *IntegrationSuite) TestCancelTimer() {
 	}
 }
 
-func (s *IntegrationSuite) TestCancelTimer_CancelFiredAndBuffered() {
+func (s *IntegrationSuite) TestCancelTimer_CancelFiredAndBuffered_SLOW() {
 	id := "integration-cancel-timer-fired-and-buffered-test"
 	wt := "integration-cancel-timer-fired-and-buffered-test-type"
 	tl := "integration-cancel-timer-fired-and-buffered-test-tasklist"

--- a/host/integrationbase.go
+++ b/host/integrationbase.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -46,6 +47,13 @@ import (
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin/sqlite"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/environment"
+)
+
+const (
+	defaultTestLimit   = 3 * time.Second
+	slowTestLimit      = 40 * time.Second
+	suiteOverheadLimit = 30 * time.Second
+	slowTestSuffix     = "_SLOW"
 )
 
 type (
@@ -349,6 +357,30 @@ func (s *IntegrationBase) registerArchivalDomain() error {
 		)
 	}
 	return err
+}
+
+func (s *IntegrationBase) HandleStats(suiteName string, stats *suite.SuiteInformation) {
+	suiteDuration := stats.End.Sub(stats.Start)
+
+	var timeInTests time.Duration
+	for testName, info := range stats.TestStats {
+		testDuration := info.End.Sub(info.Start)
+
+		allowedTime := defaultTestLimit
+		if strings.HasSuffix(testName, slowTestSuffix) {
+			allowedTime = slowTestLimit
+		}
+
+		if testDuration > allowedTime {
+			s.Fail("Test took too long", "%s took %v (limit %v)", testName, testDuration, allowedTime)
+		}
+		timeInTests += testDuration
+	}
+
+	suiteOverhead := suiteDuration - timeInTests
+	if suiteOverhead > suiteOverheadLimit {
+		s.Fail("Test suite took too long to setup and teardown", "%s had overhead of %v (limit %v)", suiteName, suiteOverhead, suiteOverheadLimit)
+	}
 }
 
 // PrettyPrintHistory prints history in human readable format

--- a/host/pinot_test.go
+++ b/host/pinot_test.go
@@ -171,7 +171,7 @@ func (s *PinotIntegrationSuite) TearDownSuite() {
 	// currently it is not supported
 }
 
-func (s *PinotIntegrationSuite) TestListOpenWorkflow() {
+func (s *PinotIntegrationSuite) TestListOpenWorkflow_SLOW() {
 	id := "pinot-integration-start-workflow-test"
 	wt := "pinot-integration-start-workflow-test-type"
 	tl := "pinot-integration-start-workflow-test-tasklist"
@@ -217,7 +217,7 @@ func (s *PinotIntegrationSuite) TestListOpenWorkflow() {
 	s.Equal(attrValBytes, openExecution.SearchAttributes.GetIndexedFields()[s.testSearchAttributeKey])
 }
 
-func (s *PinotIntegrationSuite) TestListWorkflow() {
+func (s *PinotIntegrationSuite) TestListWorkflow_SLOW() {
 	id := "pinot-integration-list-workflow-test"
 	wt := "pinot-integration-list-workflow-test-type"
 	tl := "pinot-integration-list-workflow-test-tasklist"
@@ -331,7 +331,7 @@ func (s *PinotIntegrationSuite) startWorkflow(
 	return we
 }
 
-func (s *PinotIntegrationSuite) TestListCronWorkflows() {
+func (s *PinotIntegrationSuite) TestListCronWorkflows_SLOW() {
 	we1 := s.startWorkflow("cron", true)
 	we2 := s.startWorkflow("regular", false)
 
@@ -342,14 +342,14 @@ func (s *PinotIntegrationSuite) TestListCronWorkflows() {
 	s.testHelperForReadOnce(we2.GetRunID(), query, false, true)
 }
 
-func (s *PinotIntegrationSuite) TestIsGlobalSearchAttribute() {
+func (s *PinotIntegrationSuite) TestIsGlobalSearchAttribute_SLOW() {
 	we := s.startWorkflow("local", true)
 	// global domains are disabled for this integration test, so we can only test the false case
 	query := fmt.Sprintf(`NumClusters = "1"`)
 	s.testHelperForReadOnce(we.GetRunID(), query, false, true)
 }
 
-func (s *PinotIntegrationSuite) TestListWorkflow_ExecutionTime() {
+func (s *PinotIntegrationSuite) TestListWorkflow_ExecutionTime_SLOW() {
 	id := "pinot-integration-list-workflow-execution-time-test"
 	wt := "pinot-integration-list-workflow-execution-time-test-type"
 	tl := "pinot-integration-list-workflow-execution-time-test-tasklist"
@@ -373,7 +373,7 @@ func (s *PinotIntegrationSuite) TestListWorkflow_ExecutionTime() {
 	s.testHelperForReadOnce(we.GetRunID(), query, false, false)
 }
 
-func (s *PinotIntegrationSuite) TestListWorkflow_SearchAttribute() {
+func (s *PinotIntegrationSuite) TestListWorkflow_SearchAttribute_SLOW() {
 	id := "pinot-integration-list-workflow-by-search-attr-test"
 	wt := "pinot-integration-list-workflow-by-search-attr-test-type"
 	tl := "pinot-integration-list-workflow-by-search-attr-test-tasklist"
@@ -453,7 +453,7 @@ func (s *PinotIntegrationSuite) TestListWorkflow_SearchAttribute() {
 	s.Equal(expectedSearchAttributes, descResp.WorkflowExecutionInfo.GetSearchAttributes())
 }
 
-func (s *PinotIntegrationSuite) TestListWorkflow_PageToken() {
+func (s *PinotIntegrationSuite) TestListWorkflow_PageToken_SLOW() {
 	id := "pinot-integration-list-workflow-token-test"
 	wt := "pinot-integration-list-workflow-token-test-type"
 	tl := "pinot-integration-list-workflow-token-test-tasklist"
@@ -465,7 +465,7 @@ func (s *PinotIntegrationSuite) TestListWorkflow_PageToken() {
 	s.testListWorkflowHelper(numOfWorkflows, pageSize, request, id, wt, false)
 }
 
-func (s *PinotIntegrationSuite) TestListWorkflow_SearchAfter() {
+func (s *PinotIntegrationSuite) TestListWorkflow_SearchAfter_SLOW() {
 	id := "pinot-integration-list-workflow-searchAfter-test"
 	wt := "pinot-integration-list-workflow-searchAfter-test-type"
 	tl := "pinot-integration-list-workflow-searchAfter-test-tasklist"
@@ -477,7 +477,7 @@ func (s *PinotIntegrationSuite) TestListWorkflow_SearchAfter() {
 	s.testListWorkflowHelper(numOfWorkflows, pageSize, request, id, wt, false)
 }
 
-func (s *PinotIntegrationSuite) TestListWorkflow_OrQuery() {
+func (s *PinotIntegrationSuite) TestListWorkflow_OrQuery_SLOW() {
 	id := "pinot-integration-list-workflow-or-query-test"
 	wt := "pinot-integration-list-workflow-or-query-test-type"
 	tl := "pinot-integration-list-workflow-or-query-test-tasklist"
@@ -588,7 +588,7 @@ func (s *PinotIntegrationSuite) TestListWorkflow_OrQuery() {
 }
 
 // To test last page search trigger max window size error
-func (s *PinotIntegrationSuite) TestListWorkflow_MaxWindowSize() {
+func (s *PinotIntegrationSuite) TestListWorkflow_MaxWindowSize_SLOW() {
 	id := "pinot-integration-list-workflow-max-window-size-test"
 	wt := "pinot-integration-list-workflow-max-window-size-test-type"
 	tl := "pinot-integration-list-workflow-max-window-size-test-tasklist"
@@ -634,7 +634,7 @@ func (s *PinotIntegrationSuite) TestListWorkflow_MaxWindowSize() {
 	s.True(len(resp.GetNextPageToken()) == 0)
 }
 
-func (s *PinotIntegrationSuite) TestListWorkflow_OrderBy() {
+func (s *PinotIntegrationSuite) TestListWorkflow_OrderBy_SLOW() {
 	id := "pinot-integration-list-workflow-order-by-test"
 	wt := "pinot-integration-list-workflow-order-by-test-type"
 	tl := "pinot-integration-list-workflow-order-by-test-tasklist"
@@ -846,7 +846,7 @@ func (s *PinotIntegrationSuite) testListWorkflowHelper(numOfWorkflows, pageSize 
 	s.Nil(nextPageToken)
 }
 
-func (s *PinotIntegrationSuite) TestScanWorkflow() {
+func (s *PinotIntegrationSuite) TestScanWorkflow_SLOW() {
 	id := "pinot-integration-scan-workflow-test"
 	wt := "pinot-integration-scan-workflow-test-type"
 	tl := "pinot-integration-scan-workflow-test-tasklist"
@@ -877,7 +877,7 @@ func (s *PinotIntegrationSuite) TestScanWorkflow() {
 	s.testHelperForReadOnce(we.GetRunID(), query, true, false)
 }
 
-func (s *PinotIntegrationSuite) TestScanWorkflow_SearchAttribute() {
+func (s *PinotIntegrationSuite) TestScanWorkflow_SearchAttribute_SLOW() {
 	id := "pinot-integration-scan-workflow-search-attr-test"
 	wt := "pinot-integration-scan-workflow-search-attr-test-type"
 	tl := "pinot-integration-scan-workflow-search-attr-test-tasklist"
@@ -898,7 +898,7 @@ func (s *PinotIntegrationSuite) TestScanWorkflow_SearchAttribute() {
 	s.testHelperForReadOnce(we.GetRunID(), query, true, false)
 }
 
-func (s *PinotIntegrationSuite) TestScanWorkflow_PageToken() {
+func (s *PinotIntegrationSuite) TestScanWorkflow_PageToken_SLOW() {
 	id := "pinot-integration-scan-workflow-token-test"
 	wt := "pinot-integration-scan-workflow-token-test-type"
 	tl := "pinot-integration-scan-workflow-token-test-tasklist"
@@ -926,7 +926,7 @@ func (s *PinotIntegrationSuite) TestScanWorkflow_PageToken() {
 	s.testListWorkflowHelper(numOfWorkflows, pageSize, request, id, wt, true)
 }
 
-func (s *PinotIntegrationSuite) TestCountWorkflow() {
+func (s *PinotIntegrationSuite) TestCountWorkflow_SLOW() {
 	id := "pinot-integration-count-workflow-test"
 	wt := "pinot-integration-count-workflow-test-type"
 	tl := "pinot-integration-count-workflow-test-tasklist"
@@ -967,7 +967,7 @@ func (s *PinotIntegrationSuite) TestCountWorkflow() {
 	s.Equal(int64(0), resp.GetCount())
 }
 
-func (s *PinotIntegrationSuite) TestUpsertWorkflowExecution() {
+func (s *PinotIntegrationSuite) TestUpsertWorkflowExecution_SLOW() {
 	id := "pinot-integration-upsert-workflow-test"
 	wt := "pinot-integration-upsert-workflow-test-type"
 	tl := "pinot-integration-upsert-workflow-test-tasklist"

--- a/host/query_workflow_test.go
+++ b/host/query_workflow_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/uber/cadence/common/types"
 )
 
-func (s *IntegrationSuite) TestQueryWorkflow_Sticky() {
+func (s *IntegrationSuite) TestQueryWorkflow_Sticky_SLOW() {
 	id := "interation-query-workflow-test-sticky"
 	wt := "interation-query-workflow-test-sticky-type"
 	tl := "interation-query-workflow-test-sticky-tasklist"
@@ -775,7 +775,7 @@ func (s *IntegrationSuite) TestQueryWorkflow_Consistent_PiggybackQuery() {
 	s.Equal("consistent query result", queryResultString)
 }
 
-func (s *IntegrationSuite) TestQueryWorkflow_Consistent_Timeout() {
+func (s *IntegrationSuite) TestQueryWorkflow_Consistent_Timeout_SLOW() {
 	id := "integration-query-workflow-test-consistent-timeout"
 	wt := "integration-query-workflow-test-consistent-timeout-type"
 	tl := "integration-query-workflow-test-consistent-timeout-tasklist"
@@ -939,7 +939,7 @@ func (s *IntegrationSuite) TestQueryWorkflow_Consistent_Timeout() {
 	s.Error(queryResult.Err) // got a timeout error
 }
 
-func (s *IntegrationSuite) TestQueryWorkflow_Consistent_BlockedByStarted_NonSticky() {
+func (s *IntegrationSuite) TestQueryWorkflow_Consistent_BlockedByStarted_NonSticky_SLOW() {
 	id := "integration-query-workflow-test-consistent-blocked-by-started-non-sticky"
 	wt := "integration-query-workflow-test-consistent-blocked-by-started-non-sticky-type"
 	tl := "integration-query-workflow-test-consistent-blocked-by-started-non-sticky-tasklist"
@@ -1130,7 +1130,7 @@ func (s *IntegrationSuite) TestQueryWorkflow_Consistent_BlockedByStarted_NonStic
 	s.Equal("query-result", queryResultString)
 }
 
-func (s *IntegrationSuite) TestQueryWorkflow_Consistent_NewDecisionTask_Sticky() {
+func (s *IntegrationSuite) TestQueryWorkflow_Consistent_NewDecisionTask_Sticky_SLOW() {
 	id := "integration-query-workflow-test-consistent-new-decision-task-sticky"
 	wt := "integration-query-workflow-test-consistent-new-decision-task-sticky-type"
 	tl := "integration-query-workflow-test-consistent-new-decision-task-sticky-tasklist"

--- a/host/reset_workflow_test.go
+++ b/host/reset_workflow_test.go
@@ -46,7 +46,7 @@ import (
 //
 // Topology exercised: baseRunID --(continue-as-new)--> currentRunID (open)
 // Reset baseRunID with SkipSignalReapply=false to trigger the chain traversal.
-func (s *IntegrationSuite) TestResetWorkflow_ContinueAsNew_DeadlockRegression() {
+func (s *IntegrationSuite) TestResetWorkflow_ContinueAsNew_DeadlockRegression_SLOW() {
 	id := "integration-reset-workflow-can-deadlock-regression-test"
 	wt := "integration-reset-workflow-can-deadlock-regression-test-type"
 	tl := "integration-reset-workflow-can-deadlock-regression-test-tasklist"

--- a/host/retry_policy_workflow_test.go
+++ b/host/retry_policy_workflow_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/uber/cadence/common/types"
 )
 
-func (s *IntegrationSuite) TestWorkflowRetryPolicyTimeout() {
+func (s *IntegrationSuite) TestWorkflowRetryPolicyTimeout_SLOW() {
 	id := "integration-workflow-retry-policy-timeout-test"
 	wt := "integration-workflow-retry-policy-timeout-test-type"
 	tl := "integration-workflow-retry-policy-timeout-test-tasklist"
@@ -97,7 +97,7 @@ func (s *IntegrationSuite) TestWorkflowRetryPolicyTimeout() {
 	s.True(delta < 4*time.Second)
 }
 
-func (s *IntegrationSuite) TestWorkflowRetryPolicyContinueAsNewAsRetry() {
+func (s *IntegrationSuite) TestWorkflowRetryPolicyContinueAsNewAsRetry_SLOW() {
 	id := "integration-workflow-retry-policy-continue-as-new-retry-test"
 	wt := "integration-workflow-retry-policy-continue-as-new-retry-test-type"
 	tl := "integration-workflow-retry-policy-continue-as-new-retry-test-tasklist"

--- a/host/schedule_test.go
+++ b/host/schedule_test.go
@@ -32,7 +32,7 @@ import (
 // TestScheduleSmokeTest verifies the schedule pipeline end-to-end against the
 // integration test cluster: CreateSchedule, wait for the scheduler workflow to
 // fire at least one target run, DeleteSchedule.
-func (s *IntegrationSuite) TestScheduleSmokeTest() {
+func (s *IntegrationSuite) TestScheduleSmokeTest_SLOW() {
 	if s.TestClusterConfig.WorkerConfig == nil || !s.TestClusterConfig.WorkerConfig.EnableScheduler {
 		s.T().Skip("scheduler worker manager not enabled on this cluster")
 	}

--- a/host/task_list_isolation_test.go
+++ b/host/task_list_isolation_test.go
@@ -119,7 +119,7 @@ func (s *TaskListIsolationIntegrationSuite) TestTaskListIsolation() {
 	}
 }
 
-func (s *TaskListIsolationIntegrationSuite) TestTaskListIsolationLeak() {
+func (s *TaskListIsolationIntegrationSuite) TestTaskListIsolationLeak_SLOW() {
 	runID := s.startWorkflow("a").RunID
 
 	bPoller := s.createPoller("b")

--- a/host/workflowsidinternalratelimit_test.go
+++ b/host/workflowsidinternalratelimit_test.go
@@ -109,7 +109,7 @@ func (s *WorkflowIDInternalRateLimitIntegrationSuite) TearDownSuite() {
 	s.TearDownBaseSuite()
 }
 
-func (s *WorkflowIDInternalRateLimitIntegrationSuite) TestWorkflowIDSpecificInternalRateLimits() {
+func (s *WorkflowIDInternalRateLimitIntegrationSuite) TestWorkflowIDSpecificInternalRateLimits_SLOW() {
 	const (
 		testWorkflowID   = "integration-workflow-specific-internal-rate-limit-test"
 		testWorkflowType = "integration-workflow-specific-internal-rate-limit-test-type"


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Go and testify's Suite feature don't have a great mechanism for granularly controlling test timeout. We need to enforce that integration tests execute quickly to ensure that changes don't accidentally break behavior by slowing it down and to provide a better developer experience.

Inspect test stats after suite execution and fail the suite if the tests are too slow.

Introduce a default per-test limit of 3s. Most tests complete in a fraction of a second, so this timeout is generous to avoid flakes.

Allow tests to suffix themselves with _SLOW to get a timeout of 40s. Update all existing slow tests to include this suffix.

Additionally compare the time of the suite to the total time of its tests and fail suites with significant overhead. Most suites take 11s to startup due to waiting for the domain cache to refresh and otherwise have little overhead. Significant overhead indicates some structural issue with the suite, such as incorrect cleanup.

**Why?**
- Prevent performance/behavior regressions being introduced in tests.
- Improve developer experience by providing faster feedback on changes.

**How did you test it?**
- Running the integration tests locally

**Potential risks**
- This could introduce additional flakiness. Tests may pass in the runs used to validate this change that are just below the threshold, or some tests may be significantly variable in how long they take to execute.

**Release notes**


**Documentation Changes**

