### PR TITLE
feat(cli): default batch start to v2 workflow, deprecate v1

### DIFF
--- a/canary/batch.go
+++ b/canary/batch.go
@@ -43,7 +43,7 @@ func init() {
 const (
 	// TODO: to get rid of them:
 	//  after batch job has an API, we should use the API: https://github.com/uber/cadence/issues/2225
-	sysBatchWFTypeName        = "cadence-sys-batch-workflow"
+	sysBatchWFTypeName        = "cadence-sys-batch-workflow-v2"
 	systemBatcherTaskListName = "cadence-sys-batcher-tasklist"
 
 	// there are two level, so totally 5*5 + 5 == 30 descendants

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -49,6 +49,10 @@ const (
 	// BatcherTaskListName is the tasklist name
 	BatcherTaskListName = "cadence-sys-batcher-tasklist"
 	// BatchWFTypeName is the workflow type
+	//
+	// Deprecated: superseded by BatchWFV2TypeName / BatchWorkflowV2. Kept registered
+	// only to serve in-flight v1 executions started before the switch to v2.
+	// TODO: remove once no v1 executions remain.
 	BatchWFTypeName   = "cadence-sys-batch-workflow"
 	batchActivityName = "cadence-sys-batch-activity"
 	// InfiniteDuration is a long duration(20 yrs) we used for infinite workflow running
@@ -106,6 +110,10 @@ func init() {
 }
 
 // BatchWorkflow is the workflow that runs a batch job of resetting workflows
+//
+// Deprecated: superseded by BatchWorkflowV2. Kept registered only to serve
+// in-flight v1 executions started before the switch to v2.
+// TODO: remove once no v1 executions remain.
 func BatchWorkflow(ctx workflow.Context, batchParams BatchParams) (HeartBeatDetails, error) {
 	batchParams = setDefaultParams(batchParams)
 	err := validateParams(batchParams)

--- a/service/worker/domaindeprecation/workflow.go
+++ b/service/worker/domaindeprecation/workflow.go
@@ -132,7 +132,7 @@ func (w *domainDeprecator) DomainDeprecationWorkflow(ctx workflow.Context, param
 		})
 
 		var result batcher.HeartBeatDetails
-		err = workflow.ExecuteChildWorkflow(childWorkflowOptions, batcher.BatchWorkflow, batchParams).Get(ctx, &result)
+		err = workflow.ExecuteChildWorkflow(childWorkflowOptions, batcher.BatchWorkflowV2, batchParams).Get(ctx, &result)
 		if err != nil {
 			return fmt.Errorf("batch workflow failed on attempt %d: %v", attempt, err)
 		}

--- a/service/worker/domaindeprecation/workflow_test.go
+++ b/service/worker/domaindeprecation/workflow_test.go
@@ -90,7 +90,7 @@ func (s *domainDeprecationWorkflowTestSuite) TearDownTest() {
 func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_Success() {
 	s.workflowEnv.OnActivity(disableArchivalActivity, mock.Anything, defaultParams).Return(nil)
 	s.workflowEnv.OnActivity(deprecateDomainActivity, mock.Anything, defaultParams).Return(nil)
-	s.workflowEnv.OnWorkflow(batcher.BatchWorkflow, mock.Anything, mock.Anything).Return(
+	s.workflowEnv.OnWorkflow(batcher.BatchWorkflowV2, mock.Anything, mock.Anything).Return(
 		batcher.HeartBeatDetails{
 			SuccessCount: 10,
 			ErrorCount:   0,
@@ -125,7 +125,7 @@ func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_BatchTerminate_ChildWo
 	mockErr := errors.New("batch workflow failed")
 	s.workflowEnv.OnActivity(disableArchivalActivity, mock.Anything, defaultParams).Return(nil)
 	s.workflowEnv.OnActivity(deprecateDomainActivity, mock.Anything, defaultParams).Return(nil)
-	s.workflowEnv.OnWorkflow(batcher.BatchWorkflow, mock.Anything, mock.Anything).Return(
+	s.workflowEnv.OnWorkflow(batcher.BatchWorkflowV2, mock.Anything, mock.Anything).Return(
 		batcher.HeartBeatDetails{}, mockErr)
 
 	s.workflowEnv.ExecuteWorkflow(DomainDeprecationWorkflowTypeName, defaultParams)
@@ -138,7 +138,7 @@ func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_CheckOpenWorkflows_Err
 	mockErr := errors.New("error")
 	s.workflowEnv.OnActivity(disableArchivalActivity, mock.Anything, defaultParams).Return(nil)
 	s.workflowEnv.OnActivity(deprecateDomainActivity, mock.Anything, defaultParams).Return(nil)
-	s.workflowEnv.OnWorkflow(batcher.BatchWorkflow, mock.Anything, mock.Anything).Return(
+	s.workflowEnv.OnWorkflow(batcher.BatchWorkflowV2, mock.Anything, mock.Anything).Return(
 		batcher.HeartBeatDetails{
 			SuccessCount: 10,
 			ErrorCount:   0,

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -246,7 +246,6 @@ const (
 	FlagClusterAttributeScope          = "cluster_attribute_scope"
 	FlagClusterAttributeName           = "cluster_attribute_name"
 	FlagClusterAttributesJSON          = "cluster_attributes_json"
-	FlagBatchV2                        = "v2"
 
 	FlagClustersUsage = "Clusters (example: --clusters clusterA,clusterB or --cl clusterA --cl clusterB)"
 )

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -246,6 +246,9 @@ const (
 	FlagClusterAttributeScope          = "cluster_attribute_scope"
 	FlagClusterAttributeName           = "cluster_attribute_name"
 	FlagClusterAttributesJSON          = "cluster_attributes_json"
+	// FlagBatchV1 forces the deprecated v1 batch workflow as a fallback.
+	// TODO: remove together with the v1 batch workflow once it is fully deprecated.
+	FlagBatchV1 = "v1"
 
 	FlagClustersUsage = "Clusters (example: --clusters clusterA,clusterB or --cl clusterA --cl clusterB)"
 )

--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -566,6 +566,11 @@ func newBatchCommands() []*cli.Command {
 					Value: batcher.DefaultMaxActivityRetries,
 					Usage: "Max retries of batch activity, before retrying the whole workflow (0 means unlimited)",
 				},
+				// TODO: remove this flag once the v1 batch workflow is fully deprecated.
+				&cli.BoolFlag{
+					Name:  FlagBatchV1,
+					Usage: "Fallback to the deprecated v1 batch workflow (v1 is deprecated; defaults to v2)",
+				},
 			},
 			Action: StartBatchJob,
 		},

--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -566,10 +566,6 @@ func newBatchCommands() []*cli.Command {
 					Value: batcher.DefaultMaxActivityRetries,
 					Usage: "Max retries of batch activity, before retrying the whole workflow (0 means unlimited)",
 				},
-				&cli.BoolFlag{
-					Name:  FlagBatchV2,
-					Usage: "Use V2 batch workflow with runtime signal-based tuning support",
-				},
 			},
 			Action: StartBatchJob,
 		},

--- a/tools/cli/workflow_batch_commands.go
+++ b/tools/cli/workflow_batch_commands.go
@@ -317,6 +317,10 @@ func StartBatchJob(c *cli.Context) error {
 		return commoncli.Problem("Failed to encode batch job search attributes", err)
 	}
 	wfTypeName := batcher.BatchWFV2TypeName
+	// TODO: remove this fallback once the v1 batch workflow is fully deprecated.
+	if c.Bool(FlagBatchV1) {
+		wfTypeName = batcher.BatchWFTypeName
+	}
 
 	workflowID := uuid.NewRandom().String()
 	request := &types.StartWorkflowExecutionRequest{

--- a/tools/cli/workflow_batch_commands.go
+++ b/tools/cli/workflow_batch_commands.go
@@ -316,10 +316,7 @@ func StartBatchJob(c *cli.Context) error {
 	if err != nil {
 		return commoncli.Problem("Failed to encode batch job search attributes", err)
 	}
-	wfTypeName := batcher.BatchWFTypeName
-	if c.Bool(FlagBatchV2) {
-		wfTypeName = batcher.BatchWFV2TypeName
-	}
+	wfTypeName := batcher.BatchWFV2TypeName
 
 	workflowID := uuid.NewRandom().String()
 	request := &types.StartWorkflowExecutionRequest{


### PR DESCRIPTION
## What changed

Removes the `--v2` opt-in flag from `cadence workflow batch start`. The CLI now always launches the v2 batch workflow (`cadence-sys-batch-workflow-v2`).

The old v1 `BatchWorkflow` / `BatchWFTypeName` stays **registered and alive** to serve any in-flight v1 executions, but is marked `Deprecated:` with a TODO to remove it once none remain.

Remaining v1 callers are repointed to v2:
- `domaindeprecation` child workflow → `batcher.BatchWorkflowV2`
- `canary` `sysBatchWFTypeName` → `cadence-sys-batch-workflow-v2`

The other batch subcommands (`describe`, `terminate`, `list`) are type-agnostic — they act by job/workflow ID or filter by the `CustomDomain` search attribute — so they already work with v2 jobs and needed no changes.

## Why

v2 is the intended default going forward (it supports runtime signal-based tuning). Gating it behind a flag left v1 as the default; this makes v2 the standard path and starts the deprecation of v1.

## How tested

- `go test -race ./service/worker/batcher/... ./service/worker/domaindeprecation/...`
- Manual: `cadence workflow batch start --help` no longer lists `--v2`; started jobs use the v2 type and still appear under `batch list`.