### PR TITLE
fix(grpc): Don't propagate grpc- headers by default

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -6145,6 +6145,10 @@ var ListKeys = map[ListKey]DynamicList{
 				"Add":   true,
 				"Match": "",
 			},
+			map[string]interface{}{ // config imports dynamicconfig, sadly
+				"Add":   false,
+				"Match": "^grpc-.*",
+			},
 		},
 	},
 }

--- a/common/dynamicconfig/dynamicproperties/constants_test.go
+++ b/common/dynamicconfig/dynamicproperties/constants_test.go
@@ -364,6 +364,10 @@ func (s *constantSuite) TestListKey() {
 					"Add":   true,
 					"Match": "",
 				},
+				map[string]interface{}{
+					"Add":   false,
+					"Match": "^grpc-.*",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Change the default value of admin.HeaderForwardingRules to not propagate headers prefixed with "grpc-" by default. This influences only the header propagation from cadence-frontend to cadence-history or cadence-matching. Propagating these headers does not influence Cadence's behavior.

This does however impact forks of Cadence and new feature development. In particular, if a build of Cadence happens to import a library that adds compression support then the gRPC client will begin adding the header `grpc-accept-encoding`. This occurs after the header propagation middleware blindly copies the header over, and results in two headers with this name. yarpc then rejects the request with an error, breaking any requests that cadence-frontend proxies to either history or matching.

<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- The default configuration value of `admin.HeaderForwardingRules` to not forward grpc- headers.

**Why?**
- Prevent incorrectly adding duplicate gRPC headers

**How did you test it?**
- Unit tests, integration tests, and manually running the cadence server

**Potential risks**
- Maybe there's a grpc header that we want to explicitly forward?
- Users that set this configuration option would not benefit from this change

**Release notes**
Changed the default value of `admin.HeaderForwardingRules` to not forward grpc- headers. These headers aren't useful for Cadence to forward, and they can result in duplicate headers which break communications between instances.

**Documentation Changes**

