### PR TITLE
fix: Don't emit TaskList PartitionConfig metrics for Sticky TaskLists

### DIFF
--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -351,6 +351,9 @@ func (c *taskListManagerImpl) handleErr(err error) error {
 }
 
 func (c *taskListManagerImpl) TaskListPartitionConfig() *types.TaskListPartitionConfig {
+	if c.taskListKind != types.TaskListKindNormal {
+		return nil
+	}
 	c.partitionConfigLock.RLock()
 	defer c.partitionConfigLock.RUnlock()
 


### PR DESCRIPTION
These metrics are meaningless (always a value of 1) and of a very high cardinality due to each having a unique root partition. TaskList specific metrics are typically normalized according to their type, but the root partition tag is not.

<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Stop emitting TaskList PartitionConfig metrics for Sticky TaskLists

**Why?**
- The metrics are useless and have a high cardinality

**How did you test it?**
- Unit tests

**Potential risks**


**Release notes**


**Documentation Changes**

