### PR TITLE
feat(dynamicconfig): add CollectionFilterOption and a generic Matcher dispatch

### DIFF
--- a/common/dynamicconfig/config.go
+++ b/common/dynamicconfig/config.go
@@ -40,14 +40,13 @@ const (
 func NewCollection(
 	client Client,
 	logger log.Logger,
-	filterOptions ...dynamicproperties.FilterOption,
+	opts ...dynamicproperties.CollectionFilterOption,
 ) *Collection {
-
 	return &Collection{
-		client:        client,
-		logger:        logger,
-		errCount:      -1,
-		filterOptions: filterOptions,
+		client:                  client,
+		logger:                  logger,
+		errCount:                -1,
+		CollectionFilterOptions: *dynamicproperties.NewCollectionFilterOptions(opts...),
 	}
 }
 
@@ -55,10 +54,10 @@ func NewCollection(
 // can be directly accessed by calling the function without propagating the client everywhere in
 // code
 type Collection struct {
-	client        Client
-	logger        log.Logger
-	errCount      int64
-	filterOptions []dynamicproperties.FilterOption
+	client   Client
+	logger   log.Logger
+	errCount int64
+	dynamicproperties.CollectionFilterOptions
 }
 
 func (c *Collection) logError(
@@ -570,7 +569,7 @@ func (c *Collection) toFilterMap(opts ...dynamicproperties.FilterOption) map[dyn
 	for _, opt := range opts {
 		opt(m)
 	}
-	for _, opt := range c.filterOptions {
+	for _, opt := range c.FilterOptions {
 		opt(m)
 	}
 	return m

--- a/common/dynamicconfig/configstore/config_store_client.go
+++ b/common/dynamicconfig/configstore/config_store_client.go
@@ -582,12 +582,22 @@ func matchFilters(dcValue *types.DynamicConfigValue, filters map[dynamicproperti
 
 	for _, valueFilter := range dcValue.Filters {
 		filterKey := dynamicproperties.ParseFilter(valueFilter.Name)
-		if filters[filterKey] == nil {
+		filterValue := filters[filterKey]
+		if filterValue == nil {
 			return false
 		}
 
 		requestValue, err := convertFromDataBlob(valueFilter.Value)
-		if err != nil || filters[filterKey] != requestValue {
+		if err != nil {
+			return false
+		}
+		if m, ok := filterValue.(dynamicproperties.Matcher); ok {
+			if !m.Matches(requestValue) {
+				return false
+			}
+			continue
+		}
+		if filterValue != requestValue {
 			return false
 		}
 	}

--- a/common/dynamicconfig/configstore/config_store_client_test.go
+++ b/common/dynamicconfig/configstore/config_store_client_test.go
@@ -563,6 +563,17 @@ func (s *configStoreClientSuite) TestValidateConfig_InvalidConfig() {
 	s.Error(err)
 }
 
+// testMatcherValue is a Matcher implementation used only to prove that
+// matchFilters() dispatches to Matches() for any filter-map value implementing
+// the interface, independent of which Filter key it's stored under.
+type testMatcherValue struct {
+	matches bool
+}
+
+func (v testMatcherValue) Matches(constraint interface{}) bool {
+	return v.matches
+}
+
 func (s *configStoreClientSuite) TestMatchFilters() {
 	testCases := []struct {
 		v       *types.DynamicConfigValue
@@ -680,6 +691,44 @@ func (s *configStoreClientSuite) TestMatchFilters() {
 			},
 			filters: map[dynamicproperties.Filter]interface{}{
 				dynamicproperties.TaskListName: "sample-task-list",
+			},
+			matched: false,
+		},
+		{
+			// a filter-map value implementing Matcher is dispatched to Matches(),
+			// not compared via equality
+			v: &types.DynamicConfigValue{
+				Value: nil,
+				Filters: []*types.DynamicConfigFilter{
+					{
+						Name: "domainName",
+						Value: &types.DataBlob{
+							EncodingType: types.EncodingTypeJSON.Ptr(),
+							Data:         jsonMarshalHelper("the constraint value"),
+						},
+					},
+				},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.DomainName: testMatcherValue{matches: true},
+			},
+			matched: true,
+		},
+		{
+			v: &types.DynamicConfigValue{
+				Value: nil,
+				Filters: []*types.DynamicConfigFilter{
+					{
+						Name: "domainName",
+						Value: &types.DataBlob{
+							EncodingType: types.EncodingTypeJSON.Ptr(),
+							Data:         jsonMarshalHelper("the constraint value"),
+						},
+					},
+				},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.DomainName: testMatcherValue{matches: false},
 			},
 			matched: false,
 		},

--- a/common/dynamicconfig/dynamicproperties/filter.go
+++ b/common/dynamicconfig/dynamicproperties/filter.go
@@ -105,8 +105,53 @@ const (
 	LastFilterTypeForTest
 )
 
+// Matcher lets a filter-map value define its own comparison against a constraint,
+// instead of match()/matchFilters()'s default equality check. Implement this on a
+// filter's value type when a constraint isn't a plain exact match.
+type Matcher interface {
+	Matches(constraint interface{}) bool
+}
+
 // FilterOption is used to provide filters for dynamic config keys
 type FilterOption func(filterMap map[Filter]interface{})
+
+// ShardIDFilterOption builds a FilterOption once the shard id is known, for options
+// that also depend on a value fixed at Collection-construction time (e.g. the
+// cluster's shard count). Applied only within ShardID-scoped getters.
+type ShardIDFilterOption func(shardID int) FilterOption
+
+// CollectionFilterOption configures a Collection at construction time. Implemented
+// by FilterOption (applied to every getter call) and ShardIDFilterOption (applied
+// only within ShardID-scoped getters, once the shard id is known). Sealed to this
+// package: the apply method is unexported.
+type CollectionFilterOption interface {
+	apply(*CollectionFilterOptions)
+}
+
+// CollectionFilterOptions is the classified result of a NewCollection(...) call's
+// options.
+type CollectionFilterOptions struct {
+	FilterOptions        []FilterOption
+	ShardIDFilterOptions []ShardIDFilterOption
+}
+
+func (f FilterOption) apply(s *CollectionFilterOptions) {
+	s.FilterOptions = append(s.FilterOptions, f)
+}
+
+func (f ShardIDFilterOption) apply(s *CollectionFilterOptions) {
+	s.ShardIDFilterOptions = append(s.ShardIDFilterOptions, f)
+}
+
+// NewCollectionFilterOptions classifies raw CollectionFilterOption values into their
+// FilterOption / ShardIDFilterOption buckets.
+func NewCollectionFilterOptions(opts ...CollectionFilterOption) *CollectionFilterOptions {
+	s := &CollectionFilterOptions{}
+	for _, opt := range opts {
+		opt.apply(s)
+	}
+	return s
+}
 
 // TaskListFilter filters by task list name
 func TaskListFilter(name string) FilterOption {

--- a/common/dynamicconfig/dynamicproperties/filter_test.go
+++ b/common/dynamicconfig/dynamicproperties/filter_test.go
@@ -1,0 +1,74 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package dynamicproperties
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCollectionFilterOptions(t *testing.T) {
+	tests := []struct {
+		name                     string
+		opts                     []CollectionFilterOption
+		wantFilterOptionCount    int
+		wantShardIDFilterOptions int
+	}{
+		{
+			name: "no options",
+		},
+		{
+			name: "only FilterOptions",
+			opts: []CollectionFilterOption{
+				ClusterNameFilter("cluster0"),
+				DomainFilter("domain0"),
+			},
+			wantFilterOptionCount: 2,
+		},
+		{
+			name: "only ShardIDFilterOptions",
+			opts: []CollectionFilterOption{
+				ShardIDFilterOption(func(shardID int) FilterOption { return ShardIDFilter(shardID) }),
+			},
+			wantShardIDFilterOptions: 1,
+		},
+		{
+			name: "mixed",
+			opts: []CollectionFilterOption{
+				ClusterNameFilter("cluster0"),
+				ShardIDFilterOption(func(shardID int) FilterOption { return ShardIDFilter(shardID) }),
+				DomainFilter("domain0"),
+			},
+			wantFilterOptionCount:    2,
+			wantShardIDFilterOptions: 1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NewCollectionFilterOptions(tc.opts...)
+			assert.Len(t, got.FilterOptions, tc.wantFilterOptionCount)
+			assert.Len(t, got.ShardIDFilterOptions, tc.wantShardIDFilterOptions)
+		})
+	}
+}

--- a/common/dynamicconfig/file_based_client.go
+++ b/common/dynamicconfig/file_based_client.go
@@ -315,7 +315,17 @@ func match(v *constrainedValue, filters map[dynamicproperties.Filter]interface{}
 
 	for constrain, constrainedValue := range v.Constraints {
 		constrainKey := dynamicproperties.ParseFilter(constrain)
-		if filters[constrainKey] == nil || filters[constrainKey] != constrainedValue {
+		filterValue := filters[constrainKey]
+		if filterValue == nil {
+			return false
+		}
+		if m, ok := filterValue.(dynamicproperties.Matcher); ok {
+			if !m.Matches(constrainedValue) {
+				return false
+			}
+			continue
+		}
+		if filterValue != constrainedValue {
 			return false
 		}
 	}

--- a/common/dynamicconfig/file_based_client_test.go
+++ b/common/dynamicconfig/file_based_client_test.go
@@ -237,6 +237,17 @@ func (s *fileBasedClientSuite) TestValidateConfig_ShortPollInterval() {
 
 }
 
+// testMatcherValue is a Matcher implementation used only to prove that match()
+// dispatches to Matches() for any filter-map value implementing the interface,
+// independent of which Filter key it's stored under.
+type testMatcherValue struct {
+	matches bool
+}
+
+func (v testMatcherValue) Matches(constraint interface{}) bool {
+	return v.matches
+}
+
 func (s *fileBasedClientSuite) TestMatch() {
 	testCases := []struct {
 		v       *constrainedValue
@@ -302,6 +313,26 @@ func (s *fileBasedClientSuite) TestMatch() {
 			},
 			filters: map[dynamicproperties.Filter]interface{}{
 				dynamicproperties.TaskListName: "sample-task-list",
+			},
+			matched: false,
+		},
+		{
+			// a filter-map value implementing Matcher is dispatched to Matches(),
+			// not compared via equality
+			v: &constrainedValue{
+				Constraints: map[string]interface{}{"domainName": "the constraint value"},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.DomainName: testMatcherValue{matches: true},
+			},
+			matched: true,
+		},
+		{
+			v: &constrainedValue{
+				Constraints: map[string]interface{}{"domainName": "the constraint value"},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.DomainName: testMatcherValue{matches: false},
 			},
 			matched: false,
 		},


### PR DESCRIPTION
**What changed?**
Adds two small, additive extension points to `common/dynamicconfig`, with no behavior change on their own — nothing in the repo uses either one yet.

1. `dynamicproperties.CollectionFilterOption` — a sum type accepted by `dynamicconfig.NewCollection(...)`. `FilterOption` (existing) still applies to every getter call, as before. `ShardIDFilterOption func(shardID int) FilterOption` (new) resolves to a `FilterOption` once the shard id is known at call time, for options that also depend on a value fixed at `Collection`-construction time. `NewCollection`'s call-site shape is unchanged — only the variadic element type widens, so every existing caller (all ~60 of them, which only ever pass plain `FilterOption`s like `ClusterNameFilter`) keeps compiling with zero source changes, since `FilterOption` implements the new interface automatically.
2. `dynamicproperties.Matcher` — lets a filter-map value opt into custom constraint matching (`Matches(constraint interface{}) bool`) instead of the default equality check in `match()`/`matchFilters()`, without either function needing to special-case which filter keys need it.

This is infrastructure split out of a larger change (percentage-based shard rollouts) that will land as a follow-up PR depending on this one — splitting it out lets this piece be reviewed on its own, since it's a pure, low-risk extension of the existing filter mechanism.

**Why?**
The follow-up change needs a way to thread a value that's fixed once per `Collection` (a cluster's shard count) into filter construction, without mutable state on `Collection` and without special-casing a new filter by name inside the two independent matching implementations. Both extension points are generic — reusable by any future filter with similar needs, not specific to shard counts or percentages.

**How did you test it?**
`go test ./common/dynamicconfig/...`, plus a full `go build ./...` to confirm none of the ~60 other `NewCollection` call sites needed changes.

New cases:
- `go test -v ./common/dynamicconfig/dynamicproperties/... -run TestNewCollectionFilterOptions`
- `go test -v ./common/dynamicconfig/... -run TestFileBasedClientSuite/TestMatch`
- `go test -v ./common/dynamicconfig/configstore/... -run TestConfigStoreClientSuite/TestMatchFilters`

**Potential risks**
None expected — both additions are inert until something implements `ShardIDFilterOption` or `Matcher`, which nothing in this PR does. Existing equality-based matching and `FilterOption` behavior are unchanged.

**Release notes**
N/A — internal extension points only.

**Documentation Changes**
N/A
