### PR TITLE
ci: Pin pinot docker images to an amd compatible version

### DIFF
--- a/docker/docker-compose-pinot.yml
+++ b/docker/docker-compose-pinot.yml
@@ -39,7 +39,7 @@ services:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
   pinot-controller:
-    image: apachepinot/pinot:latest
+    image: apachepinot/pinot:1.4.0
     command: "StartController -zkAddress zookeeper:2181"
     container_name: pinot-controller
     restart: unless-stopped
@@ -50,7 +50,7 @@ services:
     depends_on:
       - zookeeper
   pinot-broker:
-    image: apachepinot/pinot:latest
+    image: apachepinot/pinot:1.4.0
     command: "StartBroker -zkAddress zookeeper:2181"
     restart: unless-stopped
     container_name: "pinot-broker"
@@ -61,7 +61,7 @@ services:
     depends_on:
       - pinot-controller
   pinot-server:
-    image: apachepinot/pinot:latest
+    image: apachepinot/pinot:1.4.0
     command: "StartServer -zkAddress zookeeper:2181"
     restart: unless-stopped
     container_name: "pinot-server"

--- a/docker/github_actions/docker-compose-local-pinot.yml
+++ b/docker/github_actions/docker-compose-local-pinot.yml
@@ -80,7 +80,7 @@ services:
           - zookeeper
 
   pinot-controller:
-    image: apachepinot/pinot:latest
+    image: apachepinot/pinot:1.4.0
     command: "StartController -zkAddress zookeeper:2181 -controllerPort 9001"
     container_name: pinot-controller
     restart: unless-stopped
@@ -95,7 +95,7 @@ services:
         aliases:
           - pinot-controller
   pinot-broker:
-    image: apachepinot/pinot:latest
+    image: apachepinot/pinot:1.4.0
     command: "StartBroker -zkAddress zookeeper:2181"
     restart: unless-stopped
     container_name: "pinot-broker"
@@ -110,7 +110,7 @@ services:
         aliases:
           - pinot-broker
   pinot-server:
-    image: apachepinot/pinot:latest
+    image: apachepinot/pinot:1.4.0
     command: "StartServer -zkAddress zookeeper:2181"
     restart: unless-stopped
     container_name: "pinot-server"
@@ -126,7 +126,7 @@ services:
           - pinot-server
 
   pinot-admin:
-    image: apachepinot/pinot:latest
+    image: apachepinot/pinot:1.4.0
     container_name: pinot-admin
     depends_on:
       - pinot-controller

--- a/docker/github_actions/docker-compose-pinot.yml
+++ b/docker/github_actions/docker-compose-pinot.yml
@@ -80,7 +80,7 @@ services:
           - zookeeper
   # Needs a new pinot version to run the new json match query
   pinot-controller:
-    image: apachepinot/pinot:latest
+    image: apachepinot/pinot:1.4.0
     command: "StartController -zkAddress zookeeper:2181 -controllerPort 9001"
     container_name: pinot-controller
     restart: unless-stopped
@@ -95,7 +95,7 @@ services:
         aliases:
           - pinot-controller
   pinot-broker:
-    image: apachepinot/pinot:latest
+    image: apachepinot/pinot:1.4.0
     command: "StartBroker -zkAddress zookeeper:2181"
     restart: unless-stopped
     container_name: "pinot-broker"
@@ -110,7 +110,7 @@ services:
         aliases:
           - pinot-broker
   pinot-server:
-    image: apachepinot/pinot:latest
+    image: apachepinot/pinot:1.4.0
     command: "StartServer -zkAddress zookeeper:2181"
     restart: unless-stopped
     container_name: "pinot-server"
@@ -126,7 +126,7 @@ services:
           - pinot-server
 
   pinot-admin:
-    image: apachepinot/pinot:latest
+    image: apachepinot/pinot:1.4.0
     container_name: pinot-admin
     depends_on:
       - pinot-controller


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

Updates all pinot image references to pin them to 1.4.0

**Why?**

Later versions are not compatible with the GitHub actions runtime - causing all pinot related integration tests to fail. 

**How did you test it?**

Testing it via this PR. 

**Potential risks**

This will mean that we are stuck on v1.4.0 until we are able to either a) upgrade our GitHub action runners b) there is a newer version that supports running on multiple architectures. This is a security risk if any vulnerabilities are discovered in v1.4.0. 

**Release notes**

N/A

**Documentation Changes**

N/A