### PR TITLE
feat: Add metrics to track the number of tasks scheduled for history queue v2

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2989,6 +2989,8 @@ const (
 	TaskProcessingLatencyPerTaskListHistogram
 	TaskQueueLatencyPerTaskListHistogram
 	TaskScheduleLatencyPerTaskListHistogram
+	TaskScheduleSubmittedPerTaskList
+	TaskScheduleThrottledPerTaskList
 
 	NumHistoryMetrics
 )
@@ -3631,6 +3633,8 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 		TaskProcessingLatencyPerTaskListHistogram: {metricName: "task_latency_processing_per_task_list_ns", metricType: Histogram, exponentialBuckets: High1ms24h},
 		TaskQueueLatencyPerTaskListHistogram:      {metricName: "task_latency_queue_per_task_list_ns", metricType: Histogram, exponentialBuckets: High1ms24h},
 		TaskScheduleLatencyPerTaskListHistogram:   {metricName: "task_latency_schedule_per_task_list_ns", metricType: Histogram, exponentialBuckets: High1ms24h},
+		TaskScheduleSubmittedPerTaskList:          {metricName: "task_schedule_submitted_per_task_list", metricType: Counter},
+		TaskScheduleThrottledPerTaskList:          {metricName: "task_schedule_throttled_per_task_list", metricType: Counter},
 
 		TaskBatchCompleteCounter:                                      {metricName: "task_batch_complete_counter", metricType: Counter},
 		TaskBatchCompleteFailure:                                      {metricName: "task_batch_complete_error", metricType: Counter},

--- a/service/history/queuev2/virtual_queue.go
+++ b/service/history/queuev2/virtual_queue.go
@@ -410,6 +410,7 @@ func (q *virtualQueueImpl) loadAndSubmitTasks() {
 		// shard level metrics for the duration between a task being written to a queue and being fetched from it
 		q.metricsScope.RecordHistogramDuration(metrics.TaskEnqueueToFetchLatency, now.Sub(task.GetVisibilityTimestamp()))
 		task.SetInitialSubmitTime(now)
+		taskListTaggedScope := q.metricsScope.Tagged(common.GetTaskListTag(task.GetOriginalTaskList(), task.GetOriginalTaskListKind()))
 		submitted, err := q.processor.TrySubmit(task)
 		if err != nil {
 			select {
@@ -421,7 +422,10 @@ func (q *virtualQueueImpl) loadAndSubmitTasks() {
 		}
 		if !submitted {
 			q.metricsScope.IncCounter(metrics.ProcessingQueueThrottledCounter)
+			taskListTaggedScope.IncCounter(metrics.TaskScheduleThrottledPerTaskList)
 			q.rescheduler.RescheduleTask(task, q.timeSource.Now().Add(taskSchedulerThrottleBackoffInterval))
+		} else {
+			taskListTaggedScope.IncCounter(metrics.TaskScheduleSubmittedPerTaskList)
 		}
 	}
 

--- a/service/history/queuev2/virtual_queue_test.go
+++ b/service/history/queuev2/virtual_queue_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/quotas"
+	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/history/task"
 )
 
@@ -641,6 +642,8 @@ func TestVirtualQueue_LoadAndSubmitTasks(t *testing.T) {
 	mockTask1.EXPECT().GetTaskKey().Return(persistence.NewHistoryTaskKey(mockTimeSource.Now().Add(time.Second*-1), 1))
 	mockTask1.EXPECT().GetVisibilityTimestamp().Return(mockTimeSource.Now().Add(time.Second * -1))
 	mockTask1.EXPECT().SetInitialSubmitTime(gomock.Any()).Times(1)
+	mockTask1.EXPECT().GetOriginalTaskList().Return("some random taskList")
+	mockTask1.EXPECT().GetOriginalTaskListKind().Return(types.TaskListKindNormal)
 	mockTask2 := task.NewMockTask(ctrl)
 	mockTask2.EXPECT().GetDomainID().Return("some random domainID")
 	mockTask2.EXPECT().GetWorkflowID().Return("some random workflowID")
@@ -653,6 +656,8 @@ func TestVirtualQueue_LoadAndSubmitTasks(t *testing.T) {
 	mockTask3.EXPECT().GetTaskKey().Return(persistence.NewHistoryTaskKey(mockTimeSource.Now().Add(time.Second*-1), 1))
 	mockTask3.EXPECT().GetVisibilityTimestamp().Return(mockTimeSource.Now().Add(time.Second * -1))
 	mockTask3.EXPECT().SetInitialSubmitTime(gomock.Any()).Times(1)
+	mockTask3.EXPECT().GetOriginalTaskList().Return("some random taskList")
+	mockTask3.EXPECT().GetOriginalTaskListKind().Return(types.TaskListKindNormal)
 
 	mockMonitor.EXPECT().GetTotalPendingTaskCount().Return(0)
 	mockPauseController.EXPECT().IsPaused().Return(false)


### PR DESCRIPTION

<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Add metrics to track the number of tasks submitted to / throttled by scheduler per task list for history queue v2

related to https://github.com/cadence-workflow/cadence/issues/7724

**Why?**
Improve observability

**How did you test it?**
go test ./service/history/queuev2/... -race

**Potential risks**
No.

**Release notes**


**Documentation Changes**

