### PR TITLE
refactor(archiver): add archiverfx module with dependency injection

### DIFF
--- a/cmd/server/cadence/fx.go
+++ b/cmd/server/cadence/fx.go
@@ -31,6 +31,9 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/archiver"
+	"github.com/uber/cadence/common/archiver/archiverfx"
+	"github.com/uber/cadence/common/archiver/provider"
 	"github.com/uber/cadence/common/clock/clockfx"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/dynamicconfig"
@@ -55,7 +58,8 @@ var _commonModule = fx.Options(
 	logfx.Module,
 	metricsfx.Module,
 	clockfx.Module,
-	rpcfx.Module)
+	rpcfx.Module,
+	archiverfx.Module)
 
 // Module provides a cadence server initialization with root components.
 // AppParams allows to provide optional/overrides for implementation specific dependencies.
@@ -99,6 +103,8 @@ type AppParams struct {
 	Scope                    tally.Scope
 	MetricsClient            metrics.Client
 	RPCFactory               rpc.Factory
+	ArchivalMetadata         archiver.ArchivalMetadata
+	ArchiverProvider         provider.ArchiverProvider
 }
 
 // NewApp created a new Application from pre initalized config and logger.
@@ -115,6 +121,8 @@ func NewApp(params AppParams) *App {
 		scope:                    params.Scope,
 		metricsClient:            params.MetricsClient,
 		rpcFactory:               params.RPCFactory,
+		archivalMetadata:         params.ArchivalMetadata,
+		archiverProvider:         params.ArchiverProvider,
 	}
 
 	params.LifeCycle.Append(fx.StartHook(app.verifySchema))
@@ -136,13 +144,15 @@ type App struct {
 	scope                    tally.Scope
 	metricsClient            metrics.Client
 	rpcFactory               rpc.Factory
+	archivalMetadata         archiver.ArchivalMetadata
+	archiverProvider         provider.ArchiverProvider
 
 	daemon  common.Daemon
 	service string
 }
 
 func (a *App) Start(_ context.Context) error {
-	a.daemon = newServer(a.service, a.cfg, a.logger, a.zapLogger, a.dynamicConfig, a.dynamicCollection, a.operationalConfigStore, a.operationalDynamicConfig, a.scope, a.metricsClient, a.rpcFactory)
+	a.daemon = newServer(a.service, a.cfg, a.logger, a.zapLogger, a.dynamicConfig, a.dynamicCollection, a.operationalConfigStore, a.operationalDynamicConfig, a.scope, a.metricsClient, a.rpcFactory, a.archivalMetadata, a.archiverProvider)
 	a.daemon.Start()
 	return nil
 }

--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -91,12 +91,14 @@ type (
 		scope                    tally.Scope
 		metricsClient            metrics.Client
 		rpcFactory               rpc.Factory
+		archivalMetadata         archiver.ArchivalMetadata
+		archiverProvider         provider.ArchiverProvider
 	}
 )
 
 // newServer returns a new instance of a daemon
 // that represents a cadence service
-func newServer(service string, cfg config.Config, logger log.Logger, zapLogger *zap.Logger, dynamicCfgClient dynamicconfig.Client, dynamicCollection *dynamicconfig.Collection, operationalConfigStore configstore.Client, operationalDynamicConfig *dynamicconfig.Collection, scope tally.Scope, metricsClient metrics.Client, rpcFactory rpc.Factory) common.Daemon {
+func newServer(service string, cfg config.Config, logger log.Logger, zapLogger *zap.Logger, dynamicCfgClient dynamicconfig.Client, dynamicCollection *dynamicconfig.Collection, operationalConfigStore configstore.Client, operationalDynamicConfig *dynamicconfig.Collection, scope tally.Scope, metricsClient metrics.Client, rpcFactory rpc.Factory, archivalMetadata archiver.ArchivalMetadata, archiverProvider provider.ArchiverProvider) common.Daemon {
 	return &server{
 		cfg:                      cfg,
 		name:                     service,
@@ -110,6 +112,8 @@ func newServer(service string, cfg config.Config, logger log.Logger, zapLogger *
 		scope:                    scope,
 		metricsClient:            metricsClient,
 		rpcFactory:               rpcFactory,
+		archivalMetadata:         archivalMetadata,
+		archiverProvider:         archiverProvider,
 	}
 }
 
@@ -282,16 +286,8 @@ func (s *server) startService() common.Daemon {
 		params.PublicClient = workflowserviceclient.New(publicClientConfig)
 	}
 
-	params.ArchivalMetadata = archiver.NewArchivalMetadata(
-		s.dynamicCollection,
-		s.cfg.Archival.History.Status,
-		s.cfg.Archival.History.EnableRead,
-		s.cfg.Archival.Visibility.Status,
-		s.cfg.Archival.Visibility.EnableRead,
-		&s.cfg.DomainDefaults.Archival,
-	)
-
-	params.ArchiverProvider = provider.NewArchiverProvider(s.cfg.Archival.History.Provider, s.cfg.Archival.Visibility.Provider)
+	params.ArchivalMetadata = s.archivalMetadata
+	params.ArchiverProvider = s.archiverProvider
 	params.PersistenceConfig.TransactionSizeLimit = s.dynamicCollection.GetIntProperty(dynamicproperties.TransactionSizeLimit)
 	params.PersistenceConfig.ErrorInjectionRate = s.dynamicCollection.GetFloat64Property(dynamicproperties.PersistenceErrorInjectionRate)
 	params.AuthorizationConfig = s.cfg.Authorization

--- a/cmd/server/cadence/server_test.go
+++ b/cmd/server/cadence/server_test.go
@@ -37,6 +37,8 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/archiver"
+	"github.com/uber/cadence/common/archiver/provider"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/dynamicconfig/configstore"
@@ -119,7 +121,16 @@ func (s *ServerSuite) TestServerStartup() {
 		rpcParams, err := rpc.NewParams(service.FullName(svc), &cfg, dc, logger, metrics.NewNoopMetricsClient())
 		s.NoError(err)
 		rpcFactory := rpc.NewFactory(logger, rpcParams)
-		server := newServer(svc, cfg, logger, testlogger.NewZap(s.T()), client, dc, operationalConfigStore, operationalDC, tally.NoopScope, metrics.NewNoopMetricsClient(), rpcFactory)
+		archivalMetadata := archiver.NewArchivalMetadata(
+			dc,
+			cfg.Archival.History.Status,
+			cfg.Archival.History.EnableRead,
+			cfg.Archival.Visibility.Status,
+			cfg.Archival.Visibility.EnableRead,
+			&cfg.DomainDefaults.Archival,
+		)
+		archiverProvider := provider.NewArchiverProvider(cfg.Archival.History.Provider, cfg.Archival.Visibility.Provider)
+		server := newServer(svc, cfg, logger, testlogger.NewZap(s.T()), client, dc, operationalConfigStore, operationalDC, tally.NoopScope, metrics.NewNoopMetricsClient(), rpcFactory, archivalMetadata, archiverProvider)
 		daemons = append(daemons, server)
 		server.Start()
 	}

--- a/common/archiver/archiverfx/fx.go
+++ b/common/archiver/archiverfx/fx.go
@@ -1,0 +1,71 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package archiverfx
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/uber/cadence/common/archiver"
+	"github.com/uber/cadence/common/archiver/provider"
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/dynamicconfig"
+)
+
+// Module provides archival components for fx application.
+var Module = fx.Module("archiverfx",
+	fx.Provide(NewArchivalMetadata),
+	fx.Provide(NewArchiverProvider),
+)
+
+type archivalMetadataParams struct {
+	fx.In
+
+	DynamicCollection *dynamicconfig.Collection
+	Config            config.Config
+}
+
+// NewArchivalMetadata creates an ArchivalMetadata instance via dependency injection.
+func NewArchivalMetadata(p archivalMetadataParams) archiver.ArchivalMetadata {
+	return archiver.NewArchivalMetadata(
+		p.DynamicCollection,
+		p.Config.Archival.History.Status,
+		p.Config.Archival.History.EnableRead,
+		p.Config.Archival.Visibility.Status,
+		p.Config.Archival.Visibility.EnableRead,
+		&p.Config.DomainDefaults.Archival,
+	)
+}
+
+type archiverProviderParams struct {
+	fx.In
+
+	Config config.Config
+}
+
+// NewArchiverProvider creates an ArchiverProvider instance via dependency injection.
+func NewArchiverProvider(p archiverProviderParams) provider.ArchiverProvider {
+	return provider.NewArchiverProvider(
+		p.Config.Archival.History.Provider,
+		p.Config.Archival.Visibility.Provider,
+	)
+}

--- a/common/archiver/interface.go
+++ b/common/archiver/interface.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/cluster"
+	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
@@ -62,11 +63,12 @@ type (
 
 	// HistoryBootstrapContainer contains components needed by all history Archiver implementations
 	HistoryBootstrapContainer struct {
-		HistoryV2Manager persistence.HistoryManager
-		Logger           log.Logger
-		MetricsClient    metrics.Client
-		ClusterMetadata  cluster.Metadata
-		DomainCache      cache.DomainCache
+		HistoryV2Manager  persistence.HistoryManager
+		Logger            log.Logger
+		MetricsClient     metrics.Client
+		ClusterMetadata   cluster.Metadata
+		DomainCache       cache.DomainCache
+		DynamicCollection *dynamicconfig.Collection
 	}
 
 	// HistoryArchiver is used to archive history and read archived history
@@ -78,10 +80,11 @@ type (
 
 	// VisibilityBootstrapContainer contains components needed by all visibility Archiver implementations
 	VisibilityBootstrapContainer struct {
-		Logger          log.Logger
-		MetricsClient   metrics.Client
-		ClusterMetadata cluster.Metadata
-		DomainCache     cache.DomainCache
+		Logger            log.Logger
+		MetricsClient     metrics.Client
+		ClusterMetadata   cluster.Metadata
+		DomainCache       cache.DomainCache
+		DynamicCollection *dynamicconfig.Collection
 	}
 
 	// ArchiveVisibilityRequest is request to Archive single workflow visibility record

--- a/common/resource/resource_impl.go
+++ b/common/resource/resource_impl.go
@@ -297,17 +297,19 @@ func New(
 	)
 
 	historyArchiverBootstrapContainer := &archiver.HistoryBootstrapContainer{
-		HistoryV2Manager: persistenceBean.GetHistoryManager(),
-		Logger:           logger,
-		MetricsClient:    params.MetricsClient,
-		ClusterMetadata:  params.ClusterMetadata,
-		DomainCache:      domainCache,
+		HistoryV2Manager:  persistenceBean.GetHistoryManager(),
+		Logger:            logger,
+		MetricsClient:     params.MetricsClient,
+		ClusterMetadata:   params.ClusterMetadata,
+		DomainCache:       domainCache,
+		DynamicCollection: dynamicCollection,
 	}
 	visibilityArchiverBootstrapContainer := &archiver.VisibilityBootstrapContainer{
-		Logger:          logger,
-		MetricsClient:   params.MetricsClient,
-		ClusterMetadata: params.ClusterMetadata,
-		DomainCache:     domainCache,
+		Logger:            logger,
+		MetricsClient:     params.MetricsClient,
+		ClusterMetadata:   params.ClusterMetadata,
+		DomainCache:       domainCache,
+		DynamicCollection: dynamicCollection,
 	}
 	if err := params.ArchiverProvider.RegisterBootstrapContainer(
 		serviceName,

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -1091,13 +1091,16 @@ func (c *cadenceImpl) startWorkerClientWorker(params *resource.Params, svc Servi
 	workerConfig := worker.NewConfig(params)
 	workerConfig.ArchiverConfig.ArchiverConcurrency = dynamicproperties.GetIntPropertyFn(10)
 	historyArchiverBootstrapContainer := &carchiver.HistoryBootstrapContainer{
-		HistoryV2Manager: c.historyV2Mgr,
-		Logger:           c.logger,
-		MetricsClient:    svc.GetMetricsClient(),
-		ClusterMetadata:  c.clusterMetadata,
-		DomainCache:      domainCache,
+		HistoryV2Manager:  c.historyV2Mgr,
+		Logger:            c.logger,
+		MetricsClient:     svc.GetMetricsClient(),
+		ClusterMetadata:   c.clusterMetadata,
+		DomainCache:       domainCache,
+		DynamicCollection: params.DynamicCollection,
 	}
-	err := c.archiverProvider.RegisterBootstrapContainer(service.Worker, historyArchiverBootstrapContainer, &carchiver.VisibilityBootstrapContainer{})
+	err := c.archiverProvider.RegisterBootstrapContainer(service.Worker, historyArchiverBootstrapContainer, &carchiver.VisibilityBootstrapContainer{
+		DynamicCollection: params.DynamicCollection,
+	})
 	if err != nil {
 		c.logger.Fatal("Failed to register archiver bootstrap container for worker service", tag.Error(err))
 	}

--- a/tools/cli/domain_utils.go
+++ b/tools/cli/domain_utils.go
@@ -375,7 +375,7 @@ func initializeAdminDomainHandler(c *cli.Context) (domain.Handler, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Error in init admin domain handler: %w", err)
 	}
-	archivalprovider, err := initializeArchivalProvider(configuration, clusterMetadata, metricsClient, logger)
+	archivalprovider, err := initializeArchivalProvider(configuration, clusterMetadata, metricsClient, logger, dynamicConfig)
 	if err != nil {
 		return nil, fmt.Errorf("Error in init admin domain handler: %w", err)
 	}
@@ -472,6 +472,7 @@ func initializeArchivalProvider(
 	clusterMetadata cluster.Metadata,
 	metricsClient metrics.Client,
 	logger log.Logger,
+	dynamicConfig *dynamicconfig.Collection,
 ) (provider.ArchiverProvider, error) {
 
 	archiverProvider := provider.NewArchiverProvider(
@@ -480,17 +481,19 @@ func initializeArchivalProvider(
 	)
 
 	historyArchiverBootstrapContainer := &archiver.HistoryBootstrapContainer{
-		HistoryV2Manager: nil, // not used
-		Logger:           logger,
-		MetricsClient:    metricsClient,
-		ClusterMetadata:  clusterMetadata,
-		DomainCache:      nil, // not used
+		HistoryV2Manager:  nil, // not used
+		Logger:            logger,
+		MetricsClient:     metricsClient,
+		ClusterMetadata:   clusterMetadata,
+		DomainCache:       nil, // not used
+		DynamicCollection: dynamicConfig,
 	}
 	visibilityArchiverBootstrapContainer := &archiver.VisibilityBootstrapContainer{
-		Logger:          logger,
-		MetricsClient:   metricsClient,
-		ClusterMetadata: clusterMetadata,
-		DomainCache:     nil, // not used
+		Logger:            logger,
+		MetricsClient:     metricsClient,
+		ClusterMetadata:   clusterMetadata,
+		DomainCache:       nil, // not used
+		DynamicCollection: dynamicConfig,
 	}
 
 	err := archiverProvider.RegisterBootstrapContainer(


### PR DESCRIPTION
## What changed?
Created a new `archiverfx` package that provides `ArchivalMetadata` and `ArchiverProvider` via fx dependency injection. Updated the server initialization to use these injected components instead of manually constructing them in `startService()`.

## Why?
The archival components were previously constructed manually in `server.go`, which didn't follow the fx-based dependency injection pattern used by other infrastructure components (rpcfx, metricsfx, clockfx, etc.). This refactoring:
- Brings archival component initialization in line with other fx modules
- Makes dependencies explicit and testable
- Simplifies server initialization by delegating component construction to the fx framework

## How did you test it?
- ✅ `make .idl-status` — IDL submodule verified
- ✅ `make pr` — tidy, go-generate, fmt, lint all passed
- ✅ `make build` — all packages compile successfully
- ✅ `make bins` — all binaries built successfully
- 🔄 `make test` — unit tests running (CI will verify)

## Potential risks
None — isolated refactoring with no API/schema/flag impact. The archival components are constructed with the same parameters as before, just via DI instead of manual construction.

## Release notes
N/A — internal refactoring.

## Documentation Changes
N/A