### PR TITLE
feat(dynamicconfig): add ShardIDPercentage filter for gradual shard rollouts

### DIFF
--- a/common/dynamicconfig/config.go
+++ b/common/dynamicconfig/config.go
@@ -40,14 +40,13 @@ const (
 func NewCollection(
 	client Client,
 	logger log.Logger,
-	filterOptions ...dynamicproperties.FilterOption,
+	opts ...dynamicproperties.CollectionFilterOption,
 ) *Collection {
-
 	return &Collection{
-		client:        client,
-		logger:        logger,
-		errCount:      -1,
-		filterOptions: filterOptions,
+		client:                  client,
+		logger:                  logger,
+		errCount:                -1,
+		CollectionFilterOptions: *dynamicproperties.NewCollectionFilterOptions(opts...),
 	}
 }
 
@@ -55,10 +54,10 @@ func NewCollection(
 // can be directly accessed by calling the function without propagating the client everywhere in
 // code
 type Collection struct {
-	client        Client
-	logger        log.Logger
-	errCount      int64
-	filterOptions []dynamicproperties.FilterOption
+	client   Client
+	logger   log.Logger
+	errCount int64
+	dynamicproperties.CollectionFilterOptions
 }
 
 func (c *Collection) logError(
@@ -570,7 +569,7 @@ func (c *Collection) toFilterMap(opts ...dynamicproperties.FilterOption) map[dyn
 	for _, opt := range opts {
 		opt(m)
 	}
-	for _, opt := range c.filterOptions {
+	for _, opt := range c.FilterOptions {
 		opt(m)
 	}
 	return m

--- a/common/dynamicconfig/config.go
+++ b/common/dynamicconfig/config.go
@@ -198,10 +198,23 @@ func (c *Collection) GetIntPropertyFilteredByDomainAndTaskList(key dynamicproper
 	}
 }
 
-// GetIntPropertyFilteredByShardID gets property with shardID as filter and asserts that it's an integer
+// shardIDFilters builds the filter options for a ShardID-scoped getter call: the
+// exact shard id, plus any Collection-construction-time ShardIDFilterOptions
+// (e.g. ShardIDPercentageFilterOption) resolved for this shard id.
+func (c *Collection) shardIDFilters(shardID int) []dynamicproperties.FilterOption {
+	opts := make([]dynamicproperties.FilterOption, 0, 1+len(c.ShardIDFilterOptions))
+	opts = append(opts, dynamicproperties.ShardIDFilter(shardID))
+	for _, sf := range c.ShardIDFilterOptions {
+		opts = append(opts, sf(shardID))
+	}
+	return opts
+}
+
+// GetIntPropertyFilteredByShardID gets property with shardID as filter and asserts that it's an integer.
+// The constraint may match either exactly (shardID) or by percentage (shardIDPercentage).
 func (c *Collection) GetIntPropertyFilteredByShardID(key dynamicproperties.IntKey) dynamicproperties.IntPropertyFnWithShardIDFilter {
 	return func(shardID int) int {
-		filters := c.toFilterMap(dynamicproperties.ShardIDFilter(shardID))
+		filters := c.toFilterMap(c.shardIDFilters(shardID)...)
 		val, err := c.client.GetIntValue(
 			key,
 			filters,
@@ -214,10 +227,11 @@ func (c *Collection) GetIntPropertyFilteredByShardID(key dynamicproperties.IntKe
 	}
 }
 
-// GetBoolPropertyFilteredByShardID gets property with shardID as filter and asserts that it's a bool
+// GetBoolPropertyFilteredByShardID gets property with shardID as filter and asserts that it's a bool.
+// The constraint may match either exactly (shardID) or by percentage (shardIDPercentage).
 func (c *Collection) GetBoolPropertyFilteredByShardID(key dynamicproperties.BoolKey) dynamicproperties.BoolPropertyFnWithShardIDFilter {
 	return func(shardID int) bool {
-		filters := c.toFilterMap(dynamicproperties.ShardIDFilter(shardID))
+		filters := c.toFilterMap(c.shardIDFilters(shardID)...)
 		val, err := c.client.GetBoolValue(
 			key,
 			filters,
@@ -246,10 +260,11 @@ func (c *Collection) GetFloat64Property(key dynamicproperties.FloatKey) dynamicp
 	}
 }
 
-// GetFloat64PropertyFilteredByShardID gets property with shardID filter and asserts that it's a float64
+// GetFloat64PropertyFilteredByShardID gets property with shardID filter and asserts that it's a float64.
+// The constraint may match either exactly (shardID) or by percentage (shardIDPercentage).
 func (c *Collection) GetFloat64PropertyFilteredByShardID(key dynamicproperties.FloatKey) dynamicproperties.FloatPropertyFnWithShardIDFilter {
 	return func(shardID int) float64 {
-		filters := c.toFilterMap(dynamicproperties.ShardIDFilter(shardID))
+		filters := c.toFilterMap(c.shardIDFilters(shardID)...)
 		val, err := c.client.GetFloatValue(
 			key,
 			filters,
@@ -350,10 +365,11 @@ func (c *Collection) GetDurationPropertyFilteredByTaskListInfo(key dynamicproper
 	}
 }
 
-// GetDurationPropertyFilteredByShardID gets property with shardID id as filter and asserts that it's a duration
+// GetDurationPropertyFilteredByShardID gets property with shardID id as filter and asserts that it's a duration.
+// The constraint may match either exactly (shardID) or by percentage (shardIDPercentage).
 func (c *Collection) GetDurationPropertyFilteredByShardID(key dynamicproperties.DurationKey) dynamicproperties.DurationPropertyFnWithShardIDFilter {
 	return func(shardID int) time.Duration {
-		filters := c.toFilterMap(dynamicproperties.ShardIDFilter(shardID))
+		filters := c.toFilterMap(c.shardIDFilters(shardID)...)
 		val, err := c.client.GetDurationValue(
 			key,
 			filters,

--- a/common/dynamicconfig/configstore/config_store_client.go
+++ b/common/dynamicconfig/configstore/config_store_client.go
@@ -582,12 +582,22 @@ func matchFilters(dcValue *types.DynamicConfigValue, filters map[dynamicproperti
 
 	for _, valueFilter := range dcValue.Filters {
 		filterKey := dynamicproperties.ParseFilter(valueFilter.Name)
-		if filters[filterKey] == nil {
+		filterValue := filters[filterKey]
+		if filterValue == nil {
 			return false
 		}
 
 		requestValue, err := convertFromDataBlob(valueFilter.Value)
-		if err != nil || filters[filterKey] != requestValue {
+		if err != nil {
+			return false
+		}
+		if m, ok := filterValue.(dynamicproperties.Matcher); ok {
+			if !m.Matches(requestValue) {
+				return false
+			}
+			continue
+		}
+		if filterValue != requestValue {
 			return false
 		}
 	}

--- a/common/dynamicconfig/configstore/config_store_client_test.go
+++ b/common/dynamicconfig/configstore/config_store_client_test.go
@@ -563,9 +563,6 @@ func (s *configStoreClientSuite) TestValidateConfig_InvalidConfig() {
 	s.Error(err)
 }
 
-// testMatcherValue is a Matcher implementation used only to prove that
-// matchFilters() dispatches to Matches() for any filter-map value implementing
-// the interface, independent of which Filter key it's stored under.
 type testMatcherValue struct {
 	matches bool
 }
@@ -580,6 +577,44 @@ func (s *configStoreClientSuite) TestMatchFilters() {
 		filters map[dynamicproperties.Filter]interface{}
 		matched bool
 	}{
+		{
+			// filter value implementing Matcher dispatches to Matches() instead of equality
+			v: &types.DynamicConfigValue{
+				Value: nil,
+				Filters: []*types.DynamicConfigFilter{
+					{
+						Name: "domainName",
+						Value: &types.DataBlob{
+							EncodingType: types.EncodingTypeJSON.Ptr(),
+							Data:         jsonMarshalHelper("irrelevant"),
+						},
+					},
+				},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.DomainName: testMatcherValue{matches: true},
+			},
+			matched: true,
+		},
+		{
+			// same Matcher dispatch, but Matches() returns false
+			v: &types.DynamicConfigValue{
+				Value: nil,
+				Filters: []*types.DynamicConfigFilter{
+					{
+						Name: "domainName",
+						Value: &types.DataBlob{
+							EncodingType: types.EncodingTypeJSON.Ptr(),
+							Data:         jsonMarshalHelper("irrelevant"),
+						},
+					},
+				},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.DomainName: testMatcherValue{matches: false},
+			},
+			matched: false,
+		},
 		{
 			v: &types.DynamicConfigValue{
 				Value:   nil,
@@ -695,40 +730,239 @@ func (s *configStoreClientSuite) TestMatchFilters() {
 			matched: false,
 		},
 		{
-			// a filter-map value implementing Matcher is dispatched to Matches(),
-			// not compared via equality
+			// shardID 500 is within the first 60% bucket of a 1000-shard cluster
 			v: &types.DynamicConfigValue{
 				Value: nil,
 				Filters: []*types.DynamicConfigFilter{
 					{
-						Name: "domainName",
+						Name: "shardIDPercentage",
 						Value: &types.DataBlob{
 							EncodingType: types.EncodingTypeJSON.Ptr(),
-							Data:         jsonMarshalHelper("the constraint value"),
+							Data:         jsonMarshalHelper(60.0),
 						},
 					},
 				},
 			},
 			filters: map[dynamicproperties.Filter]interface{}{
-				dynamicproperties.DomainName: testMatcherValue{matches: true},
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 500, NumberOfShards: 1000},
 			},
 			matched: true,
 		},
 		{
+			// shardID 500 is outside the first 40% bucket of a 1000-shard cluster
 			v: &types.DynamicConfigValue{
 				Value: nil,
 				Filters: []*types.DynamicConfigFilter{
 					{
-						Name: "domainName",
+						Name: "shardIDPercentage",
 						Value: &types.DataBlob{
 							EncodingType: types.EncodingTypeJSON.Ptr(),
-							Data:         jsonMarshalHelper("the constraint value"),
+							Data:         jsonMarshalHelper(40.0),
 						},
 					},
 				},
 			},
 			filters: map[dynamicproperties.Filter]interface{}{
-				dynamicproperties.DomainName: testMatcherValue{matches: false},
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 500, NumberOfShards: 1000},
+			},
+			matched: false,
+		},
+		{
+			// 0% matches nothing, not even shard 0
+			v: &types.DynamicConfigValue{
+				Value: nil,
+				Filters: []*types.DynamicConfigFilter{
+					{
+						Name: "shardIDPercentage",
+						Value: &types.DataBlob{
+							EncodingType: types.EncodingTypeJSON.Ptr(),
+							Data:         jsonMarshalHelper(0.0),
+						},
+					},
+				},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 0, NumberOfShards: 1000},
+			},
+			matched: false,
+		},
+		{
+			// 100% matches every shard
+			v: &types.DynamicConfigValue{
+				Value: nil,
+				Filters: []*types.DynamicConfigFilter{
+					{
+						Name: "shardIDPercentage",
+						Value: &types.DataBlob{
+							EncodingType: types.EncodingTypeJSON.Ptr(),
+							Data:         jsonMarshalHelper(100.0),
+						},
+					},
+				},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 999, NumberOfShards: 1000},
+			},
+			matched: true,
+		},
+		{
+			// out-of-range percentage (>100) fails closed, never matches
+			v: &types.DynamicConfigValue{
+				Value: nil,
+				Filters: []*types.DynamicConfigFilter{
+					{
+						Name: "shardIDPercentage",
+						Value: &types.DataBlob{
+							EncodingType: types.EncodingTypeJSON.Ptr(),
+							Data:         jsonMarshalHelper(150.0),
+						},
+					},
+				},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 5, NumberOfShards: 1000},
+			},
+			matched: false,
+		},
+		{
+			// out-of-range percentage (<0) fails closed, never matches
+			v: &types.DynamicConfigValue{
+				Value: nil,
+				Filters: []*types.DynamicConfigFilter{
+					{
+						Name: "shardIDPercentage",
+						Value: &types.DataBlob{
+							EncodingType: types.EncodingTypeJSON.Ptr(),
+							Data:         jsonMarshalHelper(-5.0),
+						},
+					},
+				},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 5, NumberOfShards: 1000},
+			},
+			matched: false,
+		},
+		{
+			// shardIDPercentage composes with other filters via AND
+			v: &types.DynamicConfigValue{
+				Value: nil,
+				Filters: []*types.DynamicConfigFilter{
+					{
+						Name: "shardIDPercentage",
+						Value: &types.DataBlob{
+							EncodingType: types.EncodingTypeJSON.Ptr(),
+							Data:         jsonMarshalHelper(60.0),
+						},
+					},
+					{
+						Name: "domainName",
+						Value: &types.DataBlob{
+							EncodingType: types.EncodingTypeJSON.Ptr(),
+							Data:         jsonMarshalHelper("samples-domain"),
+						},
+					},
+				},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 500, NumberOfShards: 1000},
+				dynamicproperties.DomainName:        "some other domain",
+			},
+			matched: false,
+		},
+		{
+			// raising the percentage from 10 to 11 only ever adds shard 105
+			v: &types.DynamicConfigValue{
+				Value: nil,
+				Filters: []*types.DynamicConfigFilter{
+					{
+						Name: "shardIDPercentage",
+						Value: &types.DataBlob{
+							EncodingType: types.EncodingTypeJSON.Ptr(),
+							Data:         jsonMarshalHelper(11.0),
+						},
+					},
+				},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 105, NumberOfShards: 1000},
+			},
+			matched: true,
+		},
+		{
+			// bucketing is relative to the real shard count, not a fixed 1000: with 8 shards,
+			// shard 1 is 12.5%, which falls inside a 50% threshold
+			v: &types.DynamicConfigValue{
+				Value: nil,
+				Filters: []*types.DynamicConfigFilter{
+					{
+						Name: "shardIDPercentage",
+						Value: &types.DataBlob{
+							EncodingType: types.EncodingTypeJSON.Ptr(),
+							Data:         jsonMarshalHelper(50.0),
+						},
+					},
+				},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 1, NumberOfShards: 8},
+			},
+			matched: true,
+		},
+		{
+			// with only 8 shards, shard 5 is 62.5%, which falls outside a 50% threshold
+			v: &types.DynamicConfigValue{
+				Value: nil,
+				Filters: []*types.DynamicConfigFilter{
+					{
+						Name: "shardIDPercentage",
+						Value: &types.DataBlob{
+							EncodingType: types.EncodingTypeJSON.Ptr(),
+							Data:         jsonMarshalHelper(50.0),
+						},
+					},
+				},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 5, NumberOfShards: 8},
+			},
+			matched: false,
+		},
+		{
+			// numberOfShards unset (zero value) fails closed
+			v: &types.DynamicConfigValue{
+				Value: nil,
+				Filters: []*types.DynamicConfigFilter{
+					{
+						Name: "shardIDPercentage",
+						Value: &types.DataBlob{
+							EncodingType: types.EncodingTypeJSON.Ptr(),
+							Data:         jsonMarshalHelper(100.0),
+						},
+					},
+				},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 5, NumberOfShards: 0},
+			},
+			matched: false,
+		},
+		{
+			// negative numberOfShards fails closed
+			v: &types.DynamicConfigValue{
+				Value: nil,
+				Filters: []*types.DynamicConfigFilter{
+					{
+						Name: "shardIDPercentage",
+						Value: &types.DataBlob{
+							EncodingType: types.EncodingTypeJSON.Ptr(),
+							Data:         jsonMarshalHelper(100.0),
+						},
+					},
+				},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 5, NumberOfShards: -1},
 			},
 			matched: false,
 		},
@@ -737,6 +971,59 @@ func (s *configStoreClientSuite) TestMatchFilters() {
 	for index, tc := range testCases {
 		matched := matchFilters(tc.v, tc.filters)
 		s.Equal(tc.matched, matched, fmt.Sprintf("Test case %v failed", index))
+	}
+}
+
+// TestShardIDPercentageTiers verifies that multiple shardIDPercentage entries under the
+// same key, listed in ascending threshold order, behave as non-overlapping tiers: the
+// first entry whose threshold the shard is below wins, since getValueWithFilters returns
+// on the first match in entry order.
+func (s *configStoreClientSuite) TestShardIDPercentageTiers() {
+	key := dynamicproperties.TestGetIntPropertyFilteredByShardIDKey
+	client := &configStoreClient{logger: log.NewNoop()}
+	client.values.Store(cacheEntry{
+		dcEntries: map[string]*types.DynamicConfigEntry{
+			key.String(): {
+				Name: key.String(),
+				Values: []*types.DynamicConfigValue{
+					{ // [0%, 10%)
+						Value: &types.DataBlob{EncodingType: types.EncodingTypeJSON.Ptr(), Data: jsonMarshalHelper(1)},
+						Filters: []*types.DynamicConfigFilter{
+							{Name: "shardIDPercentage", Value: &types.DataBlob{EncodingType: types.EncodingTypeJSON.Ptr(), Data: jsonMarshalHelper(10.0)}},
+						},
+					},
+					{ // [10%, 20%)
+						Value: &types.DataBlob{EncodingType: types.EncodingTypeJSON.Ptr(), Data: jsonMarshalHelper(2)},
+						Filters: []*types.DynamicConfigFilter{
+							{Name: "shardIDPercentage", Value: &types.DataBlob{EncodingType: types.EncodingTypeJSON.Ptr(), Data: jsonMarshalHelper(20.0)}},
+						},
+					},
+					{ // default: [20%, 100%)
+						Value:   &types.DataBlob{EncodingType: types.EncodingTypeJSON.Ptr(), Data: jsonMarshalHelper(3)},
+						Filters: nil,
+					},
+				},
+			},
+		},
+	})
+
+	tests := []struct {
+		shardID  int
+		expected int
+	}{
+		{shardID: 50, expected: 1},  // 5% -> first tier
+		{shardID: 99, expected: 1},  // 9.9% -> first tier
+		{shardID: 100, expected: 2}, // 10% -> second tier
+		{shardID: 199, expected: 2}, // 19.9% -> second tier
+		{shardID: 200, expected: 3}, // 20% -> default
+		{shardID: 999, expected: 3}, // 99.9% -> default
+	}
+	for _, tc := range tests {
+		v, err := client.GetIntValue(key, map[dynamicproperties.Filter]interface{}{
+			dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: tc.shardID, NumberOfShards: 1000},
+		})
+		s.NoError(err)
+		s.Equal(tc.expected, v, "shardID %d", tc.shardID)
 	}
 }
 

--- a/common/dynamicconfig/configstore/config_store_client_test.go
+++ b/common/dynamicconfig/configstore/config_store_client_test.go
@@ -563,6 +563,17 @@ func (s *configStoreClientSuite) TestValidateConfig_InvalidConfig() {
 	s.Error(err)
 }
 
+// testMatcherValue is a Matcher implementation used only to prove that
+// matchFilters() dispatches to Matches() for any filter-map value implementing
+// the interface, independent of which Filter key it's stored under.
+type testMatcherValue struct {
+	matches bool
+}
+
+func (v testMatcherValue) Matches(constraint interface{}) bool {
+	return v.matches
+}
+
 func (s *configStoreClientSuite) TestMatchFilters() {
 	testCases := []struct {
 		v       *types.DynamicConfigValue
@@ -680,6 +691,44 @@ func (s *configStoreClientSuite) TestMatchFilters() {
 			},
 			filters: map[dynamicproperties.Filter]interface{}{
 				dynamicproperties.TaskListName: "sample-task-list",
+			},
+			matched: false,
+		},
+		{
+			// a filter-map value implementing Matcher is dispatched to Matches(),
+			// not compared via equality
+			v: &types.DynamicConfigValue{
+				Value: nil,
+				Filters: []*types.DynamicConfigFilter{
+					{
+						Name: "domainName",
+						Value: &types.DataBlob{
+							EncodingType: types.EncodingTypeJSON.Ptr(),
+							Data:         jsonMarshalHelper("the constraint value"),
+						},
+					},
+				},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.DomainName: testMatcherValue{matches: true},
+			},
+			matched: true,
+		},
+		{
+			v: &types.DynamicConfigValue{
+				Value: nil,
+				Filters: []*types.DynamicConfigFilter{
+					{
+						Name: "domainName",
+						Value: &types.DataBlob{
+							EncodingType: types.EncodingTypeJSON.Ptr(),
+							Data:         jsonMarshalHelper("the constraint value"),
+						},
+					},
+				},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.DomainName: testMatcherValue{matches: false},
 			},
 			matched: false,
 		},

--- a/common/dynamicconfig/dynamicproperties/filter.go
+++ b/common/dynamicconfig/dynamicproperties/filter.go
@@ -105,8 +105,53 @@ const (
 	LastFilterTypeForTest
 )
 
+// Matcher lets a filter-map value define its own comparison against a constraint,
+// instead of match()/matchFilters()'s default equality check. Implement this on a
+// filter's value type when a constraint isn't a plain exact match.
+type Matcher interface {
+	Matches(constraint interface{}) bool
+}
+
 // FilterOption is used to provide filters for dynamic config keys
 type FilterOption func(filterMap map[Filter]interface{})
+
+// ShardIDFilterOption builds a FilterOption once the shard id is known, for options
+// that also depend on a value fixed at Collection-construction time (e.g. the
+// cluster's shard count). Applied only within ShardID-scoped getters.
+type ShardIDFilterOption func(shardID int) FilterOption
+
+// CollectionFilterOption configures a Collection at construction time. Implemented
+// by FilterOption (applied to every getter call) and ShardIDFilterOption (applied
+// only within ShardID-scoped getters, once the shard id is known). Sealed to this
+// package: the apply method is unexported.
+type CollectionFilterOption interface {
+	apply(*CollectionFilterOptions)
+}
+
+// CollectionFilterOptions is the classified result of a NewCollection(...) call's
+// options.
+type CollectionFilterOptions struct {
+	FilterOptions        []FilterOption
+	ShardIDFilterOptions []ShardIDFilterOption
+}
+
+func (f FilterOption) apply(s *CollectionFilterOptions) {
+	s.FilterOptions = append(s.FilterOptions, f)
+}
+
+func (f ShardIDFilterOption) apply(s *CollectionFilterOptions) {
+	s.ShardIDFilterOptions = append(s.ShardIDFilterOptions, f)
+}
+
+// NewCollectionFilterOptions classifies raw CollectionFilterOption values into their
+// FilterOption / ShardIDFilterOption buckets.
+func NewCollectionFilterOptions(opts ...CollectionFilterOption) *CollectionFilterOptions {
+	s := &CollectionFilterOptions{}
+	for _, opt := range opts {
+		opt.apply(s)
+	}
+	return s
+}
 
 // TaskListFilter filters by task list name
 func TaskListFilter(name string) FilterOption {

--- a/common/dynamicconfig/dynamicproperties/filter.go
+++ b/common/dynamicconfig/dynamicproperties/filter.go
@@ -59,6 +59,8 @@ func ParseFilter(filterName string) Filter {
 		return RatelimitKey
 	case "namespace":
 		return Namespace
+	case "shardIDPercentage":
+		return ShardIDPercentage
 	default:
 		return UnknownFilter
 	}
@@ -76,6 +78,7 @@ var filters = []string{
 	"workflowType",
 	"ratelimitKey",
 	"namespace",
+	"shardIDPercentage",
 }
 
 const (
@@ -100,6 +103,8 @@ const (
 	RatelimitKey
 	// Namespace is the entity of independent shard distribution mechanism
 	Namespace
+	// ShardIDPercentage matches a percentage of shard IDs, for gradual rollouts
+	ShardIDPercentage
 
 	// LastFilterTypeForTest must be the last one in this const group for testing purpose
 	LastFilterTypeForTest
@@ -107,7 +112,8 @@ const (
 
 // Matcher lets a filter-map value define its own comparison against a constraint,
 // instead of match()/matchFilters()'s default equality check. Implement this on a
-// filter's value type when a constraint isn't a plain exact match.
+// filter's value type when a constraint isn't a plain exact match (e.g. a
+// percentage threshold, as ShardIDPercentageValue does).
 type Matcher interface {
 	Matches(constraint interface{}) bool
 }
@@ -188,6 +194,40 @@ func ShardIDFilter(shardID int) FilterOption {
 	}
 }
 
+// ShardIDPercentageFilter carries the actual shard id and the cluster's real shard
+// count, to be compared against a percentage threshold configured on the dynamic
+// config constraint. numberOfShards is required to interpret the percentage
+// correctly, since a shardIDPercentage constraint is relative to the real shard
+// count, not a fixed bucket space.
+func ShardIDPercentageFilter(shardID int, numberOfShards int) FilterOption {
+	return func(filterMap map[Filter]interface{}) {
+		filterMap[ShardIDPercentage] = ShardIDPercentageValue{ShardID: shardID, NumberOfShards: numberOfShards}
+	}
+}
+
+// ShardIDPercentageFilterOption records the cluster's real shard count at Collection
+// construction time, so ShardID-scoped getters can apply ShardIDPercentageFilter once
+// the shard id becomes known at call time.
+func ShardIDPercentageFilterOption(numberOfShards int) ShardIDFilterOption {
+	return func(shardID int) FilterOption {
+		return ShardIDPercentageFilter(shardID, numberOfShards)
+	}
+}
+
+// ShardIDPercentageValue bundles the actual shard id together with the cluster's
+// real shard count. Both are needed together to interpret a shardIDPercentage
+// constraint, since the percentage is relative to the real shard count.
+type ShardIDPercentageValue struct {
+	ShardID        int
+	NumberOfShards int
+}
+
+// Matches implements Matcher, so match()/matchFilters() dispatch shardIDPercentage
+// constraints here instead of comparing via equality.
+func (v ShardIDPercentageValue) Matches(constraint interface{}) bool {
+	return ShardIDPercentageMatches(v, constraint)
+}
+
 // ClusterNameFilter filters by cluster name
 func ClusterNameFilter(clusterName string) FilterOption {
 	return func(filterMap map[Filter]interface{}) {
@@ -213,6 +253,40 @@ func WorkflowTypeFilter(name string) FilterOption {
 func RatelimitKeyFilter(key string) FilterOption {
 	return func(filterMap map[Filter]interface{}) {
 		filterMap[RatelimitKey] = key
+	}
+}
+
+// ShardIDPercentageMatches returns true if shardIDValue (a ShardIDPercentageValue,
+// bundling the actual shard id and the cluster's real shard count) falls within the
+// given percentage (0.0-100.0) of shard ids. Deterministic and monotonic in
+// percentage: raising percentage only ever adds shard ids to the matched set.
+// An out-of-range percentage, a non-positive shard count, or a value of the wrong
+// type, results in no match.
+func ShardIDPercentageMatches(shardIDValue interface{}, percentageValue interface{}) bool {
+	v, ok := shardIDValue.(ShardIDPercentageValue)
+	if !ok || v.NumberOfShards <= 0 {
+		return false
+	}
+	percentage, ok := toFloat64(percentageValue)
+	if !ok || percentage < 0 || percentage > 100 {
+		return false
+	}
+	bucket := v.ShardID % v.NumberOfShards
+	return float64(bucket) < percentage/100*float64(v.NumberOfShards)
+}
+
+func toFloat64(v interface{}) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	default:
+		return 0, false
 	}
 }
 

--- a/common/dynamicconfig/dynamicproperties/filter_test.go
+++ b/common/dynamicconfig/dynamicproperties/filter_test.go
@@ -1,0 +1,74 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package dynamicproperties
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCollectionFilterOptions(t *testing.T) {
+	tests := []struct {
+		name                     string
+		opts                     []CollectionFilterOption
+		wantFilterOptionCount    int
+		wantShardIDFilterOptions int
+	}{
+		{
+			name: "no options",
+		},
+		{
+			name: "only FilterOptions",
+			opts: []CollectionFilterOption{
+				ClusterNameFilter("cluster0"),
+				DomainFilter("domain0"),
+			},
+			wantFilterOptionCount: 2,
+		},
+		{
+			name: "only ShardIDFilterOptions",
+			opts: []CollectionFilterOption{
+				ShardIDFilterOption(func(shardID int) FilterOption { return ShardIDFilter(shardID) }),
+			},
+			wantShardIDFilterOptions: 1,
+		},
+		{
+			name: "mixed",
+			opts: []CollectionFilterOption{
+				ClusterNameFilter("cluster0"),
+				ShardIDFilterOption(func(shardID int) FilterOption { return ShardIDFilter(shardID) }),
+				DomainFilter("domain0"),
+			},
+			wantFilterOptionCount:    2,
+			wantShardIDFilterOptions: 1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NewCollectionFilterOptions(tc.opts...)
+			assert.Len(t, got.FilterOptions, tc.wantFilterOptionCount)
+			assert.Len(t, got.ShardIDFilterOptions, tc.wantShardIDFilterOptions)
+		})
+	}
+}

--- a/common/dynamicconfig/file_based_client.go
+++ b/common/dynamicconfig/file_based_client.go
@@ -315,7 +315,17 @@ func match(v *constrainedValue, filters map[dynamicproperties.Filter]interface{}
 
 	for constrain, constrainedValue := range v.Constraints {
 		constrainKey := dynamicproperties.ParseFilter(constrain)
-		if filters[constrainKey] == nil || filters[constrainKey] != constrainedValue {
+		filterValue := filters[constrainKey]
+		if filterValue == nil {
+			return false
+		}
+		if m, ok := filterValue.(dynamicproperties.Matcher); ok {
+			if !m.Matches(constrainedValue) {
+				return false
+			}
+			continue
+		}
+		if filterValue != constrainedValue {
 			return false
 		}
 	}

--- a/common/dynamicconfig/file_based_client_test.go
+++ b/common/dynamicconfig/file_based_client_test.go
@@ -237,9 +237,6 @@ func (s *fileBasedClientSuite) TestValidateConfig_ShortPollInterval() {
 
 }
 
-// testMatcherValue is a Matcher implementation used only to prove that match()
-// dispatches to Matches() for any filter-map value implementing the interface,
-// independent of which Filter key it's stored under.
 type testMatcherValue struct {
 	matches bool
 }
@@ -254,6 +251,26 @@ func (s *fileBasedClientSuite) TestMatch() {
 		filters map[dynamicproperties.Filter]interface{}
 		matched bool
 	}{
+		{
+			// filter value implementing Matcher dispatches to Matches() instead of equality
+			v: &constrainedValue{
+				Constraints: map[string]interface{}{"domainName": "irrelevant"},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.DomainName: testMatcherValue{matches: true},
+			},
+			matched: true,
+		},
+		{
+			// same Matcher dispatch, but Matches() returns false
+			v: &constrainedValue{
+				Constraints: map[string]interface{}{"domainName": "irrelevant"},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.DomainName: testMatcherValue{matches: false},
+			},
+			matched: false,
+		},
 		{
 			v: &constrainedValue{
 				Constraints: map[string]interface{}{},
@@ -317,22 +334,128 @@ func (s *fileBasedClientSuite) TestMatch() {
 			matched: false,
 		},
 		{
-			// a filter-map value implementing Matcher is dispatched to Matches(),
-			// not compared via equality
+			// shardID 500 is within the first 60% bucket of a 1000-shard cluster
 			v: &constrainedValue{
-				Constraints: map[string]interface{}{"domainName": "the constraint value"},
+				Constraints: map[string]interface{}{"shardIDPercentage": 60.0},
 			},
 			filters: map[dynamicproperties.Filter]interface{}{
-				dynamicproperties.DomainName: testMatcherValue{matches: true},
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 500, NumberOfShards: 1000},
 			},
 			matched: true,
 		},
 		{
+			// shardID 500 is outside the first 40% bucket of a 1000-shard cluster
 			v: &constrainedValue{
-				Constraints: map[string]interface{}{"domainName": "the constraint value"},
+				Constraints: map[string]interface{}{"shardIDPercentage": 40.0},
 			},
 			filters: map[dynamicproperties.Filter]interface{}{
-				dynamicproperties.DomainName: testMatcherValue{matches: false},
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 500, NumberOfShards: 1000},
+			},
+			matched: false,
+		},
+		{
+			// 0% matches nothing, not even shard 0
+			v: &constrainedValue{
+				Constraints: map[string]interface{}{"shardIDPercentage": 0.0},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 0, NumberOfShards: 1000},
+			},
+			matched: false,
+		},
+		{
+			// 100% matches every shard
+			v: &constrainedValue{
+				Constraints: map[string]interface{}{"shardIDPercentage": 100.0},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 999, NumberOfShards: 1000},
+			},
+			matched: true,
+		},
+		{
+			// out-of-range percentage (>100) fails closed, never matches
+			v: &constrainedValue{
+				Constraints: map[string]interface{}{"shardIDPercentage": 150.0},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 5, NumberOfShards: 1000},
+			},
+			matched: false,
+		},
+		{
+			// out-of-range percentage (<0) fails closed, never matches
+			v: &constrainedValue{
+				Constraints: map[string]interface{}{"shardIDPercentage": -5.0},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 5, NumberOfShards: 1000},
+			},
+			matched: false,
+		},
+		{
+			// shardIDPercentage composes with other filters via AND
+			v: &constrainedValue{
+				Constraints: map[string]interface{}{
+					"shardIDPercentage": 60.0,
+					"domainName":        "samples-domain",
+				},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 500, NumberOfShards: 1000},
+				dynamicproperties.DomainName:        "some other domain",
+			},
+			matched: false,
+		},
+		{
+			// raising the percentage from 10 to 11 only ever adds shard 105, matching test above the monotonicity boundary
+			v: &constrainedValue{
+				Constraints: map[string]interface{}{"shardIDPercentage": 11.0},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 105, NumberOfShards: 1000},
+			},
+			matched: true,
+		},
+		{
+			// bucketing is relative to the real shard count, not a fixed 1000: with 8 shards,
+			// shard 1 is 12.5%, which falls inside a 50% threshold
+			v: &constrainedValue{
+				Constraints: map[string]interface{}{"shardIDPercentage": 50.0},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 1, NumberOfShards: 8},
+			},
+			matched: true,
+		},
+		{
+			// with only 8 shards, shard 5 is 62.5%, which falls outside a 50% threshold
+			// (the old fixed-1000 bucketing would have wrongly matched, since 5 % 1000 = 5 < 500)
+			v: &constrainedValue{
+				Constraints: map[string]interface{}{"shardIDPercentage": 50.0},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 5, NumberOfShards: 8},
+			},
+			matched: false,
+		},
+		{
+			// numberOfShards unset (zero value) fails closed
+			v: &constrainedValue{
+				Constraints: map[string]interface{}{"shardIDPercentage": 100.0},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 5, NumberOfShards: 0},
+			},
+			matched: false,
+		},
+		{
+			// negative numberOfShards fails closed
+			v: &constrainedValue{
+				Constraints: map[string]interface{}{"shardIDPercentage": 100.0},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: 5, NumberOfShards: -1},
 			},
 			matched: false,
 		},
@@ -341,6 +464,42 @@ func (s *fileBasedClientSuite) TestMatch() {
 	for index, tc := range testCases {
 		matched := match(tc.v, tc.filters)
 		s.Equal(tc.matched, matched, fmt.Sprintf("Test case %v failved", index))
+	}
+}
+
+// TestShardIDPercentageTiers verifies that multiple shardIDPercentage entries under the
+// same key, listed in ascending threshold order, behave as non-overlapping tiers: the
+// first entry whose threshold the shard is below wins, since getValueWithFilters returns
+// on the first match in list order.
+func (s *fileBasedClientSuite) TestShardIDPercentageTiers() {
+	client := &fileBasedClient{logger: log.NewNoop()}
+	key := dynamicproperties.TestGetIntPropertyFilteredByShardIDKey
+	err := client.storeValues(map[string][]*constrainedValue{
+		key.String(): {
+			{Value: 1, Constraints: map[string]interface{}{"shardIDPercentage": 10.0}}, // [0%, 10%)
+			{Value: 2, Constraints: map[string]interface{}{"shardIDPercentage": 20.0}}, // [10%, 20%)
+			{Value: 3, Constraints: map[string]interface{}{}},                          // default: [20%, 100%)
+		},
+	})
+	s.Require().NoError(err)
+
+	tests := []struct {
+		shardID  int
+		expected int
+	}{
+		{shardID: 50, expected: 1},  // 5% -> first tier
+		{shardID: 99, expected: 1},  // 9.9% -> first tier
+		{shardID: 100, expected: 2}, // 10% -> second tier (first tier's "< 10%" excludes it)
+		{shardID: 199, expected: 2}, // 19.9% -> second tier
+		{shardID: 200, expected: 3}, // 20% -> default, since neither tier's threshold covers it
+		{shardID: 999, expected: 3}, // 99.9% -> default
+	}
+	for _, tc := range tests {
+		v, err := client.GetIntValue(key, map[dynamicproperties.Filter]interface{}{
+			dynamicproperties.ShardIDPercentage: dynamicproperties.ShardIDPercentageValue{ShardID: tc.shardID, NumberOfShards: 1000},
+		})
+		s.NoError(err)
+		s.Equal(tc.expected, v, "shardID %d", tc.shardID)
 	}
 }
 

--- a/common/dynamicconfig/file_based_client_test.go
+++ b/common/dynamicconfig/file_based_client_test.go
@@ -237,6 +237,17 @@ func (s *fileBasedClientSuite) TestValidateConfig_ShortPollInterval() {
 
 }
 
+// testMatcherValue is a Matcher implementation used only to prove that match()
+// dispatches to Matches() for any filter-map value implementing the interface,
+// independent of which Filter key it's stored under.
+type testMatcherValue struct {
+	matches bool
+}
+
+func (v testMatcherValue) Matches(constraint interface{}) bool {
+	return v.matches
+}
+
 func (s *fileBasedClientSuite) TestMatch() {
 	testCases := []struct {
 		v       *constrainedValue
@@ -302,6 +313,26 @@ func (s *fileBasedClientSuite) TestMatch() {
 			},
 			filters: map[dynamicproperties.Filter]interface{}{
 				dynamicproperties.TaskListName: "sample-task-list",
+			},
+			matched: false,
+		},
+		{
+			// a filter-map value implementing Matcher is dispatched to Matches(),
+			// not compared via equality
+			v: &constrainedValue{
+				Constraints: map[string]interface{}{"domainName": "the constraint value"},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.DomainName: testMatcherValue{matches: true},
+			},
+			matched: true,
+		},
+		{
+			v: &constrainedValue{
+				Constraints: map[string]interface{}{"domainName": "the constraint value"},
+			},
+			filters: map[dynamicproperties.Filter]interface{}{
+				dynamicproperties.DomainName: testMatcherValue{matches: false},
 			},
 			matched: false,
 		},

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -60,12 +60,15 @@ type Service struct {
 func NewService(
 	params *commonResource.Params,
 ) (resource.Resource, error) {
+	dc := dynamicconfig.NewCollection(
+		params.DynamicConfig,
+		params.Logger,
+		dynamicproperties.ClusterNameFilter(params.ClusterMetadata.GetCurrentClusterName()),
+		dynamicproperties.ShardIDPercentageFilterOption(params.PersistenceConfig.NumHistoryShards),
+	)
+
 	serviceConfig := config.New(
-		dynamicconfig.NewCollection(
-			params.DynamicConfig,
-			params.Logger,
-			dynamicproperties.ClusterNameFilter(params.ClusterMetadata.GetCurrentClusterName()),
-		),
+		dc,
 		params.PersistenceConfig.NumHistoryShards,
 		params.RPCFactory.GetMaxMessageSize(),
 		params.PersistenceConfig.IsAdvancedVisibilityConfigExist(),


### PR DESCRIPTION
## Summary

Depends on #8354 — please review/merge that first. This PR's diff will include #8354's changes until it merges; once it does, this diff will shrink to just the delta below.

Adds the `ShardIDPercentage` dynamic config filter on top of the generic `ShardIDFilterOption`/`Matcher` infra from #8354. Lets a dynamic config value match a percentage of shard IDs (relative to the cluster's real shard count) for gradual rollouts, instead of only matching an exact shard ID.

- `ShardIDPercentageFilter`/`ShardIDPercentageFilterOption`/`ShardIDPercentageValue`/`ShardIDPercentageMatches` in `dynamicproperties/filter.go`
- `Collection.shardIDFilters` helper wiring `ShardIDFilterOptions` into the 4 `GetXPropertyFilteredByShardID` getters
- History service now passes `ShardIDPercentageFilterOption(NumHistoryShards)` into `NewCollection`

## Test plan

- `go test ./common/dynamicconfig/... ./service/history/...`
- `make pr GEN_DIR=common/dynamicconfig`