### PR TITLE
fix: Change error type

### DIFF
--- a/common/persistence/sql/sql_execution_store_util.go
+++ b/common/persistence/sql/sql_execution_store_util.go
@@ -1095,7 +1095,7 @@ func createExecution(
 		}
 	}
 	if rowsAffected != 1 {
-		return &types.EntityNotExistsError{
+		return &types.InternalServiceError{
 			Message: fmt.Sprintf("createExecution failed. Affected %v rows updated instead of 1.", rowsAffected),
 		}
 	}
@@ -1145,7 +1145,7 @@ func updateExecution(
 		}
 	}
 	if rowsAffected != 1 {
-		return &types.EntityNotExistsError{
+		return &types.InternalServiceError{
 			Message: fmt.Sprintf("updateExecution failed. Affected %v rows updated instead of 1.", rowsAffected),
 		}
 	}

--- a/common/persistence/wrappers/metered/historytaskdlq_generated.go
+++ b/common/persistence/wrappers/metered/historytaskdlq_generated.go
@@ -50,7 +50,9 @@ func (c *meteredHistoryTaskDLQManager) CreateHistoryDLQAckLevelIfNotExists(ctx c
 		return err
 	}
 
-	err = c.call(metrics.PersistenceCreateHistoryDLQAckLevelIfNotExistsScope, op, getCustomMetricTags(request)...)
+	retryCount := getRetryCountFromContext(ctx)
+
+	err = c.call(metrics.PersistenceCreateHistoryDLQAckLevelIfNotExistsScope, op, append(getCustomMetricTags(request), metrics.IsRetryTag(retryCount > 0))...)
 	return
 }
 


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Change error type of some sql operations so that these failures can be retried

**Why?**
EntityNotExistError is a non-retriable error in many scenarios. When rows affected doesn't match the expectation, it doesn't mean that the data doesn't exist and we should still retry the operation.

**How did you test it?**
go test ./common/persistence/sql/...

**Potential risks**
No.

**Release notes**


**Documentation Changes**

