### PR TITLE
fix(matching): Exclude short-lived bits tasklists from shard-distributor

### DIFF
--- a/common/membership/tasklist_differentiator.go
+++ b/common/membership/tasklist_differentiator.go
@@ -2,19 +2,29 @@ package membership
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/dgryski/go-farm"
 )
 
 const uuidRegex = `[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`
 
+// bitsMarker is the marker the cadencefx BITS interceptor injects into dynamic/short-lived task list names
+const bitsMarker = "/cdnc-bits/"
+
 var uuidRegexp = regexp.MustCompile(uuidRegex)
 
 func TaskListExcludedFromShardDistributor(taskListName string, percentageOnboarded uint64, excludeShortLivedTaskLists bool) bool {
-	// This regex checks if the task list name has a UUID, if it does we
-	// consider it a short lived tasklist that will not be managed by the shard distributor.
-	excludeShortLivedTaskLists = excludeShortLivedTaskLists && uuidRegexp.MatchString(taskListName)
+	// A task list is considered short-lived (and therefore not managed by the
+	// shard distributor) if its name either contains a UUID or carries the BITS
+	// marker. The marker check catches BITS task lists whose UUID was truncated
+	// by the client-side length cap.
+	excludeShortLivedTaskLists = excludeShortLivedTaskLists && isShortLivedTaskList(taskListName)
 	return excludeShortLivedTaskLists || !belowPercentage(taskListName, percentageOnboarded)
+}
+
+func isShortLivedTaskList(taskListName string) bool {
+	return uuidRegexp.MatchString(taskListName) || strings.Contains(taskListName, bitsMarker)
 }
 
 func belowPercentage(taskListName string, percentageOnboarded uint64) bool {

--- a/common/membership/tasklist_differentiator_test.go
+++ b/common/membership/tasklist_differentiator_test.go
@@ -105,6 +105,34 @@ func TestTaskListExcludedFromShardDistributor(t *testing.T) {
 			percentageOnboarded:        60,
 			excludeShortLivedTaskLists: true,
 		},
+		{
+			name:                       "BITS task list with truncated UUID - exclude enabled",
+			taskListName:               "testss/cdnc-bits/58a3fcd1-678f-4a0a-b0ad-c91a020",
+			want:                       true,
+			percentageOnboarded:        100,
+			excludeShortLivedTaskLists: true,
+		},
+		{
+			name:                       "BITS task list with truncated UUID - exclude disabled",
+			taskListName:               "testss/cdnc-bits/58a3fcd1-678f-4a0a-b0ad-c91a020",
+			want:                       false,
+			percentageOnboarded:        100,
+			excludeShortLivedTaskLists: false,
+		},
+		{
+			name:                       "BITS task list with full UUID - exclude enabled",
+			taskListName:               "tl/cdnc-bits/u/integration:bits-pipeline/31012248-c298-4245-833e-ab439eeaf17b",
+			want:                       true,
+			percentageOnboarded:        100,
+			excludeShortLivedTaskLists: true,
+		},
+		{
+			name:                       "BITS marker present but exclude disabled falls back to percentage",
+			taskListName:               "testss/cdnc-bits/58a3fcd1-678f-4a0a-b0ad-c91a020",
+			want:                       true,
+			percentageOnboarded:        0,
+			excludeShortLivedTaskLists: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
This PR excludes BITS (with prefix`/cdnc-bits/`) task lists from the shard distributor even when their trailing UUID has been truncated

**Why?**
`TaskListExcludedFromShardDistributor` only treated a task list as short-lived if it contained a full canonical `8-4-4-4-12` UUID. The cadencefx BITS interceptor caps the encoded task list name at 100 chars, which can truncate
that UUID (e.g. `.../cdnc-bits/58a3fcd1-678f-4a0a-b0ad-c91a020` - last group is 7 hex, not 12). Those task lists slipped past the UUID regex and distributed by shard-manager.

**How did you test it?**
unit-tests

**Potential risks**
Low risk - since bits tasklists will continue operate with hash-ring

**Release notes**
N/A

**Documentation Changes**
N/A
