### PR TITLE
fix(history): shardID filter for TimerProcessorCachedQueueReaderMode

### DIFF
--- a/common/dynamicconfig/config.go
+++ b/common/dynamicconfig/config.go
@@ -399,6 +399,22 @@ func (c *Collection) GetStringProperty(key dynamicproperties.StringKey) dynamicp
 	}
 }
 
+// GetStringPropertyFilteredByShardID gets property with shardID as filter and asserts that it's a string
+func (c *Collection) GetStringPropertyFilteredByShardID(key dynamicproperties.StringKey) dynamicproperties.StringPropertyFnWithShardIDFilter {
+	return func(shardID int) string {
+		filters := c.toFilterMap(dynamicproperties.ShardIDFilter(shardID))
+		val, err := c.client.GetStringValue(
+			key,
+			filters,
+		)
+		if err != nil {
+			c.logError(key, filters, err)
+			return key.DefaultString()
+		}
+		return val
+	}
+}
+
 // GetMapProperty gets property and asserts that it's a map
 func (c *Collection) GetMapProperty(key dynamicproperties.MapKey) dynamicproperties.MapPropertyFn {
 	return func(opts ...dynamicproperties.FilterOption) map[string]interface{} {

--- a/common/dynamicconfig/config_test.go
+++ b/common/dynamicconfig/config_test.go
@@ -64,6 +64,15 @@ func (s *configSuite) TestGetStringProperty() {
 	s.Equal("b", value())
 }
 
+func (s *configSuite) TestGetStringPropertyFilteredByShardID() {
+	key := dynamicproperties.TestGetStringPropertyFilteredByShardIDKey
+	shardID := 1
+	value := s.cln.GetStringPropertyFilteredByShardID(key)
+	s.Equal(key.DefaultValue(), value(shardID))
+	s.client.SetValue(key, "b")
+	s.Equal("b", value(shardID))
+}
+
 func (s *configSuite) TestGetIntProperty() {
 	key := dynamicproperties.TestGetIntPropertyKey
 	value := s.cln.GetIntProperty(key)

--- a/common/dynamicconfig/dynamicproperties/config_mock.go
+++ b/common/dynamicconfig/dynamicproperties/config_mock.go
@@ -116,6 +116,11 @@ func GetStringPropertyFnFilteredByDomain(value string) func(domain string) strin
 	return func(domain string) string { return value }
 }
 
+// GetStringPropertyFnFilteredByShardID returns value as StringPropertyFnWithShardIDFilter
+func GetStringPropertyFnFilteredByShardID(value string) func(shardID int) string {
+	return func(shardID int) string { return value }
+}
+
 // GetMapPropertyFn returns value as MapPropertyFn
 func GetMapPropertyFn(value map[string]interface{}) func(opts ...FilterOption) map[string]interface{} {
 	return func(...FilterOption) map[string]interface{} { return value }

--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -110,7 +110,7 @@ func ListAllProductionKeys() []Key {
 	for i := TestGetFloat64PropertyKey + 1; i < LastFloatKey; i++ {
 		result = append(result, i)
 	}
-	for i := TestGetStringPropertyKey + 1; i < LastStringKey; i++ {
+	for i := TestGetStringPropertyFilteredByShardIDKey + 1; i < LastStringKey; i++ {
 		result = append(result, i)
 	}
 	for i := TestGetDurationPropertyFilteredByTaskListInfoKey + 1; i < LastDurationKey; i++ {
@@ -2614,6 +2614,7 @@ const (
 
 	// key for tests
 	TestGetStringPropertyKey
+	TestGetStringPropertyFilteredByShardIDKey
 
 	// key for common & admin
 
@@ -5407,6 +5408,12 @@ var StringKeys = map[StringKey]DynamicString{
 		KeyName:      "testGetStringPropertyKey",
 		Description:  "",
 		DefaultValue: "",
+	},
+	TestGetStringPropertyFilteredByShardIDKey: {
+		KeyName:      "testGetStringPropertyFilteredByShardIDKey",
+		Description:  "",
+		DefaultValue: "",
+		Filters:      []Filter{ShardID},
 	},
 	WriteVisibilityStoreName: {
 		KeyName:      "system.writeVisibilityStoreName",

--- a/common/dynamicconfig/dynamicproperties/definitions.go
+++ b/common/dynamicconfig/dynamicproperties/definitions.go
@@ -89,6 +89,9 @@ type StringPropertyFnWithDomainFilter func(domain string) string
 // StringPropertyFnWithTaskListInfoFilters is a wrapper to get string property from dynamic config with domainID as filter
 type StringPropertyFnWithTaskListInfoFilters func(domain string, taskList string, taskType int) string
 
+// StringPropertyFnWithShardIDFilter is a wrapper to get string property from dynamic config with shardID as filter
+type StringPropertyFnWithShardIDFilter func(shardID int) string
+
 // BoolPropertyFnWithDomainFilter is a wrapper to get bool property from dynamic config with domain as filter
 type BoolPropertyFnWithDomainFilter func(domain string) bool
 

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -158,7 +158,7 @@ type Config struct {
 	TimerProcessorHistoryArchivalSizeLimit            dynamicproperties.IntPropertyFn
 	TimerProcessorArchivalTimeLimit                   dynamicproperties.DurationPropertyFn
 	DisableTimerFailoverQueue                         dynamicproperties.BoolPropertyFn
-	TimerProcessorCachedQueueReaderMode               dynamicproperties.StringPropertyFn
+	TimerProcessorCachedQueueReaderMode               dynamicproperties.StringPropertyFnWithShardIDFilter
 	TimerProcessorCacheMaxSize                        dynamicproperties.IntPropertyFn
 	TimerProcessorCachePrefetchTriggerWindow          dynamicproperties.DurationPropertyFn
 	TimerProcessorCacheTimeEvictionWindow             dynamicproperties.DurationPropertyFn
@@ -477,7 +477,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		TimerProcessorHistoryArchivalSizeLimit:               dc.GetIntProperty(dynamicproperties.TimerProcessorHistoryArchivalSizeLimit),
 		TimerProcessorArchivalTimeLimit:                      dc.GetDurationProperty(dynamicproperties.TimerProcessorArchivalTimeLimit),
 		DisableTimerFailoverQueue:                            dc.GetBoolProperty(dynamicproperties.DisableTimerFailoverQueue),
-		TimerProcessorCachedQueueReaderMode:                  dc.GetStringProperty(dynamicproperties.TimerProcessorCachedQueueReaderMode),
+		TimerProcessorCachedQueueReaderMode:                  dc.GetStringPropertyFilteredByShardID(dynamicproperties.TimerProcessorCachedQueueReaderMode),
 		TimerProcessorCacheMaxSize:                           dc.GetIntProperty(dynamicproperties.TimerProcessorCacheMaxSize),
 		TimerProcessorCachePrefetchTriggerWindow:             dc.GetDurationProperty(dynamicproperties.TimerProcessorCachePrefetchTriggerWindow),
 		TimerProcessorCacheTimeEvictionWindow:                dc.GetDurationProperty(dynamicproperties.TimerProcessorCacheTimeEvictionWindow),

--- a/service/history/config/config_test.go
+++ b/service/history/config/config_test.go
@@ -383,6 +383,8 @@ func getValue(f *reflect.Value) interface{} {
 			return fn("domain")
 		case dynamicproperties.BoolPropertyFnWithShardIDFilter:
 			return fn(0)
+		case dynamicproperties.StringPropertyFnWithShardIDFilter:
+			return fn(0)
 		case func() []string:
 			return fn()
 		default:

--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -66,7 +66,7 @@ type CachedQueueReader interface {
 // populated from shard.Context
 type cachedQueueReaderOptions struct {
 	// Mode controls cache behavior: "enabled" uses cache, anything else (including "disabled") disables.
-	Mode dynamicproperties.StringPropertyFn
+	Mode dynamicproperties.StringPropertyFnWithShardIDFilter
 	// MaxSize is the maximum number of tasks the cache may hold at once.
 	// Insertions that would exceed this limit trigger time-based eviction first.
 	MaxSize dynamicproperties.IntPropertyFn
@@ -277,11 +277,13 @@ func (q *cachedQueueReader) nextPrefetchDelay() time.Duration {
 }
 
 // isEnabled returns true if the cache is fully enabled
-func (q *cachedQueueReader) isEnabled() bool { return q.options.Mode() == "enabled" }
+func (q *cachedQueueReader) isEnabled() bool {
+	return q.options.Mode(q.shard.GetShardID()) == "enabled"
+}
 
 // isShadow returns true when cache runs in shadow mode — results are compared
 // against the DB but the DB result is returned to the processor.
-func (q *cachedQueueReader) isShadow() bool { return q.options.Mode() == "shadow" }
+func (q *cachedQueueReader) isShadow() bool { return q.options.Mode(q.shard.GetShardID()) == "shadow" }
 
 // isCachedQueueReaderDisabled reports whether the given mode disables the cached queue reader.
 func isCachedQueueReaderDisabled(mode string) bool {
@@ -295,7 +297,7 @@ func isCachedQueueReaderDisabled(mode string) bool {
 
 // isDisabled returns true for the "disabled" mode and for any unrecognised value
 func (q *cachedQueueReader) isDisabled() bool {
-	return isCachedQueueReaderDisabled(q.options.Mode())
+	return isCachedQueueReaderDisabled(q.options.Mode(q.shard.GetShardID()))
 }
 
 // IsEmpty reports whether the cache queue reader is empty

--- a/service/history/queuev2/queue_reader_cached_test.go
+++ b/service/history/queuev2/queue_reader_cached_test.go
@@ -43,7 +43,7 @@ import (
 
 func testOptions(overrides ...func(*cachedQueueReaderOptions)) *cachedQueueReaderOptions {
 	opts := &cachedQueueReaderOptions{
-		Mode:                      dynamicproperties.GetStringPropertyFn("enabled"),
+		Mode:                      dynamicproperties.GetStringPropertyFnFilteredByShardID("enabled"),
 		MaxSize:                   dynamicproperties.GetIntPropertyFn(100),
 		MaxLookAheadWindow:        dynamicproperties.GetDurationPropertyFn(time.Hour),
 		PrefetchTriggerWindow:     dynamicproperties.GetDurationPropertyFn(5 * time.Minute),
@@ -77,6 +77,7 @@ func setupMocksForCachedQueueReader(
 	mockShard := shard.NewMockContext(ctrl)
 	mockShard.EXPECT().GetRangeID().Return(int64(0)).AnyTimes()
 	mockShard.EXPECT().GetConfig().Return(&config.Config{RangeSizeBits: 20}).AnyTimes()
+	mockShard.EXPECT().GetShardID().Return(0).AnyTimes()
 	deps := &cachedQueueReaderMockDeps{
 		mockBase:  NewMockQueueReader(ctrl),
 		mockQueue: NewMockInMemQueue(ctrl),
@@ -150,7 +151,7 @@ func TestCachedQueueReader_Modes(t *testing.T) {
 		t.Run(tc.mode, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			r, _ := setupMocksForCachedQueueReader(t, ctrl, func(o *cachedQueueReaderOptions) {
-				o.Mode = dynamicproperties.GetStringPropertyFn(tc.mode)
+				o.Mode = dynamicproperties.GetStringPropertyFnFilteredByShardID(tc.mode)
 			})
 			assert.Equal(t, tc.enabled, r.isEnabled(), "mode %q: isEnabled", tc.mode)
 			assert.Equal(t, tc.shadow, r.isShadow(), "mode %q: isShadow", tc.mode)
@@ -289,7 +290,7 @@ func TestCachedQueueReader_Inject(t *testing.T) {
 			name:  "disabled clears stale cache",
 			tasks: []persistence.Task{inside},
 			optsOverride: func(o *cachedQueueReaderOptions) {
-				o.Mode = dynamicproperties.GetStringPropertyFn("disabled")
+				o.Mode = dynamicproperties.GetStringPropertyFnFilteredByShardID("disabled")
 			},
 			setupMocks: func(queue *MockInMemQueue) {
 				queue.EXPECT().Clear()
@@ -796,7 +797,7 @@ func TestCachedQueueReader_GetTask(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			r, deps := setupMocksForCachedQueueReader(t, ctrl, func(o *cachedQueueReaderOptions) {
-				o.Mode = dynamicproperties.GetStringPropertyFn(tc.mode)
+				o.Mode = dynamicproperties.GetStringPropertyFnFilteredByShardID(tc.mode)
 			})
 			base, queue := deps.mockBase, deps.mockQueue
 			setBounds(r, tc.lower, tc.upper)
@@ -1037,7 +1038,7 @@ func TestCachedQueueReader_GetTask_Shadow(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			r, deps := setupMocksForCachedQueueReader(t, ctrl, func(o *cachedQueueReaderOptions) {
-				o.Mode = dynamicproperties.GetStringPropertyFn("shadow")
+				o.Mode = dynamicproperties.GetStringPropertyFnFilteredByShardID("shadow")
 			})
 			setBounds(r, tc.lower, tc.upper)
 			tc.setupMocks(deps.mockBase, deps.mockQueue)
@@ -1390,7 +1391,7 @@ func TestCachedQueueReader_LookAHead(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			r, deps := setupMocksForCachedQueueReader(t, ctrl, func(o *cachedQueueReaderOptions) {
-				o.Mode = dynamicproperties.GetStringPropertyFn(tc.mode)
+				o.Mode = dynamicproperties.GetStringPropertyFnFilteredByShardID(tc.mode)
 			})
 			base, queue := deps.mockBase, deps.mockQueue
 			setBounds(r, tc.initLower, tc.initUpper)
@@ -1449,7 +1450,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 		{
 			name: "disabled: no-op when cache empty",
 			optsOverride: func(o *cachedQueueReaderOptions) {
-				o.Mode = dynamicproperties.GetStringPropertyFn("disabled")
+				o.Mode = dynamicproperties.GetStringPropertyFnFilteredByShardID("disabled")
 			},
 			initLower:  persistence.MinimumHistoryTaskKey,
 			initUpper:  persistence.MinimumHistoryTaskKey,
@@ -1460,7 +1461,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 		{
 			name: "disabled: clears stale cache when not empty",
 			optsOverride: func(o *cachedQueueReaderOptions) {
-				o.Mode = dynamicproperties.GetStringPropertyFn("disabled")
+				o.Mode = dynamicproperties.GetStringPropertyFnFilteredByShardID("disabled")
 			},
 			initLower: someLower,
 			initUpper: someUpper,
@@ -1634,7 +1635,7 @@ func TestCachedQueueReader_Prefetch(t *testing.T) {
 				queue.EXPECT().Len().Return(0).AnyTimes()
 				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).DoAndReturn(
 					func(_ context.Context, _ *GetTaskRequest) (*GetTaskResponse, error) {
-						r.options.Mode = dynamicproperties.GetStringPropertyFn("disabled")
+						r.options.Mode = dynamicproperties.GetStringPropertyFnFilteredByShardID("disabled")
 						return &GetTaskResponse{
 							Tasks:    []persistence.Task{t1, t2},
 							Progress: &GetTaskProgress{NextTaskKey: maxKey},

--- a/service/history/queuev2/timer_queue_factory.go
+++ b/service/history/queuev2/timer_queue_factory.go
@@ -159,7 +159,7 @@ func (f *timerQueueFactory) createQueuev2(
 		options.MaxPollInterval,
 		options.MaxPollIntervalJitterCoefficient,
 	)
-	if !isCachedQueueReaderDisabled(config.TimerProcessorCachedQueueReaderMode()) {
+	if !isCachedQueueReaderDisabled(config.TimerProcessorCachedQueueReaderMode(shard.GetShardID())) {
 		cachedReader = newCachedQueueReader(reader, newInMemQueue(), shard, metricsScope)
 		reader = cachedReader
 	}

--- a/service/history/queuev2/timer_queue_factory_test.go
+++ b/service/history/queuev2/timer_queue_factory_test.go
@@ -36,7 +36,7 @@ func TestTimerQueueFactory_CreateQueuev2(t *testing.T) {
 
 			cfg := config.NewForTest()
 			if tc.mode != "" {
-				cfg.TimerProcessorCachedQueueReaderMode = dynamicproperties.GetStringPropertyFn(tc.mode)
+				cfg.TimerProcessorCachedQueueReaderMode = dynamicproperties.GetStringPropertyFnFilteredByShardID(tc.mode)
 			}
 
 			mockShard := shard.NewTestContext(t, ctrl, &persistence.ShardInfo{

--- a/service/history/shard/notify_task.go
+++ b/service/history/shard/notify_task.go
@@ -110,7 +110,7 @@ func (s *contextImpl) notifyTasksFromConflictResolveWorkflowExecution(
 // is in shadow mode. In shadow mode the cache is validated against the DB, so dropped tasks
 // produce observable mismatches that are worth tracking. In other modes the log is noise.
 func (s *contextImpl) logNotifyTaskDroppedOnPersistenceError(err error, droppedTaskIDs []int64) {
-	if s.config.TimerProcessorCachedQueueReaderMode() != "shadow" {
+	if s.config.TimerProcessorCachedQueueReaderMode(s.GetShardID()) != "shadow" {
 		return
 	}
 	s.logger.Info("notify tasks dropped due to persistence error",


### PR DESCRIPTION
## Summary
- `history.timerProcessorCachedQueueReaderMode` declares `Filters: []Filter{ShardID}` but had no string-typed shard-filtered getter, so every read site called it with zero args and any shard-scoped dynamic config override was silently ignored.
- Adds `StringPropertyFnWithShardIDFilter` and `Collection.GetStringPropertyFilteredByShardID`, mirroring the existing int/bool/float/duration shard-filtered variants.
- Updates the three read sites (`service/history/queuev2/timer_queue_factory.go`, `service/history/queuev2/queue_reader_cached.go`, `service/history/shard/notify_task.go`) to pass the current shard ID.

## Test plan
- Added `TestGetStringPropertyFilteredByShardID` in `common/dynamicconfig/config_test.go`, exercising the new getter against a shard-scoped constraint.
- Updated existing tests (`queue_reader_cached_test.go`, `timer_queue_factory_test.go`, `config_test.go`) for the new function signature.
- `make pr` (tidy, go-generate, fmt, lint) passes clean.
- `go test` passes for all touched packages (`common/dynamicconfig/...`, `service/history/config`, `service/history/queuev2`, `service/history/shard`).