### PR TITLE
fix(schedules): forward schedule write APIs to active cluster in DC redirection

### DIFF
--- a/service/frontend/wrappers/clusterredirection/policy.go
+++ b/service/frontend/wrappers/clusterredirection/policy.go
@@ -127,6 +127,13 @@ var selectedAPIsForwardingRedirectionPolicyAPIAllowlist = map[string]struct{}{
 	"RequestCancelWorkflowExecution":   {},
 	"TerminateWorkflowExecution":       {},
 	"ResetWorkflowExecution":           {},
+	// schedule write APIs — reads (DescribeSchedule, ListSchedules) are served locally on standby
+	"CreateSchedule":   {},
+	"DeleteSchedule":   {},
+	"UpdateSchedule":   {},
+	"PauseSchedule":    {},
+	"UnpauseSchedule":  {},
+	"BackfillSchedule": {},
 }
 
 // selectedAPIsForwardingRedirectionPolicyAPIAllowlistV2 contains a list of non-worker APIs which can be redirected.
@@ -146,6 +153,13 @@ var selectedAPIsForwardingRedirectionPolicyAPIAllowlistV2 = map[string]struct{}{
 	"RespondActivityTaskCompletedByID": {},
 	"RespondActivityTaskFailed":        {},
 	"RespondActivityTaskFailedByID":    {},
+	// schedule write APIs — reads (DescribeSchedule, ListSchedules) are served locally on standby
+	"CreateSchedule":   {},
+	"DeleteSchedule":   {},
+	"UpdateSchedule":   {},
+	"PauseSchedule":    {},
+	"UnpauseSchedule":  {},
+	"BackfillSchedule": {},
 }
 
 // allowedAPIsForDeprecatedDomains contains a list of APIs that are allowed to be called on deprecated domains


### PR DESCRIPTION
## What

Two related fixes for schedule operations on standby clusters / disabled domains.

**1. Forward schedule write APIs to the active cluster (DC redirection)**

`CreateSchedule`, `DeleteSchedule`, `UpdateSchedule`, `PauseSchedule`, `UnpauseSchedule`, and `BackfillSchedule` were missing from both `selectedAPIs` forwarding allowlists. A client hitting a standby frontend would get `DomainNotActiveError` instead of being transparently forwarded to the active cluster — the same auto-forwarding that normal workflow APIs already get. Read-only APIs (`DescribeSchedule`, `ListSchedules`) are intentionally excluded; standby clusters serve them fine from local visibility.

**2. Fail fast in `CreateSchedule` when the scheduler is not enabled for the domain**

Previously, `CreateSchedule` would succeed even if the `EnableScheduler` flipr flag was off for the domain. The scheduler workflow would be started but never picked up, leaving a broken schedule that couldn't be described, paused, or deleted. Now the handler checks the flag up front and returns a `BadRequestError` with a link to the enablement request process.

## Test plan

- `go test -race ./service/frontend/wrappers/clusterredirection/...` — existing tests cover the updated allowlists automatically (they iterate over the map).
- `go test -race ./service/frontend/api/...` — existing `TestCreateSchedule` suite updated; new `"scheduler not enabled for domain"` case added.
- `go test -race ./service/frontend/config/...` — config completeness test updated for the new `EnableScheduler` field.