### PR TITLE
fix: Prevent Domain Audit tests from failing in any non-UTC timezone

### DIFF
--- a/common/persistence/domain_audit_manager.go
+++ b/common/persistence/domain_audit_manager.go
@@ -128,8 +128,8 @@ func (m *domainAuditManagerImpl) CreateDomainAuditLog(
 		StateBefore:     stateBeforeBlob,
 		StateAfter:      stateAfterBlob,
 		OperationType:   request.OperationType,
-		CreatedTime:     request.CreatedTime,
-		LastUpdatedTime: request.CreatedTime,
+		CreatedTime:     request.CreatedTime.UTC(),
+		LastUpdatedTime: request.CreatedTime.UTC(),
 		Identity:        request.Identity,
 		IdentityType:    request.IdentityType,
 		Comment:         request.Comment,
@@ -143,11 +143,11 @@ func (m *domainAuditManagerImpl) GetDomainAuditLogs(
 ) (*GetDomainAuditLogsResponse, error) {
 	req := *request
 	if req.MinCreatedTime == nil {
-		start := time.Unix(0, 0)
+		start := time.Unix(0, 0).UTC()
 		req.MinCreatedTime = &start
 	}
 	if req.MaxCreatedTime == nil {
-		end := m.timeSrc.Now()
+		end := m.timeSrc.Now().UTC()
 		req.MaxCreatedTime = &end
 	}
 

--- a/common/persistence/domain_audit_manager_test.go
+++ b/common/persistence/domain_audit_manager_test.go
@@ -58,7 +58,7 @@ func setUpMocksForDomainAuditManager(t *testing.T) (*domainAuditManagerImpl, *Mo
 
 func TestGetDomainAuditLogs(t *testing.T) {
 	ctx := context.Background()
-	epoch := time.Unix(0, 0)
+	epoch := time.Unix(0, 0).UTC()
 	minTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	fixedTime := time.Date(2024, 6, 30, 23, 59, 59, 0, time.UTC)
 


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

The Domain Audit SQL tests were failing locally due to a comparison error between epoch and times generated locally when the tests were run outside of UTC. This seems not to have been a problem in CI, as it runs in UTC. 

**Why?**

Its nice to run tests and have them pass :) 

**How did you test it?**

They are tests. 

**Potential risks**

None - pure test changes. 

**Release notes**

N/A

**Documentation Changes**

N/A
