### PR TITLE
fix(ringpop): Ringpop bootstrap failure doesn't crash service

### DIFF
--- a/common/daemon.go
+++ b/common/daemon.go
@@ -20,6 +20,8 @@
 
 package common
 
+import "context"
+
 const (
 	// used for background threads
 
@@ -34,8 +36,17 @@ const (
 type (
 	// Daemon is the base interfaces implemented by
 	// background tasks within Cadence
+	//
+	// Deprecated: Use DaemonV2 instead for context-aware lifecycle management
 	Daemon interface {
 		Start()
 		Stop()
+	}
+
+	// DaemonV2 is the context-aware version of Daemon
+	// for background tasks that need graceful shutdown coordination
+	DaemonV2 interface {
+		Start(context.Context) error
+		Stop(context.Context) error
 	}
 )

--- a/common/membership/hashring.go
+++ b/common/membership/hashring.go
@@ -21,6 +21,7 @@
 package membership
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"sort"
@@ -54,7 +55,7 @@ const (
 
 // PeerProvider is used to retrieve membership information from provider
 type PeerProvider interface {
-	common.Daemon
+	common.DaemonV2
 
 	GetMembers(service string) ([]HostInfo, error)
 	WhoAmI() (HostInfo, error)
@@ -154,7 +155,9 @@ func (r *Ring) Stop() {
 	r.logger.Info("Stopping hashring", tag.ComponentHashring)
 	defer r.logger.Info("Stopped hashring", tag.ComponentHashring)
 
-	r.peerProvider.Stop()
+	if err := r.peerProvider.Stop(context.Background()); err != nil {
+		r.logger.Error("failed to stop peer provider", tag.Error(err))
+	}
 	r.value.Store(emptyHashring())
 
 	r.subscribers.Lock()

--- a/common/membership/hashring_test.go
+++ b/common/membership/hashring_test.go
@@ -148,7 +148,7 @@ func newHashringTestData(t *testing.T) *hashringTestData {
 
 // starts hashring' background work and verifies all the goroutines closed at the end
 func (td *hashringTestData) startHashRing() {
-	td.mockPeerProvider.EXPECT().Stop()
+	td.mockPeerProvider.EXPECT().Stop(gomock.Any()).Return(nil)
 
 	td.t.Cleanup(func() {
 		td.hashRing.Stop()
@@ -425,7 +425,7 @@ func TestErrorIsPropagatedWhenProviderFails(t *testing.T) {
 func TestStopWillStopProvider(t *testing.T) {
 	td := newHashringTestData(t)
 
-	td.mockPeerProvider.EXPECT().Stop().Times(1)
+	td.mockPeerProvider.EXPECT().Stop(gomock.Any()).Times(1).Return(nil)
 
 	td.hashRing.status = common.DaemonStatusStarted
 	td.hashRing.Stop()

--- a/common/membership/membershipfx/memebershipfx_test.go
+++ b/common/membership/membershipfx/memebershipfx_test.go
@@ -42,13 +42,13 @@ func TestFxStartStop(t *testing.T) {
 	app := fxtest.New(t, fx.Provide(func() appParams {
 		ctrl := gomock.NewController(t)
 		provider := membership.NewMockPeerProvider(ctrl)
-		provider.EXPECT().Start()
-		provider.EXPECT().Stop()
+		provider.EXPECT().Start(gomock.Any()).Return(nil)
+		provider.EXPECT().Stop(gomock.Any()).Return(nil)
 		for _, s := range service.ListWithRing {
 			provider.EXPECT().Subscribe(s, gomock.Any()).Return(nil)
 			provider.EXPECT().GetMembers(s).Return([]membership.HostInfo{}, nil)
 			// this is also called by every ring, but could be called multiple times.
-			provider.EXPECT().Stop()
+			provider.EXPECT().Stop(gomock.Any()).Return(nil)
 		}
 		factory := rpc.NewMockFactory(ctrl)
 		factory.EXPECT().Start(gomock.Any()).Return(nil)

--- a/common/membership/peerprovider_mock.go
+++ b/common/membership/peerprovider_mock.go
@@ -10,6 +10,7 @@
 package membership
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
@@ -69,27 +70,31 @@ func (mr *MockPeerProviderMockRecorder) SelfEvict() *gomock.Call {
 }
 
 // Start mocks base method.
-func (m *MockPeerProvider) Start() {
+func (m *MockPeerProvider) Start(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Start")
+	ret := m.ctrl.Call(m, "Start", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockPeerProviderMockRecorder) Start() *gomock.Call {
+func (mr *MockPeerProviderMockRecorder) Start(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockPeerProvider)(nil).Start))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockPeerProvider)(nil).Start), arg0)
 }
 
 // Stop mocks base method.
-func (m *MockPeerProvider) Stop() {
+func (m *MockPeerProvider) Stop(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Stop")
+	ret := m.ctrl.Call(m, "Stop", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // Stop indicates an expected call of Stop.
-func (mr *MockPeerProviderMockRecorder) Stop() *gomock.Call {
+func (mr *MockPeerProviderMockRecorder) Stop(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockPeerProvider)(nil).Stop))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockPeerProvider)(nil).Stop), arg0)
 }
 
 // Subscribe mocks base method.

--- a/common/membership/resolver.go
+++ b/common/membership/resolver.go
@@ -24,6 +24,7 @@
 package membership
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -128,7 +129,9 @@ func (rpo *MultiringResolver) Start() {
 	rpo.logger.Info("Starting membership resolver", tag.ComponentMembershipResolver)
 	defer rpo.logger.Info("Started membership resolver", tag.ComponentMembershipResolver)
 
-	rpo.provider.Start()
+	if err := rpo.provider.Start(context.Background()); err != nil {
+		rpo.logger.Fatal("failed to start peer provider", tag.Error(err))
+	}
 
 	rpo.mu.Lock()
 	defer rpo.mu.Unlock()
@@ -156,7 +159,9 @@ func (rpo *MultiringResolver) Stop() {
 		ring.Stop()
 	}
 
-	rpo.provider.Stop()
+	if err := rpo.provider.Stop(context.Background()); err != nil {
+		rpo.logger.Error("failed to stop peer provider", tag.Error(err))
+	}
 }
 
 // WhoAmI asks to provide current instance address

--- a/common/membership/resolver_test.go
+++ b/common/membership/resolver_test.go
@@ -43,7 +43,7 @@ func TestSubscribeIsCalledOnPeerProvider(t *testing.T) {
 	assert.NoError(t, err)
 
 	// After membership is started, we expect start, subscribe and GetMembers on PeerProvider
-	pp.EXPECT().Start().Times(1)
+	pp.EXPECT().Start(gomock.Any()).Times(1).Return(nil)
 	pp.EXPECT().Subscribe(gomock.Any(), gomock.Any()).Times(len(testServices))
 	pp.EXPECT().GetMembers(gomock.Any()).Times(len(testServices))
 
@@ -123,7 +123,7 @@ func TestCallsAreForwardedToProvider(t *testing.T) {
 
 	mockedPeer.EXPECT().WhoAmI().Times(1)
 	mockedPeer.EXPECT().SelfEvict().Times(1)
-	mockedPeer.EXPECT().Stop().Times(1)
+	mockedPeer.EXPECT().Stop(gomock.Any()).Times(1).Return(nil)
 
 	a.status = common.DaemonStatusStarted
 	a.WhoAmI()

--- a/common/peerprovider/ringpopprovider/provider.go
+++ b/common/peerprovider/ringpopprovider/provider.go
@@ -23,6 +23,7 @@
 package ringpopprovider
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strconv"
@@ -124,18 +125,26 @@ func NewRingpopProvider(
 }
 
 // Start starts ringpop
-func (r *Provider) Start() {
+func (r *Provider) Start(ctx context.Context) error {
 	if !atomic.CompareAndSwapInt32(
 		&r.status,
 		common.DaemonStatusInitialized,
 		common.DaemonStatusStarted,
 	) {
-		return
+		return nil
 	}
 
-	_, err := r.ringpop.Bootstrap(r.bootParams)
+	var err error
+	defer func() {
+		if err != nil {
+			r.ringpop.RemoveListener(r)
+			atomic.StoreInt32(&r.status, common.DaemonStatusInitialized)
+		}
+	}()
+
+	_, err = r.ringpop.Bootstrap(r.bootParams)
 	if err != nil {
-		r.logger.Fatal("unable to bootstrap ringpop", tag.Error(err))
+		return fmt.Errorf("bootstrap ringpop: %w", err)
 	}
 
 	// Get updates from ringpop ring
@@ -143,19 +152,21 @@ func (r *Provider) Start() {
 
 	labels, err := r.ringpop.Labels()
 	if err != nil {
-		r.logger.Fatal("unable to get ring pop labels", tag.Error(err))
+		return fmt.Errorf("get ringpop labels: %w", err)
 	}
 
 	// set port labels
 	for name, port := range r.portmap {
 		if err = labels.Set(name, strconv.Itoa(int(port))); err != nil {
-			r.logger.Fatal("unable to set port label", tag.Error(err))
+			return fmt.Errorf("set port label %s: %w", name, err)
 		}
 	}
 
 	if err = labels.Set(roleKey, r.service); err != nil {
-		r.logger.Fatal("unable to set ringpop role label", tag.Error(err))
+		return fmt.Errorf("set role label: %w", err)
 	}
+
+	return nil
 }
 
 // HandleEvent handles updates from ringpop
@@ -272,17 +283,18 @@ func (r *Provider) WhoAmI() (membership.HostInfo, error) {
 }
 
 // Stop stops ringpop
-func (r *Provider) Stop() {
+func (r *Provider) Stop(ctx context.Context) error {
 	if !atomic.CompareAndSwapInt32(
 		&r.status,
 		common.DaemonStatusStarted,
 		common.DaemonStatusStopped,
 	) {
-		return
+		return nil
 	}
 
 	r.ringpop.RemoveListener(r)
 	r.ringpop.Destroy()
+	return nil
 }
 
 // Subscribe allows to be subscribed for ring changes

--- a/common/peerprovider/ringpopprovider/provider_test.go
+++ b/common/peerprovider/ringpopprovider/provider_test.go
@@ -23,6 +23,7 @@
 package ringpopprovider
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -98,9 +99,15 @@ func TestRingpopProvider(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			p.Start()
+			if err := p.Start(context.Background()); err != nil {
+				t.Errorf("Failed to start provider: %v", err)
+			}
 		}()
-		t.Cleanup(p.Stop)
+		t.Cleanup(func() {
+			if err := p.Stop(context.Background()); err != nil {
+				t.Errorf("Failed to stop provider: %v", err)
+			}
+		})
 	}
 
 	t.Logf("Waiting for %d ringpop providers to start", len(matchingChs)+len(irrelevantChs))


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Introduce DaemonV2 and deprecate Daemon
- Update peerprovider interface and ringpop provider to implement DaemonV2
- ringpop provider bootstrap failure now doesn't crash service, but membership resolver bootstrap failure still crash the service

fixes https://github.com/cadence-workflow/cadence/issues/8397

**Why?**
Inside Uber, we've migrated to a different peer provider but cannot fully offboard ringpop provider because of the bootstrap failure.

**How did you test it?**
go test ./common/membership/...
go test ./common/peerprovider/ringpopprovider/...

**Potential risks**
No.

**Release notes**


**Documentation Changes**

