### PR TITLE
fix(frontend): reject CreateSchedule when scheduler is not enabled for domain

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -163,6 +163,12 @@ func (wh *WorkflowHandler) CreateSchedule(
 	if domainName == "" {
 		return nil, validate.ErrDomainNotSet
 	}
+	if !wh.config.EnableScheduler(domainName) {
+		return nil, &types.BadRequestError{Message: fmt.Sprintf(
+			"Schedules are not enabled for domain %q. File an enablement request at go/cadence-schedules-onboard and post in #cadence-users.",
+			domainName,
+		)}
+	}
 	scheduleID := request.GetScheduleID()
 	if scheduleID == "" {
 		return nil, &types.BadRequestError{Message: "ScheduleID is not set on request."}

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -76,6 +76,7 @@ func newScheduleTestFixture(t *testing.T) *scheduleTestFixture {
 		10, false, "hostname", mockResource.Logger,
 	)
 	config.EmitSignalNameMetricsTag = dynamicproperties.GetBoolPropertyFnFilteredByDomain(true)
+	config.EnableScheduler = dynamicproperties.GetBoolPropertyFnFilteredByDomain(true)
 
 	handler := NewWorkflowHandler(mockResource, config, versionChecker, nil)
 
@@ -123,6 +124,13 @@ func TestCreateSchedule(t *testing.T) {
 		"empty domain": {
 			request: &types.CreateScheduleRequest{},
 			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"scheduler not enabled for domain": {
+			request: &types.CreateScheduleRequest{Domain: testDomain, ScheduleID: "s1"},
+			mockFn: func(f *scheduleTestFixture) {
+				f.handler.config.EnableScheduler = dynamicproperties.GetBoolPropertyFnFilteredByDomain(false)
+			},
 			wantErr: true,
 		},
 		"empty schedule ID": {

--- a/service/frontend/config/config.go
+++ b/service/frontend/config/config.go
@@ -127,6 +127,10 @@ type Config struct {
 	// Emit signal related metrics with signal name tag. Be aware of cardinality.
 	EmitSignalNameMetricsTag dynamicproperties.BoolPropertyFnWithDomainFilter
 
+	// EnableScheduler controls whether the scheduler worker is enabled for a domain.
+	// CreateSchedule validates this flag so clients get a clear error instead of a broken schedule.
+	EnableScheduler dynamicproperties.BoolPropertyFnWithDomainFilter
+
 	// HostName for machine running the service
 	HostName string
 }
@@ -206,6 +210,7 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, isAdvancedVis
 		Lockdown:                                          dc.GetBoolPropertyFilteredByDomain(dynamicproperties.Lockdown),
 		EnableTasklistIsolation:                           dc.GetBoolPropertyFilteredByDomain(dynamicproperties.EnableTasklistIsolation),
 		EnableDomainAuditLogging:                          dc.GetBoolProperty(dynamicproperties.EnableDomainAuditLogging),
+		EnableScheduler:                                   dc.GetBoolPropertyFilteredByDomain(dynamicproperties.EnableScheduler),
 		DomainConfig: domain.Config{
 			MaxBadBinaryCount:           dc.GetIntPropertyFilteredByDomain(dynamicproperties.FrontendMaxBadBinaries),
 			MinRetentionDays:            dc.GetIntProperty(dynamicproperties.MinRetentionDays),

--- a/service/frontend/config/config_test.go
+++ b/service/frontend/config/config_test.go
@@ -105,6 +105,7 @@ func TestNewConfig(t *testing.T) {
 		"EmitSignalNameMetricsTag":                          {dynamicproperties.FrontendEmitSignalNameMetricsTag, true},
 		"Lockdown":                                          {dynamicproperties.Lockdown, false},
 		"EnableTasklistIsolation":                           {dynamicproperties.EnableTasklistIsolation, true},
+		"EnableScheduler":                                   {dynamicproperties.EnableScheduler, true},
 		"GlobalRatelimiterKeyMode":                          {dynamicproperties.FrontendGlobalRatelimiterMode, "disabled"},
 		"GlobalRatelimiterUpdateInterval":                   {dynamicproperties.GlobalRatelimiterUpdateInterval, 3 * time.Second},
 		"PinotOptimizedQueryColumns":                        {dynamicproperties.PinotOptimizedQueryColumns, map[string]interface{}{"foo": "bar"}},

--- a/service/frontend/wrappers/clusterredirection/policy.go
+++ b/service/frontend/wrappers/clusterredirection/policy.go
@@ -127,6 +127,13 @@ var selectedAPIsForwardingRedirectionPolicyAPIAllowlist = map[string]struct{}{
 	"RequestCancelWorkflowExecution":   {},
 	"TerminateWorkflowExecution":       {},
 	"ResetWorkflowExecution":           {},
+	// schedule write APIs — reads (DescribeSchedule, ListSchedules) are served locally on standby
+	"CreateSchedule":   {},
+	"DeleteSchedule":   {},
+	"UpdateSchedule":   {},
+	"PauseSchedule":    {},
+	"UnpauseSchedule":  {},
+	"BackfillSchedule": {},
 }
 
 // selectedAPIsForwardingRedirectionPolicyAPIAllowlistV2 contains a list of non-worker APIs which can be redirected.
@@ -146,6 +153,13 @@ var selectedAPIsForwardingRedirectionPolicyAPIAllowlistV2 = map[string]struct{}{
 	"RespondActivityTaskCompletedByID": {},
 	"RespondActivityTaskFailed":        {},
 	"RespondActivityTaskFailedByID":    {},
+	// schedule write APIs — reads (DescribeSchedule, ListSchedules) are served locally on standby
+	"CreateSchedule":   {},
+	"DeleteSchedule":   {},
+	"UpdateSchedule":   {},
+	"PauseSchedule":    {},
+	"UnpauseSchedule":  {},
+	"BackfillSchedule": {},
 }
 
 // allowedAPIsForDeprecatedDomains contains a list of APIs that are allowed to be called on deprecated domains


### PR DESCRIPTION
## What

`CreateSchedule` would succeed even when the `EnableScheduler` flipr flag was off for the domain. The scheduler workflow got started but never picked up, leaving a broken schedule that couldn't be described, paused, or deleted until the feature was manually enabled.

Now the handler checks the flag up front and returns a `BadRequestError` with a pointer to the enablement request process.

## Why

Reported by a user who created a schedule in staging (enabled by default), assumed production was the same, hit the broken state, and had no actionable error to go on.

## Test plan

- New `"scheduler not enabled for domain"` case in `TestCreateSchedule`.
- `go test -race ./service/frontend/api/... ./service/frontend/config/...` passes.