### PR TITLE
fix(sqlite): use subquery instead of CTE for filter tasks for range deletion

### DIFF
--- a/common/persistence/sql/sqlplugin/sqlite/events.go
+++ b/common/persistence/sql/sqlplugin/sqlite/events.go
@@ -30,16 +30,14 @@ import (
 )
 
 const (
-	deleteHistoryNodesQuery = `WITH events_to_delete AS (
-    SELECT shard_id, tree_id, branch_id, node_id, txn_id
-    FROM history_node
-    WHERE shard_id = ? AND tree_id = ? AND branch_id = ? AND node_id >= ?
-    ORDER BY shard_id, tree_id, branch_id, node_id, txn_id
-    LIMIT ?
+	deleteHistoryNodesQuery = `DELETE FROM history_node
+WHERE rowid in (
+SELECT rowid FROM history_node
+WHERE shard_id = ? AND tree_id = ? AND branch_id = ? AND node_id >= ?
+ORDER BY shard_id, tree_id, branch_id, node_id, txn_id
+LIMIT ?
 )
-
-DELETE FROM history_node
-WHERE (shard_id, tree_id, branch_id, node_id, txn_id) IN (SELECT shard_id, tree_id, branch_id, node_id, txn_id FROM events_to_delete);`
+`
 )
 
 // DeleteFromHistoryNode deletes one or more rows from history_node table

--- a/common/persistence/sql/sqlplugin/sqlite/execution.go
+++ b/common/persistence/sql/sqlplugin/sqlite/execution.go
@@ -46,29 +46,21 @@ shard_id, domain_id, workflow_id, run_id, create_request_id, state, close_status
 FROM current_executions WHERE shard_id = ? AND domain_id = ? AND workflow_id = ?`
 	lockCurrentExecutionQuery = getCurrentExecutionQuery
 
-	rangeDeleteTransferTaskQuery        = `DELETE FROM transfer_tasks WHERE shard_id = ? AND task_id >= ? AND task_id < ?`
-	rangeDeleteTransferTaskByBatchQuery = `WITH tasks_to_delete AS (
-    SELECT shard_id, task_id
-    FROM transfer_tasks
-    WHERE shard_id = ? AND task_id >= ? AND task_id < ?
-    ORDER BY task_id
-    LIMIT ?
-)
+	rangeDeleteTransferTaskQuery = `DELETE FROM transfer_tasks WHERE shard_id = ? AND task_id >= ? AND task_id < ?`
 
-DELETE FROM transfer_tasks
-WHERE (shard_id, task_id) IN (SELECT shard_id, task_id FROM tasks_to_delete);`
-
+	rangeDeleteTransferTaskByBatchQuery = `DELETE FROM transfer_tasks WHERE rowid IN (
+SELECT rowid FROM transfer_tasks 
+WHERE shard_id = ? AND task_id >= ? AND task_id < ?
+ORDER BY task_id
+LIMIT ?  
+)`
 	rangeDeleteReplicationTaskQuery        = `DELETE FROM replication_tasks WHERE shard_id = ? AND task_id < ?`
-	rangeDeleteReplicationTaskByBatchQuery = `WITH tasks_to_delete AS (
-    SELECT shard_id, task_id
-    FROM replication_tasks
-    WHERE shard_id = ? AND task_id < ?
-    ORDER BY task_id
-    LIMIT ?
-)
-
-DELETE FROM replication_tasks
-WHERE (shard_id, task_id) IN (SELECT shard_id, task_id FROM tasks_to_delete);`
+	rangeDeleteReplicationTaskByBatchQuery = `DELETE FROM replication_tasks
+WHERE rowid  IN (
+SELECT rowid FROM replication_tasks
+WHERE shard_id = ? AND task_id < ?
+ORDER BY task_id
+LIMIT ?);`
 
 	rangeDeleteTimerTaskQuery        = `DELETE FROM timer_tasks WHERE shard_id = ? AND visibility_timestamp >= ? AND visibility_timestamp < ?`
 	rangeDeleteTimerTaskByBatchQuery = `DELETE FROM timer_tasks WHERE rowid IN (

--- a/common/persistence/sql/sqlplugin/sqlite/execution.go
+++ b/common/persistence/sql/sqlplugin/sqlite/execution.go
@@ -71,16 +71,10 @@ DELETE FROM replication_tasks
 WHERE (shard_id, task_id) IN (SELECT shard_id, task_id FROM tasks_to_delete);`
 
 	rangeDeleteTimerTaskQuery        = `DELETE FROM timer_tasks WHERE shard_id = ? AND visibility_timestamp >= ? AND visibility_timestamp < ?`
-	rangeDeleteTimerTaskByBatchQuery = `WITH tasks_to_delete AS (
-    SELECT shard_id, visibility_timestamp, task_id
-    FROM timer_tasks
+	rangeDeleteTimerTaskByBatchQuery = `DELETE FROM timer_tasks WHERE rowid IN (
+    SELECT rowid FROM timer_tasks
     WHERE shard_id = ? AND visibility_timestamp >= ? AND visibility_timestamp < ?
-    ORDER BY visibility_timestamp,task_id
-    LIMIT ?
-)
-
-DELETE FROM timer_tasks
-WHERE (shard_id, visibility_timestamp, task_id) IN (SELECT shard_id, visibility_timestamp, task_id FROM tasks_to_delete);`
+    ORDER BY visibility_timestamp, task_id LIMIT ?);`
 )
 
 // ReadLockExecutions acquires a write lock on a single row in executions table

--- a/common/persistence/sql/sqlplugin/sqlite/task.go
+++ b/common/persistence/sql/sqlplugin/sqlite/task.go
@@ -37,16 +37,12 @@ const (
 	deleteTaskQry = `DELETE FROM tasks ` +
 		`WHERE domain_id = ? AND task_list_name = ? AND task_type = ? AND task_id = ?`
 
-	rangeDeleteTaskQry = `WITH tasks_to_delete AS (
-    SELECT domain_id,task_list_name,task_type,task_id 
-    FROM tasks
-    WHERE domain_id = ? AND task_list_name = ? AND task_type = ? AND task_id <= ?
-    ORDER BY domain_id,task_list_name,task_type,task_id
-    LIMIT ?
-)
-
-DELETE FROM tasks
-WHERE (domain_id,task_list_name,task_type,task_id) IN (SELECT domain_id,task_list_name,task_type,task_id FROM tasks_to_delete);`
+	rangeDeleteTaskQry = `DELETE FROM tasks WHERE rowid IN (
+SELECT rowid FROM tasks 
+WHERE domain_id = ? AND task_list_name = ? AND task_type = ? AND task_id <= ?
+ORDER BY domain_id,task_list_name,task_type,task_id
+LIMIT ?
+)`
 )
 
 // LockTaskLists locks a row in task_lists table


### PR DESCRIPTION
Use subquery instead of CTE on sqlite plugin for all kind of range deletes with limit, close https://github.com/cadence-workflow/cadence/issues/8039 

<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Use subquery instead of CTE on sqlite plugin to avoid wasm out-of-bounds panic in RangeDeleteFromTimerTasks batch delete with limit.
- Replace CTE usage in all queries  in sqlplugin/sqlite also.

**Why?**
To fix the flaky test behavior in golang-integration-test-with-sqlite, we want to try to replace CTE usage with subquery for queries sent to sqlite.

**How did you test it?**
```
make cover_integration_profile PERSISTENCE_TYPE=sql PERSISTENCE_PLUGIN=sqlite
```

**Potential risks**
None

**Release notes**
Use subquery instead of CTE on sqlite plugin for all kind of range deletes with limit.

**Documentation Changes**
N/A
