### PR TITLE
feat: add refresh task to batch operations

### DIFF
--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -79,10 +79,12 @@ const (
 	BatchTypeSignal = "signal"
 	// BatchTypeReplicate is batch type for replicating workflows
 	BatchTypeReplicate = "replicate"
+	// BatchTypeRefresh is batch type for refreshing workflow tasks.
+	BatchTypeRefresh = "refresh"
 )
 
 // AllBatchTypes is the batch types we supported
-var AllBatchTypes = []string{BatchTypeTerminate, BatchTypeCancel, BatchTypeSignal, BatchTypeReplicate}
+var AllBatchTypes = []string{BatchTypeTerminate, BatchTypeCancel, BatchTypeSignal, BatchTypeReplicate, BatchTypeRefresh}
 
 var (
 	BatchActivityRetryPolicy = cadence.RetryPolicy{
@@ -313,6 +315,17 @@ func startTaskProcessor(
 							WorkflowID:    workflowID,
 							RunID:         runID,
 							RemoteCluster: batchParams.ReplicateParams.SourceCluster,
+						})
+					})
+			case BatchTypeRefresh:
+				err = processTask(ctx, limiter, task, batchParams, client, common.BoolPtr(false),
+					func(workflowID, runID string) error {
+						return client.RefreshWorkflowTasks(ctx, &types.RefreshWorkflowTasksRequest{
+							Domain: batchParams.DomainName,
+							Execution: &types.WorkflowExecution{
+								WorkflowID: workflowID,
+								RunID:      runID,
+							},
 						})
 					})
 			}

--- a/service/worker/batcher/workflow_params.go
+++ b/service/worker/batcher/workflow_params.go
@@ -50,6 +50,8 @@ func validateParams(params BatchParams) error {
 	case BatchTypeCancel:
 		fallthrough
 	case BatchTypeTerminate:
+		fallthrough
+	case BatchTypeRefresh:
 		return nil
 	default:
 		return fmt.Errorf("not supported batch type: %v", params.BatchType)

--- a/service/worker/batcher/workflow_refresh_test.go
+++ b/service/worker/batcher/workflow_refresh_test.go
@@ -1,0 +1,306 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package batcher
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/uber-go/tally"
+	"go.uber.org/cadence/testsuite"
+	"go.uber.org/cadence/worker"
+	"go.uber.org/mock/gomock"
+
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/types"
+)
+
+func TestRefreshBatchActivity(t *testing.T) {
+	tests := []struct {
+		name       string
+		activity   interface{}
+		wantTuning bool
+	}{
+		{
+			name:     "V1",
+			activity: BatchActivity,
+		},
+		{
+			name:       "V2",
+			activity:   batchActivityV2,
+			wantTuning: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var suite testsuite.WorkflowTestSuite
+			activityEnv := suite.NewTestActivityEnvironment()
+			activityEnv.RegisterActivity(tt.activity)
+
+			batcher, mockResource := setuptest(t)
+			setRefreshActivityWorkerOptions(activityEnv, batcher)
+
+			params := createParams(BatchTypeRefresh)
+			params.Concurrency = 1
+			params.RPS = 100
+			params.PageSize = 10
+			expectedExecution := &types.WorkflowExecution{
+				WorkflowID: "workflow-id",
+				RunID:      "run-id",
+			}
+
+			mockResource.FrontendClient.EXPECT().
+				DescribeDomain(gomock.Any(), gomock.Any()).
+				Return(&types.DescribeDomainResponse{}, nil)
+			mockResource.FrontendClient.EXPECT().
+				CountWorkflowExecutions(gomock.Any(), &types.CountWorkflowExecutionsRequest{
+					Domain: params.DomainName,
+					Query:  params.Query,
+				}).
+				Return(&types.CountWorkflowExecutionsResponse{Count: 1}, nil)
+			mockResource.FrontendClient.EXPECT().
+				ScanWorkflowExecutions(gomock.Any(), &types.ListWorkflowExecutionsRequest{
+					Domain:   params.DomainName,
+					PageSize: int32(params.PageSize),
+					Query:    params.Query,
+				}).
+				Return(&types.ListWorkflowExecutionsResponse{
+					Executions: []*types.WorkflowExecutionInfo{{Execution: expectedExecution}},
+				}, nil)
+			mockResource.FrontendClient.EXPECT().
+				RefreshWorkflowTasks(gomock.Any(), &types.RefreshWorkflowTasksRequest{
+					Domain:    params.DomainName,
+					Execution: expectedExecution,
+				}).
+				Return(nil)
+			mockResource.FrontendClient.EXPECT().
+				DescribeWorkflowExecution(gomock.Any(), &types.DescribeWorkflowExecutionRequest{
+					Domain:    params.DomainName,
+					Execution: expectedExecution,
+				}).
+				Return(&types.DescribeWorkflowExecutionResponse{
+					PendingChildren: []*types.PendingChildExecutionInfo{{
+						WorkflowID: "child-workflow-id",
+						RunID:      "child-run-id",
+					}},
+				}, nil)
+
+			value, err := activityEnv.ExecuteActivity(tt.activity, params)
+			if err != nil {
+				t.Fatalf("ExecuteActivity() error = %v", err)
+			}
+
+			var result HeartBeatDetails
+			if err := value.Get(&result); err != nil {
+				t.Fatalf("Get() error = %v", err)
+			}
+			if result.SuccessCount != 1 {
+				t.Errorf("SuccessCount = %d, want 1", result.SuccessCount)
+			}
+			if result.ErrorCount != 0 {
+				t.Errorf("ErrorCount = %d, want 0", result.ErrorCount)
+			}
+			if result.CurrentPage != 1 {
+				t.Errorf("CurrentPage = %d, want 1", result.CurrentPage)
+			}
+			if tt.wantTuning && (result.RPS != params.RPS || result.Concurrency != params.Concurrency) {
+				t.Errorf("V2 tuning details = (%d, %d), want (%d, %d)", result.RPS, result.Concurrency, params.RPS, params.Concurrency)
+			}
+		})
+	}
+}
+
+func TestRefreshBatchActivityEntityNotExistsIsSuccess(t *testing.T) {
+	tests := []struct {
+		name     string
+		activity interface{}
+	}{
+		{
+			name:     "V1",
+			activity: BatchActivity,
+		},
+		{
+			name:     "V2",
+			activity: batchActivityV2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var suite testsuite.WorkflowTestSuite
+			activityEnv := suite.NewTestActivityEnvironment()
+			activityEnv.RegisterActivity(tt.activity)
+
+			batcher, mockResource := setuptest(t)
+			setRefreshActivityWorkerOptions(activityEnv, batcher)
+
+			params := createParams(BatchTypeRefresh)
+			params.Concurrency = 1
+			params.RPS = 100
+			expectedExecution := &types.WorkflowExecution{
+				WorkflowID: "workflow-id",
+				RunID:      "run-id",
+			}
+
+			mockResource.FrontendClient.EXPECT().
+				DescribeDomain(gomock.Any(), gomock.Any()).
+				Return(&types.DescribeDomainResponse{}, nil)
+			mockResource.FrontendClient.EXPECT().
+				CountWorkflowExecutions(gomock.Any(), gomock.Any()).
+				Return(&types.CountWorkflowExecutionsResponse{Count: 1}, nil)
+			mockResource.FrontendClient.EXPECT().
+				ScanWorkflowExecutions(gomock.Any(), gomock.Any()).
+				Return(&types.ListWorkflowExecutionsResponse{
+					Executions: []*types.WorkflowExecutionInfo{{Execution: expectedExecution}},
+				}, nil)
+			mockResource.FrontendClient.EXPECT().
+				RefreshWorkflowTasks(gomock.Any(), &types.RefreshWorkflowTasksRequest{
+					Domain:    params.DomainName,
+					Execution: expectedExecution,
+				}).
+				Return(&types.EntityNotExistsError{})
+
+			value, err := activityEnv.ExecuteActivity(tt.activity, params)
+			if err != nil {
+				t.Fatalf("ExecuteActivity() error = %v", err)
+			}
+
+			var result HeartBeatDetails
+			if err := value.Get(&result); err != nil {
+				t.Fatalf("Get() error = %v", err)
+			}
+			if result.SuccessCount != 1 || result.ErrorCount != 0 {
+				t.Errorf("progress = %+v, want one successful no-op", result)
+			}
+		})
+	}
+}
+
+func TestRefreshTaskProcessorRetriesRetryableErrors(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	activityEnv := suite.NewTestActivityEnvironment()
+	activityEnv.RegisterActivity(BatchActivity)
+
+	batcher, mockResource := setuptest(t)
+	setRefreshActivityWorkerOptions(activityEnv, batcher)
+
+	params := createParams(BatchTypeRefresh)
+	params.Concurrency = 1
+	params.RPS = 100
+	params.AttemptsOnRetryableError = 1
+	params._nonRetryableErrors = make(map[string]struct{})
+	execution := types.WorkflowExecution{
+		WorkflowID: "workflow-id",
+		RunID:      "run-id",
+	}
+	request := &types.RefreshWorkflowTasksRequest{
+		Domain:    params.DomainName,
+		Execution: &execution,
+	}
+
+	mockResource.FrontendClient.EXPECT().
+		DescribeDomain(gomock.Any(), gomock.Any()).
+		Return(&types.DescribeDomainResponse{}, nil)
+	mockResource.FrontendClient.EXPECT().
+		CountWorkflowExecutions(gomock.Any(), gomock.Any()).
+		Return(&types.CountWorkflowExecutionsResponse{Count: 1}, nil)
+	mockResource.FrontendClient.EXPECT().
+		ScanWorkflowExecutions(gomock.Any(), gomock.Any()).
+		Return(&types.ListWorkflowExecutionsResponse{
+			Executions: []*types.WorkflowExecutionInfo{{Execution: &execution}},
+		}, nil)
+	firstRefresh := mockResource.FrontendClient.EXPECT().
+		RefreshWorkflowTasks(gomock.Any(), request).
+		Return(errors.New("transient error"))
+	secondRefresh := mockResource.FrontendClient.EXPECT().
+		RefreshWorkflowTasks(gomock.Any(), request).
+		Return(nil)
+	describe := mockResource.FrontendClient.EXPECT().
+		DescribeWorkflowExecution(gomock.Any(), &types.DescribeWorkflowExecutionRequest{
+			Domain:    params.DomainName,
+			Execution: &execution,
+		}).
+		Return(&types.DescribeWorkflowExecutionResponse{}, nil)
+	gomock.InOrder(firstRefresh, secondRefresh, describe)
+
+	value, err := activityEnv.ExecuteActivity(BatchActivity, params)
+	if err != nil {
+		t.Fatalf("ExecuteActivity() error = %v", err)
+	}
+
+	var result HeartBeatDetails
+	if err := value.Get(&result); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if result.SuccessCount != 1 || result.ErrorCount != 0 {
+		t.Errorf("progress = %+v, want one retried success", result)
+	}
+}
+
+func TestValidateRefreshBatchParams(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  BatchParams
+		wantErr string
+	}{
+		{
+			name:   "refresh needs no operation-specific parameters",
+			params: createParams(BatchTypeRefresh),
+		},
+		{
+			name:    "unsupported batch type",
+			params:  createParams("unsupported"),
+			wantErr: "not supported batch type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateParams(tt.params)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateParams() error = %v", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != "not supported batch type: unsupported" {
+				t.Fatalf("validateParams() error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func setRefreshActivityWorkerOptions(activityEnv *testsuite.TestActivityEnvironment, batcher *Batcher) {
+	setRefreshBatcherMetrics(batcher)
+	ctx := context.WithValue(context.Background(), BatcherContextKey, batcher)
+	activityEnv.SetWorkerOptions(worker.Options{
+		MetricsScope:              tally.TestScope(nil),
+		BackgroundActivityContext: ctx,
+		Tracer:                    opentracing.GlobalTracer(),
+	})
+}
+
+func setRefreshBatcherMetrics(batcher *Batcher) {
+	batcher.metricsClient = metrics.NewClient(tally.NoopScope, metrics.Worker, metrics.MigrationConfig{})
+}

--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -366,7 +366,7 @@ func newWorkflowCommands() []*cli.Command {
 			Name:        "batch",
 			Usage:       "batch operation on a list of workflows from query.",
 			Subcommands: newBatchCommands(),
-			ArgsUsage: "\n\t To make a batch operation use wf batch start command and specify --batch_type to terminate/signal/cancel workflows.\n" +
+			ArgsUsage: "\n\t To make a batch operation use wf batch start command and specify --batch_type from: " + strings.Join(batcher.AllBatchTypes, ",") + ".\n" +
 				"\t ex: to batch terminate workflows run: cadence batch start --batch_type terminate --query <targeted_workflows_query>\n" +
 				"\t cadence wf batch terminate - is used to terminate a batch operation not workflows.\n" +
 				"\t To inspect the progress run: cadence wf batch desc --job_id <your_job_id>",

--- a/tools/cli/workflow_batch_commands_test.go
+++ b/tools/cli/workflow_batch_commands_test.go
@@ -67,6 +67,26 @@ func TestStartBatchJob(t *testing.T) {
 			expectedOutput: "batch job is started",
 		},
 		{
+			name: "Valid Start Refresh Batch Job",
+			setup: func(mockClient *frontend.MockClient) {
+				mockClient.EXPECT().CountWorkflowExecutions(gomock.Any(), gomock.Any()).Return(&types.CountWorkflowExecutionsResponse{
+					Count: 100,
+				}, nil)
+				mockClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).Return(&types.StartWorkflowExecutionResponse{
+					RunID: "run-id-example",
+				}, nil)
+			},
+			flags: map[string]interface{}{
+				FlagDomain:    "test-domain",
+				FlagListQuery: "workflowType='batch'",
+				FlagReason:    "Testing batch refresh job",
+				FlagBatchType: batcher.BatchTypeRefresh,
+				FlagYes:       true,
+			},
+			expectedError:  "",
+			expectedOutput: "batch job is started",
+		},
+		{
 			name:  "Missing Domain",
 			setup: func(mockClient *frontend.MockClient) {},
 			flags: map[string]interface{}{
@@ -128,7 +148,7 @@ func TestStartBatchJob(t *testing.T) {
 				FlagReason:    "Testing batch job",
 				FlagBatchType: "invalidBatchType",
 			},
-			expectedError: "batchType is not valid, supported:terminate,cancel,signal,replicate",
+			expectedError: "batchType is not valid, supported:terminate,cancel,signal,replicate,refresh",
 		},
 		{
 			name: "Count Workflow Executions Failure",
@@ -520,9 +540,6 @@ func TestListBatchJobs(t *testing.T) {
 }
 
 func TestValidateBatchType(t *testing.T) {
-	// Mock batch types for testing
-	batcher.AllBatchTypes = []string{"signal", "replicate", "terminate"}
-
 	tests := []struct {
 		name      string
 		batchType string
@@ -536,6 +553,11 @@ func TestValidateBatchType(t *testing.T) {
 		{
 			name:      "Valid batch type - replicate",
 			batchType: "replicate",
+			expected:  true,
+		},
+		{
+			name:      "Valid batch type - refresh",
+			batchType: batcher.BatchTypeRefresh,
 			expected:  true,
 		},
 		{


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Added a refresh batch operation that refreshes workflow tasks for workflows matching a query.

**Why?**
Allows operators to refresh workflow tasks for many workflows at once without handling each workflow individually.

**How did you test it?**
unit tests

**Potential risks**


**Release notes**


**Documentation Changes**

