### PR TITLE
fix: Render the number of cluster attributes on domain describe, fix tool hint

### DIFF
--- a/tools/cli/domain_commands.go
+++ b/tools/cli/domain_commands.go
@@ -659,7 +659,7 @@ VisibilityArchivalURI: {{.}}{{end}}
 {{table .}}{{end}}
 {{with .FailoverInfo}}Graceful failover info:
 {{table .}}{{end}}
-{{if .IsActiveActiveDomain}}To see active clusters by cluster attribute use --print-json.
+{{if .IsActiveActiveDomain}}ActiveClustersByClusterAttribute: {{.ClusterAttributeCount}} cluster attribute(s), omitted here as the list can be very large. To see them use --format json.
 {{end}}`
 
 // DescribeDomain updates a domain
@@ -693,11 +693,12 @@ func (d *domainCLIImpl) DescribeDomain(c *cli.Context) error {
 	}
 
 	if printJSON {
+		fmt.Fprintln(os.Stderr, "Warning: --print_json is deprecated, use --format json instead. Note their output shapes differ: --format json prints the CLI view of the domain, --print_json prints the raw server response.")
 		output, err := json.Marshal(resp)
 		if err != nil {
 			return commoncli.Problem("Failed to encode domain response into JSON.", err)
 		}
-		fmt.Println(string(output))
+		fmt.Fprintln(getDeps(c).Output(), string(output))
 		return nil
 	}
 
@@ -752,6 +753,23 @@ type DomainRow struct {
 	FailoverInfo             *FailoverInfoRow
 	LongRunningWorkFlowNum   *int
 	IsActiveActiveDomain     bool
+	// ActiveClusters can be very large for active-active domains, so it is only
+	// included in --format json output, not in the default template or tables.
+	ActiveClusters *types.ActiveClusters
+}
+
+// ClusterAttributeCount returns the total number of cluster attributes across
+// all attribute scopes. Used by templateDomain; being a method, it is excluded
+// from --format json output.
+func (d DomainRow) ClusterAttributeCount() int {
+	if d.ActiveClusters == nil {
+		return 0
+	}
+	count := 0
+	for _, scope := range d.ActiveClusters.AttributeScopes {
+		count += len(scope.ClusterAttributes)
+	}
+	return count
 }
 
 type DomainMigrationRow struct {
@@ -796,6 +814,7 @@ func newDomainRow(domain *types.DescribeDomainResponse) DomainRow {
 		BadBinaries:              newBadBinaryRows(domain.Configuration.BadBinaries),
 		FailoverInfo:             newFailoverInfoRow(domain.FailoverInfo),
 		IsActiveActiveDomain:     domain.ReplicationConfiguration.IsActiveActive(),
+		ActiveClusters:           domain.ReplicationConfiguration.GetActiveClusters(),
 	}
 }
 

--- a/tools/cli/domain_commands_test.go
+++ b/tools/cli/domain_commands_test.go
@@ -30,8 +30,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
+	"github.com/uber/cadence/client/frontend"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/tools/cli/clitest"
 )
 
 func (s *cliAppSuite) TestDomainRegister() {
@@ -979,6 +981,87 @@ func TestRenderFailoverHistoryTable(t *testing.T) {
 			result := output.String()
 			for _, expected := range tc.expectedOutput {
 				assert.Contains(t, result, expected, "output should contain '%s'", expected)
+			}
+		})
+	}
+}
+
+func TestDescribeDomain_ActiveActiveOutput(t *testing.T) {
+	describeResponse := &types.DescribeDomainResponse{
+		DomainInfo: &types.DomainInfo{
+			Name: "test-domain",
+			UUID: "test-uuid",
+		},
+		Configuration: &types.DomainConfiguration{
+			WorkflowExecutionRetentionPeriodInDays: 3,
+		},
+		ReplicationConfiguration: &types.DomainReplicationConfiguration{
+			ActiveClusterName: "c1",
+			Clusters: []*types.ClusterReplicationConfiguration{
+				{ClusterName: "c1"},
+				{ClusterName: "c2"},
+			},
+			ActiveClusters: &types.ActiveClusters{
+				AttributeScopes: map[string]types.ClusterAttributeScope{
+					"region": {
+						ClusterAttributes: map[string]types.ActiveClusterInfo{
+							"seattle":       {ActiveClusterName: "c1", FailoverVersion: 1},
+							"san_francisco": {ActiveClusterName: "c2", FailoverVersion: 2},
+						},
+					},
+				},
+			},
+		},
+		IsGlobalDomain: true,
+	}
+
+	tests := []struct {
+		name        string
+		command     string
+		wantContain []string
+		notContain  []string
+	}{
+		{
+			name:    "default output shows cluster attribute summary and --format json hint",
+			command: "cadence --do test-domain domain describe",
+			wantContain: []string{
+				"ActiveClustersByClusterAttribute: 2 cluster attribute(s)",
+				"--format json",
+			},
+			notContain: []string{"--print-json"},
+		},
+		{
+			name:        "format json includes active clusters by cluster attribute",
+			command:     "cadence --do test-domain domain describe --format json",
+			wantContain: []string{`"attributeScopes"`, `"seattle"`, `"san_francisco"`},
+		},
+		{
+			name:        "print_json still prints the raw server response",
+			command:     "cadence --do test-domain domain describe --print_json",
+			wantContain: []string{`"activeClusters"`, `"seattle"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			serverFrontendClient := frontend.NewMockClient(ctrl)
+			ioHandler := &testIOHandler{}
+			app := NewCliApp(
+				&clientFactoryMock{serverFrontendClient: serverFrontendClient},
+				WithIOHandler(ioHandler),
+			)
+			serverFrontendClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(describeResponse, nil)
+
+			err := clitest.RunCommandLine(t, app, tt.command)
+			assert.NoError(t, err)
+
+			out := ioHandler.outputBytes.String()
+			for _, want := range tt.wantContain {
+				assert.Contains(t, out, want)
+			}
+			for _, not := range tt.notContain {
+				assert.NotContains(t, out, not)
 			}
 		})
 	}

--- a/tools/cli/domain_utils.go
+++ b/tools/cli/domain_utils.go
@@ -248,7 +248,7 @@ var (
 		&cli.BoolFlag{
 			Name:    FlagPrintJSON,
 			Aliases: []string{"pjson"},
-			Usage:   "Print in raw JSON format",
+			Usage:   "Print the raw server response in JSON format (DEPRECATED: use --format json)",
 		},
 		getFormatFlag(),
 	}


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

When `cadence domain desc` is used:
- The number of cluster attributes is rendered
- --format json will render all existing ClusterAttributes 
- --print_json is deprecated and consistent with --format json 

**Why?**

Previously when `cadence domain desc` was run against an active-active domain, the following happened:
- by default it did not render any information about ClusterAttributes, only that it is or isn't an Active-Active domain
- when --format json was passed the ClusterAttributes were also not rendered
- when --print_json was passed ClusterAttributes were rendered, but in a different format to --format json

Additionally, the hint to print the full set of ClusterAttributes had a typo; directing users to use an invalid flag (--print-json).

This is because one can configure an unbounded number of cluster attributes, significantly degrading the readability of a given domain if it was always printed. 

This change removes the confusing multiple json rendering options and includes more information about cluster attributes by default. 

**How did you test it?**

Unit tests, locally. 

**Potential risks**

N/A

**Release notes**

N/A

**Documentation Changes**

N/A