### PR TITLE
feat(graceful failover): add graceful failover option to cadence-sys-failover-v2-workflow

### DIFF
--- a/common/constants/constants.go
+++ b/common/constants/constants.go
@@ -182,6 +182,10 @@ const (
 	DomainDataKeyForClusterAttributePreferences = "ClusterAttributePreferences"
 	// DomainDataKeyForFailoverHistory is the key of DomainData for failover history
 	DomainDataKeyForFailoverHistory = "FailoverHistory"
+	// DomainDataKeyForFailoverTimeoutSeconds is the key of DomainData for graceful failover timeout.
+	// When set to a value > 0, failover and rebalance workflows use graceful failover with this timeout.
+	// When empty or zero, force failover is used.
+	DomainDataKeyForFailoverTimeoutSeconds = "fts"
 	// DomainDataKeyForReadGroups stores which groups have read permission of the domain API
 	DomainDataKeyForReadGroups = "READ_GROUPS"
 	// DomainDataKeyForWriteGroups stores which groups have write permission of the domain API

--- a/common/constants/constants.go
+++ b/common/constants/constants.go
@@ -185,7 +185,7 @@ const (
 	// DomainDataKeyForFailoverTimeoutSeconds is the key of DomainData for graceful failover timeout.
 	// When set to a value > 0, failover and rebalance workflows use graceful failover with this timeout.
 	// When empty or zero, force failover is used.
-	DomainDataKeyForFailoverTimeoutSeconds = "fts"
+	DomainDataKeyForFailoverTimeoutSeconds = "FailoverTimeoutInSeconds"
 	// DomainDataKeyForReadGroups stores which groups have read permission of the domain API
 	DomainDataKeyForReadGroups = "READ_GROUPS"
 	// DomainDataKeyForWriteGroups stores which groups have write permission of the domain API

--- a/service/worker/failovermanager/failover_workflow_v2.go
+++ b/service/worker/failovermanager/failover_workflow_v2.go
@@ -29,6 +29,7 @@ import (
 
 	"go.uber.org/cadence/activity"
 	"go.uber.org/cadence/workflow"
+	"go.uber.org/zap"
 
 	"github.com/uber/cadence/common/types"
 )
@@ -206,7 +207,7 @@ func GetDomainsForFailoverV2Activity(ctx context.Context, params *GetDomainsForF
 		if !isEligibleForFailover(domain) {
 			continue
 		}
-		prefs, snapshot, ok := failoverPreferencesForDomain(domain, params.SourceClusters, params.TargetCluster, params.ClusterAttributes)
+		prefs, snapshot, ok := failoverPreferencesForDomain(domain, params.SourceClusters, params.TargetCluster, params.ClusterAttributes, logger)
 		if !ok {
 			continue
 		}
@@ -224,6 +225,7 @@ func failoverPreferencesForDomain(
 	sourceClusters []string,
 	targetCluster string,
 	clusterAttributeFilter []types.ClusterAttribute,
+	logger *zap.Logger,
 ) (DomainFailoverPreferences, DomainSnapshot, bool) {
 	name := domain.GetDomainInfo().GetName()
 	prefs := DomainFailoverPreferences{DomainName: name}
@@ -264,7 +266,7 @@ func failoverPreferencesForDomain(
 	if prefs.TargetCluster == "" && len(prefs.ClusterAttributeUpdates) == 0 {
 		return DomainFailoverPreferences{}, DomainSnapshot{}, false
 	}
-	prefs.FailoverTimeoutSeconds = getFailoverTimeoutSeconds(domain)
+	prefs.FailoverTimeoutSeconds = getFailoverTimeoutSeconds(domain, logger)
 	return prefs, snapshot, true
 }
 

--- a/service/worker/failovermanager/failover_workflow_v2.go
+++ b/service/worker/failovermanager/failover_workflow_v2.go
@@ -210,7 +210,6 @@ func GetDomainsForFailoverV2Activity(ctx context.Context, params *GetDomainsForF
 		if !ok {
 			continue
 		}
-		prefs.FailoverTimeoutSeconds = getFailoverTimeoutSeconds(domain)
 		warnIfMissingPollers(ctx, logger, prefs)
 		result.Preferences = append(result.Preferences, prefs)
 		result.Snapshots = append(result.Snapshots, snapshot)
@@ -265,6 +264,7 @@ func failoverPreferencesForDomain(
 	if prefs.TargetCluster == "" && len(prefs.ClusterAttributeUpdates) == 0 {
 		return DomainFailoverPreferences{}, DomainSnapshot{}, false
 	}
+	prefs.FailoverTimeoutSeconds = getFailoverTimeoutSeconds(domain)
 	return prefs, snapshot, true
 }
 

--- a/service/worker/failovermanager/failover_workflow_v2.go
+++ b/service/worker/failovermanager/failover_workflow_v2.go
@@ -210,6 +210,7 @@ func GetDomainsForFailoverV2Activity(ctx context.Context, params *GetDomainsForF
 		if !ok {
 			continue
 		}
+		prefs.FailoverTimeoutSeconds = getFailoverTimeoutSeconds(domain)
 		warnIfMissingPollers(ctx, logger, prefs)
 		result.Preferences = append(result.Preferences, prefs)
 		result.Snapshots = append(result.Snapshots, snapshot)

--- a/service/worker/failovermanager/failover_workflow_v2_test.go
+++ b/service/worker/failovermanager/failover_workflow_v2_test.go
@@ -32,6 +32,7 @@ import (
 	"go.uber.org/cadence/testsuite"
 	"go.uber.org/cadence/workflow"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
 
 	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/types"
@@ -236,7 +237,7 @@ func TestFailoverPreferencesForDomain(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prefs, snapshot, ok := failoverPreferencesForDomain(tt.domain, []string{src}, tgt, tt.filter)
+			prefs, snapshot, ok := failoverPreferencesForDomain(tt.domain, []string{src}, tgt, tt.filter, zap.NewNop())
 			assert.Equal(t, tt.wantOK, ok)
 			if !tt.wantOK {
 				return

--- a/service/worker/failovermanager/rebalance_workflow_v2.go
+++ b/service/worker/failovermanager/rebalance_workflow_v2.go
@@ -144,7 +144,6 @@ func GetDomainsForRebalanceV2Activity(ctx context.Context) ([]DomainFailoverPref
 				zap.String("domain", domain.GetDomainInfo().GetName()), zap.Error(err))
 			continue
 		}
-		prefs.FailoverTimeoutSeconds = getFailoverTimeoutSeconds(domain)
 		warnIfMissingPollers(ctx, logger, prefs)
 		res = append(res, prefs)
 	}
@@ -178,6 +177,7 @@ func rebalancePreferencesForDomain(domain *types.DescribeDomainResponse) (Domain
 	if prefs.TargetCluster == "" && len(prefs.ClusterAttributeUpdates) == 0 {
 		return DomainFailoverPreferences{}, errNoRebalanceRequiredV2
 	}
+	prefs.FailoverTimeoutSeconds = getFailoverTimeoutSeconds(domain)
 	return prefs, nil
 }
 

--- a/service/worker/failovermanager/rebalance_workflow_v2.go
+++ b/service/worker/failovermanager/rebalance_workflow_v2.go
@@ -138,7 +138,7 @@ func GetDomainsForRebalanceV2Activity(ctx context.Context) ([]DomainFailoverPref
 	}
 	var res []DomainFailoverPreferences
 	for _, domain := range domains {
-		prefs, err := rebalancePreferencesForDomain(domain)
+		prefs, err := rebalancePreferencesForDomain(domain, logger)
 		if err != nil {
 			logger.Info("skipping domain: no rebalance required",
 				zap.String("domain", domain.GetDomainInfo().GetName()), zap.Error(err))
@@ -153,7 +153,7 @@ func GetDomainsForRebalanceV2Activity(ctx context.Context) ([]DomainFailoverPref
 // rebalancePreferencesForDomain builds the preferences for one domain, or returns an error when the
 // domain is ineligible or already balanced. A malformed ClusterAttributePreferences value is treated
 // as "no attribute preferences" so a single bad domain does not block the rest.
-func rebalancePreferencesForDomain(domain *types.DescribeDomainResponse) (DomainFailoverPreferences, error) {
+func rebalancePreferencesForDomain(domain *types.DescribeDomainResponse, logger *zap.Logger) (DomainFailoverPreferences, error) {
 	if !isEligibleForFailover(domain) {
 		return DomainFailoverPreferences{}, errors.New("domain is not eligible for rebalance")
 	}
@@ -177,7 +177,7 @@ func rebalancePreferencesForDomain(domain *types.DescribeDomainResponse) (Domain
 	if prefs.TargetCluster == "" && len(prefs.ClusterAttributeUpdates) == 0 {
 		return DomainFailoverPreferences{}, errNoRebalanceRequiredV2
 	}
-	prefs.FailoverTimeoutSeconds = getFailoverTimeoutSeconds(domain)
+	prefs.FailoverTimeoutSeconds = getFailoverTimeoutSeconds(domain, logger)
 	return prefs, nil
 }
 

--- a/service/worker/failovermanager/rebalance_workflow_v2.go
+++ b/service/worker/failovermanager/rebalance_workflow_v2.go
@@ -144,6 +144,7 @@ func GetDomainsForRebalanceV2Activity(ctx context.Context) ([]DomainFailoverPref
 				zap.String("domain", domain.GetDomainInfo().GetName()), zap.Error(err))
 			continue
 		}
+		prefs.FailoverTimeoutSeconds = getFailoverTimeoutSeconds(domain)
 		warnIfMissingPollers(ctx, logger, prefs)
 		res = append(res, prefs)
 	}

--- a/service/worker/failovermanager/rebalance_workflow_v2_test.go
+++ b/service/worker/failovermanager/rebalance_workflow_v2_test.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/cadence/testsuite"
 	"go.uber.org/cadence/workflow"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
 
 	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/types"
@@ -162,7 +163,7 @@ func TestRebalancePreferencesForDomain(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prefs, err := rebalancePreferencesForDomain(tt.domain)
+			prefs, err := rebalancePreferencesForDomain(tt.domain, zap.NewNop())
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/service/worker/failovermanager/shared.go
+++ b/service/worker/failovermanager/shared.go
@@ -330,13 +330,17 @@ func failedDomainNames(failures []DomainFailoverFailure) []string {
 	return names
 }
 
-func getFailoverTimeoutSeconds(domain *types.DescribeDomainResponse) int32 {
+func getFailoverTimeoutSeconds(domain *types.DescribeDomainResponse, logger *zap.Logger) int32 {
 	raw := domain.GetDomainInfo().GetData()[constants.DomainDataKeyForFailoverTimeoutSeconds]
 	if raw == "" {
 		return 0
 	}
 	v, err := strconv.Atoi(raw)
 	if err != nil || v <= 0 || v > math.MaxInt32 {
+		logger.Warn("ignoring invalid failover timeout seconds in domain data",
+			zap.String("domain", domain.GetDomainInfo().GetName()),
+			zap.String("failoverTimeoutInSeconds", raw),
+		)
 		return 0
 	}
 	return int32(v)

--- a/service/worker/failovermanager/shared.go
+++ b/service/worker/failovermanager/shared.go
@@ -26,6 +26,7 @@ package failovermanager
 
 import (
 	"context"
+	"math"
 	"slices"
 	"strconv"
 	"time"
@@ -335,7 +336,7 @@ func getFailoverTimeoutSeconds(domain *types.DescribeDomainResponse) int32 {
 		return 0
 	}
 	v, err := strconv.Atoi(raw)
-	if err != nil || v <= 0 {
+	if err != nil || v <= 0 || v > math.MaxInt32 {
 		return 0
 	}
 	return int32(v)

--- a/service/worker/failovermanager/shared.go
+++ b/service/worker/failovermanager/shared.go
@@ -27,12 +27,14 @@ package failovermanager
 import (
 	"context"
 	"slices"
+	"strconv"
 	"time"
 
 	"go.uber.org/cadence/workflow"
 	"go.uber.org/zap"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/types"
 )
 
@@ -57,6 +59,9 @@ type (
 		TargetCluster string
 		// ClusterAttributeUpdates lists all ClusterAttribute level changes.
 		ClusterAttributeUpdates []ClusterAttributePreference
+		// FailoverTimeoutSeconds, when > 0, triggers a graceful failover with this timeout.
+		// When zero, force failover is used.
+		FailoverTimeoutSeconds int32
 	}
 
 	// FailoverActivityV2Params is the arg for the shared FailoverActivityV2.
@@ -118,6 +123,9 @@ func failoverDomains(ctx context.Context, prefs []DomainFailoverPreferences) (*F
 		}
 		if len(p.ClusterAttributeUpdates) > 0 {
 			failoverRequest.ActiveClusters = buildActiveClustersFromUpdates(p.ClusterAttributeUpdates)
+		}
+		if p.FailoverTimeoutSeconds > 0 {
+			failoverRequest.FailoverTimeoutInSeconds = common.Int32Ptr(p.FailoverTimeoutSeconds)
 		}
 
 		if _, err := frontendClient.FailoverDomain(ctx, failoverRequest); err != nil {
@@ -319,4 +327,16 @@ func failedDomainNames(failures []DomainFailoverFailure) []string {
 		names[i] = f.DomainName
 	}
 	return names
+}
+
+func getFailoverTimeoutSeconds(domain *types.DescribeDomainResponse) int32 {
+	raw := domain.GetDomainInfo().GetData()[constants.DomainDataKeyForFailoverTimeoutSeconds]
+	if raw == "" {
+		return 0
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v <= 0 {
+		return 0
+	}
+	return int32(v)
 }

--- a/service/worker/failovermanager/shared_test.go
+++ b/service/worker/failovermanager/shared_test.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/cadence/worker"
 	"go.uber.org/cadence/workflow"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/yarpc"
 
 	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/metrics"
@@ -292,4 +293,77 @@ func TestFailoverActivityV2_WhenADomainFailsItIsReportedFailedWithTheError(t *te
 	require.Len(t, result.FailedDomains, 1)
 	assert.Equal(t, "d1", result.FailedDomains[0].DomainName)
 	assert.Contains(t, result.FailedDomains[0].Error, "boom")
+}
+
+func TestGetFailoverTimeoutSeconds(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string]string
+		want int32
+	}{
+		{"missing key", nil, 0},
+		{"empty value", map[string]string{"fts": ""}, 0},
+		{"zero", map[string]string{"fts": "0"}, 0},
+		{"negative", map[string]string{"fts": "-5"}, 0},
+		{"non-numeric", map[string]string{"fts": "abc"}, 0},
+		{"valid", map[string]string{"fts": "300"}, 300},
+		{"valid small", map[string]string{"fts": "1"}, 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			domain := createDomainResponse(createDomainResponseParams{
+				name:              "test",
+				activeClusterName: "cluster0",
+				isManaged:         true,
+				isGlobal:          true,
+				data:              tc.data,
+			})
+			assert.Equal(t, tc.want, getFailoverTimeoutSeconds(domain))
+		})
+	}
+}
+
+func TestFailoverActivityV2_WhenDomainHasTimeoutItPassesGracefulFailover(t *testing.T) {
+	env, mockResource := newFailoverV2ActivityEnv(t)
+
+	var capturedReq *types.FailoverDomainRequest
+	mockResource.FrontendClient.EXPECT().FailoverDomain(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *types.FailoverDomainRequest, _ ...yarpc.CallOption) (*types.FailoverDomainResponse, error) {
+			capturedReq = req
+			return nil, nil
+		})
+
+	val, err := env.ExecuteActivity(FailoverActivityV2, &FailoverActivityV2Params{
+		DomainPreferences: []DomainFailoverPreferences{
+			{DomainName: "d1", TargetCluster: "cluster1", FailoverTimeoutSeconds: 300},
+		},
+	})
+	require.NoError(t, err)
+	var result FailoverActivityV2Result
+	require.NoError(t, val.Get(&result))
+	assert.Len(t, result.SuccessDomains, 1)
+	require.NotNil(t, capturedReq.FailoverTimeoutInSeconds)
+	assert.Equal(t, int32(300), *capturedReq.FailoverTimeoutInSeconds)
+}
+
+func TestFailoverActivityV2_WhenDomainHasNoTimeoutItUsesForceFailover(t *testing.T) {
+	env, mockResource := newFailoverV2ActivityEnv(t)
+
+	var capturedReq *types.FailoverDomainRequest
+	mockResource.FrontendClient.EXPECT().FailoverDomain(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *types.FailoverDomainRequest, _ ...yarpc.CallOption) (*types.FailoverDomainResponse, error) {
+			capturedReq = req
+			return nil, nil
+		})
+
+	val, err := env.ExecuteActivity(FailoverActivityV2, &FailoverActivityV2Params{
+		DomainPreferences: []DomainFailoverPreferences{
+			{DomainName: "d1", TargetCluster: "cluster1"},
+		},
+	})
+	require.NoError(t, err)
+	var result FailoverActivityV2Result
+	require.NoError(t, val.Get(&result))
+	assert.Len(t, result.SuccessDomains, 1)
+	assert.Nil(t, capturedReq.FailoverTimeoutInSeconds)
 }

--- a/service/worker/failovermanager/shared_test.go
+++ b/service/worker/failovermanager/shared_test.go
@@ -34,6 +34,7 @@ import (
 	"go.uber.org/cadence/workflow"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/yarpc"
+	"go.uber.org/zap"
 
 	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/metrics"
@@ -302,12 +303,12 @@ func TestGetFailoverTimeoutSeconds(t *testing.T) {
 		want int32
 	}{
 		{"missing key", nil, 0},
-		{"empty value", map[string]string{"fts": ""}, 0},
-		{"zero", map[string]string{"fts": "0"}, 0},
-		{"negative", map[string]string{"fts": "-5"}, 0},
-		{"non-numeric", map[string]string{"fts": "abc"}, 0},
-		{"valid", map[string]string{"fts": "300"}, 300},
-		{"valid small", map[string]string{"fts": "1"}, 1},
+		{"empty value", map[string]string{constants.DomainDataKeyForFailoverTimeoutSeconds: ""}, 0},
+		{"zero", map[string]string{constants.DomainDataKeyForFailoverTimeoutSeconds: "0"}, 0},
+		{"negative", map[string]string{constants.DomainDataKeyForFailoverTimeoutSeconds: "-5"}, 0},
+		{"non-numeric", map[string]string{constants.DomainDataKeyForFailoverTimeoutSeconds: "abc"}, 0},
+		{"valid", map[string]string{constants.DomainDataKeyForFailoverTimeoutSeconds: "300"}, 300},
+		{"valid small", map[string]string{constants.DomainDataKeyForFailoverTimeoutSeconds: "1"}, 1},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -318,7 +319,7 @@ func TestGetFailoverTimeoutSeconds(t *testing.T) {
 				isGlobal:          true,
 				data:              tc.data,
 			})
-			assert.Equal(t, tc.want, getFailoverTimeoutSeconds(domain))
+			assert.Equal(t, tc.want, getFailoverTimeoutSeconds(domain, zap.NewNop()))
 		})
 	}
 }


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Added option to set failover timeout in seconds in domain data to execute a graceful failover when using cadence-sys-failover-v2-workflow

https://github.com/cadence-workflow/cadence/issues/8138

**Why?**
cadence-sys-failover-v2-workflow by default executes all failovers as force failovers. We need a way to let domains decide what type of failover they want and the timeout if graceful

**How did you test it?**
Added tests to unit tests

go test -race -count=1 -run "TestGetFailoverTimeoutSeconds|TestFailoverActivityV2_WhenDomainHasTimeout|TestFailoverActivityV2_WhenDomainHasNoTimeout" ./service/worker/failovermanager/...

**Potential risks**
There is a risk that it impacts the cadence-sys-failover-v2-workflow if there is a bug introduced to it. The additions are very defensive

**Release notes**
Added option to choose graceful failover for domain when using cadence-sys-failover-v2-workflow

**Documentation Changes**
N/A
