### PR TITLE
chore(graceful failover): add pending shards to graceful failover timeout log

### DIFF
--- a/common/domain/failover_watcher.go
+++ b/common/domain/failover_watcher.go
@@ -28,6 +28,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/uber/cadence/client/history"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/cache"
@@ -38,6 +39,7 @@ import (
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/types"
 )
 
 const (
@@ -62,6 +64,7 @@ type (
 		clusterMetadata cluster.Metadata
 		domainManager   persistence.DomainManager
 		domainCache     cache.DomainCache
+		historyClient   history.Client
 		timeSource      clock.TimeSource
 		scope           metrics.Scope
 		logger          log.Logger
@@ -75,6 +78,7 @@ func NewFailoverWatcher(
 	domainCache cache.DomainCache,
 	domainManager persistence.DomainManager,
 	clusterMetadata cluster.Metadata,
+	historyClient history.Client,
 	timeSource clock.TimeSource,
 	refreshInterval dynamicproperties.DurationPropertyFn,
 	refreshJitter dynamicproperties.FloatPropertyFn,
@@ -96,6 +100,7 @@ func NewFailoverWatcher(
 		clusterMetadata: clusterMetadata,
 		domainCache:     domainCache,
 		domainManager:   domainManager,
+		historyClient:   historyClient,
 		timeSource:      timeSource,
 		scope:           metricsClient.Scope(metrics.DomainFailoverScope),
 		logger:          logger,
@@ -160,6 +165,25 @@ func (p *failoverWatcherImpl) handleFailoverTimeout(
 	failoverEndTime := domain.GetFailoverEndTime()
 	if domain.IsDomainPendingActive() && p.timeSource.Now().After(time.Unix(0, *failoverEndTime)) {
 		domainID := domain.GetInfo().ID
+
+		var pendingShards []int32
+		var completedShardCount int32
+		if p.historyClient != nil {
+			failoverInfo, infoErr := p.historyClient.GetFailoverInfo(context.Background(), &types.GetFailoverInfoRequest{
+				DomainID: domainID,
+			})
+			if infoErr != nil {
+				p.logger.Error("Failed to get failover info before force-completing",
+					tag.WorkflowDomainID(domainID),
+					tag.WorkflowDomainName(domain.GetInfo().Name),
+					tag.Error(infoErr),
+				)
+			} else {
+				pendingShards = failoverInfo.GetPendingShards()
+				completedShardCount = failoverInfo.GetCompletedShardCount()
+			}
+		}
+
 		// force failover the domain without setting the failover timeout
 		updated, err := CleanPendingActiveState(
 			p.domainManager,
@@ -186,6 +210,9 @@ func (p *failoverWatcherImpl) handleFailoverTimeout(
 			tag.PrevActiveCluster(sourceCluster),
 			tag.ActiveClusterName(domain.GetReplicationConfig().ActiveClusterName),
 			tag.Dynamic("failover-end-time", time.Unix(0, *failoverEndTime)),
+			tag.Dynamic("completed-shard-count", completedShardCount),
+			tag.Dynamic("pending-shard-count", len(pendingShards)),
+			tag.Dynamic("pending-shards", pendingShards),
 		)
 		p.scope.Tagged(metrics.DomainTag(domain.GetInfo().Name)).IncCounter(metrics.GracefulFailoverFailure)
 	}

--- a/common/domain/failover_watcher.go
+++ b/common/domain/failover_watcher.go
@@ -169,9 +169,11 @@ func (p *failoverWatcherImpl) handleFailoverTimeout(
 		var pendingShards []int32
 		var completedShardCount int32
 		if p.historyClient != nil {
-			failoverInfo, infoErr := p.historyClient.GetFailoverInfo(context.Background(), &types.GetFailoverInfoRequest{
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			failoverInfo, infoErr := p.historyClient.GetFailoverInfo(ctx, &types.GetFailoverInfoRequest{
 				DomainID: domainID,
 			})
+			cancel()
 			if infoErr != nil {
 				p.logger.Error("Failed to get failover info before force-completing",
 					tag.WorkflowDomainID(domainID),

--- a/common/domain/failover_watcher_test.go
+++ b/common/domain/failover_watcher_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/mock/gomock"
 
+	"github.com/uber/cadence/client/history"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/clock"
@@ -43,6 +44,7 @@ import (
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/types"
 )
 
 type (
@@ -52,10 +54,11 @@ type (
 		*require.Assertions
 		controller *gomock.Controller
 
-		mockDomainCache *cache.MockDomainCache
-		timeSource      clock.TimeSource
-		mockMetadataMgr *mocks.MetadataManager
-		watcher         *failoverWatcherImpl
+		mockDomainCache   *cache.MockDomainCache
+		mockHistoryClient *history.MockClient
+		timeSource        clock.TimeSource
+		mockMetadataMgr   *mocks.MetadataManager
+		watcher           *failoverWatcherImpl
 	}
 )
 
@@ -78,6 +81,7 @@ func (s *failoverWatcherSuite) SetupTest() {
 	s.controller = gomock.NewController(s.T())
 
 	s.mockDomainCache = cache.NewMockDomainCache(s.controller)
+	s.mockHistoryClient = history.NewMockClient(s.controller)
 	s.timeSource = clock.NewMockedTimeSource()
 	s.mockMetadataMgr = &mocks.MetadataManager{}
 
@@ -92,6 +96,7 @@ func (s *failoverWatcherSuite) SetupTest() {
 		s.mockDomainCache,
 		s.mockMetadataMgr,
 		cluster.GetTestClusterMetadata(true),
+		s.mockHistoryClient,
 		s.timeSource,
 		dynamicproperties.GetDurationPropertyFn(10*time.Second),
 		dynamicproperties.GetFloatPropertyFn(0.2),
@@ -239,6 +244,13 @@ func (s *failoverWatcherSuite) TestHandleFailoverTimeout() {
 		NotificationVersion:         1,
 	}).Return(nil).Times(1)
 
+	s.mockHistoryClient.EXPECT().GetFailoverInfo(gomock.Any(), &types.GetFailoverInfoRequest{
+		DomainID: domainName,
+	}).Return(&types.GetFailoverInfoResponse{
+		CompletedShardCount: 1,
+		PendingShards:       []int32{1},
+	}, nil).Times(1)
+
 	domainEntry := cache.NewDomainCacheEntryForTest(
 		info,
 		domainConfig,
@@ -310,6 +322,11 @@ func (s *failoverWatcherSuite) TestRefreshDomainLoop() {
 	}, nil).Once()
 
 	s.mockMetadataMgr.On("UpdateDomain", mock.Anything, mock.Anything).Return(nil).Once()
+
+	s.mockHistoryClient.EXPECT().GetFailoverInfo(gomock.Any(), gomock.Any()).Return(&types.GetFailoverInfoResponse{
+		CompletedShardCount: 0,
+		PendingShards:       []int32{0, 1},
+	}, nil).AnyTimes()
 
 	s.watcher.Start()
 

--- a/service/frontend/admin/handler.go
+++ b/service/frontend/admin/handler.go
@@ -142,6 +142,7 @@ func NewHandler(
 			resource.GetDomainCache(),
 			resource.GetDomainManager(),
 			resource.GetClusterMetadata(),
+			resource.GetHistoryClient(),
 			resource.GetTimeSource(),
 			config.DomainFailoverRefreshInterval,
 			config.DomainFailoverRefreshTimerJitterCoefficient,


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Added pending shards and pending shard count to graceful failover timeout log. For this, the watcher makes a call to the coordinator to get the failover status.

https://github.com/cadence-workflow/cadence/issues/8138

**Why?**
The log currently doesn't have the pending shards during graceful failover timeout. Having the shards help users investigate the cause and impact for the shards that were still pending.

**How did you test it?**
Updated test in unit tests
go test -race -count=1 -run TestFailoverWatcherSuite ./common/domain/...

**Potential risks**
There is an extra call made to the the history service. If it fails, we still continue, so there is no impact to the existing flow. Graceful failovers don't happen very often and the added latency is irrelevant.

**Release notes**
N/A

**Documentation Changes**
N/A
