### PR TITLE
fix(ringpop): Allow ringpop to bootstrap when dns lookup returns no host

### DIFF
--- a/common/peerprovider/ringpopprovider/factory.go
+++ b/common/peerprovider/ringpopprovider/factory.go
@@ -56,15 +56,22 @@ func (provider *dnsProvider) Hosts() ([]string, error) {
 		host, port, err := net.SplitHostPort(hostPort)
 		if err != nil {
 			provider.Logger.Warn("could not split host and port", tag.Address(hostPort), tag.Error(err))
-			continue
+			return nil, err
 		}
 
 		resolved, exists := resolvedHosts[host]
 		if !exists {
 			resolved, err = provider.Resolver.LookupHost(context.Background(), host)
 			if err != nil {
+				var dnsErr *net.DNSError
+				if errors.As(err, &dnsErr) {
+					// If no host found, do not fail the bootstrap process, just bootstrap as single-node cluster
+					if dnsErr.IsNotFound {
+						continue
+					}
+				}
 				provider.Logger.Warn("could not resolve host", tag.Address(host), tag.Error(err))
-				continue
+				return nil, err
 			}
 			resolvedHosts[host] = resolved
 		}
@@ -73,7 +80,7 @@ func (provider *dnsProvider) Hosts() ([]string, error) {
 		}
 	}
 	if len(results) == 0 {
-		return nil, errors.New("no hosts found, and bootstrap requires at least one")
+		provider.Logger.Info("no hosts found via DNS, will bootstrap as single-node cluster")
 	}
 	return results, nil
 }
@@ -131,8 +138,15 @@ func (provider *dnsSRVProvider) Hosts() ([]string, error) {
 				addrs, err := provider.Resolver.LookupHost(context.Background(), s.Target)
 
 				if err != nil {
-					provider.Logger.Warn("could not resolve srv dns host", tag.Address(s.Target), tag.Error(err))
-					continue
+					var dnsErr *net.DNSError
+					if errors.As(err, &dnsErr) {
+						// If no host found, do not fail the bootstrap process, just bootstrap as single-node cluster
+						if dnsErr.IsNotFound {
+							continue
+						}
+					}
+					provider.Logger.Warn("could not resolve host", tag.Address(s.Target), tag.Error(err))
+					return nil, err
 				}
 				for _, a := range addrs {
 					targets = append(targets, net.JoinHostPort(a, fmt.Sprintf("%d", s.Port)))
@@ -146,7 +160,7 @@ func (provider *dnsSRVProvider) Hosts() ([]string, error) {
 	}
 
 	if len(results) == 0 {
-		return nil, errors.New("no hosts found, and bootstrap requires at least one")
+		provider.Logger.Info("no hosts found via DNS SRV, will bootstrap as single-node cluster")
 	}
 	return results, nil
 }

--- a/common/peerprovider/ringpopprovider/factory_test.go
+++ b/common/peerprovider/ringpopprovider/factory_test.go
@@ -21,6 +21,14 @@ type mockResolver struct {
 func (resolver *mockResolver) LookupHost(ctx context.Context, host string) ([]string, error) {
 	addrs, ok := resolver.Hosts[host]
 	if !ok {
+		// Return a DNSError with IsNotFound to test that code path
+		if host == "notfound.example.net" {
+			return nil, &net.DNSError{
+				Err:        "no such host",
+				Name:       host,
+				IsNotFound: true,
+			}
+		}
 		return nil, fmt.Errorf("Host was not resolved: %s", host)
 	}
 	return addrs, nil
@@ -63,6 +71,7 @@ func TestDNSMode(t *testing.T) {
 		cfg.BootstrapHosts,
 	)
 
+	// Test deduplication of bootstrap hosts
 	provider := newDNSProvider(
 		cfg.BootstrapHosts,
 		&mockResolver{
@@ -70,7 +79,6 @@ func TestDNSMode(t *testing.T) {
 		},
 		logger,
 	)
-	cfg.DiscoveryProvider = provider
 	assert.ElementsMatch(
 		t,
 		[]string{
@@ -83,7 +91,15 @@ func TestDNSMode(t *testing.T) {
 		"duplicate entries should be removed",
 	)
 
-	hostports, err := cfg.DiscoveryProvider.Hosts()
+	// Test successful resolution with valid hosts
+	provider = newDNSProvider(
+		[]string{"example.net:1111", "example.net:1112"},
+		&mockResolver{
+			Hosts: map[string][]string{"example.net": []string{"10.0.0.0", "10.0.0.1"}},
+		},
+		logger,
+	)
+	hostports, err := provider.Hosts()
 	assert.Nil(t, err)
 	assert.ElementsMatch(
 		t,
@@ -94,14 +110,53 @@ func TestDNSMode(t *testing.T) {
 		hostports,
 	)
 
-	cfg.DiscoveryProvider = newDNSProvider(
-		cfg.BootstrapHosts,
+	// Test error when host has no port (SplitHostPort fails)
+	provider = newDNSProvider(
+		[]string{"badhostport"},
 		&mockResolver{Hosts: map[string][]string{}},
 		logger,
 	)
-	hostports, err = cfg.DiscoveryProvider.Hosts()
-	assert.Nil(t, hostports)
-	assert.NotNil(t, err, "error should be returned when no hosts")
+	_, err = provider.Hosts()
+	assert.NotNil(t, err, "should return error for malformed host:port")
+
+	// Test error when DNS resolution fails (not IsNotFound)
+	provider = newDNSProvider(
+		[]string{"unknown.example.net:1111"},
+		&mockResolver{Hosts: map[string][]string{}},
+		logger,
+	)
+	_, err = provider.Hosts()
+	assert.NotNil(t, err, "should return error when DNS resolution fails")
+
+	// Test DNS IsNotFound case - should continue and return empty
+	provider = newDNSProvider(
+		[]string{"notfound.example.net:1111"},
+		&mockResolver{Hosts: map[string][]string{}},
+		logger,
+	)
+	hostports, err = provider.Hosts()
+	assert.Nil(t, err, "should not return error for DNS not found")
+	assert.Empty(t, hostports, "should return empty list when DNS not found")
+
+	// Test DNS IsNotFound mixed with successful resolution
+	provider = newDNSProvider(
+		[]string{"notfound.example.net:1111", "example.net:1112"},
+		&mockResolver{Hosts: map[string][]string{"example.net": []string{"10.0.0.1"}}},
+		logger,
+	)
+	hostports, err = provider.Hosts()
+	assert.Nil(t, err)
+	assert.ElementsMatch(t, []string{"10.0.0.1:1112"}, hostports, "should skip not found and return resolved")
+
+	// Test empty result when DNS returns IsNotFound for all hosts
+	provider = newDNSProvider(
+		[]string{"example.net:1111"},
+		&mockResolver{Hosts: map[string][]string{"example.net": []string{}}},
+		logger,
+	)
+	hostports, err = provider.Hosts()
+	assert.Nil(t, err)
+	assert.Empty(t, hostports, "should return empty list when DNS returns empty")
 }
 
 func TestDNSSRVMode(t *testing.T) {
@@ -125,8 +180,34 @@ func TestDNSSRVMode(t *testing.T) {
 		cfg.BootstrapHosts,
 	)
 
+	// Test deduplication
 	provider := newDNSSRVProvider(
 		cfg.BootstrapHosts,
+		&mockResolver{
+			SRV: map[string][]net.SRV{
+				"service-a": []net.SRV{{Target: "az1-service-a.addr.example.net", Port: 7755}},
+			},
+			Hosts: map[string][]string{
+				"az1-service-a.addr.example.net": []string{"10.0.0.1"},
+			},
+		},
+		logger,
+	)
+	assert.ElementsMatch(
+		t,
+		[]string{
+			"service-a.example.net",
+			"service-b.example.net",
+			"unknown-duplicate.example.net",
+			"badhostport",
+		},
+		provider.UnresolvedHosts,
+		"duplicate entries should be removed",
+	)
+
+	// Test successful SRV resolution
+	provider = newDNSSRVProvider(
+		[]string{"service-a.example.net", "service-b.example.net"},
 		&mockResolver{
 			SRV: map[string][]net.SRV{
 				"service-a": []net.SRV{{Target: "az1-service-a.addr.example.net", Port: 7755}, {Target: "az2-service-a.addr.example.net", Port: 7566}},
@@ -141,41 +222,7 @@ func TestDNSSRVMode(t *testing.T) {
 		},
 		logger,
 	)
-	cfg.DiscoveryProvider = provider
-	assert.ElementsMatch(
-		t,
-		[]string{
-			"service-a.example.net",
-			"service-b.example.net",
-			"unknown-duplicate.example.net",
-			"badhostport",
-		},
-		provider.UnresolvedHosts,
-		"duplicate entries should be removed",
-	)
-
-	// Expect unknown-duplicate.example.net to not resolve
-	_, err = cfg.DiscoveryProvider.Hosts()
-	assert.NotNil(t, err)
-
-	// Remove known bad hosts from Unresolved list
-	provider.UnresolvedHosts = []string{
-		"service-a.example.net",
-		"service-b.example.net",
-		"badhostport",
-	}
-
-	// Expect badhostport to not seperate service name
-	_, err = cfg.DiscoveryProvider.Hosts()
-	assert.NotNil(t, err)
-
-	// Remove known bad hosts from Unresolved list
-	provider.UnresolvedHosts = []string{
-		"service-a.example.net",
-		"service-b.example.net",
-	}
-
-	hostports, err := cfg.DiscoveryProvider.Hosts()
+	hostports, err := provider.Hosts()
 	assert.Nil(t, err)
 	assert.ElementsMatch(
 		t,
@@ -186,17 +233,84 @@ func TestDNSSRVMode(t *testing.T) {
 			"10.0.3.1:7896",
 		},
 		hostports,
-		"duplicate entries should be removed",
 	)
 
-	cfg.DiscoveryProvider = newDNSProvider(
-		cfg.BootstrapHosts,
-		&mockResolver{Hosts: map[string][]string{}},
+	// Test error when SRV lookup fails
+	provider = newDNSSRVProvider(
+		[]string{"unknown-duplicate.example.net"},
+		&mockResolver{
+			SRV:   map[string][]net.SRV{},
+			Hosts: map[string][]string{},
+		},
 		logger,
 	)
-	hostports, err = cfg.DiscoveryProvider.Hosts()
-	assert.Nil(t, hostports)
-	assert.NotNil(t, err, "error should be returned when no hosts")
+	_, err = provider.Hosts()
+	assert.NotNil(t, err, "should return error when SRV lookup fails")
+
+	// Test error when hostname cannot be separated (less than 3 parts)
+	provider = newDNSSRVProvider(
+		[]string{"badhostport"},
+		&mockResolver{
+			SRV:   map[string][]net.SRV{},
+			Hosts: map[string][]string{},
+		},
+		logger,
+	)
+	_, err = provider.Hosts()
+	assert.NotNil(t, err, "should return error for malformed hostname")
+
+	// Test error when individual SRV target fails to resolve
+	provider = newDNSSRVProvider(
+		[]string{"service-a.example.net"},
+		&mockResolver{
+			SRV: map[string][]net.SRV{
+				"service-a": []net.SRV{
+					{Target: "bad.addr.example.net", Port: 7755},
+				},
+			},
+			Hosts: map[string][]string{},
+		},
+		logger,
+	)
+	_, err = provider.Hosts()
+	assert.NotNil(t, err, "should return error when SRV target fails to resolve")
+
+	// Test DNS IsNotFound for SRV target - should skip and continue
+	provider = newDNSSRVProvider(
+		[]string{"service-a.example.net"},
+		&mockResolver{
+			SRV: map[string][]net.SRV{
+				"service-a": []net.SRV{
+					{Target: "notfound.example.net", Port: 7755},
+					{Target: "good.addr.example.net", Port: 7756},
+				},
+			},
+			Hosts: map[string][]string{
+				"good.addr.example.net": []string{"10.0.0.1"},
+			},
+		},
+		logger,
+	)
+	hostports, err = provider.Hosts()
+	assert.Nil(t, err, "should skip not found SRV targets")
+	assert.ElementsMatch(t, []string{"10.0.0.1:7756"}, hostports, "should return resolved targets")
+
+	// Test all SRV targets are DNS not found - should return empty
+	provider = newDNSSRVProvider(
+		[]string{"service-a.example.net"},
+		&mockResolver{
+			SRV: map[string][]net.SRV{
+				"service-a": []net.SRV{
+					{Target: "notfound.example.net", Port: 7755},
+				},
+			},
+			Hosts: map[string][]string{},
+		},
+		logger,
+	)
+	hostports, err = provider.Hosts()
+	assert.Nil(t, err)
+	assert.Empty(t, hostports, "should return empty when all SRV targets not found")
 }
 
 func getDNSConfig() string {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Allow ringpop to bootstrap when dns lookup returns no host. 
Currently, ringpop's dns mode cannot bootstrap if we don't allow unhealthy hosts to be published to dns record. This is not a good configuration in production. To solve the chicken-egg problem for ringpop bootstrap, we need to allow ringpop to bootstrap itself when the 1st host come alive and join the ring.

related to https://github.com/cadence-workflow/cadence-charts/issues/90

**Why?**
Ringpop bootstrap step fails when no hosts can be found from the dns name. However, no hosts will be added to the dns when they are not ready, which creates a chicken-egg problem.

To solve the problem, we should allow ringpop bootstrap with a one-node cluster when no hosts can be found from the dns name, allowing the 1st node to join the ring.

**How did you test it?**
go test ./common/peerprovider/ringpopprovider/...

**Potential risks**
No.

**Release notes**
N/A

**Documentation Changes**
N/A
