### PR TITLE
feat(history): emit metric for severe shadow-mode mismatches in cachedQueueReader

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2989,6 +2989,7 @@ const (
 	CachedQueueHitsCounter
 	CachedQueueMissesCounter
 	CachedQueueSizeHistogram
+	CachedQueueShadowMismatchCounter
 
 	TaskRequestsPerTaskList
 	TaskLatencyPerTaskListHistogram
@@ -3971,6 +3972,7 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 		CachedQueueHitsCounter:                                        {metricName: "cached_queue_hits", metricType: Counter},
 		CachedQueueMissesCounter:                                      {metricName: "cached_queue_misses", metricType: Counter},
 		CachedQueueSizeHistogram:                                      {metricName: "cached_queue_size", metricType: Histogram, buckets: TaskCountBuckets},
+		CachedQueueShadowMismatchCounter:                              {metricName: "cached_queue_shadow_mismatch", metricType: Counter},
 	},
 	Matching: {
 		PollSuccessPerTaskListCounter:                                    {metricName: "poll_success_per_tl", metricRollupName: "poll_success"},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -97,11 +97,12 @@ const (
 
 // Common tags for all services
 const (
-	OperationTagName      = "operation"
-	CadenceRoleTagName    = "cadence_role"
-	CadenceServiceTagName = "cadence_service"
-	StatsTypeTagName      = "stats_type"
-	CacheTypeTagName      = "cache_type"
+	OperationTagName           = "operation"
+	CadenceRoleTagName         = "cadence_role"
+	CadenceServiceTagName      = "cadence_service"
+	StatsTypeTagName           = "stats_type"
+	CacheTypeTagName           = "cache_type"
+	ShadowMismatchRangeTagName = "shadow_mismatch_range"
 )
 
 // Common tag values

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -129,6 +129,12 @@ func CacheTypeTag(value string) Tag {
 	return metricWithUnknown(CacheTypeTagName, value)
 }
 
+// ShadowMismatchRangeTag returns a tag distinguishing which rangeID bucket ("current" or
+// "previous") a cached queue reader's shadow-mode mismatch count belongs to.
+func ShadowMismatchRangeTag(value string) Tag {
+	return metricWithUnknown(ShadowMismatchRangeTagName, value)
+}
+
 // WithCacheScopeLabels returns a scope tagged with the cache metric labels required for consistent Prometheus registration.
 func WithCacheScopeLabels(scope Scope, shardTag Tag, sourceClusterVal string, cacheTypeVal string) Scope {
 	return scope.Tagged(

--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -950,6 +950,7 @@ func (q *cachedQueueReader) reportShadowComparison(result findMismatchesInShadow
 	case !result.NewRange.isEmpty():
 		q.logger.Info("stale shard owner, no check for mismatches", logTags...)
 	case len(result.CurrentRange.Missed) > 0:
+		q.metrics.AddCounter(metrics.CachedQueueShadowMismatchCounter, int64(len(result.CurrentRange.Missed)))
 		q.logger.Warn("potential severe mismatch between db and cache states", logTags...)
 	case len(result.CurrentRange.Extra) > 0 || !result.PreviousRange.isEmpty():
 		q.logger.Info("potential non-critical mismatch between db and cache states", logTags...)

--- a/service/history/queuev2/queue_reader_cached.go
+++ b/service/history/queuev2/queue_reader_cached.go
@@ -939,6 +939,10 @@ func (q *cachedQueueReader) getTaskRangeID(taskID int64) int64 {
 //     for visibility only.
 //  4. Otherwise: cache and DB agreed.
 func (q *cachedQueueReader) reportShadowComparison(result findMismatchesInShadowResult, logTags []tag.Tag) {
+	// Metric emission must run before capping below: capping truncates the slices for
+	// logging, which would undercount the metric for large comparisons.
+	q.emitShadowMismatchMetrics(result)
+
 	// Cap the number of mismatched task keys logged to avoid excessively large logs.
 	result.NewRange = result.NewRange.cap()
 	result.CurrentRange = result.CurrentRange.cap()
@@ -950,12 +954,29 @@ func (q *cachedQueueReader) reportShadowComparison(result findMismatchesInShadow
 	case !result.NewRange.isEmpty():
 		q.logger.Info("stale shard owner, no check for mismatches", logTags...)
 	case len(result.CurrentRange.Missed) > 0:
-		q.metrics.AddCounter(metrics.CachedQueueShadowMismatchCounter, int64(len(result.CurrentRange.Missed)))
 		q.logger.Warn("potential severe mismatch between db and cache states", logTags...)
 	case len(result.CurrentRange.Extra) > 0 || !result.PreviousRange.isEmpty():
 		q.logger.Info("potential non-critical mismatch between db and cache states", logTags...)
 	default:
 		q.logger.Debug("shadow comparison matched", logTags...)
+	}
+}
+
+// emitShadowMismatchMetrics records CachedQueueShadowMismatchCounter for both the current-range
+// and previous-range missed-task buckets, tagged by which bucket they came from so the two never
+// mix into one series. Skipped entirely when NewRange is non-empty: a stale shard owner makes the
+// whole comparison untrustworthy, not just the log severity.
+func (q *cachedQueueReader) emitShadowMismatchMetrics(result findMismatchesInShadowResult) {
+	if !result.NewRange.isEmpty() {
+		return
+	}
+	if len(result.CurrentRange.Missed) > 0 {
+		q.metrics.Tagged(metrics.ShadowMismatchRangeTag("current")).
+			AddCounter(metrics.CachedQueueShadowMismatchCounter, int64(len(result.CurrentRange.Missed)))
+	}
+	if len(result.PreviousRange.Missed) > 0 {
+		q.metrics.Tagged(metrics.ShadowMismatchRangeTag("previous")).
+			AddCounter(metrics.CachedQueueShadowMismatchCounter, int64(len(result.PreviousRange.Missed)))
 	}
 }
 

--- a/service/history/queuev2/queue_reader_cached_test.go
+++ b/service/history/queuev2/queue_reader_cached_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/metrics"
+	metricsmocks "github.com/uber/cadence/common/metrics/mocks"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/service/history/config"
 	"github.com/uber/cadence/service/history/shard"
@@ -836,6 +837,10 @@ func TestCachedQueueReader_GetTask_Shadow(t *testing.T) {
 		setupMocks func(base *MockQueueReader, queue *MockInMemQueue)
 		wantErr    bool
 		wantResp   *GetTaskResponse
+		// wantShadowMismatchCount, when non-zero, swaps the reader's metrics scope for a
+		// mock and asserts CachedQueueShadowMismatchCounter fires with this exact delta.
+		// Zero means the counter must not fire; the shared no-op scope is used instead.
+		wantShadowMismatchCount int
 	}{
 		{
 			// Cache is populated and DB returns the same tasks → returns DB result.
@@ -895,6 +900,7 @@ func TestCachedQueueReader_GetTask_Shadow(t *testing.T) {
 					NextTaskKey: upper,
 				},
 			},
+			wantShadowMismatchCount: 1,
 		},
 		{
 			// Cache has an extra task not in DB (inject race) → ExtraInCache only; returns DB result.
@@ -1041,6 +1047,13 @@ func TestCachedQueueReader_GetTask_Shadow(t *testing.T) {
 			})
 			setBounds(r, tc.lower, tc.upper)
 			tc.setupMocks(deps.mockBase, deps.mockQueue)
+
+			if tc.wantShadowMismatchCount != 0 {
+				mockScope := metricsmocks.NewScope(t)
+				mockScope.EXPECT().IncCounter(metrics.CachedQueueHitsCounter).Once()
+				mockScope.EXPECT().AddCounter(metrics.CachedQueueShadowMismatchCounter, int64(tc.wantShadowMismatchCount)).Once()
+				r.metrics = mockScope
+			}
 
 			resp, err := r.GetTask(context.Background(), tc.req)
 

--- a/service/history/queuev2/queue_reader_cached_test.go
+++ b/service/history/queuev2/queue_reader_cached_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/metrics"
-	metricsmocks "github.com/uber/cadence/common/metrics/mocks"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/service/history/config"
 	"github.com/uber/cadence/service/history/shard"
@@ -74,9 +73,21 @@ func setupMocksForCachedQueueReader(
 	ctrl *gomock.Controller,
 	overrides ...func(*cachedQueueReaderOptions),
 ) (*cachedQueueReader, *cachedQueueReaderMockDeps) {
+	return setupMocksForCachedQueueReaderWithRangeID(t, ctrl, 0, overrides...)
+}
+
+// setupMocksForCachedQueueReaderWithRangeID is like setupMocksForCachedQueueReader but lets the
+// caller control the shard's current rangeID, needed to construct tasks that resolve to
+// findMismatchesInShadow's PreviousRange bucket (taskRangeID < currentRangeID).
+func setupMocksForCachedQueueReaderWithRangeID(
+	t *testing.T,
+	ctrl *gomock.Controller,
+	rangeID int64,
+	overrides ...func(*cachedQueueReaderOptions),
+) (*cachedQueueReader, *cachedQueueReaderMockDeps) {
 	t.Helper()
 	mockShard := shard.NewMockContext(ctrl)
-	mockShard.EXPECT().GetRangeID().Return(int64(0)).AnyTimes()
+	mockShard.EXPECT().GetRangeID().Return(rangeID).AnyTimes()
 	mockShard.EXPECT().GetConfig().Return(&config.Config{RangeSizeBits: 20}).AnyTimes()
 	deps := &cachedQueueReaderMockDeps{
 		mockBase:  NewMockQueueReader(ctrl),
@@ -828,6 +839,9 @@ func TestCachedQueueReader_GetTask_Shadow(t *testing.T) {
 	// tOtherOwner has a taskID in rangeID=1 (1<<20 at RangeSizeBits=20).
 	// The default mock GetRangeID()=0, so this task will be classified into NewRange.
 	tOtherOwner := newTask(1<<20, now.Add(40*time.Minute))
+	// tPreviousOwner has a taskID in rangeID=0. Used only with a case that overrides
+	// the current rangeID to 1, so this task is classified into PreviousRange.
+	tPreviousOwner := newTask(5, now.Add(50*time.Minute))
 
 	tests := []struct {
 		name       string
@@ -837,10 +851,15 @@ func TestCachedQueueReader_GetTask_Shadow(t *testing.T) {
 		setupMocks func(base *MockQueueReader, queue *MockInMemQueue)
 		wantErr    bool
 		wantResp   *GetTaskResponse
-		// wantShadowMismatchCount, when non-zero, swaps the reader's metrics scope for a
-		// mock and asserts CachedQueueShadowMismatchCounter fires with this exact delta.
-		// Zero means the counter must not fire; the shared no-op scope is used instead.
-		wantShadowMismatchCount int
+		// rangeID overrides the shard's current rangeID for this case (default 0).
+		// Only the previous-range case needs a non-zero value, so tasks built at
+		// rangeID 0 resolve to findMismatchesInShadow's PreviousRange bucket.
+		rangeID int64
+		// wantShadowMismatchByTag, when non-nil, swaps the reader's metrics scope for a
+		// fake and asserts CachedQueueShadowMismatchCounter fired exactly these
+		// range-tag -> delta pairs (an empty, non-nil map asserts it fired zero times).
+		// Nil means don't check metrics at all; the shared no-op scope is used instead.
+		wantShadowMismatchByTag map[string]int64
 	}{
 		{
 			// Cache is populated and DB returns the same tasks → returns DB result.
@@ -900,7 +919,40 @@ func TestCachedQueueReader_GetTask_Shadow(t *testing.T) {
 					NextTaskKey: upper,
 				},
 			},
-			wantShadowMismatchCount: 1,
+			wantShadowMismatchByTag: map[string]int64{"current": 1},
+		},
+		{
+			// DB has a task owned by a previous rangeID, missing from cache → PreviousRange.Missed;
+			// tagged separately from the current-range severe mismatch counter.
+			name:  "cache hit, task missing from cache, previous rangeID: non-critical mismatch, tagged separately",
+			lower: lower, upper: upper,
+			rangeID: 1,
+			req: &GetTaskRequest{
+				Progress:  newProgress(lower, upper),
+				Predicate: NewUniversalPredicate(),
+				PageSize:  10,
+			},
+			setupMocks: func(base *MockQueueReader, queue *MockInMemQueue) {
+				queue.EXPECT().Len().Return(0).AnyTimes()
+				// Cache has only t1; DB has t1 and tPreviousOwner (rangeID=0, current rangeID=1).
+				queue.EXPECT().GetTasks(lower, upper, gomock.Any(), 10).
+					Return([]persistence.Task{t1}, upper)
+				base.EXPECT().GetTask(gomock.Any(), gomock.Any()).Return(&GetTaskResponse{
+					Tasks: []persistence.Task{t1, tPreviousOwner},
+					Progress: &GetTaskProgress{
+						Range:       Range{InclusiveMinTaskKey: upper, ExclusiveMaxTaskKey: upper},
+						NextTaskKey: upper,
+					},
+				}, nil)
+			},
+			wantResp: &GetTaskResponse{
+				Tasks: []persistence.Task{t1, tPreviousOwner},
+				Progress: &GetTaskProgress{
+					Range:       Range{InclusiveMinTaskKey: upper, ExclusiveMaxTaskKey: upper},
+					NextTaskKey: upper,
+				},
+			},
+			wantShadowMismatchByTag: map[string]int64{"previous": 1},
 		},
 		{
 			// Cache has an extra task not in DB (inject race) → ExtraInCache only; returns DB result.
@@ -1036,23 +1088,23 @@ func TestCachedQueueReader_GetTask_Shadow(t *testing.T) {
 					NextTaskKey: upper,
 				},
 			},
+			wantShadowMismatchByTag: map[string]int64{},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			r, deps := setupMocksForCachedQueueReader(t, ctrl, func(o *cachedQueueReaderOptions) {
+			r, deps := setupMocksForCachedQueueReaderWithRangeID(t, ctrl, tc.rangeID, func(o *cachedQueueReaderOptions) {
 				o.Mode = dynamicproperties.GetStringPropertyFn("shadow")
 			})
 			setBounds(r, tc.lower, tc.upper)
 			tc.setupMocks(deps.mockBase, deps.mockQueue)
 
-			if tc.wantShadowMismatchCount != 0 {
-				mockScope := metricsmocks.NewScope(t)
-				mockScope.EXPECT().IncCounter(metrics.CachedQueueHitsCounter).Once()
-				mockScope.EXPECT().AddCounter(metrics.CachedQueueShadowMismatchCounter, int64(tc.wantShadowMismatchCount)).Once()
-				r.metrics = mockScope
+			var fakeScope *fakeShadowMetricsScope
+			if tc.wantShadowMismatchByTag != nil {
+				fakeScope = newFakeShadowMetricsScope(t)
+				r.metrics = fakeScope
 			}
 
 			resp, err := r.GetTask(context.Background(), tc.req)
@@ -1063,8 +1115,52 @@ func TestCachedQueueReader_GetTask_Shadow(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.Equal(t, tc.wantResp, resp)
+			if fakeScope != nil {
+				require.Equal(t, 1, fakeScope.hitsCount)
+				require.Equal(t, tc.wantShadowMismatchByTag, fakeScope.mismatchByTag)
+			}
 		})
 	}
+}
+
+// fakeShadowMetricsScope is a hand-rolled metrics.Scope test double (embeds the shared
+// no-op scope for every unused method) that records the two calls needed to assert
+// shadow-mode mismatch metric emission: the pre-shadow cache-hit counter, and any
+// CachedQueueShadowMismatchCounter deltas, bucketed by the ShadowMismatchRangeTag value
+// they were tagged with via Tagged().
+type fakeShadowMetricsScope struct {
+	metrics.Scope
+	t             *testing.T
+	hitsCount     int
+	mismatchByTag map[string]int64
+}
+
+func newFakeShadowMetricsScope(t *testing.T) *fakeShadowMetricsScope {
+	return &fakeShadowMetricsScope{Scope: metrics.NoopScope, t: t, mismatchByTag: map[string]int64{}}
+}
+
+func (f *fakeShadowMetricsScope) IncCounter(counter metrics.MetricIdx) {
+	if counter == metrics.CachedQueueHitsCounter {
+		f.hitsCount++
+	}
+}
+
+func (f *fakeShadowMetricsScope) Tagged(tags ...metrics.Tag) metrics.Scope {
+	require.Len(f.t, tags, 1)
+	require.Equal(f.t, metrics.ShadowMismatchRangeTagName, tags[0].Key())
+	return &fakeTaggedShadowMetricsScope{fakeShadowMetricsScope: f, rangeTag: tags[0].Value()}
+}
+
+// fakeTaggedShadowMetricsScope is the scope returned by fakeShadowMetricsScope.Tagged,
+// recording AddCounter calls against the range tag value it was created with.
+type fakeTaggedShadowMetricsScope struct {
+	*fakeShadowMetricsScope
+	rangeTag string
+}
+
+func (f *fakeTaggedShadowMetricsScope) AddCounter(counter metrics.MetricIdx, delta int64) {
+	require.Equal(f.t, metrics.CachedQueueShadowMismatchCounter, counter)
+	f.mismatchByTag[f.rangeTag] += delta
 }
 
 func TestFindMismatchesInShadow(t *testing.T) {


### PR DESCRIPTION
**What changed?**

Adds a `CachedQueueShadowMismatchCounter` metric to `cachedQueueReader`, incremented by the number of tasks the DB returned but the cache snapshot missed for the current shard rangeID — the same condition that already produces a "potential severe mismatch" warning log.

**Why?**

`cachedQueueReader`'s shadow mode compares cache reads against the DB but only surfaces divergence via logs. Operators running a shadow-mode rollout have no numeric signal to build a dashboard or alert on cache reliability before promoting to `enabled` mode. This adds a counter for exactly the mismatch category that would matter if the cache were live — a DB task the cache missed for a rangeID it currently owns — while leaving benign findings (stale shard ownership, previous-owner leftovers, cache-only extras from injection races) as log-only, since those don't indicate real data loss. No new denominator metric is introduced; a ratio can be computed against the existing `NewHistoryTaskCounter` from the same scope.

**How did you test it?**

`go test ./service/history/queuev2/... ./common/metrics/...`

Extended `TestCachedQueueReader_GetTask_Shadow`'s "task missing from cache" case to swap in a mock `metrics.Scope` and assert `AddCounter(CachedQueueShadowMismatchCounter, 1)` fires exactly once; all other cases in that table keep the shared no-op scope to prove the counter does not fire for non-severe outcomes.

Also ran `make build` and `make lint` clean.

**Potential risks**

None — additive metric only, no behavior change to what's returned to callers or which mismatches are logged.

**Release notes**

N/A — internal observability metric, no user-facing change.

**Documentation Changes**

N/A