### PR TITLE
fix(persistence): DBUnavailableError is now transient

### DIFF
--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -2712,8 +2712,9 @@ func IsTransientError(err error) bool {
 	var internalServiceError *types.InternalServiceError
 	var serviceBusyError *types.ServiceBusyError
 	var timeoutError *TimeoutError
+	var dbUnavailableError *DBUnavailableError
 	switch {
-	case errors.As(err, &internalServiceError), errors.As(err, &serviceBusyError), errors.As(err, &timeoutError):
+	case errors.As(err, &internalServiceError), errors.As(err, &serviceBusyError), errors.As(err, &timeoutError), errors.As(err, &dbUnavailableError):
 		return true
 	}
 

--- a/common/persistence/data_manager_interfaces_test.go
+++ b/common/persistence/data_manager_interfaces_test.go
@@ -151,6 +151,8 @@ func TestIsTransientError(t *testing.T) {
 		&types.ServiceBusyError{},
 		&types.InternalServiceError{},
 		&TimeoutError{},
+		&DBUnavailableError{},
+		fmt.Errorf("wrapped: %w", &DBUnavailableError{Msg: "db down"}),
 	}
 	for _, err := range transientErrors {
 		require.True(t, IsTransientError(err))

--- a/service/history/engine/engineimpl/describe_workflow_execution_test.go
+++ b/service/history/engine/engineimpl/describe_workflow_execution_test.go
@@ -177,15 +177,17 @@ func TestDescribeWorkflowExecution(t *testing.T) {
 				)
 				mockMutableState.EXPECT().GetDomainEntry().Return(domainEntry)
 
-				// This will trigger corruption check failure with different error
+				// This will trigger corruption check failure with different error.
+				// Non-start-event errors are returned directly without marking the
+				// workflow corrupted, so GetExecutionInfo() is not called here.
 				mockMutableState.EXPECT().GetStartEvent(gomock.Any()).Return(nil, &types.InternalServiceError{Message: "Database error"})
 
-				// Mock GetExecutionInfo() call for corruption marking
+				// NO corruption marking
 				mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{
 					WorkflowID:       "test-wf",
 					RunID:            "test-run",
 					WorkflowTypeName: "test-type",
-				})
+				}).Times(0)
 			},
 			enableCorruptionCheck: true,
 			expectError:           true,

--- a/service/history/engine/engineimpl/history_engine.go
+++ b/service/history/engine/engineimpl/history_engine.go
@@ -410,18 +410,16 @@ func (e *historyEngineImpl) checkForHistoryCorruptions(ctx context.Context, muta
 	// Ensure that we can obtain start event. Failing to do so means corrupted history or resurrected mutable state record.
 	_, err := mutableState.GetStartEvent(ctx)
 	if err != nil {
-		info := mutableState.GetExecutionInfo()
-		// Mark workflow as corrupted. So that new one can be restarted.
-		info.State = persistence.WorkflowStateCorrupted
-
-		e.logger.Error("history corruption check failed",
-			tag.WorkflowDomainName(domainName),
-			tag.WorkflowID(info.WorkflowID),
-			tag.WorkflowRunID(info.RunID),
-			tag.WorkflowType(info.WorkflowTypeName),
-			tag.Error(err))
-
 		if errors.Is(err, execution.ErrMissingWorkflowStartEvent) {
+			info := mutableState.GetExecutionInfo()
+			// Mark workflow as corrupted. So that new one can be restarted.
+			info.State = persistence.WorkflowStateCorrupted
+			e.logger.Error("history corruption check failed",
+				tag.WorkflowDomainName(domainName),
+				tag.WorkflowID(info.WorkflowID),
+				tag.WorkflowRunID(info.RunID),
+				tag.WorkflowType(info.WorkflowTypeName),
+				tag.Error(err))
 			return true, nil
 		}
 		return false, err


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

Transient Error

DBUnavailableError is previous mis-categorized as non-transient error and thus GetStartEvent would return ErrMissingWorkflowStartEvent and subsequently failed the checkForHistoryCorruptions. This resulted a false-positive corrupted state for a running workflow since the next signalwithstart will create a new run and use `templateUpdateCurrentWorkflowExecutionQuery` regardless of previous workflow_state. 

There is no way to process the workflow run unless we restart it. 

Corruption Check

* log only when check returns true to avoid confusion

**Why?**

Before: QUORUM-unavailable → masked as "missing start event" → corrupted=true → ContinueAsNew → run-id-only CAS overwrites current R1→R2 → healthy running R1 silently orphaned (two runs).

After: QUORUM-unavailable → checkForHistoryCorruptions returns (false, DBUnavailableError) → SignalWithStartWorkflowExecution returns that error to the caller. No new run is created; R1 stays current, running, and intact. The client retries signalWithStart (it's idempotent via RequestID); once the DB can serve QUORUM again, GetStartEvent succeeds, corrupted=false, and since R1 is running it takes the normal "just signal R1" path — no duplicate run.


**How did you test it?**

Unit Test

**Potential risks**


**Release notes**


**Documentation Changes**

