### PR TITLE
fix(metrics): normalize persistence metric labels for Prometheus

### DIFF
--- a/common/persistence/wrappers/metered/base.go
+++ b/common/persistence/wrappers/metered/base.go
@@ -65,6 +65,26 @@ func ensureTaskCategoryTag(tags []metrics.Tag) []metrics.Tag {
 	return append(tags, metrics.TaskCategoryTag("none"))
 }
 
+// dropDomainTag removes any domain tag from tags. It exists for the row-count and
+// payload-size metrics (see emitRowCountMetrics/emitPayloadSizeMetrics), which -
+// unlike the request/latency family - use a single metric name across every
+// persistence operation rather than splitting into overall/per-domain variants.
+// getCustomMetricTags(req) is shared with that request/latency family and returns
+// a domain tag for some request types (e.g. ReadHistoryBranchRequest) and not
+// others; letting it through here would multiply these metrics' cardinality by
+// every domain in the cluster while duplicating the discrimination the built-in
+// operation tag already provides, and would collide with the metric registered by
+// the domain-less request types sharing the same metric name.
+func dropDomainTag(tags []metrics.Tag) []metrics.Tag {
+	filtered := make([]metrics.Tag, 0, len(tags))
+	for _, t := range tags {
+		if t.Key() != domainTagKey {
+			filtered = append(filtered, t)
+		}
+	}
+	return filtered
+}
+
 type base struct {
 	metricClient                  metrics.Client
 	logger                        log.Logger
@@ -258,6 +278,13 @@ type extraLogRequest interface {
 	GetExtraLogTags() []tag.Tag
 }
 
+// rowMetricTags builds the tag set shared by the row-count and payload-size
+// metrics: task_category is always present (defaulted like the request/latency
+// family), while domain is deliberately excluded — see dropDomainTag.
+func rowMetricTags(req any) []metrics.Tag {
+	return ensureTaskCategoryTag(dropDomainTag(getCustomMetricTags(req)))
+}
+
 func (p *base) emitRowCountMetrics(methodName string, req any, res any) {
 	scope, ok := emptyCountedMethods[methodName]
 	if !ok {
@@ -270,7 +297,7 @@ func (p *base) emitRowCountMetrics(methodName string, req any, res any) {
 		return
 	}
 
-	metricScope := p.metricClient.Scope(scope.scope, getCustomMetricTags(req)...)
+	metricScope := p.metricClient.Scope(scope.scope, rowMetricTags(req)...)
 
 	if resLen.Len() == 0 {
 		metricScope.IncCounter(metrics.PersistenceEmptyResponseCounter)
@@ -290,7 +317,7 @@ func (p *base) emitPayloadSizeMetrics(methodName string, req any, res any) {
 		return
 	}
 
-	metricScope := p.metricClient.Scope(scope.scope, getCustomMetricTags(req)...)
+	metricScope := p.metricClient.Scope(scope.scope, rowMetricTags(req)...)
 	metricScope.RecordHistogramValue(metrics.PersistenceResponsePayloadSize, float64(resSize.ByteSize()))
 }
 

--- a/common/persistence/wrappers/metered/metered_test.go
+++ b/common/persistence/wrappers/metered/metered_test.go
@@ -53,16 +53,17 @@ var _staticMethods = map[string]bool{
 	"GetShardID": true,
 }
 
+// TestPersistenceMetricsLabelConsistency exercises every method of every metered
+// wrapper against a single, shared Prometheus-backed metrics client. Prometheus
+// rejects registering the same metric name twice with a different label set, so
+// running all wrappers/methods through one registry surfaces label inconsistencies
+// between methods and between wrapper types (e.g. shard-enabled vs shard-disabled
+// ExecutionManager, or ExecutionManager vs HistoryManager sharing a metric name).
+//
+// Functional errors returned by the wrapped calls are intentionally ignored: the
+// mocks below return zero-value responses that aren't semantically valid, so the
+// only thing worth asserting on is the absence of Prometheus registration errors.
 func TestPersistenceMetricsLabelConsistency(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	wrapped := persistence.NewMockExecutionManager(ctrl)
-	wrapped.EXPECT().GetShardID().Return(1).AnyTimes()
-	wrapped.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{}, nil).Times(2)
-	wrapped.EXPECT().GetHistoryTasks(gomock.Any(), gomock.Any()).Return(&persistence.GetHistoryTasksResponse{}, nil).Times(1)
-	wrapped.EXPECT().GetReplicationDLQSize(gomock.Any(), gomock.Any()).Return(&persistence.GetReplicationDLQSizeResponse{}, nil).Times(1)
-	historyStore := persistence.NewMockHistoryManager(ctrl)
-	historyStore.EXPECT().AppendHistoryNodes(gomock.Any(), gomock.Any()).Return(&persistence.AppendHistoryNodesResponse{}, nil).Times(1)
-
 	var registrationErrors []error
 	promCfg := &tallyp8s.Configuration{
 		OnError:   "none",
@@ -82,45 +83,44 @@ func TestPersistenceMetricsLabelConsistency(t *testing.T) {
 		CachedReporter: reporter,
 		Separator:      tallyp8s.DefaultSeparator,
 	}, time.Second)
-	defer closer.Close()
 
 	metricsClient := metrics.NewClient(rootScope, metrics.History, metrics.MigrationConfig{})
+	logger := log.NewNoop()
 
-	shardMetricsManager := NewExecutionManager(
-		wrapped,
-		metricsClient,
-		log.NewNoop(),
-		&config.Persistence{EnablePersistenceLatencyHistogramMetrics: true},
-		dynamicproperties.GetBoolPropertyFn(true),
-	)
-	noShardMetricsManager := NewExecutionManager(
-		wrapped,
-		metricsClient,
-		log.NewNoop(),
-		&config.Persistence{EnablePersistenceLatencyHistogramMetrics: true},
-		dynamicproperties.GetBoolPropertyFn(false),
-	)
-	historyManager := NewHistoryManager(
-		historyStore,
-		metricsClient,
-		log.NewNoop(),
-		&config.Persistence{EnablePersistenceLatencyHistogramMetrics: true},
-	)
+	for _, tc := range persistenceWrapperTestCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
 
-	ctx := context.Background()
-	_, err = shardMetricsManager.GetWorkflowExecution(ctx, &persistence.GetWorkflowExecutionRequest{})
-	assert.NoError(t, err)
-	_, err = shardMetricsManager.GetHistoryTasks(ctx, &persistence.GetHistoryTasksRequest{
-		TaskCategory: persistence.HistoryTaskCategoryTransfer,
-	})
-	assert.NoError(t, err)
-	_, err = shardMetricsManager.GetReplicationDLQSize(ctx, &persistence.GetReplicationDLQSizeRequest{})
-	assert.NoError(t, err)
-	_, err = noShardMetricsManager.GetWorkflowExecution(ctx, &persistence.GetWorkflowExecutionRequest{})
-	assert.NoError(t, err)
-	_, err = historyManager.AppendHistoryNodes(ctx, &persistence.AppendHistoryNodesRequest{})
-	assert.NoError(t, err)
+			newObj, mocked := tc.prepareMock(t, ctrl, metricsClient, logger)
+			prepareMockForTest(t, mocked, nil)
 
+			invokeAllMethods(t, newObj)
+		})
+	}
+
+	// The calls above all return zero-value (empty, Len()==0) responses, so they
+	// only ever exercise the PersistenceEmptyResponseCounter branch of
+	// emitRowCountMetrics. Call every emptyCountedMethods entry once more with a
+	// non-empty response so the PersistenceResponseRowSize histogram branch gets
+	// registered too, and any label inconsistency there is caught as well.
+	for _, tc := range nonEmptyRowCountTestCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			tc.invoke(t, ctrl, metricsClient, logger)
+		})
+	}
+
+	// Metric registration happens as metrics are emitted, and reporting/flushing
+	// happens on Close(); force it here so registrationErrors is fully populated.
+	require.NoError(t, closer.Close())
+
+	// Log every registration error for diagnosability, then fail: these indicate a
+	// metric name being registered with inconsistent labels across persistence
+	// operations, which silently drops data in production (Prometheus keeps
+	// whichever registration won the race and rejects the rest).
+	for _, regErr := range registrationErrors {
+		t.Logf("Prometheus registration error (label inconsistency): %v", regErr)
+	}
 	assert.Empty(t, registrationErrors, "Prometheus registration errors must not be emitted")
 }
 
@@ -160,8 +160,15 @@ func TestGetRetryCountFromContext(t *testing.T) {
 	require.Equal(t, map[string]int64{"false": 1, "true": 1}, countsByIsRetry)
 }
 
-func TestWrappersAgainstPreviousImplementation(t *testing.T) {
-	for _, tc := range []struct {
+// persistenceWrapperTestCases enumerates every metered wrapper constructor so that
+// tests can exercise all of them generically. ExecutionManager is included twice,
+// once per shard-reporting mode, since that flag changes which metric labels are
+// emitted for the same metric names.
+func persistenceWrapperTestCases() []struct {
+	name        string
+	prepareMock func(t *testing.T, ctrl *gomock.Controller, newMetricsClient metrics.Client, newLogger log.Logger) (newManager any, mocked any)
+} {
+	return []struct {
 		name        string
 		prepareMock func(t *testing.T, ctrl *gomock.Controller, newMetricsClient metrics.Client, newLogger log.Logger) (newManager any, mocked any)
 	}{
@@ -248,7 +255,140 @@ func TestWrappersAgainstPreviousImplementation(t *testing.T) {
 				return newObj, wrapped
 			},
 		},
-	} {
+		{
+			name: "ExecutionManagerShardReportingDisabled",
+			prepareMock: func(t *testing.T, ctrl *gomock.Controller, newMetricsClient metrics.Client, newLogger log.Logger) (newManager any, mocked any) {
+				wrapped := persistence.NewMockExecutionManager(ctrl)
+
+				wrapped.EXPECT().GetShardID().Return(0).AnyTimes()
+
+				newObj := NewExecutionManager(wrapped, newMetricsClient, newLogger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true},
+					dynamicproperties.GetBoolPropertyFn(false))
+
+				return newObj, wrapped
+			},
+		},
+	}
+}
+
+// nonEmptyRowCountTestCases covers every emptyCountedMethods entry with a
+// non-empty (Len() > 0) response, one method call each, so the
+// PersistenceResponseRowSize histogram branch of emitRowCountMetrics gets
+// registered against the shared Prometheus registry at least once.
+//
+// ExecutionManager.GetReplicationTasksFromDLQ is intentionally omitted: its
+// response type, *persistence.GetReplicationDLQTasksResponse, doesn't implement
+// the lengther interface, so emitRowCountMetrics silently no-ops for it today
+// regardless of response content.
+func nonEmptyRowCountTestCases() []struct {
+	name   string
+	invoke func(t *testing.T, ctrl *gomock.Controller, metricsClient metrics.Client, logger log.Logger)
+} {
+	ctx := context.Background()
+	return []struct {
+		name   string
+		invoke func(t *testing.T, ctrl *gomock.Controller, metricsClient metrics.Client, logger log.Logger)
+	}{
+		{
+			name: "ExecutionManager.ListCurrentExecutions",
+			invoke: func(t *testing.T, ctrl *gomock.Controller, metricsClient metrics.Client, logger log.Logger) {
+				wrapped := persistence.NewMockExecutionManager(ctrl)
+				wrapped.EXPECT().GetShardID().Return(0).AnyTimes()
+				wrapped.EXPECT().ListCurrentExecutions(gomock.Any(), gomock.Any()).Return(&persistence.ListCurrentExecutionsResponse{
+					Executions: []*persistence.CurrentWorkflowExecution{{}},
+				}, nil)
+
+				mgr := NewExecutionManager(wrapped, metricsClient, logger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true},
+					dynamicproperties.GetBoolPropertyFn(true))
+				_, err := mgr.ListCurrentExecutions(ctx, &persistence.ListCurrentExecutionsRequest{})
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "ExecutionManager.GetHistoryTasks",
+			invoke: func(t *testing.T, ctrl *gomock.Controller, metricsClient metrics.Client, logger log.Logger) {
+				wrapped := persistence.NewMockExecutionManager(ctrl)
+				wrapped.EXPECT().GetShardID().Return(0).AnyTimes()
+				wrapped.EXPECT().GetHistoryTasks(gomock.Any(), gomock.Any()).Return(&persistence.GetHistoryTasksResponse{
+					Tasks: []persistence.Task{&persistence.ActivityTask{}},
+				}, nil)
+
+				mgr := NewExecutionManager(wrapped, metricsClient, logger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true},
+					dynamicproperties.GetBoolPropertyFn(true))
+				_, err := mgr.GetHistoryTasks(ctx, &persistence.GetHistoryTasksRequest{TaskCategory: persistence.HistoryTaskCategoryTransfer})
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "TaskManager.GetTasks",
+			invoke: func(t *testing.T, ctrl *gomock.Controller, metricsClient metrics.Client, logger log.Logger) {
+				wrapped := persistence.NewMockTaskManager(ctrl)
+				wrapped.EXPECT().GetTasks(gomock.Any(), gomock.Any()).Return(&persistence.GetTasksResponse{
+					Tasks: []*persistence.TaskInfo{{}},
+				}, nil)
+
+				mgr := NewTaskManager(wrapped, metricsClient, logger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true})
+				_, err := mgr.GetTasks(ctx, &persistence.GetTasksRequest{DomainName: "test-domain"})
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "DomainManager.ListDomains",
+			invoke: func(t *testing.T, ctrl *gomock.Controller, metricsClient metrics.Client, logger log.Logger) {
+				wrapped := persistence.NewMockDomainManager(ctrl)
+				wrapped.EXPECT().ListDomains(gomock.Any(), gomock.Any()).Return(&persistence.ListDomainsResponse{
+					Domains: []*persistence.GetDomainResponse{{}},
+				}, nil)
+
+				mgr := NewDomainManager(wrapped, metricsClient, logger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true})
+				_, err := mgr.ListDomains(ctx, &persistence.ListDomainsRequest{})
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "HistoryManager.ReadHistoryBranch",
+			invoke: func(t *testing.T, ctrl *gomock.Controller, metricsClient metrics.Client, logger log.Logger) {
+				wrapped := persistence.NewMockHistoryManager(ctrl)
+				wrapped.EXPECT().ReadHistoryBranch(gomock.Any(), gomock.Any()).Return(&persistence.ReadHistoryBranchResponse{
+					HistoryEvents: []*types.HistoryEvent{{}},
+				}, nil)
+
+				mgr := NewHistoryManager(wrapped, metricsClient, logger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true})
+				_, err := mgr.ReadHistoryBranch(ctx, &persistence.ReadHistoryBranchRequest{DomainName: "test-domain"})
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "HistoryManager.GetAllHistoryTreeBranches",
+			invoke: func(t *testing.T, ctrl *gomock.Controller, metricsClient metrics.Client, logger log.Logger) {
+				wrapped := persistence.NewMockHistoryManager(ctrl)
+				wrapped.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), gomock.Any()).Return(&persistence.GetAllHistoryTreeBranchesResponse{
+					Branches: []persistence.HistoryBranchDetail{{}},
+				}, nil)
+
+				mgr := NewHistoryManager(wrapped, metricsClient, logger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true})
+				_, err := mgr.GetAllHistoryTreeBranches(ctx, &persistence.GetAllHistoryTreeBranchesRequest{})
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "QueueManager.ReadMessages",
+			invoke: func(t *testing.T, ctrl *gomock.Controller, metricsClient metrics.Client, logger log.Logger) {
+				wrapped := persistence.NewMockQueueManager(ctrl)
+				wrapped.EXPECT().ReadMessages(gomock.Any(), gomock.Any()).Return(&persistence.ReadMessagesResponse{
+					Messages: persistence.QueueMessageList{{}},
+				}, nil)
+
+				mgr := NewQueueManager(wrapped, metricsClient, logger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true})
+				_, err := mgr.ReadMessages(ctx, &persistence.ReadMessagesRequest{})
+				require.NoError(t, err)
+			},
+		},
+	}
+}
+
+func TestWrappersAgainstPreviousImplementation(t *testing.T) {
+	for _, tc := range persistenceWrapperTestCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Run("without error", func(t *testing.T) {
 				ctrl := gomock.NewController(t)
@@ -404,6 +544,14 @@ func setupLogsCapture() (*zap.Logger, *observer.ObservedLogs) {
 }
 
 func runScenario(t *testing.T, newObj any, newLogs *observer.ObservedLogs, newMetrics tally.TestScope) {
+	invokeAllMethods(t, newObj)
+}
+
+// invokeAllMethods calls every non-static method of newObj exactly once via
+// reflection, using zero-value/newly-allocated arguments. It only asserts that
+// the call doesn't panic; return values (including errors) are ignored, since
+// callers use this to exercise metric-emission paths, not business logic.
+func invokeAllMethods(t *testing.T, newObj any) {
 	newV := reflect.ValueOf(newObj)
 	infoT := reflect.TypeOf(newV.Interface())
 	for i := 0; i < infoT.NumMethod(); i++ {
@@ -424,15 +572,9 @@ func runScenario(t *testing.T, newObj any, newLogs *observer.ObservedLogs, newMe
 				vals = append(vals, reflect.Zero(method.Type.In(i)))
 			}
 
-			var newRes []reflect.Value
 			assert.NotPanicsf(t, func() {
-				newRes = newV.MethodByName(method.Name).Call(vals)
+				newV.MethodByName(method.Name).Call(vals)
 			}, "method does not have tag defined")
-
-			if len(newRes) == 0 {
-				// Empty result means that method panicked.
-				return
-			}
 		})
 	}
 }


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Normalized persistence metric label sets emitted by the metered persistence wrappers so Prometheus does not reject metrics registered under the same name with different label keys.

- Defaulting task_category="none" on `persistence_response_payload_size`, `persistence_response_row_size` and `persistence_empty_response` when no task category applies.

related to https://github.com/cadence-workflow/cadence/issues/7844

**Why?**
follow up of https://github.com/cadence-workflow/cadence/pull/8064
Prometheus requires every metric name to use a consistent label-name set. Cadence persistence metrics could emit the same metric name from different wrapper paths with different labels, causing Prometheus reporter warnings and dropped metrics.

**How did you test it?**
Added a Prometheus-backed regression test that exercises persistence metered wrapper paths with different label dimensions and verifies no Prometheus registration errors are emitted.
go test ./common/persistence/wrappers/metered

**Potential risks**
No.

**Release notes**
This change removes domain label/tag from `persistence_response_payload_size`, `persistence_response_row_size` and `persistence_empty_response` metrics and add `task_category` label/tag to these metrics with default value "none". Selectors by metric name should still match, but dashboards/alerts that aggregate or group by labels may need to explicitly aggregate away those new dimensions.


**Documentation Changes**

