### PR TITLE
fix: Increase persistence test timeouts, handle leaked history branches in tests

### DIFF
--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -56,8 +56,8 @@ type (
 )
 
 var (
-	testContextTimeout      = 5 * time.Second
-	largeTestContextTimeout = 30 * time.Second
+	testContextTimeout      = 15 * time.Second
+	largeTestContextTimeout = 60 * time.Second
 
 	testWorkflowChecksum = checksum.Checksum{
 		Version: 22,

--- a/common/persistence/persistence-tests/historyV2PersistenceTest.go
+++ b/common/persistence/persistence-tests/historyV2PersistenceTest.go
@@ -128,15 +128,32 @@ func (s *HistoryV2PersistenceSuite) TestScanAllTrees() {
 	ctx, cancel := context.WithTimeout(context.Background(), largeTestContextTimeout)
 	defer cancel()
 
-	resp, err := s.HistoryV2Mgr.GetAllHistoryTreeBranches(ctx, &p.GetAllHistoryTreeBranchesRequest{
-		PageSize: 1,
-	})
-	s.Nil(err)
-	s.Equal(0, len(resp.Branches), "some trees were leaked in other tests")
-
 	trees := map[string]bool{}
 	totalTrees := 1002
 	pgSize := 100
+
+	// Earlier tests in this suite can leak trees when a loaded database makes their
+	// cleanup time out. Snapshot whatever is already there so this test can tell those
+	// apart from trees it did not expect at all.
+	existingTrees := map[string]struct{}{}
+	var pgToken []byte
+	for {
+		resp, err := s.HistoryV2Mgr.GetAllHistoryTreeBranches(ctx, &p.GetAllHistoryTreeBranchesRequest{
+			PageSize:      pgSize,
+			NextPageToken: pgToken,
+		})
+		s.Nil(err)
+		for _, br := range resp.Branches {
+			existingTrees[br.TreeID] = struct{}{}
+		}
+		if len(resp.NextPageToken) == 0 {
+			break
+		}
+		pgToken = resp.NextPageToken
+	}
+	if len(existingTrees) > 0 {
+		s.T().Logf("%v trees were leaked by earlier tests", len(existingTrees))
+	}
 
 	for i := 0; i < totalTrees; i++ {
 		treeID := uuid.New()
@@ -149,7 +166,7 @@ func (s *HistoryV2PersistenceSuite) TestScanAllTrees() {
 		trees[treeID] = true
 	}
 
-	var pgToken []byte
+	pgToken = nil
 	for {
 		resp, err := s.HistoryV2Mgr.GetAllHistoryTreeBranches(ctx, &p.GetAllHistoryTreeBranchesRequest{
 			PageSize:      pgSize,
@@ -164,7 +181,8 @@ func (s *HistoryV2PersistenceSuite) TestScanAllTrees() {
 				s.True(len(br.BranchID) > 0)
 				s.Equal("branchInfo", br.Info)
 			} else {
-				s.Fail("treeID not found", br.TreeID)
+				_, ok := existingTrees[br.TreeID]
+				s.True(ok, "unexpected treeID %v: not created by this test and not present before it ran", br.TreeID)
 			}
 		}
 
@@ -493,7 +511,7 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyCreateAndAppendBranches() {
 
 // TestConcurrentlyForkAndAppendBranches test
 func (s *HistoryV2PersistenceSuite) TestConcurrentlyForkAndAppendBranches() {
-	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), largeTestContextTimeout)
 	defer cancel()
 
 	treeID := uuid.New()
@@ -684,7 +702,7 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyForkAndAppendBranches() {
 	s.Eventually(func() bool {
 		branches = s.descTree(ctx, treeID)
 		return len(branches) == 0
-	}, 100*time.Millisecond, 20*time.Millisecond)
+	}, 5*time.Second, 100*time.Millisecond)
 }
 
 func (s *HistoryV2PersistenceSuite) getBranchByKey(m *sync.Map, k int) []byte {


### PR DESCRIPTION
**What changed?**

- Raised the shared persistence integration-test deadlines (testContextTimeout 5s → 15s, largeTestContextTimeout 30s → 60s in executionManagerTest.go). 
- Switched TestConcurrentlyForkAndAppendBranches to largeTestContextTimeout and widened its cleanup-verifications.
- Updated TestScanAllTrees to tolerate history trees leaked by earlier tests instead of hard-failing on them.

**Why?**

The persistence suite has been very flaky in CI - both on the master branch and individual PRs. It seems like this is due to database contention between tests. e.g In this run [30844022402](https://github.com/cadence-workflow/cadence/actions/runs/30844022402/job/91787741169) two subtests failed:

- TestConcurrentlyForkAndAppendBranches (5.09s) — GetHistoryTree timed out. Error: context deadline exceeded, hit during branch cleanup (historyV2PersistenceTest.go:802 ← deleteHistoryBranch:737 ← the cleanup Range at :676).
- TestScanAllTrees — "some trees were leaked in other tests" (expected 0, actual 1).

This fix makes TestScanAllTrees more tolerant to leaked history branches to reduce the likelihood that contention between tests will cause other failures. 

It also extends the test timeouts to reduce the likelihood that test cleanup will fail, causing downstream effects for other tests. 

**How did you test it?**

CI :pray:

**Potential risks**

This may increase our CI duration - though if it fixes the flakes, it will dramatically decrease our total CI duration as these tests are super flaky. 

**Release notes**

N/A — test infrastructure only.

**Documentation Changes**

N/A.