### PR TITLE
fix(schedules): describeSchedule should retry on query reject as well

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ go test -race -run TestFoo ./path/to/pkg/...  # run a specific test
   - Never use IDL code (`.gen/go/` or `.gen/proto/`) directly in service logic.
   - Map to `common/types` or `common/persistence` types via mappers in `common/types/mapper/`.
   - Files in `.gen/` are generated from IDL — do not edit manually.
+  - Never use yarpcerrors directly in handler logic; instead, create an new Error type in IDL and map to internal ones under common/type/errors.go.
 
 ## Pull Request Guidelines
 
@@ -83,7 +84,7 @@ Here's what's in each top-level directory in this repository:
 * **simulation/** : Black-box simulation tests that spin up a local Docker cluster and validate complex multi-component scenarios
 * **tools/** : CLI tools for Cadence workflows and also schema updates for persistence
 
-## Generic Rules 
+## Generic Rules
 
 See the `.agents/` directory for:
 - `go-style.md` - Go formatting and style (Uber style guide)

--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -62,8 +62,10 @@ var (
 	// errSchedulerContinuedAsNew marks the transient window in which the scheduler
 	// workflow has closed its previous run for ContinueAsNew and the new run is not
 	// yet visible. Both the DescribeWorkflowExecution probe and the describe query
-	// return it; once the budget is exhausted normalizeScheduleError turns it into
-	// a CodeUnavailable response telling the client to retry.
+	// return it. A scheduler still in that state once the retry budget is spent is
+	// no longer plausibly mid-transition, so normalizeScheduleError reports it as an
+	// InternalServiceError naming the stuck state rather than asking the client to
+	// keep retrying a wait the server has already performed.
 	errSchedulerContinuedAsNew = errors.New("scheduler mid-ContinueAsNew")
 )
 
@@ -772,6 +774,14 @@ func (wh *WorkflowHandler) signalScheduleWorkflow(
 }
 
 func normalizeScheduleError(err error, scheduleID, domainName string) error {
+	if errors.Is(err, errSchedulerContinuedAsNew) {
+		return &types.InternalServiceError{
+			Message: fmt.Sprintf(
+				"schedule %q in domain %q is not queryable: scheduler workflow still mid-ContinueAsNew after %d attempts",
+				scheduleID, domainName, describeScheduleRetryAttempts,
+			),
+		}
+	}
 	var notFound *types.EntityNotExistsError
 	if errors.As(err, &notFound) {
 		return &types.EntityNotExistsError{

--- a/service/frontend/api/handler_schedule.go
+++ b/service/frontend/api/handler_schedule.go
@@ -46,17 +46,42 @@ const (
 	schedulerWorkflowDecisionTimeout  = 10 * time.Second
 	defaultListSchedulesPageSize      = 10
 
-	// describeScheduleCANRetryAttempts bounds the DWE probe in describeSchedulerExecution,
-	// which retries while CloseStatus=CONTINUED_AS_NEW to ride out the executionCache
-	// invalidation window. describeScheduleQueryRetryAttempts bounds the query retry in
-	// querySchedulerWorkflow, which retries until the new run's first decision task is done.
-	// Both states typically resolve within milliseconds but can take a few seconds in loaded
-	// environments. Separate counts keep the combined DescribeSchedule worst case (~8s) within
-	// the typical 10s service SLA.
-	describeScheduleCANRetryAttempts   = 5
-	describeScheduleQueryRetryAttempts = 5
-	describeScheduleCANRetryInterval   = 1 * time.Second
+	// describeScheduleRetryAttempts bounds describeSchedulerWorkflow, which retries the
+	// DescribeWorkflowExecution probe and the describe query together as one pass. The
+	// transient states it rides out — CloseStatus=CONTINUED_AS_NEW during the
+	// executionCache invalidation window, a query rejected with CONTINUED_AS_NEW, and a
+	// run whose first decision task has not completed — typically resolve within
+	// milliseconds but can take a few seconds in loaded environments. A single budget
+	// keeps the DescribeSchedule worst case (~4s of backoff plus per-attempt RPC time)
+	// within the typical 10s service SLA regardless of which step is slow to settle.
+	describeScheduleRetryAttempts = 5
+	describeScheduleRetryInterval = 1 * time.Second
 )
+
+var (
+	// errSchedulerContinuedAsNew marks the transient window in which the scheduler
+	// workflow has closed its previous run for ContinueAsNew and the new run is not
+	// yet visible. Both the DescribeWorkflowExecution probe and the describe query
+	// return it; once the budget is exhausted normalizeScheduleError turns it into
+	// a CodeUnavailable response telling the client to retry.
+	errSchedulerContinuedAsNew = errors.New("scheduler mid-ContinueAsNew")
+)
+
+// newDescribeScheduleRetryPolicy returns a fixed-interval policy allowing at most
+// describeScheduleRetryAttempts calls of the operation. RetryPolicy counts retries
+// rather than attempts, hence the -1.
+func newDescribeScheduleRetryPolicy() backoff.RetryPolicy {
+	policy := backoff.NewExponentialRetryPolicy(describeScheduleRetryInterval)
+	policy.SetBackoffCoefficient(1)
+	policy.SetMaximumInterval(describeScheduleRetryInterval)
+	policy.SetExpirationInterval(backoff.NoInterval)
+	policy.SetMaximumAttempts(describeScheduleRetryAttempts - 1)
+	return policy
+}
+
+func isContinuedAsNew(closeStatus *types.WorkflowExecutionCloseStatus) bool {
+	return closeStatus != nil && *closeStatus == types.WorkflowExecutionCloseStatusContinuedAsNew
+}
 
 func scheduleWorkflowID(scheduleID string) string {
 	return scheduleWorkflowIDPrefix + scheduleID
@@ -274,69 +299,20 @@ func (wh *WorkflowHandler) DescribeSchedule(
 		return nil, err
 	}
 
-	// Probe the scheduler workflow's current execution status before querying.
-	//
-	// Schedulers ContinueAsNew on every UpdateSchedule and periodically to bound
-	// history. During the executionCache invalidation window on the history host,
-	// getMutableState can briefly resolve wfID-without-runID to the just-closed
-	// old run and expose CloseStatus=CONTINUED_AS_NEW for an otherwise healthy
-	// schedule. The DWE probe — retried while the close status is CONTINUED_AS_NEW —
-	// distinguishes that transient race from a genuinely closed scheduler
-	// (FAILED, TERMINATED, TIMED_OUT, COMPLETED, CANCELED), which must not be
-	// reported as ACTIVE.
-	//
-	// QueryWorkflow keeps QueryRejectConditionNotCompletedCleanly as a safety net
-	// for the small window where the scheduler closes between the two RPCs.
-	info, err := wh.describeSchedulerExecution(ctx, domainID, domainName, scheduleID, execution)
-	if err != nil {
-		return nil, err
-	}
-	if info.CloseStatus != nil {
-		if *info.CloseStatus == types.WorkflowExecutionCloseStatusContinuedAsNew {
-			return nil, yarpcerrors.Newf(yarpcerrors.CodeUnavailable,
-				"schedule %q in domain %q: scheduler mid-ContinueAsNew, retry", scheduleID, domainName)
-		}
-		return nil, &types.InternalServiceError{
-			Message: fmt.Sprintf(
-				"schedule %q in domain %q is not operational: scheduler workflow ended with status %s",
-				scheduleID, domainName, info.CloseStatus.String(),
-			),
-		}
+	var desc *scheduler.ScheduleDescription
+	op := func(ctx context.Context) error {
+		var err error
+		desc, err = wh.describeSchedulerWorkflowOnce(ctx, domainID, domainName, scheduleID, execution)
+		return err
 	}
 
-	queryResp, err := wh.querySchedulerWorkflow(ctx, domainName, scheduleID, execution)
-	if err != nil {
-		return nil, err
-	}
-
-	if queryResp == nil {
-		return nil, &types.InternalServiceError{Message: "nil query response from scheduler workflow"}
-	}
-
-	if queryResp.QueryRejected != nil {
-		closeStatus := "unknown"
-		if queryResp.QueryRejected.CloseStatus != nil {
-			closeStatus = queryResp.QueryRejected.CloseStatus.String()
-			if *queryResp.QueryRejected.CloseStatus == types.WorkflowExecutionCloseStatusContinuedAsNew {
-				return nil, yarpcerrors.Newf(yarpcerrors.CodeUnavailable,
-					"schedule %q in domain %q: scheduler mid-ContinueAsNew, retry", scheduleID, domainName)
-			}
-		}
-		return nil, &types.InternalServiceError{
-			Message: fmt.Sprintf(
-				"schedule %q in domain %q is not operational: scheduler workflow ended with status %s",
-				scheduleID, domainName, closeStatus,
-			),
-		}
-	}
-
-	if queryResp.GetQueryResult() == nil {
-		return nil, &types.InternalServiceError{Message: "empty query result from scheduler workflow"}
-	}
-
-	var desc scheduler.ScheduleDescription
-	if err := json.Unmarshal(queryResp.GetQueryResult(), &desc); err != nil {
-		return nil, &types.InternalServiceError{Message: fmt.Sprintf("failed to deserialize scheduler describe response: %v", err)}
+	throttleRetry := backoff.NewThrottleRetry(
+		backoff.WithRetryPolicy(newDescribeScheduleRetryPolicy()),
+		backoff.WithRetryableError(isRetryableDescribeScheduleError(ctx)),
+		backoff.WithClock(wh.GetTimeSource()),
+	)
+	if err := throttleRetry.Do(ctx, op); err != nil {
+		return nil, normalizeScheduleError(err, scheduleID, domainName)
 	}
 
 	return &types.DescribeScheduleResponse{
@@ -805,89 +781,137 @@ func normalizeScheduleError(err error, scheduleID, domainName string) error {
 	return err
 }
 
+// describeSchedulerWorkflowOnce performs a single probe-then-query pass.
+//
+// Schedulers ContinueAsNew on every UpdateSchedule and periodically to bound
+// history. During the executionCache invalidation window on the history host,
+// getMutableState can briefly resolve wfID-without-runID to the just-closed old
+// run and expose CloseStatus=CONTINUED_AS_NEW for an otherwise healthy schedule.
+// The probe distinguishes that transient race from a genuinely closed scheduler
+// (FAILED, TERMINATED, TIMED_OUT, COMPLETED, CANCELED), which must not be
+// reported as ACTIVE and is returned as a non-retryable error.
+//
+// The query keeps QueryRejectConditionNotCompletedCleanly as a safety net for the
+// window where the scheduler closes between the two RPCs.
+func (wh *WorkflowHandler) describeSchedulerWorkflowOnce(
+	ctx context.Context,
+	domainID, domainName, scheduleID string,
+	execution *types.WorkflowExecution,
+) (*scheduler.ScheduleDescription, error) {
+	info, err := wh.describeSchedulerExecution(ctx, domainID, domainName, execution)
+	if err != nil {
+		return nil, err
+	}
+	if info.CloseStatus != nil {
+		return nil, scheduleNotOperationalError(scheduleID, domainName, info.CloseStatus.String())
+	}
+
+	queryResp, err := wh.querySchedulerWorkflow(ctx, domainName, execution)
+	if err != nil {
+		return nil, err
+	}
+	if queryResp == nil {
+		return nil, &types.InternalServiceError{Message: "nil query response from scheduler workflow"}
+	}
+	if queryResp.QueryRejected != nil {
+		closeStatus := "unknown"
+		if queryResp.QueryRejected.CloseStatus != nil {
+			closeStatus = queryResp.QueryRejected.CloseStatus.String()
+		}
+		return nil, scheduleNotOperationalError(scheduleID, domainName, closeStatus)
+	}
+	if queryResp.GetQueryResult() == nil {
+		return nil, &types.InternalServiceError{Message: "empty query result from scheduler workflow"}
+	}
+
+	var desc scheduler.ScheduleDescription
+	if err := json.Unmarshal(queryResp.GetQueryResult(), &desc); err != nil {
+		return nil, &types.InternalServiceError{Message: fmt.Sprintf("failed to deserialize scheduler describe response: %v", err)}
+	}
+	return &desc, nil
+}
+
+func scheduleNotOperationalError(scheduleID, domainName, closeStatus string) error {
+	return &types.InternalServiceError{
+		Message: fmt.Sprintf(
+			"schedule %q in domain %q is not operational: scheduler workflow ended with status %s",
+			scheduleID, domainName, closeStatus,
+		),
+	}
+}
+
 // describeSchedulerExecution returns the latest run's WorkflowExecutionInfo for
-// the scheduler workflow, retrying briefly while CloseStatus is CONTINUED_AS_NEW
-// to ride out the executionCache invalidation window after a ContinueAsNew
-// transition. If the close status is still CONTINUED_AS_NEW after the retry
-// budget the last response is returned; the caller treats that as "not
-// operational" so an operator can investigate a scheduler stuck mid-transition.
+// the scheduler workflow, reporting errSchedulerContinuedAsNew while the close
+// status is CONTINUED_AS_NEW so the caller can retry the whole pass.
 //
 // Calls the history client directly so this internal probe does not emit
 // FrontendDescribeWorkflowExecution metrics.
 func (wh *WorkflowHandler) describeSchedulerExecution(
 	ctx context.Context,
-	domainID, domainName, scheduleID string,
+	domainID, domainName string,
 	execution *types.WorkflowExecution,
 ) (*types.WorkflowExecutionInfo, error) {
-	req := &types.HistoryDescribeWorkflowExecutionRequest{
+	resp, err := wh.GetHistoryClient().DescribeWorkflowExecution(ctx, &types.HistoryDescribeWorkflowExecutionRequest{
 		DomainUUID: domainID,
 		Request: &types.DescribeWorkflowExecutionRequest{
 			Domain:    domainName,
 			Execution: execution,
 		},
+	})
+	if err != nil {
+		return nil, err
 	}
-	var lastInfo *types.WorkflowExecutionInfo
-	for attempt := 0; attempt < describeScheduleCANRetryAttempts; attempt++ {
-		resp, err := wh.GetHistoryClient().DescribeWorkflowExecution(ctx, req)
-		if err != nil {
-			return nil, normalizeScheduleError(err, scheduleID, domainName)
-		}
-		info := resp.GetWorkflowExecutionInfo()
-		if info == nil {
-			return nil, &types.InternalServiceError{Message: "nil workflow execution info from scheduler workflow"}
-		}
-		lastInfo = info
-		if info.CloseStatus == nil || *info.CloseStatus != types.WorkflowExecutionCloseStatusContinuedAsNew {
-			return info, nil
-		}
-		if attempt == describeScheduleCANRetryAttempts-1 {
-			break
-		}
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(describeScheduleCANRetryInterval):
-		}
+	info := resp.GetWorkflowExecutionInfo()
+	if info == nil {
+		return nil, &types.InternalServiceError{Message: "nil workflow execution info from scheduler workflow"}
 	}
-	return lastInfo, nil
+	if isContinuedAsNew(info.CloseStatus) {
+		return nil, errSchedulerContinuedAsNew
+	}
+	return info, nil
 }
 
 // querySchedulerWorkflow issues a QueryWorkflow call for the scheduler's
-// describe query, retrying on transient errors until the workflow is queryable.
+// describe query.
 func (wh *WorkflowHandler) querySchedulerWorkflow(
 	ctx context.Context,
-	domainName, scheduleID string,
+	domainName string,
 	execution *types.WorkflowExecution,
 ) (*types.QueryWorkflowResponse, error) {
 	rejectCondition := types.QueryRejectConditionNotCompletedCleanly
-	req := &types.QueryWorkflowRequest{
+	resp, err := wh.QueryWorkflow(ctx, &types.QueryWorkflowRequest{
 		Domain:               domainName,
 		Execution:            execution,
 		Query:                &types.WorkflowQuery{QueryType: scheduler.QueryTypeDescribe},
 		QueryRejectCondition: &rejectCondition,
+	})
+	if err != nil {
+		return nil, err
 	}
-	var lastErr error
-	for attempt := 0; attempt < describeScheduleQueryRetryAttempts; attempt++ {
-		resp, err := wh.QueryWorkflow(ctx, req)
-		if err == nil {
-			return resp, nil
+	// A rejected query is a successful RPC, so the ContinueAsNew race has to be
+	// turned into an error to be retried.
+	if rejected := resp.GetQueryRejected(); rejected != nil && isContinuedAsNew(rejected.CloseStatus) {
+		return nil, errSchedulerContinuedAsNew
+	}
+	return resp, nil
+}
+
+// isRetryableDescribeScheduleError reports the transient conditions a describe
+// pass rides out: the scheduler being mid-ContinueAsNew, a run whose first
+// decision task has not completed yet, and history's internal query wait timing
+// out while the caller's own deadline is still live. Everything else — including
+// a genuinely closed scheduler — fails the pass immediately.
+func isRetryableDescribeScheduleError(ctx context.Context) backoff.IsRetryable {
+	return func(err error) bool {
+		if errors.Is(err, errSchedulerContinuedAsNew) {
+			return true
 		}
 		var qfe *types.QueryFailedError
-		decisionTaskPending := errors.As(err, &qfe) && strings.Contains(qfe.Message, "decision task")
-		queryTimeout := (errors.Is(err, context.DeadlineExceeded) ||
-			yarpcerrors.IsStatus(err) && yarpcerrors.FromError(err).Code() == yarpcerrors.CodeDeadlineExceeded) &&
-			ctx.Err() == nil
-		if !decisionTaskPending && !queryTimeout {
-			return nil, normalizeScheduleError(err, scheduleID, domainName)
+		if errors.As(err, &qfe) && strings.Contains(qfe.Message, "decision task") {
+			return true
 		}
-		lastErr = err
-		if attempt < describeScheduleQueryRetryAttempts-1 {
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(describeScheduleCANRetryInterval):
-			}
-		}
+		queryTimeout := errors.Is(err, context.DeadlineExceeded) ||
+			yarpcerrors.IsStatus(err) && yarpcerrors.FromError(err).Code() == yarpcerrors.CodeDeadlineExceeded
+		return queryTimeout && ctx.Err() == nil
 	}
-	return nil, normalizeScheduleError(lastErr, scheduleID, domainName)
 }

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -585,7 +585,7 @@ func TestDescribeSchedule(t *testing.T) {
 					Return(&types.DescribeWorkflowExecutionResponse{
 						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{CloseStatus: &canStatus},
 					}, nil).
-					Times(describeScheduleCANRetryAttempts)
+					Times(describeScheduleRetryAttempts)
 			},
 			wantErr: true,
 			checkErr: func(t *testing.T, err error) {
@@ -595,8 +595,9 @@ func TestDescribeSchedule(t *testing.T) {
 			},
 		},
 		// A freshly started scheduler run has not yet processed its first decision
-		// task and cannot be queried. querySchedulerWorkflow retries until the run
-		// is ready; here it succeeds on the second attempt.
+		// task and cannot be queried. The describe pass is retried until the run is
+		// ready; here it succeeds on the second attempt. Each attempt re-runs the
+		// probe, hence two DescribeWorkflowExecution calls.
 		"scheduler not yet queryable - retried until ready": {
 			request: validRequest,
 			mockFn: func(f *scheduleTestFixture) {
@@ -604,7 +605,8 @@ func TestDescribeSchedule(t *testing.T) {
 				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
 					Return(&types.DescribeWorkflowExecutionResponse{
 						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
-					}, nil)
+					}, nil).
+					Times(2)
 				gomock.InOrder(
 					f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
 						Return(nil, &types.QueryFailedError{Message: "workflow must handle at least one decision task before it can be queried"}),
@@ -625,10 +627,11 @@ func TestDescribeSchedule(t *testing.T) {
 				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
 					Return(&types.DescribeWorkflowExecutionResponse{
 						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
-					}, nil)
+					}, nil).
+					Times(describeScheduleRetryAttempts)
 				f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
 					Return(nil, &types.QueryFailedError{Message: "workflow must handle at least one decision task before it can be queried"}).
-					Times(describeScheduleQueryRetryAttempts)
+					Times(describeScheduleRetryAttempts)
 			},
 			wantErr: true,
 			checkErr: func(t *testing.T, err error) {
@@ -647,7 +650,8 @@ func TestDescribeSchedule(t *testing.T) {
 				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
 					Return(&types.DescribeWorkflowExecutionResponse{
 						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
-					}, nil)
+					}, nil).
+					Times(2)
 				gomock.InOrder(
 					f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
 						Return(nil, yarpcerrors.DeadlineExceededErrorf("query wait timed out")),
@@ -668,10 +672,11 @@ func TestDescribeSchedule(t *testing.T) {
 				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
 					Return(&types.DescribeWorkflowExecutionResponse{
 						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
-					}, nil)
+					}, nil).
+					Times(describeScheduleRetryAttempts)
 				f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
 					Return(nil, yarpcerrors.DeadlineExceededErrorf("query wait timed out")).
-					Times(describeScheduleQueryRetryAttempts)
+					Times(describeScheduleRetryAttempts)
 			},
 			wantErr: true,
 		},
@@ -685,7 +690,8 @@ func TestDescribeSchedule(t *testing.T) {
 				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
 					Return(&types.DescribeWorkflowExecutionResponse{
 						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
-					}, nil)
+					}, nil).
+					Times(2)
 				gomock.InOrder(
 					f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
 						Return(nil, context.DeadlineExceeded),
@@ -741,23 +747,52 @@ func TestDescribeSchedule(t *testing.T) {
 			},
 		},
 		// If the scheduler does ContinueAsNew between the DWE probe and the query,
-		// the query is rejected with CONTINUED_AS_NEW. Return CodeUnavailable so
-		// the client retries — the new run will be queryable momentarily.
-		"scheduler ContinueAsNew between DWE and Query - return Unavailable": {
+		// the query is rejected with CONTINUED_AS_NEW. The whole pass is retried, so
+		// the second query is preceded by a fresh probe of the new run.
+		"scheduler ContinueAsNew between DWE and Query - retried until queryable": {
 			request: validRequest,
 			mockFn: func(f *scheduleTestFixture) {
 				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
 				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
 					Return(&types.DescribeWorkflowExecutionResponse{
 						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
-					}, nil)
+					}, nil).
+					Times(2)
+				closeStatus := types.WorkflowExecutionCloseStatusContinuedAsNew
+				gomock.InOrder(
+					f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+						Return(&types.HistoryQueryWorkflowResponse{
+							Response: &types.QueryWorkflowResponse{
+								QueryRejected: &types.QueryRejected{CloseStatus: &closeStatus},
+							},
+						}, nil),
+					f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
+						Return(&types.HistoryQueryWorkflowResponse{
+							Response: &types.QueryWorkflowResponse{QueryResult: descBytes},
+						}, nil),
+				)
+			},
+			wantErr: false,
+		},
+		// If the query stays rejected with CONTINUED_AS_NEW past the retry budget,
+		// return CodeUnavailable so the client retries.
+		"scheduler ContinueAsNew between DWE and Query - retry budget exhausted": {
+			request: validRequest,
+			mockFn: func(f *scheduleTestFixture) {
+				f.domainCache.EXPECT().GetDomainID(testDomain).Return(testDomainID, nil).AnyTimes()
+				f.historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(&types.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &types.WorkflowExecutionInfo{},
+					}, nil).
+					Times(describeScheduleRetryAttempts)
 				closeStatus := types.WorkflowExecutionCloseStatusContinuedAsNew
 				f.historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).
 					Return(&types.HistoryQueryWorkflowResponse{
 						Response: &types.QueryWorkflowResponse{
 							QueryRejected: &types.QueryRejected{CloseStatus: &closeStatus},
 						},
-					}, nil)
+					}, nil).
+					Times(describeScheduleRetryAttempts)
 			},
 			wantErr: true,
 			checkErr: func(t *testing.T, err error) {

--- a/service/frontend/api/handler_schedule_test.go
+++ b/service/frontend/api/handler_schedule_test.go
@@ -575,7 +575,8 @@ func TestDescribeSchedule(t *testing.T) {
 			wantErr: false,
 		},
 		// If the close status stays CONTINUED_AS_NEW past the retry budget, the
-		// scheduler is stuck mid-transition; return CodeUnavailable so clients retry.
+		// scheduler is stuck rather than mid-transition: the server has already
+		// waited it out, so report the stuck state instead of a retry hint.
 		"scheduler mid-ContinueAsNew - retry budget exhausted": {
 			request: validRequest,
 			mockFn: func(f *scheduleTestFixture) {
@@ -589,9 +590,9 @@ func TestDescribeSchedule(t *testing.T) {
 			},
 			wantErr: true,
 			checkErr: func(t *testing.T, err error) {
-				assert.True(t, yarpcerrors.IsStatus(err))
-				assert.Equal(t, yarpcerrors.CodeUnavailable, yarpcerrors.FromError(err).Code())
-				assert.Contains(t, yarpcerrors.FromError(err).Message(), "mid-ContinueAsNew")
+				var internalErr *types.InternalServiceError
+				assert.ErrorAs(t, err, &internalErr)
+				assert.Contains(t, internalErr.Message, "mid-ContinueAsNew")
 			},
 		},
 		// A freshly started scheduler run has not yet processed its first decision
@@ -775,7 +776,7 @@ func TestDescribeSchedule(t *testing.T) {
 			wantErr: false,
 		},
 		// If the query stays rejected with CONTINUED_AS_NEW past the retry budget,
-		// return CodeUnavailable so the client retries.
+		// the scheduler is stuck; report the stuck state rather than a retry hint.
 		"scheduler ContinueAsNew between DWE and Query - retry budget exhausted": {
 			request: validRequest,
 			mockFn: func(f *scheduleTestFixture) {
@@ -796,9 +797,9 @@ func TestDescribeSchedule(t *testing.T) {
 			},
 			wantErr: true,
 			checkErr: func(t *testing.T, err error) {
-				assert.True(t, yarpcerrors.IsStatus(err))
-				assert.Equal(t, yarpcerrors.CodeUnavailable, yarpcerrors.FromError(err).Code())
-				assert.Contains(t, yarpcerrors.FromError(err).Message(), "mid-ContinueAsNew")
+				var internalErr *types.InternalServiceError
+				assert.ErrorAs(t, err, &internalErr)
+				assert.Contains(t, internalErr.Message, "mid-ContinueAsNew")
 			},
 		},
 		"success": {


### PR DESCRIPTION
**What changed?**

`DescribeSchedule` now retries the `DescribeWorkflowExecution` probe and the describe
`QueryWorkflow` call together as a single pass under `backoff.ThrottleRetry`, replacing
the two hand-rolled per-RPC retry loops with one 5-attempt budget. A query rejected with
`CloseStatus=CONTINUED_AS_NEW` is now retried rather than failing on the first try, and a
budget exhausted in that state returns `CodeUnavailable` instead of a non-retryable
`InternalServiceError`.

Also includes a small `AGENTS.md` edit: a rule against using `yarpcerrors` directly in
handler logic.

**Why?**

Schedulers ContinueAsNew on every `UpdateSchedule` and periodically to bound history.
During the executionCache invalidation window on the history host, `wfID`-without-runID
can briefly resolve to the just-closed run, so either RPC can observe
`CONTINUED_AS_NEW` for a perfectly healthy schedule.

The probe already retried that state, but the query did not: it retried only on
transport errors (first decision task pending, history query wait timeout), while a
`CONTINUED_AS_NEW` *rejection* — which arrives as a successful RPC — short-circuited to
`CodeUnavailable` immediately. So a describe issued right after an update could fail
even though a retry milliseconds later would have succeeded.

Retrying the query on its own would not have fixed it. The query would keep asking about
the generation the probe validated, so a ContinueAsNew landing between the two RPCs would
burn the budget without ever re-establishing which run is current. Retrying the pair means
every attempt re-probes, and the close status the response is built on always belongs to
the same run as the query result.

Merging the budgets also makes the latency bound independent of which step is slow. Two
independent 5-attempt budgets allowed up to ~8s of backoff; one budget caps it at four
sleeps (~4s plus per-attempt RPC time), comfortably inside the typical 10s SLA.

Finally, exhausting the probe budget used to return the last observed info, which the
caller turned into "schedule is not operational" — misleading for a transient state, and
non-retryable for clients. That path now reports `CodeUnavailable`, telling the client to
retry against the new run. Genuinely closed schedulers (FAILED, TERMINATED, TIMED_OUT,
COMPLETED, CANCELED) are still non-retryable and still never reported as ACTIVE.

**How did you test it?**

Unit tests (all in `service/frontend/api`):

    go test -race -run TestDescribeSchedule ./service/frontend/api/
    go test -race ./service/frontend/api/

`TestDescribeSchedule` covers: probe returning CONTINUED_AS_NEW retried until the new run
is running; query rejected with CONTINUED_AS_NEW retried until queryable; both of those
exhausting the budget and surfacing `CodeUnavailable`; first-decision-task-pending and
history query-wait timeout (both yarpc `CodeDeadlineExceeded` and stdlib
`context.DeadlineExceeded`) retried until ready; caller context already expired not
retried; and closed schedulers (FAILED, TERMINATED, and a FAILED query rejection) failing
immediately with `InternalServiceError`.

**Potential risks**

No IDL, API surface, or schema change; frontend-only, and both RPCs involved are
read-only and idempotent, so replaying the pair has no side effects.

Each query retry now also re-issues `DescribeWorkflowExecution`, so the describe path can
cost up to 5 extra history RPCs per request. That is only paid when the schedule is in a
transient state, and it is bounded by the same budget as before.

The error code for a scheduler stuck mid-ContinueAsNew changes from `InternalServiceError`
to `CodeUnavailable`. That is the intended fix (it makes the condition client-retryable),
but callers that alert on Internal vs Unavailable will see the classification move.
Worst-case DescribeSchedule backoff decreases from ~8s to ~4s.

**Release notes**

`DescribeSchedule` no longer fails intermittently when it races a scheduler ContinueAsNew
(most visibly, a describe issued immediately after `UpdateSchedule`). Transient races are
retried internally, and a scheduler that stays mid-transition is reported as `UNAVAILABLE`
so clients retry rather than treating it as an internal error.

**Documentation Changes**

N/A — no user-facing API or CLI surface change.