### PR TITLE
fix(cassandra): use gocql.UnsetValue instead of nil

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/shard.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/shard.go
@@ -35,9 +35,9 @@ import (
 // Return ShardOperationConditionFailure if the condition doesn't meet
 func (db *CDB) InsertShard(ctx context.Context, row *nosqlplugin.ShardRow) error {
 	cqlNowTimestamp := persistence.UnixNanoToDBTimestamp(row.CurrentTimestamp.UnixNano())
-	markerData, markerEncoding := persistence.FromDataBlob(row.PendingFailoverMarkers)
-	transferPQS, transferPQSEncoding := persistence.FromDataBlob(row.TransferProcessingQueueStates)
-	timerPQS, timerPQSEncoding := persistence.FromDataBlob(row.TimerProcessingQueueStates)
+	markerData, markerEncoding := fromDataBlobForCassandra(row.PendingFailoverMarkers)
+	transferPQS, transferPQSEncoding := fromDataBlobForCassandra(row.TransferProcessingQueueStates)
+	timerPQS, timerPQSEncoding := fromDataBlobForCassandra(row.TimerProcessingQueueStates)
 	query := db.session.Query(templateCreateShardQuery,
 		row.ShardID,
 		rowTypeShard,
@@ -245,9 +245,9 @@ func (db *CDB) UpdateRangeID(ctx context.Context, shardID int, rangeID int64, pr
 // Return ShardOperationConditionFailure if the condition doesn't meet
 func (db *CDB) UpdateShard(ctx context.Context, row *nosqlplugin.ShardRow, previousRangeID int64) error {
 	cqlNowTimestamp := persistence.UnixNanoToDBTimestamp(row.CurrentTimestamp.UnixNano())
-	markerData, markerEncoding := persistence.FromDataBlob(row.PendingFailoverMarkers)
-	transferPQS, transferPQSEncoding := persistence.FromDataBlob(row.TransferProcessingQueueStates)
-	timerPQS, timerPQSEncoding := persistence.FromDataBlob(row.TimerProcessingQueueStates)
+	markerData, markerEncoding := fromDataBlobForCassandra(row.PendingFailoverMarkers)
+	transferPQS, transferPQSEncoding := fromDataBlobForCassandra(row.TransferProcessingQueueStates)
+	timerPQS, timerPQSEncoding := fromDataBlobForCassandra(row.TimerProcessingQueueStates)
 
 	query := db.session.Query(templateUpdateShardQuery,
 		row.ShardID,

--- a/common/persistence/nosql/nosqlplugin/cassandra/shard.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/shard.go
@@ -35,9 +35,9 @@ import (
 // Return ShardOperationConditionFailure if the condition doesn't meet
 func (db *CDB) InsertShard(ctx context.Context, row *nosqlplugin.ShardRow) error {
 	cqlNowTimestamp := persistence.UnixNanoToDBTimestamp(row.CurrentTimestamp.UnixNano())
-	markerData, markerEncoding := fromDataBlobForCassandra(row.PendingFailoverMarkers)
-	transferPQS, transferPQSEncoding := fromDataBlobForCassandra(row.TransferProcessingQueueStates)
-	timerPQS, timerPQSEncoding := fromDataBlobForCassandra(row.TimerProcessingQueueStates)
+	markerData, markerEncoding := persistence.FromDataBlob(row.PendingFailoverMarkers)
+	transferPQS, transferPQSEncoding := persistence.FromDataBlob(row.TransferProcessingQueueStates)
+	timerPQS, timerPQSEncoding := persistence.FromDataBlob(row.TimerProcessingQueueStates)
 	query := db.session.Query(templateCreateShardQuery,
 		row.ShardID,
 		rowTypeShard,
@@ -245,9 +245,9 @@ func (db *CDB) UpdateRangeID(ctx context.Context, shardID int, rangeID int64, pr
 // Return ShardOperationConditionFailure if the condition doesn't meet
 func (db *CDB) UpdateShard(ctx context.Context, row *nosqlplugin.ShardRow, previousRangeID int64) error {
 	cqlNowTimestamp := persistence.UnixNanoToDBTimestamp(row.CurrentTimestamp.UnixNano())
-	markerData, markerEncoding := fromDataBlobForCassandra(row.PendingFailoverMarkers)
-	transferPQS, transferPQSEncoding := fromDataBlobForCassandra(row.TransferProcessingQueueStates)
-	timerPQS, timerPQSEncoding := fromDataBlobForCassandra(row.TimerProcessingQueueStates)
+	markerData, markerEncoding := persistence.FromDataBlob(row.PendingFailoverMarkers)
+	transferPQS, transferPQSEncoding := persistence.FromDataBlob(row.TransferProcessingQueueStates)
+	timerPQS, timerPQSEncoding := persistence.FromDataBlob(row.TimerProcessingQueueStates)
 
 	query := db.session.Query(templateUpdateShardQuery,
 		row.ShardID,

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow.go
@@ -676,7 +676,7 @@ func (db *CDB) DeleteCrossClusterTask(ctx context.Context, shardID int, targetCl
 func (db *CDB) InsertReplicationDLQTask(ctx context.Context, shardID int, sourceCluster string, replicationTask *nosqlplugin.HistoryMigrationTask) error {
 	// Use source cluster name as the workflow id for replication dlq
 	task := replicationTask.Replication
-	taskBlob, taskEncoding := persistence.FromDataBlob(replicationTask.Task)
+	taskBlob, taskEncoding := fromDataBlobForCassandra(replicationTask.Task)
 	query := db.session.Query(templateCreateReplicationTaskQuery,
 		shardID,
 		rowTypeDLQ,

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_utils.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_utils.go
@@ -28,6 +28,8 @@ import (
 	"strings"
 	"time"
 
+	gogocql "github.com/gocql/gocql"
+
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/persistence"
@@ -448,6 +450,16 @@ func createTasksByCategory(
 	// TODO: implementing writing tasks for other categories
 }
 
+// fromDataBlobForCassandra extracts data and encoding from a DataBlob for use in CQL queries.
+// Unlike persistence.FromDataBlob, it returns gocql.UnsetValue for nil blobs to avoid
+// creating cell-level tombstones on the data/data_encoding columns.
+func fromDataBlobForCassandra(blob *persistence.DataBlob) (interface{}, interface{}) {
+	if blob == nil || len(blob.Data) == 0 {
+		return gogocql.UnsetValue, gogocql.UnsetValue
+	}
+	return blob.Data, string(blob.Encoding)
+}
+
 func createTimerTasks(
 	batch gocql.Batch,
 	shardID int,
@@ -458,7 +470,7 @@ func createTimerTasks(
 ) error {
 	for _, timer := range timerTasks {
 		task := timer.Timer
-		taskBlob, taskEncoding := persistence.FromDataBlob(timer.Task)
+		taskBlob, taskEncoding := fromDataBlobForCassandra(timer.Task)
 		// Ignoring possible type cast errors.
 		ts := persistence.UnixNanoToDBTimestamp(task.VisibilityTimestamp.UnixNano())
 
@@ -499,7 +511,7 @@ func createReplicationTasks(
 ) {
 	for _, replication := range replicationTasks {
 		task := replication.Replication
-		taskBlob, taskEncoding := persistence.FromDataBlob(replication.Task)
+		taskBlob, taskEncoding := fromDataBlobForCassandra(replication.Task)
 		batch.Query(templateCreateReplicationTaskQuery,
 			shardID,
 			rowTypeReplicationTask,
@@ -540,7 +552,7 @@ func createTransferTasks(
 ) {
 	for _, transfer := range transferTasks {
 		task := transfer.Transfer
-		taskBlob, taskEncoding := persistence.FromDataBlob(transfer.Task)
+		taskBlob, taskEncoding := fromDataBlobForCassandra(transfer.Task)
 		batch.Query(templateCreateTransferTaskQuery,
 			shardID,
 			rowTypeTransferTask,

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_utils_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_utils_test.go
@@ -30,9 +30,9 @@ import (
 	"testing"
 	"time"
 
+	gogocql "github.com/gocql/gocql"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	gogocql "github.com/gocql/gocql"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_utils_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_utils_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	gogocql "github.com/gocql/gocql"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -3066,4 +3067,40 @@ func trimColumnsPart(s *string) {
 	re := regexp.MustCompile(`, columns: \(.*\)`)
 	trimmed := re.ReplaceAllString(*s, "")
 	*s = trimmed
+}
+
+func TestFromDataBlobForCassandra(t *testing.T) {
+	tests := []struct {
+		name         string
+		blob         *persistence.DataBlob
+		wantData     interface{}
+		wantEncoding interface{}
+	}{
+		{
+			name:         "nil blob returns UnsetValue",
+			blob:         nil,
+			wantData:     gogocql.UnsetValue,
+			wantEncoding: gogocql.UnsetValue,
+		},
+		{
+			name:         "empty data returns UnsetValue",
+			blob:         &persistence.DataBlob{Data: []byte{}, Encoding: "thriftrw"},
+			wantData:     gogocql.UnsetValue,
+			wantEncoding: gogocql.UnsetValue,
+		},
+		{
+			name:         "non-nil blob returns data and encoding",
+			blob:         &persistence.DataBlob{Data: []byte{1, 2, 3}, Encoding: "thriftrw"},
+			wantData:     []byte{1, 2, 3},
+			wantEncoding: "thriftrw",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data, encoding := fromDataBlobForCassandra(tc.blob)
+			assert.Equal(t, tc.wantData, data)
+			assert.Equal(t, tc.wantEncoding, encoding)
+		})
+	}
 }


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Use gocql.UnsetValue instead of nil when writing to Cassandra for DLQ replication tasks, transfer tasks, replication tasks and transfer tasks creation

https://github.com/cadence-workflow/cadence/issues/8318

**Why?**
An explicit nil value on write generates cell-level tombstones. Avoid doing that by using gocql.UnsetValue, reducing the number of tombstones created and helping compaction/tombstone removals

https://thelastpickle.com/blog/2016/09/15/Null-bindings-on-prepared-statements-and-undesired-tombstone-creation.html

```
{
        "type" : "row",
        "position" : 4574503,
        "clustering" : [ 2, "10000000-3000-f000-f000-000000000000", "20000000-3000-f000-f000-000000000000", "30000000-3000-f000-f000-000000000000", "2000-01-01 00:00:00.000Z", 10410276531 ],
        "liveness_info" : { "tstamp" : "2026-07-08T00:23:35.995Z" },
        "cells" : [
          { "name" : "created_time", "value" : "2026-07-08 00:23:35.993Z" },
          { "name" : "data", "deletion_info" : { "local_delete_time" : "2026-07-08T00:23:35Z" },
            "tstamp" : "2026-07-08T00:23:35.994999Z"
          },
          { "name" : "data_encoding", "value" : "" },
          { "name" : "transfer", "value" : {"domain_id": "339ab902-c301-4166-9ef4-a98e718d334b", "workflow_id": "Sync-Execution-State_android_restaurant_manager", "run_id": "45621932-56b5-442e-bb61-9d6063529fda", "task_id": 10410276531, "target_domain_id": "339ab902-c301-4166-9ef4-a98e718d334b", "target_workflow_id": "20000000-0000-f000-f000-000000000001", "target_run_id": "30000000-0000-f000-f000-000000000002", "task_list": "fx-worker-metes-v2", "type": 0, "schedule_id": 31, "target_child_workflow_only": false, "version": 200, "visibility_ts": "2026-07-08 00:23:35.993Z", "record_visibility": false, "target_domain_ids": [], "original_task_list": "fx-worker-metes-v2", "original_task_list_kind": 0} }
        ]
      }
```

**How did you test it?**
Added unit test
go test -race -count=1 -run TestFromDataBlobForCassandra ./common/persistence/nosql/nosqlplugin/cassandra/...

Verified that Cassandra doesn't create the tombstone

How to verify locally

1. Start Cassandra in Docker:
   docker run -d --name cassandra-test -p 9042:9042 cassandra:3.11

2. Create keyspace and install schema:
   docker exec cassandra-test cqlsh -e "CREATE KEYSPACE IF NOT EXISTS cadence WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};"
   docker cp schema/cassandra/cadence/schema.cql cassandra-test:/tmp/schema.cql
   docker exec cassandra-test cqlsh -k cadence -f /tmp/schema.cql

3. Insert a row with null data (simulates the old behavior):
   docker exec cassandra-test cqlsh -k cadence -e "INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, data, data_encoding, visibility_ts, task_id, created_time) VALUES (1, 2, 10000000-3000-f000-f000-000000000000, '20000000-3000-f000-f000-000000000000', 30000000-3000-f000-f000-000000000000, null, '', '2000-01-01 00:00:00.000Z', 100, toTimestamp(now()));"

4. Insert a row without data column (simulates gocql.UnsetValue):
   docker exec cassandra-test cqlsh -k cadence -e "INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, data_encoding, visibility_ts, task_id, created_time) VALUES (1, 2, 10000000-3000-f000-f000-000000000000, '20000000-3000-f000-f000-000000000000', 30000000-3000-f000-f000-000000000000, '', '2000-01-01 00:00:00.000Z', 101, toTimestamp(now()));"

5. Flush and dump the SSTable:
   docker exec cassandra-test nodetool flush cadence
   docker exec cassandra-test /opt/cassandra/tools/bin/sstabledump $(docker exec cassandra-test find /var/lib/cassandra/data/cadence -name "*executions*" -name "*Data.db")

6. Observe:
   - task_id=100 (null data): has `"name": "data", "deletion_info": {...}` — a cell tombstone
   - task_id=101 (omitted data): no `data` cell at all — no tombstone

7. Cleanup:
   docker rm -f cassandra-test

**Potential risks**
It touches a critical path but only changes anything when the value is nil. Risk is low

**Release notes**
Use gocql.UnsetValue instead of nil to avoid tombstone creation in Cassandra

**Documentation Changes**
N/A
