### PR TITLE
fix(history): restructure shadow-mode comparison logging in cachedQueueReader

### DIFF
--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -884,27 +884,46 @@ func toShadowMismatchTaskInfo(t persistence.Task) shadowMismatchTaskInfo {
 	}
 }
 
-// findMismatchesInShadowResult holds the outcome of a shadow comparison.
+// TaskMismatches groups the tasks found in one rangeID-relative bucket of a shadow comparison.
+type TaskMismatches struct {
+	// RangeIDs holds the distinct rangeIDs encoded in this bucket's tasks. Left unpopulated
+	// for the current-range bucket, where it would always equal CurrentRangeID.
+	RangeIDs []int64 `json:"rangeIDs,omitempty"`
+	// Extra holds tasks present in the cache snapshot but absent from the DB response.
+	Extra []shadowMismatchTaskInfo `json:"extra,omitempty"`
+	// Missed holds tasks present in the DB response but absent from the cache snapshot.
+	Missed []shadowMismatchTaskInfo `json:"missed,omitempty"`
+}
+
+func (m TaskMismatches) isEmpty() bool {
+	return len(m.Extra) == 0 && len(m.Missed) == 0
+}
+
+func (m TaskMismatches) cap() TaskMismatches {
+	m.RangeIDs = capShadowMismatchSlice(m.RangeIDs)
+	m.Extra = capShadowMismatchSlice(m.Extra)
+	m.Missed = capShadowMismatchSlice(m.Missed)
+	return m
+}
+
+// findMismatchesInShadowResult holds the outcome of a shadow comparison, with tasks partitioned
+// by their encoded rangeID relative to the shard's CurrentRangeID at comparison time.
 type findMismatchesInShadowResult struct {
-	// MissedInCacheTasks contains tasks present in DB but absent from cache, created by the current rangeID.
-	MissedInCacheTasks []shadowMismatchTaskInfo `json:"missedInCacheTaskKeys,omitempty"`
-	// ExtraInCacheTasks contains task keys present in cache but absent from the DB response, created by the current rangeID.
-	ExtraInCacheTasks []shadowMismatchTaskInfo `json:"extraInCacheTaskKeys,omitempty"`
-	// OwnerChangedTasks holds tasks absent from DB or cache whose taskID encodes a different rangeID
-	// than the current shard. It may happen when a shard movement happens, but the queue processor on the previous instance
-	// is still processing tasks, and not receiving new tasks created by the new owner.
-	// These tasks are not counted as mismatches because they cannot be served from cache, but they are still logged for visibility.
-	OwnerChangedTasks []shadowMismatchTaskInfo `json:"ownerChangedTaskKeys,omitempty"`
-	// OwnerChangedRangeIDs holds the distinct rangeIDs encoded in the OwnerChangedTasks tasks' taskIDs.
-	OwnerChangedRangeIDs []int64 `json:"ownerChangedRangeIDs,omitempty"`
+	// NewRange holds tasks whose rangeID is greater than CurrentRangeID — proof this host is
+	// stale (a newer owner already created tasks, or a prefetch already pulled tasks from a
+	// just-renewed range). Its presence means the rest of the comparison isn't trustworthy.
+	NewRange TaskMismatches `json:"newRange,omitempty"`
+	// CurrentRange holds tasks whose rangeID equals CurrentRangeID.
+	CurrentRange TaskMismatches `json:"currentRange,omitempty"`
+	// PreviousRange holds tasks whose rangeID is less than CurrentRangeID — leftovers from
+	// before the current ownership period.
+	PreviousRange TaskMismatches `json:"previousRange,omitempty"`
 	// CurrentRangeID is the shard's rangeID at the time of comparison.
 	CurrentRangeID int64 `json:"currentRangeID"`
-	// CacheTaskCount is the number of tasks in the cache snapshot
+	// CacheTaskCount is the number of tasks in the cache snapshot.
 	CacheTaskCount int `json:"cacheTaskCount"`
-	// DBTaskCount is the number of tasks in the DB response
+	// DBTaskCount is the number of tasks in the DB response.
 	DBTaskCount int `json:"dbTaskCount"`
-	// HasMismatches is true when MissedInCacheTasks or ExtraInCacheTasks is non-empty.
-	HasMismatches bool `json:"-"`
 }
 
 // getTaskRangeID extracts the rangeID encoded in taskID, which is assigned at task creation time and immutable.
@@ -912,40 +931,31 @@ func (q *cachedQueueReader) getTaskRangeID(taskID int64) int64 {
 	return taskID >> int64(q.shard.GetConfig().RangeSizeBits)
 }
 
-// reportShadowComparison logs the result of a shadow comparison.
+// reportShadowComparison logs exactly one line describing the outcome of a shadow comparison,
+// in order of decreasing severity:
+//  1. NewRange non-empty: this host is stale; nothing else is evaluated.
+//  2. CurrentRange.Missed non-empty: a task the queue processor may have skipped serving from cache.
+//  3. CurrentRange.Extra, or anything in PreviousRange: a benign or inconclusive finding, logged
+//     for visibility only.
+//  4. Otherwise: cache and DB agreed.
 func (q *cachedQueueReader) reportShadowComparison(result findMismatchesInShadowResult, logTags []tag.Tag) {
+	// Cap the number of mismatched task keys logged to avoid excessively large logs.
+	result.NewRange = result.NewRange.cap()
+	result.CurrentRange = result.CurrentRange.cap()
+	result.PreviousRange = result.PreviousRange.cap()
 
-	// Compute min ownerChangedRangeID before capping for logging, so the
-	// Info-vs-Warn decision uses the full set rather than a truncated slice.
-	var minOwnerChangedRangeID int64
-	if len(result.OwnerChangedRangeIDs) > 0 {
-		minOwnerChangedRangeID = slices.Min(result.OwnerChangedRangeIDs)
-	}
+	logTags = append(logTags, tag.Dynamic("shadowComparison", result))
 
-	// Cap the number of mismatched task keys logged to avoid excessively large logs
-	result.MissedInCacheTasks = capShadowMismatchSlice(result.MissedInCacheTasks)
-	result.ExtraInCacheTasks = capShadowMismatchSlice(result.ExtraInCacheTasks)
-	result.OwnerChangedTasks = capShadowMismatchSlice(result.OwnerChangedTasks)
-	result.OwnerChangedRangeIDs = capShadowMismatchSlice(result.OwnerChangedRangeIDs)
-
-	logTags = append(logTags, tag.Dynamic("shadowMismatch", result))
-
-	if len(result.OwnerChangedTasks) > 0 {
-		// When currentRangeID is less than all ownerChangedRangeIDs, the tasks were created
-		// by a newer shard owner. This host has already lost ownership and will be stopped soon,
-		// so it's expected to see tasks from the new owner that aren't in its cache.
-		if result.CurrentRangeID < minOwnerChangedRangeID {
-			q.logger.Info("shard ownership already transferred, new owner created tasks not in cache", logTags...)
-		} else {
-			q.logger.Warn("possible shard ownership change, missed tasks are created in another range", logTags...)
-		}
-	}
-	if !result.HasMismatches {
+	switch {
+	case !result.NewRange.isEmpty():
+		q.logger.Info("stale shard owner, no check for mismatches", logTags...)
+	case len(result.CurrentRange.Missed) > 0:
+		q.logger.Warn("potential severe mismatch between db and cache states", logTags...)
+	case len(result.CurrentRange.Extra) > 0 || !result.PreviousRange.isEmpty():
+		q.logger.Info("potential non-critical mismatch between db and cache states", logTags...)
+	default:
 		q.logger.Debug("shadow comparison matched", logTags...)
-		return
 	}
-
-	q.logger.Warn("shadow comparison mismatch", logTags...)
 }
 
 // findMismatchesInShadow compares a cache snapshot response against the DB response.
@@ -957,10 +967,10 @@ func (q *cachedQueueReader) reportShadowComparison(result findMismatchesInShadow
 // Comparing these would produce false-positive mismatches under normal
 // production traffic without indicating any real divergence in task data.
 //
-// DB tasks absent from cache are partitioned into MissedInCacheTasks (same rangeID)
-// and OwnerChangedTasks (different rangeID). Cache tasks absent from DB are similarly
-// partitioned into ExtraInCacheTasks (same rangeID) and OwnerChangedTasks (different rangeID).
-// Only MissedInCacheTasks and ExtraInCacheTasks contribute to HasMismatches.
+// Tasks missing from one side are bucketed by comparing their encoded rangeID (assigned
+// at creation and immutable) against the shard's CurrentRangeID: greater into NewRange,
+// equal into CurrentRange, less into PreviousRange. DB tasks missing from the cache land
+// in the bucket's Missed field; cache tasks missing from the DB response land in Extra.
 func (q *cachedQueueReader) findMismatchesInShadow(
 	cacheResp *GetTaskResponse,
 	dbResp *GetTaskResponse,
@@ -975,10 +985,26 @@ func (q *cachedQueueReader) findMismatchesInShadow(
 	}
 
 	var (
-		result         findMismatchesInShadowResult
-		currentRangeID = q.shard.GetRangeID()
-		rangeIDs       = map[int64]struct{}{}
+		result           findMismatchesInShadowResult
+		currentRangeID   = q.shard.GetRangeID()
+		newRangeIDs      = map[int64]struct{}{}
+		previousRangeIDs = map[int64]struct{}{}
 	)
+
+	// bucket returns the TaskMismatches this taskRangeID belongs to, relative to currentRangeID,
+	// recording the rangeID for later visibility when it isn't the current one.
+	bucket := func(taskRangeID int64) *TaskMismatches {
+		switch {
+		case taskRangeID > currentRangeID:
+			newRangeIDs[taskRangeID] = struct{}{}
+			return &result.NewRange
+		case taskRangeID < currentRangeID:
+			previousRangeIDs[taskRangeID] = struct{}{}
+			return &result.PreviousRange
+		default:
+			return &result.CurrentRange
+		}
+	}
 
 	for _, t := range dbResp.Tasks {
 		if _, ok := cacheTaskKeys[t.GetTaskID()]; ok {
@@ -986,16 +1012,8 @@ func (q *cachedQueueReader) findMismatchesInShadow(
 			continue
 		}
 
-		taskRangeID := q.getTaskRangeID(t.GetTaskID())
-		if taskRangeID == currentRangeID {
-			result.MissedInCacheTasks = append(result.MissedInCacheTasks, toShadowMismatchTaskInfo(t))
-			continue
-		}
-
-		// Task ID is missing from cache and belongs to a different rangeID than the current shard
-		// It means the shard was already owned by another instance, and the task was created by that instance after the ownership change
-		result.OwnerChangedTasks = append(result.OwnerChangedTasks, toShadowMismatchTaskInfo(t))
-		rangeIDs[taskRangeID] = struct{}{}
+		b := bucket(q.getTaskRangeID(t.GetTaskID()))
+		b.Missed = append(b.Missed, toShadowMismatchTaskInfo(t))
 	}
 
 	for _, t := range cacheResp.Tasks {
@@ -1004,20 +1022,12 @@ func (q *cachedQueueReader) findMismatchesInShadow(
 			continue
 		}
 
-		taskRangeID := q.getTaskRangeID(t.GetTaskID())
-		if taskRangeID == currentRangeID {
-			// Task ID is missing from DB response, but present in cache snapshot
-			result.ExtraInCacheTasks = append(result.ExtraInCacheTasks, toShadowMismatchTaskInfo(t))
-			continue
-		}
-
-		// Task in cache but not DB, created by a previous owner — not a true mismatch
-		result.OwnerChangedTasks = append(result.OwnerChangedTasks, toShadowMismatchTaskInfo(t))
-		rangeIDs[taskRangeID] = struct{}{}
+		b := bucket(q.getTaskRangeID(t.GetTaskID()))
+		b.Extra = append(b.Extra, toShadowMismatchTaskInfo(t))
 	}
 
-	result.HasMismatches = len(result.MissedInCacheTasks) > 0 || len(result.ExtraInCacheTasks) > 0
-	result.OwnerChangedRangeIDs = slices.Collect(maps.Keys(rangeIDs))
+	result.NewRange.RangeIDs = slices.Collect(maps.Keys(newRangeIDs))
+	result.PreviousRange.RangeIDs = slices.Collect(maps.Keys(previousRangeIDs))
 	result.CurrentRangeID = currentRangeID
 	result.DBTaskCount = len(dbResp.Tasks)
 	result.CacheTaskCount = len(cacheResp.Tasks)

--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -870,22 +870,6 @@ func capShadowMismatchSlice[T any](s []T) []T {
 	return s[:shadowMismatchLogLimit]
 }
 
-// shadowTimeMismatch records a task present in both DB and cache but with mismatched scheduled times.
-type shadowTimeMismatch struct {
-	shadowMismatchTaskInfo `json:",inline"`
-	DBTime                 time.Time `json:"dbTime"`
-	CacheTime              time.Time `json:"cacheTime"`
-}
-
-// toShadowTimeMismatch constructs a shadowTimeMismatch from a persistence.Task and its scheduled times in DB and cache.
-func toShadowTimeMismatch(t persistence.Task, dbTime, cacheTime time.Time) shadowTimeMismatch {
-	return shadowTimeMismatch{
-		shadowMismatchTaskInfo: toShadowMismatchTaskInfo(t),
-		DBTime:                 dbTime,
-		CacheTime:              cacheTime,
-	}
-}
-
 // shadowMismatchTaskInfo holds identifying information about a task mismatch for logging purposes.
 type shadowMismatchTaskInfo struct {
 	TaskKey persistence.HistoryTaskKey `json:"taskKey"`
@@ -904,8 +888,6 @@ func toShadowMismatchTaskInfo(t persistence.Task) shadowMismatchTaskInfo {
 type findMismatchesInShadowResult struct {
 	// MissedInCacheTasks contains tasks present in DB but absent from cache, created by the current rangeID.
 	MissedInCacheTasks []shadowMismatchTaskInfo `json:"missedInCacheTaskKeys,omitempty"`
-	// IncorrectTimeTasks contains tasks whose ID is present in both DB and cache but whose scheduled times differ.
-	IncorrectTimeTasks []shadowTimeMismatch `json:"incorrectTimeTaskKeys,omitempty"`
 	// ExtraInCacheTasks contains task keys present in cache but absent from the DB response, created by the current rangeID.
 	ExtraInCacheTasks []shadowMismatchTaskInfo `json:"extraInCacheTaskKeys,omitempty"`
 	// OwnerChangedTasks holds tasks absent from DB or cache whose taskID encodes a different rangeID
@@ -921,7 +903,7 @@ type findMismatchesInShadowResult struct {
 	CacheTaskCount int `json:"cacheTaskCount"`
 	// DBTaskCount is the number of tasks in the DB response
 	DBTaskCount int `json:"dbTaskCount"`
-	// HasMismatches is true when MissedInCacheTasks, IncorrectTimeTasks, or ExtraInCacheTasks is non-empty.
+	// HasMismatches is true when MissedInCacheTasks or ExtraInCacheTasks is non-empty.
 	HasMismatches bool `json:"-"`
 }
 
@@ -942,7 +924,6 @@ func (q *cachedQueueReader) reportShadowComparison(result findMismatchesInShadow
 
 	// Cap the number of mismatched task keys logged to avoid excessively large logs
 	result.MissedInCacheTasks = capShadowMismatchSlice(result.MissedInCacheTasks)
-	result.IncorrectTimeTasks = capShadowMismatchSlice(result.IncorrectTimeTasks)
 	result.ExtraInCacheTasks = capShadowMismatchSlice(result.ExtraInCacheTasks)
 	result.OwnerChangedTasks = capShadowMismatchSlice(result.OwnerChangedTasks)
 	result.OwnerChangedRangeIDs = capShadowMismatchSlice(result.OwnerChangedRangeIDs)
@@ -967,41 +948,30 @@ func (q *cachedQueueReader) reportShadowComparison(result findMismatchesInShadow
 	q.logger.Warn("shadow comparison mismatch", logTags...)
 }
 
-// getTruncatedScheduledTime returns the scheduled time of a task truncated to
-// DBTimestampMinPrecision (millisecond), matching Cassandra's storage precision.
-func getTruncatedScheduledTime(t persistence.Task) time.Time {
-	return t.GetTaskKey().GetScheduledTime().Truncate(persistence.DBTimestampMinPrecision)
-}
-
 // findMismatchesInShadow compares a cache snapshot response against the DB response.
 //
-// Task comparison uses taskID as the primary key and the scheduled time truncated to
-// millisecond precision (DBTimestampMinPrecision) as a secondary check. Truncation
-// avoids false positives from injected tasks whose nanosecond timestamps Cassandra
-// rounds to milliseconds on the round-trip.
-//
-// NextTaskKey is intentionally not compared: Cassandra commonly returns a non-empty
-// paging cursor even on the last page, which causes the DB reader to report
-// lastTask.Next() while the cache (which knows its window is exhausted) reports
-// exclusiveMaxTaskKey. Comparing these would produce false-positive mismatches under
-// normal production traffic without indicating any real divergence in task data.
+// Task comparison uses taskID as the primary key. NextTaskKey is intentionally
+// not compared: Cassandra commonly returns a non-empty paging cursor even on
+// the last page, which causes the DB reader to report lastTask.Next() while
+// the cache (which knows its window is exhausted) reports exclusiveMaxTaskKey.
+// Comparing these would produce false-positive mismatches under normal
+// production traffic without indicating any real divergence in task data.
 //
 // DB tasks absent from cache are partitioned into MissedInCacheTasks (same rangeID)
 // and OwnerChangedTasks (different rangeID). Cache tasks absent from DB are similarly
 // partitioned into ExtraInCacheTasks (same rangeID) and OwnerChangedTasks (different rangeID).
-// Only MissedInCacheTasks, IncorrectTimeTasks, and ExtraInCacheTasks contribute to HasMismatches.
-// Tasks present in both but with mismatched scheduled times are recorded in IncorrectTimeTasks.
+// Only MissedInCacheTasks and ExtraInCacheTasks contribute to HasMismatches.
 func (q *cachedQueueReader) findMismatchesInShadow(
 	cacheResp *GetTaskResponse,
 	dbResp *GetTaskResponse,
 ) findMismatchesInShadowResult {
-	cacheTaskKeys := make(map[int64]time.Time, len(cacheResp.Tasks))
+	cacheTaskKeys := make(map[int64]struct{}, len(cacheResp.Tasks))
 	for _, t := range cacheResp.Tasks {
-		cacheTaskKeys[t.GetTaskID()] = getTruncatedScheduledTime(t)
+		cacheTaskKeys[t.GetTaskID()] = struct{}{}
 	}
-	dbTaskKeys := make(map[int64]time.Time, len(dbResp.Tasks))
+	dbTaskKeys := make(map[int64]struct{}, len(dbResp.Tasks))
 	for _, t := range dbResp.Tasks {
-		dbTaskKeys[t.GetTaskID()] = getTruncatedScheduledTime(t)
+		dbTaskKeys[t.GetTaskID()] = struct{}{}
 	}
 
 	var (
@@ -1011,14 +981,8 @@ func (q *cachedQueueReader) findMismatchesInShadow(
 	)
 
 	for _, t := range dbResp.Tasks {
-		cacheTime, ok := cacheTaskKeys[t.GetTaskID()]
-		if ok {
-			if cacheTime.Equal(dbTaskKeys[t.GetTaskID()]) {
-				// Task is present in both DB and cache with matching scheduled time
-				continue
-			}
-
-			result.IncorrectTimeTasks = append(result.IncorrectTimeTasks, toShadowTimeMismatch(t, dbTaskKeys[t.GetTaskID()], cacheTime))
+		if _, ok := cacheTaskKeys[t.GetTaskID()]; ok {
+			// Task is present in both DB and cache
 			continue
 		}
 
@@ -1036,7 +1000,7 @@ func (q *cachedQueueReader) findMismatchesInShadow(
 
 	for _, t := range cacheResp.Tasks {
 		if _, ok := dbTaskKeys[t.GetTaskID()]; ok {
-			// Task is present in DB (time mismatches are already captured from the DB loop above)
+			// Task is present in DB
 			continue
 		}
 
@@ -1052,7 +1016,7 @@ func (q *cachedQueueReader) findMismatchesInShadow(
 		rangeIDs[taskRangeID] = struct{}{}
 	}
 
-	result.HasMismatches = len(result.MissedInCacheTasks) > 0 || len(result.IncorrectTimeTasks) > 0 || len(result.ExtraInCacheTasks) > 0
+	result.HasMismatches = len(result.MissedInCacheTasks) > 0 || len(result.ExtraInCacheTasks) > 0
 	result.OwnerChangedRangeIDs = slices.Collect(maps.Keys(rangeIDs))
 	result.CurrentRangeID = currentRangeID
 	result.DBTaskCount = len(dbResp.Tasks)

--- a/service/history/queuev2/queue_reader_cached_test.go
+++ b/service/history/queuev2/queue_reader_cached_test.go
@@ -1156,14 +1156,14 @@ func TestFindMismatchesInShadow(t *testing.T) {
 			},
 		},
 		{
-			// Cache task has nanosecond timestamp; DB task has the same time truncated to ms.
-			// They should compare as equal after truncation.
-			name: "timestamp sub-millisecond jitter: no mismatch",
+			// Task ID is present in both DB and cache; scheduled time is not compared,
+			// so a differing scheduled time is not flagged as a mismatch.
+			name: "task ID present in both but scheduled time differs: no mismatch",
 			snapshotResp: &GetTaskResponse{
-				Tasks: []persistence.Task{newTask(1, now.Add(10*time.Minute+500*time.Nanosecond))},
+				Tasks: []persistence.Task{newTask(1, now.Add(10*time.Minute))},
 			},
 			dbResp: &GetTaskResponse{
-				Tasks: []persistence.Task{newTask(1, now.Add(10*time.Minute))},
+				Tasks: []persistence.Task{newTask(1, now.Add(11*time.Minute))},
 			},
 			wantResult: findMismatchesInShadowResult{HasMismatches: false, CacheTaskCount: 1, DBTaskCount: 1},
 		},
@@ -1181,27 +1181,6 @@ func TestFindMismatchesInShadow(t *testing.T) {
 				Progress: &GetTaskProgress{NextTaskKey: newTimeKey(now.Add(2 * time.Hour))},
 			},
 			wantResult: findMismatchesInShadowResult{HasMismatches: false, CacheTaskCount: 2, DBTaskCount: 2},
-		},
-		{
-			name: "task ID present in both but scheduled time differs → IncorrectTimeTasks",
-			snapshotResp: &GetTaskResponse{
-				Tasks: []persistence.Task{newTask(1, now.Add(10*time.Minute))},
-			},
-			dbResp: &GetTaskResponse{
-				Tasks: []persistence.Task{newTask(1, now.Add(11*time.Minute))},
-			},
-			wantResult: findMismatchesInShadowResult{
-				IncorrectTimeTasks: []shadowTimeMismatch{
-					toShadowTimeMismatch(
-						newTask(1, now.Add(11*time.Minute)),
-						now.Add(11*time.Minute).Truncate(persistence.DBTimestampMinPrecision),
-						now.Add(10*time.Minute).Truncate(persistence.DBTimestampMinPrecision),
-					),
-				},
-				HasMismatches:  true,
-				CacheTaskCount: 1,
-				DBTaskCount:    1,
-			},
 		},
 		{
 			name:         "extra task in cache: different rangeID → owner changed, not a mismatch",

--- a/service/history/queuev2/queue_reader_cached_test.go
+++ b/service/history/queuev2/queue_reader_cached_test.go
@@ -1001,9 +1001,9 @@ func TestCachedQueueReader_GetTask_Shadow(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			// DB has a task created by a different shard owner (different rangeID) → classified as
-			// OwnerChanged, not a mismatch; DB result returned normally.
-			name:  "task missing from cache, different rangeID: owner changed, no mismatch warning",
+			// DB has a task from a newer rangeID (a different/new shard owner) → classified as
+			// NewRange, not a mismatch; DB result returned normally.
+			name:  "task missing from cache, newer rangeID: stale shard owner, no mismatch warning",
 			lower: lower, upper: upper,
 			req: &GetTaskRequest{
 				Progress:  newProgress(lower, upper),
@@ -1059,10 +1059,14 @@ func TestFindMismatchesInShadow(t *testing.T) {
 	t1 := newTask(1, now.Add(10*time.Minute))
 	t2 := newTask(2, now.Add(20*time.Minute))
 	t3 := newTask(3, now.Add(30*time.Minute))
-	// Tasks with taskID in rangeID=1 range (1<<20 .. 2<<20-1) at RangeSizeBits=20.
-	// The default mock rangeID is 0, so these will be classified as OwnerChanged.
-	tOtherRange1 := newTask(1<<20, now.Add(10*time.Minute))
-	tOtherRange2 := newTask(2<<20, now.Add(20*time.Minute))
+	// Tasks with taskID in rangeID=1/2 (>= 1<<20 at RangeSizeBits=20) are newer than the
+	// default mock's currentRangeID=0: NewRange.
+	tNewRange1 := newTask(1<<20, now.Add(10*time.Minute))
+	tNewRange2 := newTask(2<<20, now.Add(20*time.Minute))
+	// A taskID of -1 encodes rangeID=-1 (arithmetic right shift preserves sign), older than
+	// the default mock's currentRangeID=0: PreviousRange. Synthetic, but exercises the bucket
+	// without needing to reconfigure the mocked shard's rangeID.
+	tPrevRange := newTask(-1, now.Add(10*time.Minute))
 
 	info := func(t persistence.Task) shadowMismatchTaskInfo { return toShadowMismatchTaskInfo(t) }
 
@@ -1076,83 +1080,122 @@ func TestFindMismatchesInShadow(t *testing.T) {
 			name:         "no mismatches",
 			snapshotResp: &GetTaskResponse{Tasks: []persistence.Task{t1, t2}},
 			dbResp:       &GetTaskResponse{Tasks: []persistence.Task{t1, t2}},
-			wantResult:   findMismatchesInShadowResult{HasMismatches: false, CacheTaskCount: 2, DBTaskCount: 2},
+			wantResult:   findMismatchesInShadowResult{CacheTaskCount: 2, DBTaskCount: 2},
 		},
 		{
 			name:         "empty on both sides",
 			snapshotResp: &GetTaskResponse{},
 			dbResp:       &GetTaskResponse{},
-			wantResult:   findMismatchesInShadowResult{HasMismatches: false},
+			wantResult:   findMismatchesInShadowResult{},
 		},
 		{
-			name:         "task missing from cache: same rangeID → real mismatch",
+			name:         "task missing from cache: current range",
 			snapshotResp: &GetTaskResponse{Tasks: []persistence.Task{t1}},
 			dbResp:       &GetTaskResponse{Tasks: []persistence.Task{t1, t2}},
 			wantResult: findMismatchesInShadowResult{
-				MissedInCacheTasks: []shadowMismatchTaskInfo{info(t2)},
-				HasMismatches:      true,
-				CacheTaskCount:     1,
-				DBTaskCount:        2,
+				CurrentRange:   TaskMismatches{Missed: []shadowMismatchTaskInfo{info(t2)}},
+				CacheTaskCount: 1,
+				DBTaskCount:    2,
 			},
 		},
 		{
-			name:         "task missing from cache: different rangeID → owner changed, not a mismatch",
+			name:         "task missing from cache: new range",
 			snapshotResp: &GetTaskResponse{Tasks: []persistence.Task{t1}},
-			dbResp:       &GetTaskResponse{Tasks: []persistence.Task{t1, tOtherRange1}},
+			dbResp:       &GetTaskResponse{Tasks: []persistence.Task{t1, tNewRange1}},
 			wantResult: findMismatchesInShadowResult{
-				OwnerChangedTasks:    []shadowMismatchTaskInfo{info(tOtherRange1)},
-				OwnerChangedRangeIDs: []int64{1},
-				HasMismatches:        false,
-				CacheTaskCount:       1,
-				DBTaskCount:          2,
+				NewRange:       TaskMismatches{RangeIDs: []int64{1}, Missed: []shadowMismatchTaskInfo{info(tNewRange1)}},
+				CacheTaskCount: 1,
+				DBTaskCount:    2,
 			},
 		},
 		{
-			name:         "mixed: same-range missing (mismatch) and different-range missing (owner change)",
+			name:         "task missing from cache: previous range",
 			snapshotResp: &GetTaskResponse{Tasks: []persistence.Task{t1}},
-			dbResp:       &GetTaskResponse{Tasks: []persistence.Task{t1, t2, tOtherRange1}},
+			dbResp:       &GetTaskResponse{Tasks: []persistence.Task{t1, tPrevRange}},
 			wantResult: findMismatchesInShadowResult{
-				MissedInCacheTasks:   []shadowMismatchTaskInfo{info(t2)},
-				OwnerChangedTasks:    []shadowMismatchTaskInfo{info(tOtherRange1)},
-				OwnerChangedRangeIDs: []int64{1},
-				HasMismatches:        true,
-				CacheTaskCount:       1,
-				DBTaskCount:          3,
+				PreviousRange:  TaskMismatches{RangeIDs: []int64{-1}, Missed: []shadowMismatchTaskInfo{info(tPrevRange)}},
+				CacheTaskCount: 1,
+				DBTaskCount:    2,
 			},
 		},
 		{
-			name:         "all db tasks from different range: no mismatch, all owner changed",
+			name:         "mixed: current range missing and new range missing",
 			snapshotResp: &GetTaskResponse{Tasks: []persistence.Task{t1}},
-			dbResp:       &GetTaskResponse{Tasks: []persistence.Task{t1, tOtherRange1, tOtherRange2}},
+			dbResp:       &GetTaskResponse{Tasks: []persistence.Task{t1, t2, tNewRange1}},
 			wantResult: findMismatchesInShadowResult{
-				OwnerChangedTasks:    []shadowMismatchTaskInfo{info(tOtherRange1), info(tOtherRange2)},
-				OwnerChangedRangeIDs: []int64{1, 2},
-				HasMismatches:        false,
-				CacheTaskCount:       1,
-				DBTaskCount:          3,
+				CurrentRange:   TaskMismatches{Missed: []shadowMismatchTaskInfo{info(t2)}},
+				NewRange:       TaskMismatches{RangeIDs: []int64{1}, Missed: []shadowMismatchTaskInfo{info(tNewRange1)}},
+				CacheTaskCount: 1,
+				DBTaskCount:    3,
 			},
 		},
 		{
-			name:         "extra task in cache",
+			name:         "mixed: current range missing and previous range missing",
+			snapshotResp: &GetTaskResponse{Tasks: []persistence.Task{t1}},
+			dbResp:       &GetTaskResponse{Tasks: []persistence.Task{t1, t2, tPrevRange}},
+			wantResult: findMismatchesInShadowResult{
+				CurrentRange:   TaskMismatches{Missed: []shadowMismatchTaskInfo{info(t2)}},
+				PreviousRange:  TaskMismatches{RangeIDs: []int64{-1}, Missed: []shadowMismatchTaskInfo{info(tPrevRange)}},
+				CacheTaskCount: 1,
+				DBTaskCount:    3,
+			},
+		},
+		{
+			name:         "all db tasks from newer ranges",
+			snapshotResp: &GetTaskResponse{Tasks: []persistence.Task{t1}},
+			dbResp:       &GetTaskResponse{Tasks: []persistence.Task{t1, tNewRange1, tNewRange2}},
+			wantResult: findMismatchesInShadowResult{
+				NewRange: TaskMismatches{
+					RangeIDs: []int64{1, 2},
+					Missed:   []shadowMismatchTaskInfo{info(tNewRange1), info(tNewRange2)},
+				},
+				CacheTaskCount: 1,
+				DBTaskCount:    3,
+			},
+		},
+		{
+			name:         "extra task in cache: current range",
 			snapshotResp: &GetTaskResponse{Tasks: []persistence.Task{t1, t2, t3}},
 			dbResp:       &GetTaskResponse{Tasks: []persistence.Task{t1, t2}},
 			wantResult: findMismatchesInShadowResult{
-				ExtraInCacheTasks: []shadowMismatchTaskInfo{info(t3)},
-				HasMismatches:     true,
-				CacheTaskCount:    3,
-				DBTaskCount:       2,
+				CurrentRange:   TaskMismatches{Extra: []shadowMismatchTaskInfo{info(t3)}},
+				CacheTaskCount: 3,
+				DBTaskCount:    2,
 			},
 		},
 		{
-			name:         "missing and extra simultaneously",
+			// Simulates a prefetch that already loaded tasks from a just-renewed range into the
+			// cache before the shard's own view of its current rangeID caught up.
+			name:         "extra task in cache: new range (prefetch)",
+			snapshotResp: &GetTaskResponse{Tasks: []persistence.Task{t1, tNewRange1}},
+			dbResp:       &GetTaskResponse{Tasks: []persistence.Task{t1}},
+			wantResult: findMismatchesInShadowResult{
+				NewRange:       TaskMismatches{RangeIDs: []int64{1}, Extra: []shadowMismatchTaskInfo{info(tNewRange1)}},
+				CacheTaskCount: 2,
+				DBTaskCount:    1,
+			},
+		},
+		{
+			name:         "extra task in cache: previous range",
+			snapshotResp: &GetTaskResponse{Tasks: []persistence.Task{t1, tPrevRange}},
+			dbResp:       &GetTaskResponse{Tasks: []persistence.Task{t1}},
+			wantResult: findMismatchesInShadowResult{
+				PreviousRange:  TaskMismatches{RangeIDs: []int64{-1}, Extra: []shadowMismatchTaskInfo{info(tPrevRange)}},
+				CacheTaskCount: 2,
+				DBTaskCount:    1,
+			},
+		},
+		{
+			name:         "missing and extra simultaneously: current range",
 			snapshotResp: &GetTaskResponse{Tasks: []persistence.Task{t1, t3}},
 			dbResp:       &GetTaskResponse{Tasks: []persistence.Task{t1, t2}},
 			wantResult: findMismatchesInShadowResult{
-				MissedInCacheTasks: []shadowMismatchTaskInfo{info(t2)},
-				ExtraInCacheTasks:  []shadowMismatchTaskInfo{info(t3)},
-				HasMismatches:      true,
-				CacheTaskCount:     2,
-				DBTaskCount:        2,
+				CurrentRange: TaskMismatches{
+					Missed: []shadowMismatchTaskInfo{info(t2)},
+					Extra:  []shadowMismatchTaskInfo{info(t3)},
+				},
+				CacheTaskCount: 2,
+				DBTaskCount:    2,
 			},
 		},
 		{
@@ -1165,7 +1208,7 @@ func TestFindMismatchesInShadow(t *testing.T) {
 			dbResp: &GetTaskResponse{
 				Tasks: []persistence.Task{newTask(1, now.Add(11*time.Minute))},
 			},
-			wantResult: findMismatchesInShadowResult{HasMismatches: false, CacheTaskCount: 1, DBTaskCount: 1},
+			wantResult: findMismatchesInShadowResult{CacheTaskCount: 1, DBTaskCount: 1},
 		},
 		{
 			// NextTaskKey is not compared: Cassandra may return a non-empty cursor on the last page,
@@ -1180,31 +1223,17 @@ func TestFindMismatchesInShadow(t *testing.T) {
 				Tasks:    []persistence.Task{t1, t2},
 				Progress: &GetTaskProgress{NextTaskKey: newTimeKey(now.Add(2 * time.Hour))},
 			},
-			wantResult: findMismatchesInShadowResult{HasMismatches: false, CacheTaskCount: 2, DBTaskCount: 2},
+			wantResult: findMismatchesInShadowResult{CacheTaskCount: 2, DBTaskCount: 2},
 		},
 		{
-			name:         "extra task in cache: different rangeID → owner changed, not a mismatch",
-			snapshotResp: &GetTaskResponse{Tasks: []persistence.Task{t1, tOtherRange1}},
+			name:         "extra task in cache: mixed current range and new range",
+			snapshotResp: &GetTaskResponse{Tasks: []persistence.Task{t1, t3, tNewRange1}},
 			dbResp:       &GetTaskResponse{Tasks: []persistence.Task{t1}},
 			wantResult: findMismatchesInShadowResult{
-				OwnerChangedTasks:    []shadowMismatchTaskInfo{info(tOtherRange1)},
-				OwnerChangedRangeIDs: []int64{1},
-				HasMismatches:        false,
-				CacheTaskCount:       2,
-				DBTaskCount:          1,
-			},
-		},
-		{
-			name:         "extra task in cache: mixed same-range (mismatch) and different-range (owner change)",
-			snapshotResp: &GetTaskResponse{Tasks: []persistence.Task{t1, t3, tOtherRange1}},
-			dbResp:       &GetTaskResponse{Tasks: []persistence.Task{t1}},
-			wantResult: findMismatchesInShadowResult{
-				ExtraInCacheTasks:    []shadowMismatchTaskInfo{info(t3)},
-				OwnerChangedTasks:    []shadowMismatchTaskInfo{info(tOtherRange1)},
-				OwnerChangedRangeIDs: []int64{1},
-				HasMismatches:        true,
-				CacheTaskCount:       3,
-				DBTaskCount:          1,
+				CurrentRange:   TaskMismatches{Extra: []shadowMismatchTaskInfo{info(t3)}},
+				NewRange:       TaskMismatches{RangeIDs: []int64{1}, Extra: []shadowMismatchTaskInfo{info(tNewRange1)}},
+				CacheTaskCount: 3,
+				DBTaskCount:    1,
 			},
 		},
 	}
@@ -1214,7 +1243,8 @@ func TestFindMismatchesInShadow(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			r, _ := setupMocksForCachedQueueReader(t, ctrl)
 			got := r.findMismatchesInShadow(tc.snapshotResp, tc.dbResp)
-			slices.Sort(got.OwnerChangedRangeIDs)
+			slices.Sort(got.NewRange.RangeIDs)
+			slices.Sort(got.PreviousRange.RangeIDs)
 			require.Equal(t, tc.wantResult, got)
 		})
 	}

--- a/service/history/queuev2/queue_reader_cached_test.go
+++ b/service/history/queuev2/queue_reader_cached_test.go
@@ -825,7 +825,7 @@ func TestCachedQueueReader_GetTask_Shadow(t *testing.T) {
 	t2 := newTask(2, now.Add(20*time.Minute))
 	t3 := newTask(3, now.Add(30*time.Minute))
 	// tOtherOwner has a taskID in rangeID=1 (1<<20 at RangeSizeBits=20).
-	// The default mock GetRangeID()=0, so this task will be classified as OwnerChanged.
+	// The default mock GetRangeID()=0, so this task will be classified into NewRange.
 	tOtherOwner := newTask(1<<20, now.Add(40*time.Minute))
 
 	tests := []struct {


### PR DESCRIPTION
**What changed?**

Restructures the shadow-mode comparison in `cachedQueueReader` (`service/history/queuev2/queue_reader_cached.go`): tasks are now bucketed by their encoded rangeID relative to the shard's current rangeID (`NewRange`/`CurrentRange`/`PreviousRange`) instead of a same-range/owner-changed split, scheduled-time comparison is removed, and exactly one log line is emitted per comparison call.

**Why?**

Previously, a shard that had already lost ownership (tasks present with a newer rangeID) could log a separate `"shadow comparison mismatch"` Warn for unrelated same-range findings even though the whole snapshot comparison is untrustworthy once ownership has moved on — the two signals fired independently. Separately, the "same rangeID" mismatch categories (missed-in-cache, extra-in-cache) were both logged at Warn severity, even though a prior investigation found extra-in-cache mismatches come from a known, benign, self-healing cause (timer-task cleanup not invalidating the cache), while missed-in-cache can indicate the queue processor genuinely skipped work. This change makes a newer rangeID on either the DB or cache side (the latter can happen via prefetch after a range renewal) short-circuit the whole comparison as a confirmed stale-owner signal, and downgrades everything that isn't proof of staleness or a same-range miss to a single lower-severity "potential" signal — so on-call engineers get one unambiguous log line per comparison instead of conflicting severities.

**How did you test it?**

`go test ./service/history/queuev2/...` — table-driven coverage in `TestFindMismatchesInShadow` exercises all three rangeID buckets from both the DB-missing and cache-missing sides (including a synthetic "prefetch loaded a newer range" case), plus `TestCachedQueueReader_GetTask_Shadow` end-to-end through `GetTask`. `make pr` (tidy, go-generate, fmt, lint) passes. `go build ./...` passes.

**Potential risks**

Logging-only change — no API/IDL, schema, or feature-flag changes, and no impact on task processing logic or the value returned from `GetTask` (shadow mode always returns the DB result). Log message text and the `shadowMismatch` → `shadowComparison` structured-log tag key both change, which could affect any saved log queries/dashboards filtering on the old message strings or tag name.

**Release notes**

N/A — internal shadow-mode diagnostic logging only, not user-facing.

**Documentation Changes**

N/A