### PR TITLE
feat(persistence): Add PostgreSQL support for active-active cluster selection policy

### DIFF
--- a/common/persistence/sql/sqldriver/interface.go
+++ b/common/persistence/sql/sqldriver/interface.go
@@ -57,9 +57,19 @@ type (
 
 	// the methods can be executed from either a started or transaction(then need to call Commit/Rollback), or without a transaction
 	commonOfDbAndTx interface {
+		// ExecContext executes a query that doesn't return rows.
+		// For example, INSERT, DELETE or UPDATE.
 		ExecContext(ctx context.Context, dbShardID int, query string, args ...interface{}) (sql.Result, error)
+
+		// NamedExecContext works same as ExecContext but it binds named query parameters like (:field_name).
 		NamedExecContext(ctx context.Context, dbShardID int, query string, arg interface{}) (sql.Result, error)
+
+		// GetContext fetches exactly one row into dest.
+		// dest parameter must be a pointer to a struct.
 		GetContext(ctx context.Context, dbShardID int, dest interface{}, query string, args ...interface{}) error
+
+		// SelectContext fetches all matching rows into dest.
+		// dest parameter must be a pointer to a slice.
 		SelectContext(ctx context.Context, dbShardID int, dest interface{}, query string, args ...interface{}) error
 	}
 )

--- a/common/persistence/sql/sqlplugin/postgres/active_cluster_selection_policy.go
+++ b/common/persistence/sql/sqlplugin/postgres/active_cluster_selection_policy.go
@@ -27,14 +27,41 @@ import (
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
 )
 
+const (
+	selectActiveClusterSelectionPolicyQry = `
+	SELECT shard_id, domain_id, workflow_id, run_id, data, data_encoding
+	FROM active_cluster_selection_policy
+	WHERE shard_id=$1 AND domain_id=$2 AND workflow_id=$3 AND run_id=$4
+	`
+
+	insertActiveClusterSelectionPolicyQry = `
+	INSERT INTO active_cluster_selection_policy (shard_id, domain_id, workflow_id, run_id, data, data_encoding)
+	VALUES ($1, $2, $3, $4, $5, $6)
+	ON CONFLICT (shard_id, domain_id, workflow_id, run_id) DO NOTHING
+	`
+
+	deleteActiveClusterSelectionPolicyQry = `
+	DELETE FROM active_cluster_selection_policy
+	WHERE shard_id=$1 AND domain_id=$2 AND workflow_id=$3 AND run_id=$4
+	`
+)
+
 func (pdb *db) InsertIntoActiveClusterSelectionPolicy(ctx context.Context, row *sqlplugin.ActiveClusterSelectionPolicyRow) (sql.Result, error) {
-	return nil, sqlplugin.ErrNotImplemented
+	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(row.ShardID, pdb.GetTotalNumDBShards())
+	return pdb.driver.ExecContext(ctx, dbShardID, insertActiveClusterSelectionPolicyQry, row.ShardID, row.DomainID, row.WorkflowID, row.RunID, row.Data, row.DataEncoding)
 }
 
 func (pdb *db) SelectFromActiveClusterSelectionPolicy(ctx context.Context, filter *sqlplugin.ActiveClusterSelectionPolicyFilter) (*sqlplugin.ActiveClusterSelectionPolicyRow, error) {
-	return nil, sqlplugin.ErrNotImplemented
+	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(filter.ShardID, pdb.GetTotalNumDBShards())
+	var row sqlplugin.ActiveClusterSelectionPolicyRow
+	err := pdb.driver.GetContext(ctx, dbShardID, &row, selectActiveClusterSelectionPolicyQry, filter.ShardID, filter.DomainID, filter.WorkflowID, filter.RunID)
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
 }
 
 func (pdb *db) DeleteFromActiveClusterSelectionPolicy(ctx context.Context, filter *sqlplugin.ActiveClusterSelectionPolicyFilter) (sql.Result, error) {
-	return nil, sqlplugin.ErrNotImplemented
+	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(filter.ShardID, pdb.GetTotalNumDBShards())
+	return pdb.driver.ExecContext(ctx, dbShardID, deleteActiveClusterSelectionPolicyQry, filter.ShardID, filter.DomainID, filter.WorkflowID, filter.RunID)
 }

--- a/common/persistence/sql/sqlplugin/postgres/active_cluster_selection_policy_test.go
+++ b/common/persistence/sql/sqlplugin/postgres/active_cluster_selection_policy_test.go
@@ -1,0 +1,258 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/uber/cadence/common/persistence/serialization"
+	"github.com/uber/cadence/common/persistence/sql/sqldriver"
+	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
+)
+
+func TestInsertIntoActiveClusterSelectionPolicy(t *testing.T) {
+	numDBShards := 30
+	testHistoryShardID := 100
+	testDomainID := serialization.MustParseUUID("10000000-0000-f000-f000-000000000001")
+	testWorkflowID := "test-workflow-id"
+	testRunID := serialization.MustParseUUID("30000000-0000-f000-f000-000000000001")
+	testData := []byte("test-data-123")
+	testDataEncoding := "thriftrw"
+
+	tests := []struct {
+		name      string
+		row       *sqlplugin.ActiveClusterSelectionPolicyRow
+		mockSetup func(*sqldriver.MockDriver)
+		wantErr   bool
+	}{
+		{
+			name: "successfully inserted active_cluster_selection_policy",
+			row: &sqlplugin.ActiveClusterSelectionPolicyRow{
+				ShardID:      testHistoryShardID,
+				DomainID:     testDomainID,
+				WorkflowID:   testWorkflowID,
+				RunID:        testRunID,
+				Data:         testData,
+				DataEncoding: testDataEncoding,
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().ExecContext(
+					gomock.Any(),
+					testHistoryShardID%numDBShards,
+					insertActiveClusterSelectionPolicyQry,
+					testHistoryShardID,
+					testDomainID,
+					testWorkflowID,
+					testRunID,
+					testData,
+					testDataEncoding,
+				).Return(nil, nil)
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDriver := sqldriver.NewMockDriver(ctrl)
+			tc.mockSetup(mockDriver)
+
+			pdb := &db{
+				driver:      mockDriver,
+				converter:   &converter{},
+				numDBShards: numDBShards,
+			}
+
+			_, err := pdb.InsertIntoActiveClusterSelectionPolicy(context.Background(), tc.row)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSelectIntoActiveClusterSelectionPolicy(t *testing.T) {
+	numDBShards := 50
+	testHistoryShardID := 999
+	testDomainID := serialization.MustParseUUID("10000000-0000-f000-f000-000000000001")
+	testWorkflowID := "test-workflow-id"
+	testRunID := serialization.MustParseUUID("30000000-0000-f000-f000-000000000001")
+	tests := []struct {
+		name      string
+		filter    *sqlplugin.ActiveClusterSelectionPolicyFilter
+		mockSetup func(*sqldriver.MockDriver)
+		wantErr   error
+	}{
+		{
+			name: "successfully selected one active_cluster_selection_policy row",
+			filter: &sqlplugin.ActiveClusterSelectionPolicyFilter{
+				ShardID:    testHistoryShardID,
+				DomainID:   testDomainID,
+				WorkflowID: testWorkflowID,
+				RunID:      testRunID,
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().GetContext(
+					gomock.Any(),
+					testHistoryShardID%numDBShards,
+					gomock.Any(),
+					selectActiveClusterSelectionPolicyQry,
+					testHistoryShardID,
+					testDomainID,
+					testWorkflowID,
+					testRunID,
+				).DoAndReturn(func(_ context.Context, _ int, dest interface{}, _ string, _ ...interface{}) error {
+					row := dest.(*sqlplugin.ActiveClusterSelectionPolicyRow)
+					row.ShardID = testHistoryShardID
+					row.DomainID = testDomainID
+					row.WorkflowID = testWorkflowID
+					row.RunID = testRunID
+					row.Data = []byte("test-data-123")
+					row.DataEncoding = "thriftrw"
+					return nil
+				})
+			},
+			wantErr: nil,
+		},
+		{
+			name: "no matched row",
+			filter: &sqlplugin.ActiveClusterSelectionPolicyFilter{
+				ShardID:    testHistoryShardID,
+				DomainID:   testDomainID,
+				WorkflowID: testWorkflowID,
+				RunID:      testRunID,
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().GetContext(
+					gomock.Any(),
+					testHistoryShardID%numDBShards,
+					gomock.Any(),
+					selectActiveClusterSelectionPolicyQry,
+					testHistoryShardID,
+					testDomainID,
+					testWorkflowID,
+					testRunID,
+				).Return(sql.ErrNoRows)
+			},
+			wantErr: sql.ErrNoRows,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDriver := sqldriver.NewMockDriver(ctrl)
+			tc.mockSetup(mockDriver)
+
+			pdb := &db{
+				driver:      mockDriver,
+				converter:   &converter{},
+				numDBShards: numDBShards,
+			}
+
+			result, err := pdb.SelectFromActiveClusterSelectionPolicy(context.Background(), tc.filter)
+			if tc.wantErr != nil {
+				assert.Nil(t, result)
+				assert.ErrorIs(t, err, tc.wantErr)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Equal(t, testHistoryShardID, result.ShardID)
+				assert.Equal(t, testDomainID, result.DomainID)
+				assert.Equal(t, testWorkflowID, result.WorkflowID)
+				assert.Equal(t, testRunID, result.RunID)
+			}
+		})
+	}
+}
+
+func TestDeleteFromActiveClusterSelectionPolicy(t *testing.T) {
+	numDBShards := 800
+	testHistoryShardID := 1111
+	testDomainID := serialization.MustParseUUID("10000000-0000-f000-f000-000000000001")
+	testWorkflowID := "test-workflow-id"
+	testRunID := serialization.MustParseUUID("30000000-0000-f000-f000-000000000001")
+	tests := []struct {
+		name      string
+		filter    *sqlplugin.ActiveClusterSelectionPolicyFilter
+		mockSetup func(*sqldriver.MockDriver)
+		wantErr   bool
+	}{
+		{
+			name: "successfully deleted one active_cluster_selection_policy row",
+			filter: &sqlplugin.ActiveClusterSelectionPolicyFilter{
+				ShardID:    testHistoryShardID,
+				DomainID:   testDomainID,
+				WorkflowID: testWorkflowID,
+				RunID:      testRunID,
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().ExecContext(
+					gomock.Any(),
+					testHistoryShardID%numDBShards,
+					deleteActiveClusterSelectionPolicyQry,
+					testHistoryShardID,
+					testDomainID,
+					testWorkflowID,
+					testRunID,
+				).Return(nil, nil)
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDriver := sqldriver.NewMockDriver(ctrl)
+			tc.mockSetup(mockDriver)
+
+			pdb := &db{
+				driver:      mockDriver,
+				converter:   &converter{},
+				numDBShards: numDBShards,
+			}
+
+			// Delete inserted row
+			_, err := pdb.DeleteFromActiveClusterSelectionPolicy(context.Background(), tc.filter)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/common/persistence/sql/sqlplugin/postgres/active_cluster_selection_policy_test.go
+++ b/common/persistence/sql/sqlplugin/postgres/active_cluster_selection_policy_test.go
@@ -23,6 +23,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,12 +42,13 @@ func TestInsertIntoActiveClusterSelectionPolicy(t *testing.T) {
 	testRunID := serialization.MustParseUUID("30000000-0000-f000-f000-000000000001")
 	testData := []byte("test-data-123")
 	testDataEncoding := "thriftrw"
+	driverErr := errors.New("driver error")
 
 	tests := []struct {
 		name      string
 		row       *sqlplugin.ActiveClusterSelectionPolicyRow
 		mockSetup func(*sqldriver.MockDriver)
-		wantErr   bool
+		wantErr   error
 	}{
 		{
 			name: "successfully inserted active_cluster_selection_policy",
@@ -71,7 +73,32 @@ func TestInsertIntoActiveClusterSelectionPolicy(t *testing.T) {
 					testDataEncoding,
 				).Return(nil, nil)
 			},
-			wantErr: false,
+			wantErr: nil,
+		},
+		{
+			name: "driver error occurred",
+			row: &sqlplugin.ActiveClusterSelectionPolicyRow{
+				ShardID:      testHistoryShardID,
+				DomainID:     testDomainID,
+				WorkflowID:   testWorkflowID,
+				RunID:        testRunID,
+				Data:         testData,
+				DataEncoding: testDataEncoding,
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().ExecContext(
+					gomock.Any(),
+					testHistoryShardID%numDBShards,
+					insertActiveClusterSelectionPolicyQry,
+					testHistoryShardID,
+					testDomainID,
+					testWorkflowID,
+					testRunID,
+					testData,
+					testDataEncoding,
+				).Return(nil, driverErr)
+			},
+			wantErr: driverErr,
 		},
 	}
 
@@ -90,9 +117,8 @@ func TestInsertIntoActiveClusterSelectionPolicy(t *testing.T) {
 			}
 
 			_, err := pdb.InsertIntoActiveClusterSelectionPolicy(context.Background(), tc.row)
-
-			if tc.wantErr {
-				assert.Error(t, err)
+			if tc.wantErr != nil {
+				assert.ErrorIs(t, err, tc.wantErr)
 			} else {
 				assert.NoError(t, err)
 			}
@@ -100,7 +126,7 @@ func TestInsertIntoActiveClusterSelectionPolicy(t *testing.T) {
 	}
 }
 
-func TestSelectIntoActiveClusterSelectionPolicy(t *testing.T) {
+func TestSelectFromActiveClusterSelectionPolicy(t *testing.T) {
 	numDBShards := 50
 	testHistoryShardID := 999
 	testDomainID := serialization.MustParseUUID("10000000-0000-f000-f000-000000000001")
@@ -205,11 +231,12 @@ func TestDeleteFromActiveClusterSelectionPolicy(t *testing.T) {
 	testDomainID := serialization.MustParseUUID("10000000-0000-f000-f000-000000000001")
 	testWorkflowID := "test-workflow-id"
 	testRunID := serialization.MustParseUUID("30000000-0000-f000-f000-000000000001")
+	contextTimeoutErr := context.DeadlineExceeded
 	tests := []struct {
 		name      string
 		filter    *sqlplugin.ActiveClusterSelectionPolicyFilter
 		mockSetup func(*sqldriver.MockDriver)
-		wantErr   bool
+		wantErr   error
 	}{
 		{
 			name: "successfully deleted one active_cluster_selection_policy row",
@@ -230,7 +257,28 @@ func TestDeleteFromActiveClusterSelectionPolicy(t *testing.T) {
 					testRunID,
 				).Return(nil, nil)
 			},
-			wantErr: false,
+			wantErr: nil,
+		},
+		{
+			name: "context timeout error occurred",
+			filter: &sqlplugin.ActiveClusterSelectionPolicyFilter{
+				ShardID:    testHistoryShardID,
+				DomainID:   testDomainID,
+				WorkflowID: testWorkflowID,
+				RunID:      testRunID,
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().ExecContext(
+					gomock.Any(),
+					testHistoryShardID%numDBShards,
+					deleteActiveClusterSelectionPolicyQry,
+					testHistoryShardID,
+					testDomainID,
+					testWorkflowID,
+					testRunID,
+				).Return(nil, contextTimeoutErr)
+			},
+			wantErr: contextTimeoutErr,
 		},
 	}
 
@@ -250,8 +298,8 @@ func TestDeleteFromActiveClusterSelectionPolicy(t *testing.T) {
 
 			// Delete inserted row
 			_, err := pdb.DeleteFromActiveClusterSelectionPolicy(context.Background(), tc.filter)
-			if tc.wantErr {
-				assert.Error(t, err)
+			if tc.wantErr != nil {
+				assert.ErrorIs(t, err, tc.wantErr)
 			} else {
 				assert.NoError(t, err)
 			}

--- a/common/persistence/sql/sqlplugin/postgres/active_cluster_selection_policy_test.go
+++ b/common/persistence/sql/sqlplugin/postgres/active_cluster_selection_policy_test.go
@@ -192,6 +192,8 @@ func TestSelectIntoActiveClusterSelectionPolicy(t *testing.T) {
 				assert.Equal(t, testDomainID, result.DomainID)
 				assert.Equal(t, testWorkflowID, result.WorkflowID)
 				assert.Equal(t, testRunID, result.RunID)
+				assert.Equal(t, []byte("test-data-123"), result.Data)
+				assert.Equal(t, "thriftrw", result.DataEncoding)
 			}
 		})
 	}

--- a/schema/postgres/cadence/schema.sql
+++ b/schema/postgres/cadence/schema.sql
@@ -290,3 +290,14 @@ CREATE TABLE domain_audit_log (
   comment                 TEXT NOT NULL DEFAULT '',
   PRIMARY KEY (domain_id, operation_type, created_time, event_id)
 );
+
+CREATE TABLE active_cluster_selection_policy (
+  shard_id      INT          NOT NULL,
+  domain_id     BYTEA        NOT NULL,
+  workflow_id   TEXT         NOT NULL,
+  run_id        BYTEA        NOT NULL,
+  --
+  data          BYTEA        NOT NULL,
+  data_encoding VARCHAR(16)  NOT NULL,
+  PRIMARY KEY (shard_id, domain_id, workflow_id, run_id)
+);

--- a/schema/postgres/cadence/versioned/v0.8/active_cluster_selection_policy.sql
+++ b/schema/postgres/cadence/versioned/v0.8/active_cluster_selection_policy.sql
@@ -1,0 +1,10 @@
+CREATE TABLE active_cluster_selection_policy (
+  shard_id      INT          NOT NULL,
+  domain_id     BYTEA        NOT NULL,
+  workflow_id   TEXT         NOT NULL,
+  run_id        BYTEA        NOT NULL,
+  --
+  data          BYTEA        NOT NULL,
+  data_encoding VARCHAR(16)  NOT NULL,
+  PRIMARY KEY (shard_id, domain_id, workflow_id, run_id)
+);

--- a/schema/postgres/cadence/versioned/v0.8/manifest.json
+++ b/schema/postgres/cadence/versioned/v0.8/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.8",
+  "MinCompatibleVersion": "0.8",
+  "Description": "Add active_cluster_selection_policy table for active-active domain workflows",
+  "SchemaUpdateCqlFiles": [
+    "active_cluster_selection_policy.sql"
+  ]
+}

--- a/schema/postgres/version.go
+++ b/schema/postgres/version.go
@@ -24,7 +24,7 @@ package postgres
 
 // Version is the Postgres database release version
 // Cadence supports both MySQL and Postgres officially, so upgrade should be perform for both MySQL and Postgres
-const Version = "0.7"
+const Version = "0.8"
 
 // VisibilityVersion is the Postgres visibility database release version
 // Cadence supports both MySQL and Postgres officially, so upgrade should be perform for both MySQL and Postgres

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -155,7 +155,7 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDirFromEmbeddings() {
 	s.NoError(err)
 	ans, err = readSchemaDir(fsys, "0.3", "")
 	s.NoError(err)
-	s.Equal([]string{"v0.4", "v0.5", "v0.6", "v0.7"}, ans)
+	s.Equal([]string{"v0.4", "v0.5", "v0.6", "v0.7", "v0.8"}, ans)
 
 	fsys, err = fs.Sub(postgres.SchemaFS, "visibility/versioned")
 	s.NoError(err)


### PR DESCRIPTION
**Detailed Description**
- Added active_cluster_selection_policy table in postgresql schema
- Updated postgres version from v0.7 to v0.8
- Implemented CRUD methods to support active-active cluster selection policy in `postgres/active_cluster_selection_policy.go`
- Implemented related unit tests

Fixes: #7601

**Impact Analysis**
- **Backward Compatibility**: Added new PostgreSQL compatible table definition sql. There are no modification on existing tables, constraints and database system configurations.
- **Forward Compatibility**: Previous PostgreSQL active-active support in Cadence workflow were not provided.

**Testing Plan**
- **Unit Tests**: Implemented unit tests on implemented CRUD functions and checked those in local and in github actions pipeline.
- **Persistence Tests**: Checked Postgresql integration test on github actions has passed.
- **Integration Tests**: Checked Postgresql integration test on github actions has passed.
- **Compatibility Tests**: Checked postgresql tables are generated properly (please see below images).

<img width="434" height="180" alt="image" src="https://github.com/user-attachments/assets/67c002df-7b10-4300-a2a5-57cff975a1b3" />
<img width="744" height="213" alt="image" src="https://github.com/user-attachments/assets/b5586aa6-680c-424a-b09d-f82300fb0bc2" />

**Rollout Plan**
- What is the rollout plan?
- Does the order of deployment matter?
- Is it safe to rollback? Does the order of rollback matter?
- Is there a kill switch to mitigate the impact immediately?
