### PR TITLE
ci: Move more integrations tests to SLOW

### DIFF
--- a/host/continue_as_new_test.go
+++ b/host/continue_as_new_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/uber/cadence/common/types"
 )
 
-func (s *IntegrationSuite) TestContinueAsNewWorkflow() {
+func (s *IntegrationSuite) TestContinueAsNewWorkflow_SLOW() {
 	id := "integration-continue-as-new-workflow-test"
 	wt := "integration-continue-as-new-workflow-test-type"
 	tl := "integration-continue-as-new-workflow-test-tasklist"

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -3715,7 +3715,7 @@ WaitForStickyTimeoutLoop:
 	s.Equal(2, failedDecisions, "Mismatched failed decision count")
 }
 
-func (s *IntegrationSuite) TestStickyTasklistResetThenTimeout() {
+func (s *IntegrationSuite) TestStickyTasklistResetThenTimeout_SLOW() {
 	id := "integration-reset-sticky-fire-schedule-to-start-timeout"
 	wt := "integration-reset-sticky-fire-schedule-to-start-timeout-type"
 	tl := "integration-reset-sticky-fire-schedule-to-start-timeout-tasklist"


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

Added _SLOW suffixes to TestContinueAsNewWorkflow and TestStickyTasklistResetThenTimeout. 

**Why?**

These tests are hitting integration test timeouts consistently on our `master` branch, causing failures. Increase the timeouts so that we can validate whether there are real failures. 

**How did you test it?**

N/A

**Potential risks**

Our integration tests will be slower. We should monitor the actual test completion time and determine whether we can move them to an intermediary category, or improve their performance. 

**Release notes**

N/A

**Documentation Changes**

N/A