### PR TITLE
fix(canary): don't crash canary worker on start errors

### DIFF
--- a/canary/canary.go
+++ b/canary/canary.go
@@ -89,17 +89,14 @@ func (c *canaryImpl) Run(mode string) error {
 	if mode != ModeCronCanary && mode != ModeAll && mode != ModeWorker {
 		return fmt.Errorf("wrong mode to start canary")
 	}
-	var err error
 	log := c.runtime.logger
 
-	if err = c.createDomain(); err != nil {
+	if err := c.createDomain(); err != nil {
 		log.Error("createDomain failed", zap.Error(err))
-		return err
 	}
 
-	if err = c.createArchivalDomain(); err != nil {
+	if err := c.createArchivalDomain(); err != nil {
 		log.Error("createArchivalDomain failed", zap.Error(err))
-		return err
 	}
 
 	if mode == ModeAll || mode == ModeCronCanary {
@@ -108,8 +105,7 @@ func (c *canaryImpl) Run(mode string) error {
 	}
 
 	if mode == ModeAll || mode == ModeWorker {
-		err = c.startWorker()
-		if err != nil {
+		if err := c.startWorker(); err != nil {
 			log.Error("start worker failed", zap.Error(err))
 			return err
 		}
@@ -132,7 +128,7 @@ func (c *canaryImpl) startWorker() error {
 	archivalWorker := worker.New(c.archivalClient.Service, archivalDomain, archivalTaskListName, options)
 	defer archivalWorker.Stop()
 	if err := archivalWorker.Start(); err != nil {
-		return err
+		c.runtime.logger.Error("failed to start archival worker", zap.Error(err))
 	}
 	canaryWorker := worker.New(c.canaryClient.Service, c.canaryDomain, taskListName, options)
 	if c.canaryConfig.CrossClusterTestMode == CrossClusterCanaryModeFull {

--- a/canary/runner.go
+++ b/canary/runner.go
@@ -31,6 +31,7 @@ import (
 	apiv1 "github.com/uber/cadence-idl/go/proto/api/v1"
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 	"go.uber.org/cadence/compatibility"
+	"go.uber.org/multierr"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/peer"
@@ -155,22 +156,54 @@ func (r *canaryRunner) Run(mode string) error {
 		r.config.Cron.StartJobTimeout = 9 * time.Minute
 	}
 
-	var wg sync.WaitGroup
-	for _, d := range r.config.Domains {
-		canary := newCanary(d, r.RuntimeContext, r.config)
+	tasks := make([]Runnable, len(r.config.Domains))
+	for i, d := range r.config.Domains {
+		i, d := i, d
+		canaryTask := newCanary(d, r.RuntimeContext, r.config)
 		r.logger.Info("starting canary", zap.String("domain", d))
-		r.execute(canary, mode, &wg)
+		tasks[i] = runnableFunc(func(mode string) error {
+			if err := canaryTask.Run(mode); err != nil {
+				return fmt.Errorf("domain %s: %w", d, err)
+			}
+			return nil
+		})
 	}
-	wg.Wait()
-	return nil
+	return runCanaries(tasks, mode, r.logger)
 }
 
-func (r *canaryRunner) execute(task Runnable, mode string, wg *sync.WaitGroup) {
-	wg.Add(1)
-	go func() {
-		task.Run(mode)
-		wg.Done()
-	}()
+// runnableFunc adapts a plain function to the Runnable interface.
+type runnableFunc func(mode string) error
+
+func (f runnableFunc) Run(mode string) error {
+	return f(mode)
+}
+
+// runCanaries runs every task concurrently and only returns an error if
+// every task failed - a single task's start error should not take down
+// the others, since that would lose observability for the rest during
+// an incident.
+func runCanaries(tasks []Runnable, mode string, logger *zap.Logger) error {
+	var wg sync.WaitGroup
+	errs := make([]error, len(tasks))
+	for i, task := range tasks {
+		i, task := i, task
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := task.Run(mode); err != nil {
+				logger.Error("canary failed to run", zap.Error(err))
+				errs[i] = err
+			}
+		}()
+	}
+	wg.Wait()
+
+	for _, err := range errs {
+		if err == nil {
+			return nil
+		}
+	}
+	return multierr.Combine(errs...)
 }
 
 func updateSanityChildWFList(excludes []string) {

--- a/canary/runner_test.go
+++ b/canary/runner_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package canary
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestRunCanaries(t *testing.T) {
+	errA := errors.New("domain a failed")
+	errB := errors.New("domain b failed")
+
+	tests := []struct {
+		name    string
+		results []error
+		wantErr bool
+	}{
+		{
+			name:    "all succeed",
+			results: []error{nil, nil},
+			wantErr: false,
+		},
+		{
+			name:    "one fails one succeeds",
+			results: []error{errA, nil},
+			wantErr: false,
+		},
+		{
+			name:    "all fail",
+			results: []error{errA, errB},
+			wantErr: true,
+		},
+		{
+			name:    "no tasks",
+			results: []error{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tasks := make([]Runnable, len(tt.results))
+			for i, res := range tt.results {
+				res := res
+				tasks[i] = runnableFunc(func(mode string) error {
+					return res
+				})
+			}
+
+			err := runCanaries(tasks, ModeAll, zap.NewNop())
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

During the recent failover, domain split-brain on a canary domain caused `StartWorkflow` calls to time out. That timeout propagated as a hard error out of `canaryImpl.Run`, which ended the goroutine started for that domain; since the top-level `canaryRunner.Run` didn't track per-domain results, the process exited and got restarted by the orchestrator, hitting the same failure again immediately - a crashloop that killed canary observability across the board during mitigation.

- `canary/canary.go`: `createDomain`/`createArchivalDomain` failures, and archival-worker start failures, are now logged instead of aborting startup - the canary worker still starts and polls.
- `canary/runner.go`: replaced the fire-and-forget per-domain goroutine with `runCanaries`, which runs all domains concurrently and only returns an error (causing process exit) if **every** domain failed to start. A single domain's start failure no longer takes down the others.

## Why

If one canary type/domain fails to start, it shouldn't take down all the others - losing observability during an incident (which can last hours) is worse than one degraded canary.

## Test plan

- `go build ./canary/... ./cmd/canary/...`
- `go test ./canary/...` (added `canary/runner_test.go` covering the new aggregation logic: all succeed, partial failure, all fail)
- `make pr GEN_DIR=canary` (tidy/go-generate/fmt/lint)