### PR TITLE
chore(cassandra): reduce VerifyCompatibleVersion timeout

### DIFF
--- a/tools/cassandra/cqlclient.go
+++ b/tools/cassandra/cqlclient.go
@@ -76,11 +76,11 @@ type (
 )
 
 const (
-	DefaultTimeout              = 30 // Timeout in seconds
-	DefaultConnectTimeout       = 2  // Connect timeout in seconds
-	DefaultVersionCheckTimeout  = 2  // Timeout in seconds for schema version compatibility checks
-	DefaultCassandraPort  = 9042
-	SystemKeyspace        = "system"
+	DefaultTimeout             = 30 // Timeout in seconds
+	DefaultConnectTimeout      = 2  // Connect timeout in seconds
+	DefaultVersionCheckTimeout = 2  // Timeout in seconds for schema version compatibility checks
+	DefaultCassandraPort       = 9042
+	SystemKeyspace             = "system"
 )
 
 const (

--- a/tools/cassandra/cqlclient.go
+++ b/tools/cassandra/cqlclient.go
@@ -76,8 +76,9 @@ type (
 )
 
 const (
-	DefaultTimeout        = 30 // Timeout in seconds
-	DefaultConnectTimeout = 2  // Connect timeout in seconds
+	DefaultTimeout              = 30 // Timeout in seconds
+	DefaultConnectTimeout       = 2  // Connect timeout in seconds
+	DefaultVersionCheckTimeout  = 2  // Timeout in seconds for schema version compatibility checks
 	DefaultCassandraPort  = 9042
 	SystemKeyspace        = "system"
 )

--- a/tools/cassandra/handler.go
+++ b/tools/cassandra/handler.go
@@ -109,7 +109,7 @@ func CheckCompatibleVersion(
 		Password:              cfg.Password,
 		Keyspace:              cfg.Keyspace,
 		AllowedAuthenticators: cfg.AllowedAuthenticators,
-		Timeout:               DefaultConnectTimeout,
+		Timeout:               DefaultVersionCheckTimeout,
 		ConnectTimeout:        DefaultConnectTimeout,
 		TLS:                   cfg.TLS,
 		ProtoVersion:          cfg.ProtoVersion,

--- a/tools/cassandra/handler.go
+++ b/tools/cassandra/handler.go
@@ -109,7 +109,7 @@ func CheckCompatibleVersion(
 		Password:              cfg.Password,
 		Keyspace:              cfg.Keyspace,
 		AllowedAuthenticators: cfg.AllowedAuthenticators,
-		Timeout:               DefaultTimeout,
+		Timeout:               DefaultConnectTimeout,
 		ConnectTimeout:        DefaultConnectTimeout,
 		TLS:                   cfg.TLS,
 		ProtoVersion:          cfg.ProtoVersion,


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Reduced the Cassandra session timeout for schema version compatibility checks from 30s to 2s during server startup.

**Why?**
A 30s session timeout is excessive for a single-row key lookup. If the context timeout from an RPC caller is shorter than 2x the session timeout, Cassandra query retries cannot complete before the context deadline is exceeded, reducing fault tolerance. A 2s timeout is sufficient for ReadSchemaVersion and leaves room for retries within typical context deadlines.

**How did you test it?**
Unit tests and integration tests in host/cli/cassandra/cassandra_tool_version_test.go that cover both CheckCompatibleVersion and VerifyCompatibleVersion. 

go test -race -run TestCheckCompatibleVersion ./host/cli/cassandra/...

go test -race -run "TestCheckCompatibleVersion|TestVerifyCompatibleVersion" ./host/cli/cassandra/...

The schema version check is a simple key lookup — if it takes longer than 2s, Cassandra is in a degraded state where blocking the deployment is the desired behavior.

**Potential risks**
If Cassandra is temporarily slow during deployment (e.g., under heavy compaction), the schema version check could fail and block startup. However, a query taking >2s for a single-row read indicates a serious issue where proceeding with deployment is likely unsafe anyway.

**Release notes**
N/A

**Documentation Changes**
N/A
