### PR TITLE
fix(metrics): normalize persistence metric labels for Prometheus

### DIFF
--- a/common/persistence/wrappers/metered/base.go
+++ b/common/persistence/wrappers/metered/base.go
@@ -270,7 +270,7 @@ func (p *base) emitRowCountMetrics(methodName string, req any, res any) {
 		return
 	}
 
-	metricScope := p.metricClient.Scope(scope.scope, getCustomMetricTags(req)...)
+	metricScope := p.metricClient.Scope(scope.scope, ensureTaskCategoryTag(getCustomMetricTags(req))...)
 
 	if resLen.Len() == 0 {
 		metricScope.IncCounter(metrics.PersistenceEmptyResponseCounter)
@@ -290,7 +290,7 @@ func (p *base) emitPayloadSizeMetrics(methodName string, req any, res any) {
 		return
 	}
 
-	metricScope := p.metricClient.Scope(scope.scope, getCustomMetricTags(req)...)
+	metricScope := p.metricClient.Scope(scope.scope, ensureTaskCategoryTag(getCustomMetricTags(req))...)
 	metricScope.RecordHistogramValue(metrics.PersistenceResponsePayloadSize, float64(resSize.ByteSize()))
 }
 


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Normalized persistence metric label sets emitted by the metered persistence wrappers so Prometheus does not reject metrics registered under the same name with different label keys.

- Defaulting task_category="none" on `persistence_response_payload_size` and `persistence_response_row_size` when no task category applies.

related to https://github.com/cadence-workflow/cadence/issues/7844

**Why?**
follow up of https://github.com/cadence-workflow/cadence/pull/8064

**How did you test it?**


**Potential risks**


**Release notes**


**Documentation Changes**

