### PR TITLE
refactor: eliminate redundant dynamicconfig.Collection creation

### DIFF
--- a/cmd/server/cadence/fx.go
+++ b/cmd/server/cadence/fx.go
@@ -69,27 +69,29 @@ func Module(serviceName string) fx.Option {
 type AppParams struct {
 	fx.In
 
-	Service       string `name:"service"`
-	AppContext    config.Context
-	Config        config.Config
-	Logger        log.Logger
-	ZapLogger     *zap.Logger
-	LifeCycle     fx.Lifecycle
-	DynamicConfig dynamicconfig.Client
-	Scope         tally.Scope
-	MetricsClient metrics.Client
+	Service           string `name:"service"`
+	AppContext        config.Context
+	Config            config.Config
+	Logger            log.Logger
+	ZapLogger         *zap.Logger
+	LifeCycle         fx.Lifecycle
+	DynamicConfig     dynamicconfig.Client
+	DynamicCollection *dynamicconfig.Collection
+	Scope             tally.Scope
+	MetricsClient     metrics.Client
 }
 
 // NewApp created a new Application from pre initalized config and logger.
 func NewApp(params AppParams) *App {
 	app := &App{
-		cfg:           params.Config,
-		logger:        params.Logger,
-		zapLogger:     params.ZapLogger,
-		service:       params.Service,
-		dynamicConfig: params.DynamicConfig,
-		scope:         params.Scope,
-		metricsClient: params.MetricsClient,
+		cfg:               params.Config,
+		logger:            params.Logger,
+		zapLogger:         params.ZapLogger,
+		service:           params.Service,
+		dynamicConfig:     params.DynamicConfig,
+		dynamicCollection: params.DynamicCollection,
+		scope:             params.Scope,
+		metricsClient:     params.MetricsClient,
 	}
 
 	params.LifeCycle.Append(fx.StartHook(app.verifySchema))
@@ -100,20 +102,21 @@ func NewApp(params AppParams) *App {
 // App is a fx application that registers itself into fx.Lifecycle and runs.
 // It is done implicitly, since it provides methods Start and Stop which are picked up by fx.
 type App struct {
-	cfg           config.Config
-	rootDir       string
-	logger        log.Logger
-	zapLogger     *zap.Logger
-	dynamicConfig dynamicconfig.Client
-	scope         tally.Scope
-	metricsClient metrics.Client
+	cfg               config.Config
+	rootDir           string
+	logger            log.Logger
+	zapLogger         *zap.Logger
+	dynamicConfig     dynamicconfig.Client
+	dynamicCollection *dynamicconfig.Collection
+	scope             tally.Scope
+	metricsClient     metrics.Client
 
 	daemon  common.Daemon
 	service string
 }
 
 func (a *App) Start(_ context.Context) error {
-	a.daemon = newServer(a.service, a.cfg, a.logger, a.zapLogger, a.dynamicConfig, a.scope, a.metricsClient)
+	a.daemon = newServer(a.service, a.cfg, a.logger, a.zapLogger, a.dynamicConfig, a.dynamicCollection, a.scope, a.metricsClient)
 	a.daemon.Start()
 	return nil
 }

--- a/cmd/server/cadence/fx.go
+++ b/cmd/server/cadence/fx.go
@@ -34,6 +34,7 @@ import (
 	"github.com/uber/cadence/common/clock/clockfx"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/dynamicconfig/configstore"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicconfigfx"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/logfx"
@@ -69,29 +70,33 @@ func Module(serviceName string) fx.Option {
 type AppParams struct {
 	fx.In
 
-	Service           string `name:"service"`
-	AppContext        config.Context
-	Config            config.Config
-	Logger            log.Logger
-	ZapLogger         *zap.Logger
-	LifeCycle         fx.Lifecycle
-	DynamicConfig     dynamicconfig.Client
-	DynamicCollection *dynamicconfig.Collection
-	Scope             tally.Scope
-	MetricsClient     metrics.Client
+	Service                  string `name:"service"`
+	AppContext               config.Context
+	Config                   config.Config
+	Logger                   log.Logger
+	ZapLogger                *zap.Logger
+	LifeCycle                fx.Lifecycle
+	DynamicConfig            dynamicconfig.Client
+	DynamicCollection        *dynamicconfig.Collection
+	OperationalConfigStore   configstore.Client        `name:"operational-config-store"`
+	OperationalDynamicConfig *dynamicconfig.Collection `name:"operational-dynamic-config"`
+	Scope                    tally.Scope
+	MetricsClient            metrics.Client
 }
 
 // NewApp created a new Application from pre initalized config and logger.
 func NewApp(params AppParams) *App {
 	app := &App{
-		cfg:               params.Config,
-		logger:            params.Logger,
-		zapLogger:         params.ZapLogger,
-		service:           params.Service,
-		dynamicConfig:     params.DynamicConfig,
-		dynamicCollection: params.DynamicCollection,
-		scope:             params.Scope,
-		metricsClient:     params.MetricsClient,
+		cfg:                      params.Config,
+		logger:                   params.Logger,
+		zapLogger:                params.ZapLogger,
+		service:                  params.Service,
+		dynamicConfig:            params.DynamicConfig,
+		dynamicCollection:        params.DynamicCollection,
+		operationalConfigStore:   params.OperationalConfigStore,
+		operationalDynamicConfig: params.OperationalDynamicConfig,
+		scope:                    params.Scope,
+		metricsClient:            params.MetricsClient,
 	}
 
 	params.LifeCycle.Append(fx.StartHook(app.verifySchema))
@@ -102,21 +107,23 @@ func NewApp(params AppParams) *App {
 // App is a fx application that registers itself into fx.Lifecycle and runs.
 // It is done implicitly, since it provides methods Start and Stop which are picked up by fx.
 type App struct {
-	cfg               config.Config
-	rootDir           string
-	logger            log.Logger
-	zapLogger         *zap.Logger
-	dynamicConfig     dynamicconfig.Client
-	dynamicCollection *dynamicconfig.Collection
-	scope             tally.Scope
-	metricsClient     metrics.Client
+	cfg                      config.Config
+	rootDir                  string
+	logger                   log.Logger
+	zapLogger                *zap.Logger
+	dynamicConfig            dynamicconfig.Client
+	dynamicCollection        *dynamicconfig.Collection
+	operationalConfigStore   configstore.Client
+	operationalDynamicConfig *dynamicconfig.Collection
+	scope                    tally.Scope
+	metricsClient            metrics.Client
 
 	daemon  common.Daemon
 	service string
 }
 
 func (a *App) Start(_ context.Context) error {
-	a.daemon = newServer(a.service, a.cfg, a.logger, a.zapLogger, a.dynamicConfig, a.dynamicCollection, a.scope, a.metricsClient)
+	a.daemon = newServer(a.service, a.cfg, a.logger, a.zapLogger, a.dynamicConfig, a.dynamicCollection, a.operationalConfigStore, a.operationalDynamicConfig, a.scope, a.metricsClient)
 	a.daemon.Start()
 	return nil
 }

--- a/cmd/server/cadence/fx.go
+++ b/cmd/server/cadence/fx.go
@@ -38,6 +38,7 @@ import (
 	"github.com/uber/cadence/common/dynamicconfig/dynamicconfigfx"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/logfx"
+	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/metrics/metricsfx"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql"
@@ -61,10 +62,22 @@ func Module(serviceName string) fx.Option {
 			Name:     serviceName,
 			FullName: service.FullName(serviceName),
 		}),
+		fx.Decorate(decorateLoggerWithService),
 		fx.Provide(NewApp),
 		// empty invoke so fx won't drop the application from the dependencies.
 		fx.Invoke(func(a *App) {}),
 	)
+}
+
+type loggerDecoratorParams struct {
+	fx.In
+
+	Logger      log.Logger
+	ServiceName string `name:"service-full-name"`
+}
+
+func decorateLoggerWithService(p loggerDecoratorParams) log.Logger {
+	return p.Logger.WithTags(tag.Service(p.ServiceName))
 }
 
 type AppParams struct {

--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -53,7 +53,6 @@ import (
 	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/dynamicconfig/configstore"
-	csc "github.com/uber/cadence/common/dynamicconfig/configstore/config"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/elasticsearch"
 	"github.com/uber/cadence/common/isolationgroup/isolationgroupapi"
@@ -63,7 +62,6 @@ import (
 	"github.com/uber/cadence/common/messaging/kafka"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/peerprovider/ringpopprovider"
-	"github.com/uber/cadence/common/persistence"
 	pnt "github.com/uber/cadence/common/pinot"
 	"github.com/uber/cadence/common/resource"
 	"github.com/uber/cadence/common/rpc"
@@ -80,32 +78,36 @@ import (
 
 type (
 	server struct {
-		name              string
-		cfg               config.Config
-		logger            log.Logger
-		zapLogger         *zap.Logger
-		doneC             chan struct{}
-		daemon            common.Daemon
-		dynamicCfgClient  dynamicconfig.Client
-		dynamicCollection *dynamicconfig.Collection
-		scope             tally.Scope
-		metricsClient     metrics.Client
+		name                     string
+		cfg                      config.Config
+		logger                   log.Logger
+		zapLogger                *zap.Logger
+		doneC                    chan struct{}
+		daemon                   common.Daemon
+		dynamicCfgClient         dynamicconfig.Client
+		dynamicCollection        *dynamicconfig.Collection
+		operationalConfigStore   configstore.Client
+		operationalDynamicConfig *dynamicconfig.Collection
+		scope                    tally.Scope
+		metricsClient            metrics.Client
 	}
 )
 
 // newServer returns a new instance of a daemon
 // that represents a cadence service
-func newServer(service string, cfg config.Config, logger log.Logger, zapLogger *zap.Logger, dynamicCfgClient dynamicconfig.Client, dynamicCollection *dynamicconfig.Collection, scope tally.Scope, metricsClient metrics.Client) common.Daemon {
+func newServer(service string, cfg config.Config, logger log.Logger, zapLogger *zap.Logger, dynamicCfgClient dynamicconfig.Client, dynamicCollection *dynamicconfig.Collection, operationalConfigStore configstore.Client, operationalDynamicConfig *dynamicconfig.Collection, scope tally.Scope, metricsClient metrics.Client) common.Daemon {
 	return &server{
-		cfg:               cfg,
-		name:              service,
-		doneC:             make(chan struct{}),
-		logger:            logger,
-		zapLogger:         zapLogger,
-		dynamicCfgClient:  dynamicCfgClient,
-		dynamicCollection: dynamicCollection,
-		scope:             scope,
-		metricsClient:     metricsClient,
+		cfg:                      cfg,
+		name:                     service,
+		doneC:                    make(chan struct{}),
+		logger:                   logger,
+		zapLogger:                zapLogger,
+		dynamicCfgClient:         dynamicCfgClient,
+		dynamicCollection:        dynamicCollection,
+		operationalConfigStore:   operationalConfigStore,
+		operationalDynamicConfig: operationalDynamicConfig,
+		scope:                    scope,
+		metricsClient:            metricsClient,
 	}
 }
 
@@ -160,15 +162,11 @@ func (s *server) startService() common.Daemon {
 	params.MetricsClient = s.metricsClient
 	params.ZapLogger = s.zapLogger
 
-	params.OperationalConfigStore = resolveOperationalConfigStore(&params, s.dynamicCollection)
-	operationalDC := dynamicconfig.NewCollection(
-		params.OperationalConfigStore,
-		params.Logger,
-		dynamicproperties.ClusterNameFilter(clusterGroupMetadata.CurrentClusterName),
-	)
+	params.OperationalConfigStore = s.operationalConfigStore
+	params.OperationalDynamicConfig = s.operationalDynamicConfig
 	params.PercentageOnboarded = membership.NewPercentageOnboarded(
 		params.MetricsClient,
-		operationalDC.GetIntProperty(dynamicproperties.MatchingPercentageOnboardedToShardManager),
+		s.operationalDynamicConfig.GetIntProperty(dynamicproperties.MatchingPercentageOnboardedToShardManager),
 	)
 
 	rpcParams, err := rpc.NewParams(params.Name, &s.cfg, s.dynamicCollection, params.Logger, params.MetricsClient)
@@ -237,7 +235,7 @@ func (s *server) startService() common.Daemon {
 		params.HashRings[s] = membership.NewHashring(s, peerProvider, clock.NewRealTimeSource(), params.Logger, params.MetricsClient.Scope(metrics.HashringScope))
 	}
 
-	wrappedRings := s.wrapHashRingsWithShardDistributor(params.HashRings, spectator, operationalDC, params.PercentageOnboarded, params.Logger)
+	wrappedRings := s.wrapHashRingsWithShardDistributor(params.HashRings, spectator, s.operationalDynamicConfig, params.PercentageOnboarded, params.Logger)
 
 	params.MembershipResolver, err = membership.NewResolver(
 		peerProvider,
@@ -504,23 +502,4 @@ func getFromDynamicConfig(params resource.Params, dc *dynamicconfig.Collection) 
 		}
 		return res
 	}
-}
-
-// resolveOperationalConfigStore returns the primary persistence-backed configstore.Client, or a no-op when persistence doesn't support one.
-func resolveOperationalConfigStore(params *resource.Params, dc *dynamicconfig.Collection) configstore.Client {
-	cscConfig := &csc.ClientConfig{
-		PollInterval:        dc.GetDurationProperty(dynamicproperties.OperationalConfigStorePollInterval)(),
-		UpdateRetryAttempts: dc.GetIntProperty(dynamicproperties.OperationalConfigStoreUpdateRetryAttempts)(),
-		FetchTimeout:        dc.GetDurationProperty(dynamicproperties.OperationalConfigStoreFetchTimeout)(),
-		UpdateTimeout:       dc.GetDurationProperty(dynamicproperties.OperationalConfigStoreUpdateTimeout)(),
-	}
-	client, err := configstore.NewConfigStoreClient(
-		cscConfig, &params.PersistenceConfig, params.Logger, params.MetricsClient,
-		persistence.OperationalDynamicConfig,
-	)
-	if err != nil {
-		params.Logger.Warn("not instantiating operational dynamic config store, this feature will not be enabled", tag.Error(err))
-		return configstore.NewNopClient()
-	}
-	return client
 }

--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -80,30 +80,32 @@ import (
 
 type (
 	server struct {
-		name             string
-		cfg              config.Config
-		logger           log.Logger
-		zapLogger        *zap.Logger
-		doneC            chan struct{}
-		daemon           common.Daemon
-		dynamicCfgClient dynamicconfig.Client
-		scope            tally.Scope
-		metricsClient    metrics.Client
+		name              string
+		cfg               config.Config
+		logger            log.Logger
+		zapLogger         *zap.Logger
+		doneC             chan struct{}
+		daemon            common.Daemon
+		dynamicCfgClient  dynamicconfig.Client
+		dynamicCollection *dynamicconfig.Collection
+		scope             tally.Scope
+		metricsClient     metrics.Client
 	}
 )
 
 // newServer returns a new instance of a daemon
 // that represents a cadence service
-func newServer(service string, cfg config.Config, logger log.Logger, zapLogger *zap.Logger, dynamicCfgClient dynamicconfig.Client, scope tally.Scope, metricsClient metrics.Client) common.Daemon {
+func newServer(service string, cfg config.Config, logger log.Logger, zapLogger *zap.Logger, dynamicCfgClient dynamicconfig.Client, dynamicCollection *dynamicconfig.Collection, scope tally.Scope, metricsClient metrics.Client) common.Daemon {
 	return &server{
-		cfg:              cfg,
-		name:             service,
-		doneC:            make(chan struct{}),
-		logger:           logger,
-		zapLogger:        zapLogger,
-		dynamicCfgClient: dynamicCfgClient,
-		scope:            scope,
-		metricsClient:    metricsClient,
+		cfg:               cfg,
+		name:              service,
+		doneC:             make(chan struct{}),
+		logger:            logger,
+		zapLogger:         zapLogger,
+		dynamicCfgClient:  dynamicCfgClient,
+		dynamicCollection: dynamicCollection,
+		scope:             scope,
+		metricsClient:     metricsClient,
 	}
 }
 
@@ -148,21 +150,17 @@ func (s *server) startService() common.Daemon {
 		Logger:            s.logger.WithTags(tag.Service(service.FullName(s.name))),
 		PersistenceConfig: s.cfg.Persistence,
 		DynamicConfig:     s.dynamicCfgClient,
+		DynamicCollection: s.dynamicCollection,
 		RPCConfig:         svcCfg.RPC,
 	}
 
 	clusterGroupMetadata := s.cfg.ClusterGroupMetadata
-	dc := dynamicconfig.NewCollection(
-		params.DynamicConfig,
-		params.Logger,
-		dynamicproperties.ClusterNameFilter(clusterGroupMetadata.CurrentClusterName),
-	)
 
 	params.MetricScope = s.scope
 	params.MetricsClient = s.metricsClient
 	params.ZapLogger = s.zapLogger
 
-	params.OperationalConfigStore = resolveOperationalConfigStore(&params, dc)
+	params.OperationalConfigStore = resolveOperationalConfigStore(&params, s.dynamicCollection)
 	operationalDC := dynamicconfig.NewCollection(
 		params.OperationalConfigStore,
 		params.Logger,
@@ -173,7 +171,7 @@ func (s *server) startService() common.Daemon {
 		operationalDC.GetIntProperty(dynamicproperties.MatchingPercentageOnboardedToShardManager),
 	)
 
-	rpcParams, err := rpc.NewParams(params.Name, &s.cfg, dc, params.Logger, params.MetricsClient)
+	rpcParams, err := rpc.NewParams(params.Name, &s.cfg, s.dynamicCollection, params.Logger, params.MetricsClient)
 	if err != nil {
 		s.logger.Fatal("error creating rpc factory params", tag.Error(err))
 	}
@@ -255,16 +253,16 @@ func (s *server) startService() common.Daemon {
 
 	params.ClusterRedirectionPolicy = s.cfg.ClusterGroupMetadata.ClusterRedirectionPolicy
 
-	params.GetIsolationGroups = getFromDynamicConfig(params, dc)
+	params.GetIsolationGroups = getFromDynamicConfig(params, s.dynamicCollection)
 
 	params.ClusterMetadata = cluster.NewMetadata(
 		*clusterGroupMetadata,
-		dc.GetBoolPropertyFilteredByDomain(dynamicproperties.UseNewInitialFailoverVersion),
+		s.dynamicCollection.GetBoolPropertyFilteredByDomain(dynamicproperties.UseNewInitialFailoverVersion),
 		params.MetricsClient,
 		params.Logger,
 	)
 
-	advancedVisMode := dc.GetStringProperty(
+	advancedVisMode := s.dynamicCollection.GetStringProperty(
 		dynamicproperties.WriteVisibilityStoreName,
 	)()
 	isAdvancedVisEnabled := common.IsAdvancedVisibilityWritingEnabled(advancedVisMode, params.PersistenceConfig.IsAdvancedVisibilityConfigExist())
@@ -294,7 +292,7 @@ func (s *server) startService() common.Daemon {
 	}
 
 	params.ArchivalMetadata = archiver.NewArchivalMetadata(
-		dc,
+		s.dynamicCollection,
 		s.cfg.Archival.History.Status,
 		s.cfg.Archival.History.EnableRead,
 		s.cfg.Archival.Visibility.Status,
@@ -303,8 +301,8 @@ func (s *server) startService() common.Daemon {
 	)
 
 	params.ArchiverProvider = provider.NewArchiverProvider(s.cfg.Archival.History.Provider, s.cfg.Archival.Visibility.Provider)
-	params.PersistenceConfig.TransactionSizeLimit = dc.GetIntProperty(dynamicproperties.TransactionSizeLimit)
-	params.PersistenceConfig.ErrorInjectionRate = dc.GetFloat64Property(dynamicproperties.PersistenceErrorInjectionRate)
+	params.PersistenceConfig.TransactionSizeLimit = s.dynamicCollection.GetIntProperty(dynamicproperties.TransactionSizeLimit)
+	params.PersistenceConfig.ErrorInjectionRate = s.dynamicCollection.GetFloat64Property(dynamicproperties.PersistenceErrorInjectionRate)
 	params.AuthorizationConfig = s.cfg.Authorization
 	params.BlobstoreClient, err = filestore.NewFilestoreClient(s.cfg.Blobstore.Filestore)
 	if err != nil {

--- a/cmd/server/cadence/server_test.go
+++ b/cmd/server/cadence/server_test.go
@@ -110,7 +110,9 @@ func (s *ServerSuite) TestServerStartup() {
 		})
 
 	for _, svc := range services {
-		server := newServer(svc, cfg, logger, testlogger.NewZap(s.T()), dynamicconfig.NewNopClient(), tally.NoopScope, metrics.NewNoopMetricsClient())
+		client := dynamicconfig.NewNopClient()
+		dc := dynamicconfig.NewNopCollection()
+		server := newServer(svc, cfg, logger, testlogger.NewZap(s.T()), client, dc, tally.NoopScope, metrics.NewNoopMetricsClient())
 		daemons = append(daemons, server)
 		server.Start()
 	}

--- a/cmd/server/cadence/server_test.go
+++ b/cmd/server/cadence/server_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/dynamicconfig/configstore"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -112,7 +113,9 @@ func (s *ServerSuite) TestServerStartup() {
 	for _, svc := range services {
 		client := dynamicconfig.NewNopClient()
 		dc := dynamicconfig.NewNopCollection()
-		server := newServer(svc, cfg, logger, testlogger.NewZap(s.T()), client, dc, tally.NoopScope, metrics.NewNoopMetricsClient())
+		operationalConfigStore := configstore.NewNopClient()
+		operationalDC := dynamicconfig.NewNopCollection()
+		server := newServer(svc, cfg, logger, testlogger.NewZap(s.T()), client, dc, operationalConfigStore, operationalDC, tally.NoopScope, metrics.NewNoopMetricsClient())
 		daemons = append(daemons, server)
 		server.Start()
 	}

--- a/common/dynamicconfig/dynamicconfigfx/fx.go
+++ b/common/dynamicconfig/dynamicconfigfx/fx.go
@@ -51,7 +51,6 @@ type Params struct {
 	Logger        log.Logger
 	MetricsClient metrics.Client
 	RootDir       string `name:"root-dir"`
-	ServiceName   string `name:"service-full-name"`
 
 	Lifecycle fx.Lifecycle
 }
@@ -128,7 +127,7 @@ func New(p Params) Result {
 	clusterGroupMetadata := p.Cfg.ClusterGroupMetadata
 	dc := dynamicconfig.NewCollection(
 		res,
-		p.Logger.WithTags(tag.Service(p.ServiceName)),
+		p.Logger,
 		dynamicproperties.ClusterNameFilter(clusterGroupMetadata.CurrentClusterName),
 	)
 
@@ -136,7 +135,7 @@ func New(p Params) Result {
 	operationalConfigStore := createOperationalConfigStore(&p.Cfg.Persistence, dc, p.Logger, p.MetricsClient)
 	operationalDC := dynamicconfig.NewCollection(
 		operationalConfigStore,
-		p.Logger.WithTags(tag.Service(p.ServiceName)),
+		p.Logger,
 		dynamicproperties.ClusterNameFilter(clusterGroupMetadata.CurrentClusterName),
 	)
 

--- a/common/dynamicconfig/dynamicconfigfx/fx.go
+++ b/common/dynamicconfig/dynamicconfigfx/fx.go
@@ -31,6 +31,7 @@ import (
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/dynamicconfig/configstore"
+	csc "github.com/uber/cadence/common/dynamicconfig/configstore/config"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/dynamicconfig/openfeatureclient"
 	"github.com/uber/cadence/common/log"
@@ -58,8 +59,10 @@ type Params struct {
 type Result struct {
 	fx.Out
 
-	Client     dynamicconfig.Client
-	Collection *dynamicconfig.Collection
+	Client                   dynamicconfig.Client
+	Collection               *dynamicconfig.Collection
+	OperationalConfigStore   configstore.Client        `name:"operational-config-store"`
+	OperationalDynamicConfig *dynamicconfig.Collection `name:"operational-dynamic-config"`
 }
 
 // New creates dynamicconfig.Client from the configuration
@@ -129,9 +132,19 @@ func New(p Params) Result {
 		dynamicproperties.ClusterNameFilter(clusterGroupMetadata.CurrentClusterName),
 	)
 
+	// Create operational config store
+	operationalConfigStore := createOperationalConfigStore(&p.Cfg.Persistence, dc, p.Logger, p.MetricsClient)
+	operationalDC := dynamicconfig.NewCollection(
+		operationalConfigStore,
+		p.Logger.WithTags(tag.Service(p.ServiceName)),
+		dynamicproperties.ClusterNameFilter(clusterGroupMetadata.CurrentClusterName),
+	)
+
 	return Result{
-		Client:     res,
-		Collection: dc,
+		Client:                   res,
+		Collection:               dc,
+		OperationalConfigStore:   operationalConfigStore,
+		OperationalDynamicConfig: operationalDC,
 	}
 }
 
@@ -142,4 +155,31 @@ func constructPathIfNeed(dir string, file string) string {
 		return dir + "/" + file
 	}
 	return file
+}
+
+// createOperationalConfigStore returns the primary persistence-backed configstore.Client, or a no-op when persistence doesn't support one.
+func createOperationalConfigStore(
+	persistenceConfig *config.Persistence,
+	dc *dynamicconfig.Collection,
+	logger log.Logger,
+	metricsClient metrics.Client,
+) configstore.Client {
+	cscConfig := &csc.ClientConfig{
+		PollInterval:        dc.GetDurationProperty(dynamicproperties.OperationalConfigStorePollInterval)(),
+		UpdateRetryAttempts: dc.GetIntProperty(dynamicproperties.OperationalConfigStoreUpdateRetryAttempts)(),
+		FetchTimeout:        dc.GetDurationProperty(dynamicproperties.OperationalConfigStoreFetchTimeout)(),
+		UpdateTimeout:       dc.GetDurationProperty(dynamicproperties.OperationalConfigStoreUpdateTimeout)(),
+	}
+	client, err := configstore.NewConfigStoreClient(
+		cscConfig,
+		persistenceConfig,
+		logger,
+		metricsClient,
+		persistence.OperationalDynamicConfig,
+	)
+	if err != nil {
+		logger.Warn("not instantiating operational dynamic config store, this feature will not be enabled", tag.Error(err))
+		return configstore.NewNopClient()
+	}
+	return client
 }

--- a/common/dynamicconfig/dynamicconfigfx/fx.go
+++ b/common/dynamicconfig/dynamicconfigfx/fx.go
@@ -50,6 +50,7 @@ type Params struct {
 	Logger        log.Logger
 	MetricsClient metrics.Client
 	RootDir       string `name:"root-dir"`
+	ServiceName   string `name:"service-full-name"`
 
 	Lifecycle fx.Lifecycle
 }
@@ -124,7 +125,7 @@ func New(p Params) Result {
 	clusterGroupMetadata := p.Cfg.ClusterGroupMetadata
 	dc := dynamicconfig.NewCollection(
 		res,
-		p.Logger,
+		p.Logger.WithTags(tag.Service(p.ServiceName)),
 		dynamicproperties.ClusterNameFilter(clusterGroupMetadata.CurrentClusterName),
 	)
 

--- a/common/log/logfx/fx.go
+++ b/common/log/logfx/fx.go
@@ -44,8 +44,7 @@ var ModuleWithoutZap = fx.Options(
 type zapBuilderParams struct {
 	fx.In
 
-	Cfg         config.Config
-	ServiceName string `name:"service-full-name"`
+	Cfg config.Config
 }
 
 func zapBuilder(p zapBuilderParams) (*zap.Logger, error) {

--- a/common/log/logfx/fx.go
+++ b/common/log/logfx/fx.go
@@ -44,7 +44,8 @@ var ModuleWithoutZap = fx.Options(
 type zapBuilderParams struct {
 	fx.In
 
-	Cfg config.Config
+	Cfg         config.Config
+	ServiceName string `name:"service-full-name"`
 }
 
 func zapBuilder(p zapBuilderParams) (*zap.Logger, error) {

--- a/common/resource/params.go
+++ b/common/resource/params.go
@@ -90,6 +90,7 @@ type (
 		IsolationGroupStore        configstore.Client       // This can be nil, the default config store will be created if so
 		IsolationGroupState        isolationgroup.State     // This can be nil, the default state store will be chosen if so
 		OperationalConfigStore     configstore.Client
+		OperationalDynamicConfig   *dynamicconfig.Collection
 		PinotConfig                *config.PinotVisibilityConfig
 		KafkaConfig                config.KafkaConfig
 		PinotClient                pinot.GenericClient

--- a/common/resource/params.go
+++ b/common/resource/params.go
@@ -80,6 +80,7 @@ type (
 		RPCConfig config.RPC
 
 		DynamicConfig              dynamicconfig.Client
+		DynamicCollection          *dynamicconfig.Collection
 		ClusterRedirectionPolicy   *config.ClusterRedirectionPolicy
 		PublicClient               workflowserviceclient.Interface
 		ArchivalMetadata           archiver.ArchivalMetadata

--- a/common/resource/resource_impl.go
+++ b/common/resource/resource_impl.go
@@ -172,11 +172,7 @@ func New(
 
 	ensureGetAllIsolationGroupsFnIsSet(params)
 
-	dynamicCollection := dynamicconfig.NewCollection(
-		params.DynamicConfig,
-		logger,
-		dynamicproperties.ClusterNameFilter(params.ClusterMetadata.GetCurrentClusterName()),
-	)
+	dynamicCollection := params.DynamicCollection
 	clientBean, err := client.NewClientBean(
 		client.NewRPCClientFactory(
 			params.RPCFactory,

--- a/common/resource/resource_impl.go
+++ b/common/resource/resource_impl.go
@@ -318,11 +318,6 @@ func New(
 	}
 
 	isolationGroupStore := createConfigStoreOrDefault(params, dynamicCollection)
-	operationalDynamicConfig := dynamicconfig.NewCollection(
-		params.OperationalConfigStore,
-		logger,
-		dynamicproperties.ClusterNameFilter(params.ClusterMetadata.GetCurrentClusterName()),
-	)
 
 	isolationGroupState, err := ensureIsolationGroupStateHandlerOrDefault(
 		params,
@@ -404,7 +399,7 @@ func New(
 		isolationGroups:           isolationGroupState,
 		isolationGroupConfigStore: isolationGroupStore, // can be nil where persistence is not available
 		operationalConfigStore:    params.OperationalConfigStore,
-		operationalDynamicConfig:  operationalDynamicConfig,
+		operationalDynamicConfig:  params.OperationalDynamicConfig,
 
 		asyncWorkflowQueueProvider: params.AsyncWorkflowQueueProvider,
 

--- a/common/resource/resource_impl_test.go
+++ b/common/resource/resource_impl_test.go
@@ -172,8 +172,13 @@ func TestStartStop(t *testing.T) {
 		RPCFactory:         rpcFac,
 		MembershipResolver: memberRes,
 		DynamicConfig:      dc,
-		TimeSource:         clock.NewRealTimeSource(),
-		PProfInitializer:   pprof,
+		DynamicCollection: dynamicconfig.NewCollection(
+			dc,
+			logger,
+			dynamicproperties.ClusterNameFilter(clusterMetadata.GetCurrentClusterName()),
+		),
+		TimeSource:       clock.NewRealTimeSource(),
+		PProfInitializer: pprof,
 		NewPersistenceBeanFn: func(persistenceClient.Factory, *persistenceClient.Params, *service.Config) (persistenceClient.Bean, error) {
 			return persistenceClientBean, nil
 		},

--- a/common/resource/resource_impl_test.go
+++ b/common/resource/resource_impl_test.go
@@ -185,6 +185,11 @@ func TestStartStop(t *testing.T) {
 		ArchiverProvider:           archiveProvider,
 		AsyncWorkflowQueueProvider: queue.NewMockProvider(ctrl),
 		OperationalConfigStore:     configstore.NewNopClient(),
+		OperationalDynamicConfig: dynamicconfig.NewCollection(
+			configstore.NewNopClient(),
+			logger,
+			dynamicproperties.ClusterNameFilter(clusterMetadata.GetCurrentClusterName()),
+		),
 	}
 
 	// bare minimum service config

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -695,6 +695,11 @@ func (c *cadenceImpl) startFrontend(hosts map[string][]membership.HostInfo, star
 	params.ClusterMetadata = c.clusterMetadata
 	params.MessagingClient = c.messagingClient
 	params.DynamicConfig = newIntegrationConfigClient(c.dynamicClient, c.frontendDynCfgOverrides)
+	params.DynamicCollection = dynamicconfig.NewCollection(
+		params.DynamicConfig,
+		c.logger,
+		dynamicproperties.ClusterNameFilter(c.clusterMetadata.GetCurrentClusterName()),
+	)
 	params.ArchivalMetadata = c.archiverMetadata
 	params.ArchiverProvider = c.archiverProvider
 	params.ESConfig = c.esConfig
@@ -782,6 +787,11 @@ func (c *cadenceImpl) startHistory(hosts map[string][]membership.HostInfo, start
 		integrationClient := newIntegrationConfigClient(c.dynamicClient, c.historyDynCfgOverrides)
 		c.overrideHistoryDynamicConfig(integrationClient)
 		params.DynamicConfig = integrationClient
+		params.DynamicCollection = dynamicconfig.NewCollection(
+			params.DynamicConfig,
+			c.logger,
+			dynamicproperties.ClusterNameFilter(c.clusterMetadata.GetCurrentClusterName()),
+		)
 		params.PublicClient = newPublicClient(params.RPCFactory.GetDispatcher())
 		params.ArchivalMetadata = c.archiverMetadata
 		params.ArchiverProvider = c.archiverProvider
@@ -869,6 +879,11 @@ func (c *cadenceImpl) startMatching(hosts map[string][]membership.HostInfo, star
 		params.MembershipResolver = newMembershipResolver(params.Name, hosts, hostport)
 		params.ClusterMetadata = c.clusterMetadata
 		params.DynamicConfig = newIntegrationConfigClient(c.dynamicClient, c.matchingDynCfgOverrides)
+		params.DynamicCollection = dynamicconfig.NewCollection(
+			params.DynamicConfig,
+			c.logger,
+			dynamicproperties.ClusterNameFilter(c.clusterMetadata.GetCurrentClusterName()),
+		)
 		params.ArchivalMetadata = c.archiverMetadata
 		params.ArchiverProvider = c.archiverProvider
 		params.GetIsolationGroups = getFromDynamicConfig(params)
@@ -942,6 +957,11 @@ func (c *cadenceImpl) startWorker(hosts map[string][]membership.HostInfo, startW
 	params.MembershipResolver = newMembershipResolver(params.Name, hosts, c.WorkerServiceHost())
 	params.ClusterMetadata = c.clusterMetadata
 	params.DynamicConfig = newIntegrationConfigClient(c.dynamicClient, c.workerDynCfgOverrides)
+	params.DynamicCollection = dynamicconfig.NewCollection(
+		params.DynamicConfig,
+		c.logger,
+		dynamicproperties.ClusterNameFilter(c.clusterMetadata.GetCurrentClusterName()),
+	)
 	params.ArchivalMetadata = c.archiverMetadata
 	params.ArchiverProvider = c.archiverProvider
 	params.GetIsolationGroups = getFromDynamicConfig(params)

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -675,6 +675,7 @@ func (c *cadenceImpl) GetMatchingClients() []matchingClient.Client {
 
 func setOperationalDefaults(params *resource.Params) {
 	params.OperationalConfigStore = configstore.NewNopClient()
+	// OperationalDynamicConfig will be set after DynamicConfig is available
 	params.PercentageOnboarded = membership.StaticPercentageOnboarded(0)
 }
 
@@ -697,6 +698,11 @@ func (c *cadenceImpl) startFrontend(hosts map[string][]membership.HostInfo, star
 	params.DynamicConfig = newIntegrationConfigClient(c.dynamicClient, c.frontendDynCfgOverrides)
 	params.DynamicCollection = dynamicconfig.NewCollection(
 		params.DynamicConfig,
+		c.logger,
+		dynamicproperties.ClusterNameFilter(c.clusterMetadata.GetCurrentClusterName()),
+	)
+	params.OperationalDynamicConfig = dynamicconfig.NewCollection(
+		params.OperationalConfigStore,
 		c.logger,
 		dynamicproperties.ClusterNameFilter(c.clusterMetadata.GetCurrentClusterName()),
 	)
@@ -792,6 +798,11 @@ func (c *cadenceImpl) startHistory(hosts map[string][]membership.HostInfo, start
 			c.logger,
 			dynamicproperties.ClusterNameFilter(c.clusterMetadata.GetCurrentClusterName()),
 		)
+		params.OperationalDynamicConfig = dynamicconfig.NewCollection(
+			params.OperationalConfigStore,
+			c.logger,
+			dynamicproperties.ClusterNameFilter(c.clusterMetadata.GetCurrentClusterName()),
+		)
 		params.PublicClient = newPublicClient(params.RPCFactory.GetDispatcher())
 		params.ArchivalMetadata = c.archiverMetadata
 		params.ArchiverProvider = c.archiverProvider
@@ -884,6 +895,11 @@ func (c *cadenceImpl) startMatching(hosts map[string][]membership.HostInfo, star
 			c.logger,
 			dynamicproperties.ClusterNameFilter(c.clusterMetadata.GetCurrentClusterName()),
 		)
+		params.OperationalDynamicConfig = dynamicconfig.NewCollection(
+			params.OperationalConfigStore,
+			c.logger,
+			dynamicproperties.ClusterNameFilter(c.clusterMetadata.GetCurrentClusterName()),
+		)
 		params.ArchivalMetadata = c.archiverMetadata
 		params.ArchiverProvider = c.archiverProvider
 		params.GetIsolationGroups = getFromDynamicConfig(params)
@@ -959,6 +975,11 @@ func (c *cadenceImpl) startWorker(hosts map[string][]membership.HostInfo, startW
 	params.DynamicConfig = newIntegrationConfigClient(c.dynamicClient, c.workerDynCfgOverrides)
 	params.DynamicCollection = dynamicconfig.NewCollection(
 		params.DynamicConfig,
+		c.logger,
+		dynamicproperties.ClusterNameFilter(c.clusterMetadata.GetCurrentClusterName()),
+	)
+	params.OperationalDynamicConfig = dynamicconfig.NewCollection(
+		params.OperationalConfigStore,
 		c.logger,
 		dynamicproperties.ClusterNameFilter(c.clusterMetadata.GetCurrentClusterName()),
 	)

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -31,7 +31,6 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/client"
 	"github.com/uber/cadence/common/domain"
-	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/quotas"
@@ -70,13 +69,8 @@ func NewService(
 ) (resource.Resource, error) {
 
 	isAdvancedVisExistInConfig := len(params.PersistenceConfig.AdvancedVisibilityStore) != 0
-	dc := dynamicconfig.NewCollection(
-		params.DynamicConfig,
-		params.Logger,
-		dynamicproperties.ClusterNameFilter(params.ClusterMetadata.GetCurrentClusterName()),
-	)
 	serviceConfig := config.NewConfig(
-		dc,
+		params.DynamicCollection,
 		params.PersistenceConfig.NumHistoryShards,
 		isAdvancedVisExistInConfig,
 		params.HostName,

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -25,8 +25,6 @@ import (
 	"time"
 
 	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/dynamicconfig"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/dynamicconfig/quotas"
 	"github.com/uber/cadence/common/log/tag"
 	commonResource "github.com/uber/cadence/common/resource"
@@ -61,11 +59,7 @@ func NewService(
 	params *commonResource.Params,
 ) (resource.Resource, error) {
 	serviceConfig := config.New(
-		dynamicconfig.NewCollection(
-			params.DynamicConfig,
-			params.Logger,
-			dynamicproperties.ClusterNameFilter(params.ClusterMetadata.GetCurrentClusterName()),
-		),
+		params.DynamicCollection,
 		params.PersistenceConfig.NumHistoryShards,
 		params.RPCFactory.GetMaxMessageSize(),
 		params.PersistenceConfig.IsAdvancedVisibilityConfigExist(),

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -56,17 +56,15 @@ func NewService(
 	params *resource.Params,
 ) (resource.Resource, error) {
 
+	operationalDC := dynamicconfig.NewCollection(
+		params.OperationalConfigStore,
+		params.Logger,
+		dynamicproperties.ClusterNameFilter(params.ClusterMetadata.GetCurrentClusterName()),
+	)
+
 	serviceConfig := config.NewConfig(
-		dynamicconfig.NewCollection(
-			params.DynamicConfig,
-			params.Logger,
-			dynamicproperties.ClusterNameFilter(params.ClusterMetadata.GetCurrentClusterName()),
-		),
-		dynamicconfig.NewCollection(
-			params.OperationalConfigStore,
-			params.Logger,
-			dynamicproperties.ClusterNameFilter(params.ClusterMetadata.GetCurrentClusterName()),
-		),
+		params.DynamicCollection,
+		operationalDC,
 		params.HostName,
 		params.RPCConfig,
 		params.GetIsolationGroups,

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -27,8 +27,6 @@ import (
 	"github.com/cadence-workflow/shard-manager/service/sharddistributor/client/clientcommon"
 
 	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/dynamicconfig"
-	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/membership"
 	"github.com/uber/cadence/common/resource"
 	"github.com/uber/cadence/common/service"
@@ -56,15 +54,9 @@ func NewService(
 	params *resource.Params,
 ) (resource.Resource, error) {
 
-	operationalDC := dynamicconfig.NewCollection(
-		params.OperationalConfigStore,
-		params.Logger,
-		dynamicproperties.ClusterNameFilter(params.ClusterMetadata.GetCurrentClusterName()),
-	)
-
 	serviceConfig := config.NewConfig(
 		params.DynamicCollection,
-		operationalDC,
+		params.OperationalDynamicConfig,
 		params.HostName,
 		params.RPCConfig,
 		params.GetIsolationGroups,

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -32,7 +32,6 @@ import (
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/domain"
-	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/persistence"
@@ -128,11 +127,7 @@ func NewService(params *resource.Params) (resource.Resource, error) {
 
 // NewConfig builds the new Config for cadence-worker service
 func NewConfig(params *resource.Params) *Config {
-	dc := dynamicconfig.NewCollection(
-		params.DynamicConfig,
-		params.Logger,
-		dynamicproperties.ClusterNameFilter(params.ClusterMetadata.GetCurrentClusterName()),
-	)
+	dc := params.DynamicCollection
 	config := &Config{
 		AdminOperationToken: dc.GetStringProperty(dynamicproperties.AdminOperationToken),
 		ArchiverConfig: &archiver.Config{


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Eliminated redundant `dynamicconfig.Collection` creation by leveraging the Collection already provided by `dynamicconfigfx.Module` through fx dependency injection.

Modified:
- `cmd/server/cadence/fx.go`: Added `DynamicCollection` to `AppParams` to receive the injected Collection
- `cmd/server/cadence/server.go`: Removed redundant `dynamicconfig.NewCollection()` call and use injected Collection
- `common/resource/params.go`: Added `DynamicCollection` field to `Params`
- `common/resource/resource_impl.go`: Use `params.DynamicCollection` instead of creating a new Collection
- `service/{frontend,history,matching,worker}/service.go`: Removed redundant Collection creation in each service
- Test files updated to provide `DynamicCollection` in test fixtures

related to https://github.com/cadence-workflow/cadence/issues/8368

**Why?**
Previously, the codebase created multiple `dynamicconfig.Collection` instances at different levels:
1. `dynamicconfigfx.Module` created a Collection with cluster name filter and provided it via fx
2. `cmd/server/cadence/server.go` (line 155) created another Collection from the same Client
3. Each service (`frontend`, `history`, `matching`, `worker`) created yet another Collection in their `NewService()` functions
4. `resource.New()` created another Collection from `params.DynamicConfig`

This resulted in 5+ redundant Collection creations with identical parameters (same Client, same logger, same cluster name filter) for every service startup.

The fix threads the fx-provided Collection through the entire initialization chain:
- `dynamicconfigfx.Module` creates one Collection
- fx injects it into `App`
- `App` passes it to `newServer()`
- `newServer()` passes it in `resource.Params`
- Services and `resource.New()` use the injected Collection

This follows the fx dependency injection pattern properly and ensures a single source of truth for dynamic configuration.

**How did you test it?**
Unit tests:
```bash
go test ./cmd/server/cadence -v -run TestServerSuite
go test ./common/resource -v -run TestStartStop
go test ./service/frontend ./service/history ./service/matching ./service/worker
```
Build verification:
make build

All tests pass successfully.

**Potential risks**
Low risk. This is a pure refactoring that eliminates redundant object creation without changing behavior:
- The same dynamicconfig.Client and cluster name filter are used, so the Collection contents are identical
- All code paths that previously created Collections now receive the same Collection via dependency injection
- No API changes, no schema changes, no feature flag changes
- Backward compatible - only affects internal initialization flow

**Release notes**
For users don't depend on `cmd/server` go module, make sure that dynamicCollection and operationalDynamicCollection are added as a new parameter for `resource.Params`.

**Documentation Changes**
N/A - No documentation updates needed. This is an internal code cleanup that doesn't affect external APIs or user-facing behavior.
