### PR TITLE
refactor: create rpc.Factory by dependency injection

### DIFF
--- a/cmd/server/cadence/fx.go
+++ b/cmd/server/cadence/fx.go
@@ -42,6 +42,8 @@ import (
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/metrics/metricsfx"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql"
+	"github.com/uber/cadence/common/rpc"
+	"github.com/uber/cadence/common/rpc/rpcfx"
 	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/tools/cassandra"
 	"github.com/uber/cadence/tools/sql"
@@ -52,7 +54,8 @@ var _commonModule = fx.Options(
 	dynamicconfigfx.Module,
 	logfx.Module,
 	metricsfx.Module,
-	clockfx.Module)
+	clockfx.Module,
+	rpcfx.Module)
 
 // Module provides a cadence server initialization with root components.
 // AppParams allows to provide optional/overrides for implementation specific dependencies.
@@ -95,6 +98,7 @@ type AppParams struct {
 	OperationalDynamicConfig *dynamicconfig.Collection `name:"operational-dynamic-config"`
 	Scope                    tally.Scope
 	MetricsClient            metrics.Client
+	RPCFactory               rpc.Factory
 }
 
 // NewApp created a new Application from pre initalized config and logger.
@@ -110,6 +114,7 @@ func NewApp(params AppParams) *App {
 		operationalDynamicConfig: params.OperationalDynamicConfig,
 		scope:                    params.Scope,
 		metricsClient:            params.MetricsClient,
+		rpcFactory:               params.RPCFactory,
 	}
 
 	params.LifeCycle.Append(fx.StartHook(app.verifySchema))
@@ -130,13 +135,14 @@ type App struct {
 	operationalDynamicConfig *dynamicconfig.Collection
 	scope                    tally.Scope
 	metricsClient            metrics.Client
+	rpcFactory               rpc.Factory
 
 	daemon  common.Daemon
 	service string
 }
 
 func (a *App) Start(_ context.Context) error {
-	a.daemon = newServer(a.service, a.cfg, a.logger, a.zapLogger, a.dynamicConfig, a.dynamicCollection, a.operationalConfigStore, a.operationalDynamicConfig, a.scope, a.metricsClient)
+	a.daemon = newServer(a.service, a.cfg, a.logger, a.zapLogger, a.dynamicConfig, a.dynamicCollection, a.operationalConfigStore, a.operationalDynamicConfig, a.scope, a.metricsClient, a.rpcFactory)
 	a.daemon.Start()
 	return nil
 }

--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -90,12 +90,13 @@ type (
 		operationalDynamicConfig *dynamicconfig.Collection
 		scope                    tally.Scope
 		metricsClient            metrics.Client
+		rpcFactory               rpc.Factory
 	}
 )
 
 // newServer returns a new instance of a daemon
 // that represents a cadence service
-func newServer(service string, cfg config.Config, logger log.Logger, zapLogger *zap.Logger, dynamicCfgClient dynamicconfig.Client, dynamicCollection *dynamicconfig.Collection, operationalConfigStore configstore.Client, operationalDynamicConfig *dynamicconfig.Collection, scope tally.Scope, metricsClient metrics.Client) common.Daemon {
+func newServer(service string, cfg config.Config, logger log.Logger, zapLogger *zap.Logger, dynamicCfgClient dynamicconfig.Client, dynamicCollection *dynamicconfig.Collection, operationalConfigStore configstore.Client, operationalDynamicConfig *dynamicconfig.Collection, scope tally.Scope, metricsClient metrics.Client, rpcFactory rpc.Factory) common.Daemon {
 	return &server{
 		cfg:                      cfg,
 		name:                     service,
@@ -108,6 +109,7 @@ func newServer(service string, cfg config.Config, logger log.Logger, zapLogger *
 		operationalDynamicConfig: operationalDynamicConfig,
 		scope:                    scope,
 		metricsClient:            metricsClient,
+		rpcFactory:               rpcFactory,
 	}
 }
 
@@ -169,21 +171,12 @@ func (s *server) startService() common.Daemon {
 		s.operationalDynamicConfig.GetIntProperty(dynamicproperties.MatchingPercentageOnboardedToShardManager),
 	)
 
-	rpcParams, err := rpc.NewParams(params.Name, &s.cfg, s.dynamicCollection, params.Logger, params.MetricsClient)
-	if err != nil {
-		s.logger.Fatal("error creating rpc factory params", tag.Error(err))
-	}
-	rpcParams.OutboundsBuilder = rpc.CombineOutbounds(
-		rpcParams.OutboundsBuilder,
-		rpc.NewCrossDCOutbounds(clusterGroupMetadata.ClusterGroup, rpc.NewDNSPeerChooserFactory(s.cfg.PublicClient.RefreshInterval, params.Logger)),
-	)
-	rpcFactory := rpc.NewFactory(params.Logger, rpcParams)
-	params.RPCFactory = rpcFactory
+	params.RPCFactory = s.rpcFactory
 
 	peerProvider, err := ringpopprovider.New(
 		params.Name,
 		&s.cfg.Ringpop,
-		rpcFactory.GetTChannel(),
+		s.rpcFactory.GetTChannel(),
 		membership.PortMap{
 			membership.PortGRPC:     svcCfg.RPC.GRPCPort,
 			membership.PortTchannel: svcCfg.RPC.Port,

--- a/cmd/server/cadence/server_test.go
+++ b/cmd/server/cadence/server_test.go
@@ -48,6 +48,7 @@ import (
 	pt "github.com/uber/cadence/common/persistence/persistence-tests"
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin/sqlite"
 	"github.com/uber/cadence/common/resource"
+	"github.com/uber/cadence/common/rpc"
 	"github.com/uber/cadence/common/service"
 )
 
@@ -115,7 +116,10 @@ func (s *ServerSuite) TestServerStartup() {
 		dc := dynamicconfig.NewNopCollection()
 		operationalConfigStore := configstore.NewNopClient()
 		operationalDC := dynamicconfig.NewNopCollection()
-		server := newServer(svc, cfg, logger, testlogger.NewZap(s.T()), client, dc, operationalConfigStore, operationalDC, tally.NoopScope, metrics.NewNoopMetricsClient())
+		rpcParams, err := rpc.NewParams(service.FullName(svc), &cfg, dc, logger, metrics.NewNoopMetricsClient())
+		s.NoError(err)
+		rpcFactory := rpc.NewFactory(logger, rpcParams)
+		server := newServer(svc, cfg, logger, testlogger.NewZap(s.T()), client, dc, operationalConfigStore, operationalDC, tally.NoopScope, metrics.NewNoopMetricsClient(), rpcFactory)
 		daemons = append(daemons, server)
 		server.Start()
 	}

--- a/common/resource/resource_impl.go
+++ b/common/resource/resource_impl.go
@@ -425,10 +425,11 @@ func (h *Impl) Start() {
 		h.logger.WithTags(tag.Error(err)).Fatal("fail to start PProf")
 	}
 
+	// TODO: move this to rpcfx
 	if err := h.rpcFactory.Start(h.membershipResolver); err != nil {
 		h.logger.WithTags(tag.Error(err)).Fatal("fail to start RPC factory")
 	}
-
+	// TODO: move this to rpcfx
 	if err := h.dispatcher.Start(); err != nil {
 		h.logger.WithTags(tag.Error(err)).Fatal("fail to start dispatcher")
 	}

--- a/common/rpc/params.go
+++ b/common/rpc/params.go
@@ -159,6 +159,12 @@ func NewParams(serviceName string, config *config.Config, dc *dynamicconfig.Coll
 		))
 	}
 
+	if config.ClusterGroupMetadata != nil {
+		outboundsBuilders = append(outboundsBuilders,
+			NewCrossDCOutbounds(config.ClusterGroupMetadata.ClusterGroup, NewDNSPeerChooserFactory(config.PublicClient.RefreshInterval, logger)),
+		)
+	}
+
 	return Params{
 		ServiceName:      serviceName,
 		HTTP:             http,

--- a/common/rpc/rpcfx/rpcfx.go
+++ b/common/rpc/rpcfx/rpcfx.go
@@ -63,28 +63,8 @@ type factoryParams struct {
 
 	Logger    log.Logger
 	RPCParams rpc.Params
-
-	Lifecycle fx.Lifecycle
 }
 
 func buildFactory(p factoryParams) rpc.Factory {
-	res := rpc.NewFactory(p.Logger, p.RPCParams)
-	p.Lifecycle.Append(fx.StartStopHook(startDispatcher(res), rpcStopper(res)))
-	return res
-}
-
-func startDispatcher(f rpc.Factory) func() error {
-	return func() error {
-		return f.GetDispatcher().Start()
-	}
-}
-
-func rpcStopper(factory rpc.Factory) func() error {
-	return func() error {
-		err := factory.GetDispatcher().Stop()
-		if err != nil {
-			return fmt.Errorf("dispatcher stop: %w", err)
-		}
-		return nil
-	}
+	return rpc.NewFactory(p.Logger, p.RPCParams)
 }


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Create rpc.Factory by using rpcfx.Module which does dependency injection
- remove the redundant lifecycle hook of rpcfx.Module

Fixes https://github.com/cadence-workflow/cadence/issues/8368

**Why?**
This follows the fx dependency injection pattern properly and ensures a single source of truth for rpc factory.

**How did you test it?**
go test ./cmd/server/...
go test ./common/rpc/...

**Potential risks**
Low risk. This is pure refactoring.

**Release notes**
n/a

**Documentation Changes**
n/a
