### PR TITLE
fix: Stop domain migration commands from panicking during command creation

### DIFF
--- a/tools/cli/domain.go
+++ b/tools/cli/domain.go
@@ -142,9 +142,11 @@ func newDomainCommands() []*cli.Command {
 				if err != nil {
 					return err
 				}
-				// exit on error already handled in the command
-				// TODO best practice is to return error if validation fails
-				err = NewDomainMigrationCommand(c).Validation(c)
+				migrationCmd, err := NewDomainMigrationCommand(c)
+				if err != nil {
+					return commoncli.Problem("Failed to initialize migration command: ", err)
+				}
+				err = migrationCmd.Validation(c)
 				if err != nil {
 					return commoncli.Problem("Failed validation: ", err)
 				}

--- a/tools/cli/domain_migration_command.go
+++ b/tools/cli/domain_migration_command.go
@@ -117,22 +117,22 @@ type DomainMigrationCommand interface {
 	DynamicConfigCheck(c *cli.Context) (DomainMigrationRow, error)
 }
 
-func (d *domainMigrationCLIImpl) NewDomainMigrationCLIImpl(c *cli.Context) (*domainMigrationCLIImpl, error) {
+func NewDomainMigrationCommand(c *cli.Context) (DomainMigrationCommand, error) {
 	fc, err := getDeps(c).ServerFrontendClient(c)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create frontend client: %w", err)
 	}
 	fcm, err := getDeps(c).ServerFrontendClientForMigration(c)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create destination frontend client: %w", err)
 	}
 	ac, err := getDeps(c).ServerAdminClient(c)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create admin client: %w", err)
 	}
 	acm, err := getDeps(c).ServerAdminClientForMigration(c)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create destination admin client: %w", err)
 	}
 	return &domainMigrationCLIImpl{
 		frontendClient:         fc,
@@ -140,11 +140,6 @@ func (d *domainMigrationCLIImpl) NewDomainMigrationCLIImpl(c *cli.Context) (*dom
 		frontendAdminClient:    ac,
 		destinationAdminClient: acm,
 	}, nil
-}
-
-// Export a function to create an instance of the domainMigrationCLIImpl.
-func NewDomainMigrationCommand(c *cli.Context) DomainMigrationCommand {
-	return &domainMigrationCLIImpl{}
 }
 
 type domainMigrationCLIImpl struct {


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

Updates creation to create a useable instance of `domainMigrationCLIImpl`. 

**Why?**

The domain migration command was panicking as the domainMigrationClientImpl was unusable when the default commands was passed: `cadence domain migration`. 

**How did you test it?**

Local runs: 

```
./cadence domain
 migration
Error: Failed validation: 
Error details:
  Error in checkers: Error in Domain flow check: Failed to count workflow. code:unknown message:received unknown error calling service: "cadence-frontend", procedure: "WorkflowService::CountWorkflowExecutions", err: dial tcp 127.0.0.1:7933: connect: connection refused; Error in checkers: Could not describe old domain, Please check to see if old domain exists before migrating. code:unknown message:received unknown error calling service: "cadence-frontend", procedure: "WorkflowService::DescribeDomain", err: dial tcp 127.0.0.1:7933: connect: connection refused; Error in checkers: Failed to get domainID for the current domain. <nil>
```

**Potential risks**

N/A

**Release notes**

N/A

**Documentation Changes**

N/A
