### PR TITLE
fix(frontend): reject CreateSchedule when scheduler is not enabled for domain

### DIFF
--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -163,6 +163,12 @@ func (wh *WorkflowHandler) CreateSchedule(
 	if domainName == "" {
 		return nil, validate.ErrDomainNotSet
 	}
+	if !wh.config.EnableScheduler(domainName) {
+		return nil, &types.BadRequestError{Message: fmt.Sprintf(
+			"Schedules are not enabled for domain %q. File an enablement request at go/cadence-schedules-onboard and post in #cadence-users.",
+			domainName,
+		)}
+	}
 	scheduleID := request.GetScheduleID()
 	if scheduleID == "" {
 		return nil, &types.BadRequestError{Message: "ScheduleID is not set on request."}

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -76,6 +76,7 @@ func newScheduleTestFixture(t *testing.T) *scheduleTestFixture {
 		10, false, "hostname", mockResource.Logger,
 	)
 	config.EmitSignalNameMetricsTag = dynamicproperties.GetBoolPropertyFnFilteredByDomain(true)
+	config.EnableScheduler = dynamicproperties.GetBoolPropertyFnFilteredByDomain(true)
 
 	handler := NewWorkflowHandler(mockResource, config, versionChecker, nil)
 
@@ -123,6 +124,13 @@ func TestCreateSchedule(t *testing.T) {
 		"empty domain": {
 			request: &types.CreateScheduleRequest{},
 			mockFn:  func(f *scheduleTestFixture) {},
+			wantErr: true,
+		},
+		"scheduler not enabled for domain": {
+			request: &types.CreateScheduleRequest{Domain: testDomain, ScheduleID: "s1"},
+			mockFn: func(f *scheduleTestFixture) {
+				f.handler.config.EnableScheduler = dynamicproperties.GetBoolPropertyFnFilteredByDomain(false)
+			},
 			wantErr: true,
 		},
 		"empty schedule ID": {

--- a/service/frontend/config/config.go
+++ b/service/frontend/config/config.go
@@ -127,6 +127,10 @@ type Config struct {
 	// Emit signal related metrics with signal name tag. Be aware of cardinality.
 	EmitSignalNameMetricsTag dynamicproperties.BoolPropertyFnWithDomainFilter
 
+	// EnableScheduler controls whether the scheduler worker is enabled for a domain.
+	// CreateSchedule validates this flag so clients get a clear error instead of a broken schedule.
+	EnableScheduler dynamicproperties.BoolPropertyFnWithDomainFilter
+
 	// HostName for machine running the service
 	HostName string
 }
@@ -206,6 +210,7 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, isAdvancedVis
 		Lockdown:                                          dc.GetBoolPropertyFilteredByDomain(dynamicproperties.Lockdown),
 		EnableTasklistIsolation:                           dc.GetBoolPropertyFilteredByDomain(dynamicproperties.EnableTasklistIsolation),
 		EnableDomainAuditLogging:                          dc.GetBoolProperty(dynamicproperties.EnableDomainAuditLogging),
+		EnableScheduler:                                   dc.GetBoolPropertyFilteredByDomain(dynamicproperties.EnableScheduler),
 		DomainConfig: domain.Config{
 			MaxBadBinaryCount:           dc.GetIntPropertyFilteredByDomain(dynamicproperties.FrontendMaxBadBinaries),
 			MinRetentionDays:            dc.GetIntProperty(dynamicproperties.MinRetentionDays),

--- a/service/frontend/config/config_test.go
+++ b/service/frontend/config/config_test.go
@@ -105,6 +105,7 @@ func TestNewConfig(t *testing.T) {
 		"EmitSignalNameMetricsTag":                          {dynamicproperties.FrontendEmitSignalNameMetricsTag, true},
 		"Lockdown":                                          {dynamicproperties.Lockdown, false},
 		"EnableTasklistIsolation":                           {dynamicproperties.EnableTasklistIsolation, true},
+		"EnableScheduler":                                   {dynamicproperties.EnableScheduler, true},
 		"GlobalRatelimiterKeyMode":                          {dynamicproperties.FrontendGlobalRatelimiterMode, "disabled"},
 		"GlobalRatelimiterUpdateInterval":                   {dynamicproperties.GlobalRatelimiterUpdateInterval, 3 * time.Second},
 		"PinotOptimizedQueryColumns":                        {dynamicproperties.PinotOptimizedQueryColumns, map[string]interface{}{"foo": "bar"}},


### PR DESCRIPTION
**What changed?**

Added an early guard in `CreateSchedule` that checks the `EnableScheduler` dynamic config flag for the domain before proceeding. Returns a `BadRequestError` with a pointer to the onboarding process if the feature is not yet enabled.

**Why?**

Previously `CreateSchedule` would succeed even when the scheduler worker was not enabled for the domain (controlled per-domain via flipr). The scheduler workflow would be started but never picked up by any worker, leaving the schedule in a permanently broken state — it could not be described, paused, updated, or deleted until someone manually enabled the flag. There was no actionable error returned to the caller.

Root cause of the user-visible incident: staging has `EnableScheduler` on by default, so testing there gave a false signal that production would work the same way.

**How did you test it?**

```
go test -race -run TestCreateSchedule ./service/frontend/api/...
go test -race ./service/frontend/config/...
```

New table case `"scheduler not enabled for domain"` added to `TestCreateSchedule`.

**Potential risks**

Existing domains that already have `EnableScheduler = false` (the default before explicit enablement) will now get an error on `CreateSchedule` instead of silently creating a broken schedule. This is the intended behavior — any domain that legitimately uses schedules must already have the flag enabled.

**Release notes**

`CreateSchedule` now returns an error immediately when the scheduler feature is not enabled for the domain, rather than creating a schedule that can never run.

**Documentation Changes**

N/A — the error message itself contains the onboarding link.