### PR TITLE
feat(deprecate domain): check for active pollers before domain deprecation

### DIFF
--- a/service/worker/domaindeprecation/activities.go
+++ b/service/worker/domaindeprecation/activities.go
@@ -48,6 +48,12 @@ func (w *domainDeprecator) CheckActivePollersActivity(ctx context.Context, param
 		return fmt.Errorf("failed to describe domain: %v", err)
 	}
 
+	if domainResp.ReplicationConfiguration == nil || len(domainResp.ReplicationConfiguration.Clusters) == 0 {
+		w.logger.Info("No replication configuration found for domain, skipping poller check",
+			tag.WorkflowDomainName(params.DomainName))
+		return nil
+	}
+
 	var activeTaskLists []string
 	for _, cluster := range domainResp.ReplicationConfiguration.Clusters {
 		clusterName := cluster.GetClusterName()

--- a/service/worker/domaindeprecation/activities.go
+++ b/service/worker/domaindeprecation/activities.go
@@ -29,7 +29,50 @@ import (
 
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/worker/scheduler"
 )
+
+// CheckActivePollersActivity checks if there are any active pollers for the domain's task lists.
+// Returns a non-retryable error if pollers are found, preventing deprecation.
+func (w *domainDeprecator) CheckActivePollersActivity(ctx context.Context, params DomainDeprecationParams) error {
+	client := w.clientBean.GetFrontendClient()
+
+	resp, err := client.GetTaskListsByDomain(ctx, &types.GetTaskListsByDomainRequest{
+		Domain: params.DomainName,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get task lists for domain %s: %v", params.DomainName, err)
+	}
+
+	var activeTaskLists []string
+	for name, tl := range resp.GetDecisionTaskListMap() {
+		if name == scheduler.TaskListName {
+			continue
+		}
+		if len(tl.GetPollers()) > 0 {
+			activeTaskLists = append(activeTaskLists, name)
+		}
+	}
+	for name, tl := range resp.GetActivityTaskListMap() {
+		if name == scheduler.TaskListName {
+			continue
+		}
+		if len(tl.GetPollers()) > 0 {
+			activeTaskLists = append(activeTaskLists, name)
+		}
+	}
+
+	if len(activeTaskLists) > 0 {
+		w.logger.Warn("Domain has active pollers",
+			tag.WorkflowDomainName(params.DomainName),
+			tag.Dynamic("active_task_lists", activeTaskLists))
+		return cadence.NewCustomError(ErrActivePollersNonRetryable,
+			fmt.Sprintf("domain %s has active pollers on task lists: %v, use Force to override", params.DomainName, activeTaskLists))
+	}
+
+	w.logger.Info("No active pollers found for domain", tag.WorkflowDomainName(params.DomainName))
+	return nil
+}
 
 // DisableArchivalActivity disables archival for the domain
 func (w *domainDeprecator) DisableArchivalActivity(ctx context.Context, params DomainDeprecationParams) error {

--- a/service/worker/domaindeprecation/activities.go
+++ b/service/worker/domaindeprecation/activities.go
@@ -32,33 +32,52 @@ import (
 	"github.com/uber/cadence/service/worker/scheduler"
 )
 
-// CheckActivePollersActivity checks if there are any active pollers for the domain's task lists.
-// Returns a non-retryable error if pollers are found, preventing deprecation.
+// CheckActivePollersActivity checks if there are any active pollers for the domain's task lists
+// across all clusters. Returns a non-retryable error if pollers are found, preventing deprecation.
 func (w *domainDeprecator) CheckActivePollersActivity(ctx context.Context, params DomainDeprecationParams) error {
 	client := w.clientBean.GetFrontendClient()
 
-	resp, err := client.GetTaskListsByDomain(ctx, &types.GetTaskListsByDomainRequest{
-		Domain: params.DomainName,
+	domainResp, err := client.DescribeDomain(ctx, &types.DescribeDomainRequest{
+		Name: &params.DomainName,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to get task lists for domain %s: %v", params.DomainName, err)
+		var entityNotExistsError *types.EntityNotExistsError
+		if errors.As(err, &entityNotExistsError) {
+			return cadence.NewCustomError(ErrDomainDoesNotExistNonRetryable)
+		}
+		return fmt.Errorf("failed to describe domain: %v", err)
 	}
 
 	var activeTaskLists []string
-	for name, tl := range resp.GetDecisionTaskListMap() {
-		if name == scheduler.TaskListName {
-			continue
+	for _, cluster := range domainResp.ReplicationConfiguration.Clusters {
+		clusterName := cluster.GetClusterName()
+		frontendClient, err := w.clientBean.GetRemoteFrontendClient(clusterName)
+		if err != nil {
+			return fmt.Errorf("failed to get frontend client for cluster %s: %v", clusterName, err)
 		}
-		if len(tl.GetPollers()) > 0 {
-			activeTaskLists = append(activeTaskLists, name)
+
+		resp, err := frontendClient.GetTaskListsByDomain(ctx, &types.GetTaskListsByDomainRequest{
+			Domain: params.DomainName,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to get task lists for domain %s in cluster %s: %v", params.DomainName, clusterName, err)
 		}
-	}
-	for name, tl := range resp.GetActivityTaskListMap() {
-		if name == scheduler.TaskListName {
-			continue
+
+		for name, tl := range resp.GetDecisionTaskListMap() {
+			if name == scheduler.TaskListName {
+				continue
+			}
+			if len(tl.GetPollers()) > 0 {
+				activeTaskLists = append(activeTaskLists, fmt.Sprintf("%s (cluster: %s)", name, clusterName))
+			}
 		}
-		if len(tl.GetPollers()) > 0 {
-			activeTaskLists = append(activeTaskLists, name)
+		for name, tl := range resp.GetActivityTaskListMap() {
+			if name == scheduler.TaskListName {
+				continue
+			}
+			if len(tl.GetPollers()) > 0 {
+				activeTaskLists = append(activeTaskLists, fmt.Sprintf("%s (cluster: %s)", name, clusterName))
+			}
 		}
 	}
 

--- a/service/worker/domaindeprecation/activities_test.go
+++ b/service/worker/domaindeprecation/activities_test.go
@@ -121,7 +121,7 @@ func TestDisableArchivalActivity(t *testing.T) {
 			name: "Error - Domain does not exist",
 			setupMocks: func() {
 				mockClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(
-					nil, types.EntityNotExistsError{},
+					nil, &types.EntityNotExistsError{},
 				)
 			},
 			expectedError: assert.AnError,
@@ -330,6 +330,16 @@ func TestCheckActivePollersActivity(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			name: "Success - nil replication configuration",
+			setupMocks: func(mockClient *frontend.MockClient, mockClientBean *client.MockBean) {
+				mockClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(
+					&types.DescribeDomainResponse{
+						ReplicationConfiguration: nil,
+					}, nil)
+			},
+			expectedError: false,
+		},
+		{
 			name: "Error - active decision pollers",
 			setupMocks: func(mockClient *frontend.MockClient, mockClientBean *client.MockBean) {
 				mockClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(
@@ -375,7 +385,7 @@ func TestCheckActivePollersActivity(t *testing.T) {
 		{
 			name: "Error - domain does not exist",
 			setupMocks: func(mockClient *frontend.MockClient, mockClientBean *client.MockBean) {
-				mockClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(nil, types.EntityNotExistsError{})
+				mockClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(nil, &types.EntityNotExistsError{})
 			},
 			expectedError: true,
 		},

--- a/service/worker/domaindeprecation/activities_test.go
+++ b/service/worker/domaindeprecation/activities_test.go
@@ -282,9 +282,9 @@ func TestCheckActivePollersActivity(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		setupMocks    func(mockClient *frontend.MockClient, mockClientBean *client.MockBean)
-		expectedError bool
+		name           string
+		setupMocks     func(mockClient *frontend.MockClient, mockClientBean *client.MockBean)
+		expectedErrMsg string
 	}{
 		{
 			name: "Success - no pollers in any cluster",
@@ -307,7 +307,6 @@ func TestCheckActivePollersActivity(t *testing.T) {
 						ActivityTaskListMap: map[string]*types.DescribeTaskListResponse{},
 					}, nil)
 			},
-			expectedError: false,
 		},
 		{
 			name: "Success - scheduler task list pollers are excluded",
@@ -327,7 +326,6 @@ func TestCheckActivePollersActivity(t *testing.T) {
 						},
 					}, nil)
 			},
-			expectedError: false,
 		},
 		{
 			name: "Success - nil replication configuration",
@@ -337,7 +335,6 @@ func TestCheckActivePollersActivity(t *testing.T) {
 						ReplicationConfiguration: nil,
 					}, nil)
 			},
-			expectedError: false,
 		},
 		{
 			name: "Error - active decision pollers",
@@ -355,7 +352,7 @@ func TestCheckActivePollersActivity(t *testing.T) {
 						ActivityTaskListMap: map[string]*types.DescribeTaskListResponse{},
 					}, nil)
 			},
-			expectedError: true,
+			expectedErrMsg: ErrActivePollersNonRetryable,
 		},
 		{
 			name: "Error - active activity pollers",
@@ -373,21 +370,21 @@ func TestCheckActivePollersActivity(t *testing.T) {
 						},
 					}, nil)
 			},
-			expectedError: true,
+			expectedErrMsg: ErrActivePollersNonRetryable,
 		},
 		{
 			name: "Error - DescribeDomain fails",
 			setupMocks: func(mockClient *frontend.MockClient, mockClientBean *client.MockBean) {
 				mockClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(nil, assert.AnError)
 			},
-			expectedError: true,
+			expectedErrMsg: "failed to describe domain",
 		},
 		{
 			name: "Error - domain does not exist",
 			setupMocks: func(mockClient *frontend.MockClient, mockClientBean *client.MockBean) {
 				mockClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(nil, &types.EntityNotExistsError{})
 			},
-			expectedError: true,
+			expectedErrMsg: ErrDomainDoesNotExistNonRetryable,
 		},
 		{
 			name: "Error - GetTaskListsByDomain fails",
@@ -399,7 +396,7 @@ func TestCheckActivePollersActivity(t *testing.T) {
 				mockClientBean.EXPECT().GetRemoteFrontendClient("cluster1").Return(mockClient, nil)
 				mockClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(nil, assert.AnError)
 			},
-			expectedError: true,
+			expectedErrMsg: "failed to get task lists for domain",
 		},
 		{
 			name: "Error - GetRemoteFrontendClient fails",
@@ -410,7 +407,7 @@ func TestCheckActivePollersActivity(t *testing.T) {
 					}, nil)
 				mockClientBean.EXPECT().GetRemoteFrontendClient("cluster1").Return(nil, assert.AnError)
 			},
-			expectedError: true,
+			expectedErrMsg: "failed to get frontend client for cluster",
 		},
 		{
 			name: "Error - active pollers in remote cluster",
@@ -435,7 +432,7 @@ func TestCheckActivePollersActivity(t *testing.T) {
 						ActivityTaskListMap: map[string]*types.DescribeTaskListResponse{},
 					}, nil)
 			},
-			expectedError: true,
+			expectedErrMsg: ErrActivePollersNonRetryable,
 		},
 	}
 
@@ -460,8 +457,8 @@ func TestCheckActivePollersActivity(t *testing.T) {
 			err := deprecator.CheckActivePollersActivity(context.Background(), DomainDeprecationParams{
 				DomainName: testDomain,
 			})
-			if tt.expectedError {
-				assert.Error(t, err)
+			if tt.expectedErrMsg != "" {
+				assert.ErrorContains(t, err, tt.expectedErrMsg)
 			} else {
 				assert.NoError(t, err)
 			}

--- a/service/worker/domaindeprecation/activities_test.go
+++ b/service/worker/domaindeprecation/activities_test.go
@@ -267,31 +267,33 @@ func TestCheckOpenWorkflowsActivity(t *testing.T) {
 }
 
 func TestCheckActivePollersActivity(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockClient := frontend.NewMockClient(ctrl)
-	mockClientBean := client.NewMockBean(ctrl)
-	mockClientBean.EXPECT().GetFrontendClient().Return(mockClient).AnyTimes()
-
-	deprecator := &domainDeprecator{
-		cfg: Config{
-			AdminOperationToken: dynamicproperties.GetStringPropertyFn(""),
-		},
-		clientBean: mockClientBean,
-		logger:     testlogger.New(t),
-	}
-
 	testDomain := "test-domain"
+
+	singleClusterReplicationConfig := &types.DomainReplicationConfiguration{
+		Clusters: []*types.ClusterReplicationConfiguration{
+			{ClusterName: "cluster1"},
+		},
+	}
+	multiClusterReplicationConfig := &types.DomainReplicationConfiguration{
+		Clusters: []*types.ClusterReplicationConfiguration{
+			{ClusterName: "cluster1"},
+			{ClusterName: "cluster2"},
+		},
+	}
 
 	tests := []struct {
 		name          string
-		setupMocks    func()
+		setupMocks    func(mockClient *frontend.MockClient, mockClientBean *client.MockBean)
 		expectedError bool
 	}{
 		{
 			name: "Success - no active pollers",
-			setupMocks: func() {
+			setupMocks: func(mockClient *frontend.MockClient, mockClientBean *client.MockBean) {
+				mockClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(
+					&types.DescribeDomainResponse{
+						ReplicationConfiguration: singleClusterReplicationConfig,
+					}, nil)
+				mockClientBean.EXPECT().GetRemoteFrontendClient("cluster1").Return(mockClient, nil)
 				mockClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(
 					&types.GetTaskListsByDomainResponse{
 						DecisionTaskListMap: map[string]*types.DescribeTaskListResponse{
@@ -306,7 +308,12 @@ func TestCheckActivePollersActivity(t *testing.T) {
 		},
 		{
 			name: "Error - active decision pollers",
-			setupMocks: func() {
+			setupMocks: func(mockClient *frontend.MockClient, mockClientBean *client.MockBean) {
+				mockClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(
+					&types.DescribeDomainResponse{
+						ReplicationConfiguration: singleClusterReplicationConfig,
+					}, nil)
+				mockClientBean.EXPECT().GetRemoteFrontendClient("cluster1").Return(mockClient, nil)
 				mockClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(
 					&types.GetTaskListsByDomainResponse{
 						DecisionTaskListMap: map[string]*types.DescribeTaskListResponse{
@@ -319,7 +326,12 @@ func TestCheckActivePollersActivity(t *testing.T) {
 		},
 		{
 			name: "Error - active activity pollers",
-			setupMocks: func() {
+			setupMocks: func(mockClient *frontend.MockClient, mockClientBean *client.MockBean) {
+				mockClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(
+					&types.DescribeDomainResponse{
+						ReplicationConfiguration: singleClusterReplicationConfig,
+					}, nil)
+				mockClientBean.EXPECT().GetRemoteFrontendClient("cluster1").Return(mockClient, nil)
 				mockClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(
 					&types.GetTaskListsByDomainResponse{
 						DecisionTaskListMap: map[string]*types.DescribeTaskListResponse{},
@@ -331,15 +343,50 @@ func TestCheckActivePollersActivity(t *testing.T) {
 			expectedError: true,
 		},
 		{
+			name: "Error - DescribeDomain fails",
+			setupMocks: func(mockClient *frontend.MockClient, mockClientBean *client.MockBean) {
+				mockClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(nil, assert.AnError)
+			},
+			expectedError: true,
+		},
+		{
+			name: "Error - domain does not exist",
+			setupMocks: func(mockClient *frontend.MockClient, mockClientBean *client.MockBean) {
+				mockClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(nil, types.EntityNotExistsError{})
+			},
+			expectedError: true,
+		},
+		{
 			name: "Error - GetTaskListsByDomain fails",
-			setupMocks: func() {
+			setupMocks: func(mockClient *frontend.MockClient, mockClientBean *client.MockBean) {
+				mockClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(
+					&types.DescribeDomainResponse{
+						ReplicationConfiguration: singleClusterReplicationConfig,
+					}, nil)
+				mockClientBean.EXPECT().GetRemoteFrontendClient("cluster1").Return(mockClient, nil)
 				mockClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(nil, assert.AnError)
 			},
 			expectedError: true,
 		},
 		{
+			name: "Error - GetRemoteFrontendClient fails",
+			setupMocks: func(mockClient *frontend.MockClient, mockClientBean *client.MockBean) {
+				mockClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(
+					&types.DescribeDomainResponse{
+						ReplicationConfiguration: singleClusterReplicationConfig,
+					}, nil)
+				mockClientBean.EXPECT().GetRemoteFrontendClient("cluster1").Return(nil, assert.AnError)
+			},
+			expectedError: true,
+		},
+		{
 			name: "Success - scheduler task list pollers are excluded",
-			setupMocks: func() {
+			setupMocks: func(mockClient *frontend.MockClient, mockClientBean *client.MockBean) {
+				mockClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(
+					&types.DescribeDomainResponse{
+						ReplicationConfiguration: singleClusterReplicationConfig,
+					}, nil)
+				mockClientBean.EXPECT().GetRemoteFrontendClient("cluster1").Return(mockClient, nil)
 				mockClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(
 					&types.GetTaskListsByDomainResponse{
 						DecisionTaskListMap: map[string]*types.DescribeTaskListResponse{
@@ -352,11 +399,74 @@ func TestCheckActivePollersActivity(t *testing.T) {
 			},
 			expectedError: false,
 		},
+		{
+			name: "Error - active pollers in remote cluster",
+			setupMocks: func(mockClient *frontend.MockClient, mockClientBean *client.MockBean) {
+				remoteClient := frontend.NewMockClient(gomock.NewController(t))
+				mockClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(
+					&types.DescribeDomainResponse{
+						ReplicationConfiguration: multiClusterReplicationConfig,
+					}, nil)
+				mockClientBean.EXPECT().GetRemoteFrontendClient("cluster1").Return(mockClient, nil)
+				mockClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(
+					&types.GetTaskListsByDomainResponse{
+						DecisionTaskListMap: map[string]*types.DescribeTaskListResponse{},
+						ActivityTaskListMap: map[string]*types.DescribeTaskListResponse{},
+					}, nil)
+				mockClientBean.EXPECT().GetRemoteFrontendClient("cluster2").Return(remoteClient, nil)
+				remoteClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(
+					&types.GetTaskListsByDomainResponse{
+						DecisionTaskListMap: map[string]*types.DescribeTaskListResponse{
+							"tl1": {Pollers: []*types.PollerInfo{{}}},
+						},
+						ActivityTaskListMap: map[string]*types.DescribeTaskListResponse{},
+					}, nil)
+			},
+			expectedError: true,
+		},
+		{
+			name: "Success - no pollers in any cluster",
+			setupMocks: func(mockClient *frontend.MockClient, mockClientBean *client.MockBean) {
+				remoteClient := frontend.NewMockClient(gomock.NewController(t))
+				mockClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(
+					&types.DescribeDomainResponse{
+						ReplicationConfiguration: multiClusterReplicationConfig,
+					}, nil)
+				mockClientBean.EXPECT().GetRemoteFrontendClient("cluster1").Return(mockClient, nil)
+				mockClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(
+					&types.GetTaskListsByDomainResponse{
+						DecisionTaskListMap: map[string]*types.DescribeTaskListResponse{},
+						ActivityTaskListMap: map[string]*types.DescribeTaskListResponse{},
+					}, nil)
+				mockClientBean.EXPECT().GetRemoteFrontendClient("cluster2").Return(remoteClient, nil)
+				remoteClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(
+					&types.GetTaskListsByDomainResponse{
+						DecisionTaskListMap: map[string]*types.DescribeTaskListResponse{},
+						ActivityTaskListMap: map[string]*types.DescribeTaskListResponse{},
+					}, nil)
+			},
+			expectedError: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.setupMocks()
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockClient := frontend.NewMockClient(ctrl)
+			mockClientBean := client.NewMockBean(ctrl)
+			mockClientBean.EXPECT().GetFrontendClient().Return(mockClient).AnyTimes()
+
+			deprecator := &domainDeprecator{
+				cfg: Config{
+					AdminOperationToken: dynamicproperties.GetStringPropertyFn(""),
+				},
+				clientBean: mockClientBean,
+				logger:     testlogger.New(t),
+			}
+
+			tt.setupMocks(mockClient, mockClientBean)
 			err := deprecator.CheckActivePollersActivity(context.Background(), DomainDeprecationParams{
 				DomainName: testDomain,
 			})

--- a/service/worker/domaindeprecation/activities_test.go
+++ b/service/worker/domaindeprecation/activities_test.go
@@ -287,7 +287,30 @@ func TestCheckActivePollersActivity(t *testing.T) {
 		expectedError bool
 	}{
 		{
-			name: "Success - no active pollers",
+			name: "Success - no pollers in any cluster",
+			setupMocks: func(mockClient *frontend.MockClient, mockClientBean *client.MockBean) {
+				remoteClient := frontend.NewMockClient(gomock.NewController(t))
+				mockClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(
+					&types.DescribeDomainResponse{
+						ReplicationConfiguration: multiClusterReplicationConfig,
+					}, nil)
+				mockClientBean.EXPECT().GetRemoteFrontendClient("cluster1").Return(mockClient, nil)
+				mockClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(
+					&types.GetTaskListsByDomainResponse{
+						DecisionTaskListMap: map[string]*types.DescribeTaskListResponse{},
+						ActivityTaskListMap: map[string]*types.DescribeTaskListResponse{},
+					}, nil)
+				mockClientBean.EXPECT().GetRemoteFrontendClient("cluster2").Return(remoteClient, nil)
+				remoteClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(
+					&types.GetTaskListsByDomainResponse{
+						DecisionTaskListMap: map[string]*types.DescribeTaskListResponse{},
+						ActivityTaskListMap: map[string]*types.DescribeTaskListResponse{},
+					}, nil)
+			},
+			expectedError: false,
+		},
+		{
+			name: "Success - scheduler task list pollers are excluded",
 			setupMocks: func(mockClient *frontend.MockClient, mockClientBean *client.MockBean) {
 				mockClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(
 					&types.DescribeDomainResponse{
@@ -297,10 +320,10 @@ func TestCheckActivePollersActivity(t *testing.T) {
 				mockClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(
 					&types.GetTaskListsByDomainResponse{
 						DecisionTaskListMap: map[string]*types.DescribeTaskListResponse{
-							"tl1": {Pollers: nil},
+							scheduler.TaskListName: {Pollers: []*types.PollerInfo{{}}},
 						},
 						ActivityTaskListMap: map[string]*types.DescribeTaskListResponse{
-							"tl1": {Pollers: nil},
+							scheduler.TaskListName: {Pollers: []*types.PollerInfo{{}}},
 						},
 					}, nil)
 			},
@@ -380,26 +403,6 @@ func TestCheckActivePollersActivity(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name: "Success - scheduler task list pollers are excluded",
-			setupMocks: func(mockClient *frontend.MockClient, mockClientBean *client.MockBean) {
-				mockClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(
-					&types.DescribeDomainResponse{
-						ReplicationConfiguration: singleClusterReplicationConfig,
-					}, nil)
-				mockClientBean.EXPECT().GetRemoteFrontendClient("cluster1").Return(mockClient, nil)
-				mockClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(
-					&types.GetTaskListsByDomainResponse{
-						DecisionTaskListMap: map[string]*types.DescribeTaskListResponse{
-							scheduler.TaskListName: {Pollers: []*types.PollerInfo{{}}},
-						},
-						ActivityTaskListMap: map[string]*types.DescribeTaskListResponse{
-							scheduler.TaskListName: {Pollers: []*types.PollerInfo{{}}},
-						},
-					}, nil)
-			},
-			expectedError: false,
-		},
-		{
 			name: "Error - active pollers in remote cluster",
 			setupMocks: func(mockClient *frontend.MockClient, mockClientBean *client.MockBean) {
 				remoteClient := frontend.NewMockClient(gomock.NewController(t))
@@ -423,29 +426,6 @@ func TestCheckActivePollersActivity(t *testing.T) {
 					}, nil)
 			},
 			expectedError: true,
-		},
-		{
-			name: "Success - no pollers in any cluster",
-			setupMocks: func(mockClient *frontend.MockClient, mockClientBean *client.MockBean) {
-				remoteClient := frontend.NewMockClient(gomock.NewController(t))
-				mockClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(
-					&types.DescribeDomainResponse{
-						ReplicationConfiguration: multiClusterReplicationConfig,
-					}, nil)
-				mockClientBean.EXPECT().GetRemoteFrontendClient("cluster1").Return(mockClient, nil)
-				mockClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(
-					&types.GetTaskListsByDomainResponse{
-						DecisionTaskListMap: map[string]*types.DescribeTaskListResponse{},
-						ActivityTaskListMap: map[string]*types.DescribeTaskListResponse{},
-					}, nil)
-				mockClientBean.EXPECT().GetRemoteFrontendClient("cluster2").Return(remoteClient, nil)
-				remoteClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(
-					&types.GetTaskListsByDomainResponse{
-						DecisionTaskListMap: map[string]*types.DescribeTaskListResponse{},
-						ActivityTaskListMap: map[string]*types.DescribeTaskListResponse{},
-					}, nil)
-			},
-			expectedError: false,
 		},
 	}
 

--- a/service/worker/domaindeprecation/activities_test.go
+++ b/service/worker/domaindeprecation/activities_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/worker/scheduler"
 )
 
 func TestDisableArchivalActivity(t *testing.T) {
@@ -259,6 +260,109 @@ func TestCheckOpenWorkflowsActivity(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.Equal(t, tt.expectedResult, hasOpenWorkflows)
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCheckActivePollersActivity(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := frontend.NewMockClient(ctrl)
+	mockClientBean := client.NewMockBean(ctrl)
+	mockClientBean.EXPECT().GetFrontendClient().Return(mockClient).AnyTimes()
+
+	deprecator := &domainDeprecator{
+		cfg: Config{
+			AdminOperationToken: dynamicproperties.GetStringPropertyFn(""),
+		},
+		clientBean: mockClientBean,
+		logger:     testlogger.New(t),
+	}
+
+	testDomain := "test-domain"
+
+	tests := []struct {
+		name          string
+		setupMocks    func()
+		expectedError bool
+	}{
+		{
+			name: "Success - no active pollers",
+			setupMocks: func() {
+				mockClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(
+					&types.GetTaskListsByDomainResponse{
+						DecisionTaskListMap: map[string]*types.DescribeTaskListResponse{
+							"tl1": {Pollers: nil},
+						},
+						ActivityTaskListMap: map[string]*types.DescribeTaskListResponse{
+							"tl1": {Pollers: nil},
+						},
+					}, nil)
+			},
+			expectedError: false,
+		},
+		{
+			name: "Error - active decision pollers",
+			setupMocks: func() {
+				mockClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(
+					&types.GetTaskListsByDomainResponse{
+						DecisionTaskListMap: map[string]*types.DescribeTaskListResponse{
+							"tl1": {Pollers: []*types.PollerInfo{{}}},
+						},
+						ActivityTaskListMap: map[string]*types.DescribeTaskListResponse{},
+					}, nil)
+			},
+			expectedError: true,
+		},
+		{
+			name: "Error - active activity pollers",
+			setupMocks: func() {
+				mockClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(
+					&types.GetTaskListsByDomainResponse{
+						DecisionTaskListMap: map[string]*types.DescribeTaskListResponse{},
+						ActivityTaskListMap: map[string]*types.DescribeTaskListResponse{
+							"tl1": {Pollers: []*types.PollerInfo{{}}},
+						},
+					}, nil)
+			},
+			expectedError: true,
+		},
+		{
+			name: "Error - GetTaskListsByDomain fails",
+			setupMocks: func() {
+				mockClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(nil, assert.AnError)
+			},
+			expectedError: true,
+		},
+		{
+			name: "Success - scheduler task list pollers are excluded",
+			setupMocks: func() {
+				mockClient.EXPECT().GetTaskListsByDomain(gomock.Any(), gomock.Any()).Return(
+					&types.GetTaskListsByDomainResponse{
+						DecisionTaskListMap: map[string]*types.DescribeTaskListResponse{
+							scheduler.TaskListName: {Pollers: []*types.PollerInfo{{}}},
+						},
+						ActivityTaskListMap: map[string]*types.DescribeTaskListResponse{
+							scheduler.TaskListName: {Pollers: []*types.PollerInfo{{}}},
+						},
+					}, nil)
+			},
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupMocks()
+			err := deprecator.CheckActivePollersActivity(context.Background(), DomainDeprecationParams{
+				DomainName: testDomain,
+			})
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
 				assert.NoError(t, err)
 			}
 		})

--- a/service/worker/domaindeprecation/entities.go
+++ b/service/worker/domaindeprecation/entities.go
@@ -26,4 +26,5 @@ package domaindeprecation
 type DomainDeprecationParams struct {
 	DomainName    string `json:"domain_name"`
 	SecurityToken string `json:"security_token"`
+	Force         bool   `json:"force"`
 }

--- a/service/worker/domaindeprecation/helpers.go
+++ b/service/worker/domaindeprecation/helpers.go
@@ -31,6 +31,8 @@ const (
 	ErrAccessDeniedNonRetryable = "AccessDeniedError"
 	// ErrWorkflowAlreadyCompletedNonRetryable is error that indicates workflow execution already completed
 	ErrWorkflowAlreadyCompletedNonRetryable = "WorkflowExecutionAlreadyCompletedError"
+	// ErrActivePollersNonRetryable indicates the domain has active pollers and cannot be deprecated without force
+	ErrActivePollersNonRetryable = "domain has active pollers"
 
 	// DefaultRPS is the default RPS
 	DefaultRPS = 50

--- a/service/worker/domaindeprecation/module.go
+++ b/service/worker/domaindeprecation/module.go
@@ -109,6 +109,7 @@ func (w *domainDeprecator) Start() error {
 	}
 	newWorker := worker.New(w.svcClient, constants.SystemLocalDomainName, DomainDeprecationTaskListName, workerOpts)
 	newWorker.RegisterWorkflowWithOptions(w.DomainDeprecationWorkflow, workflow.RegisterOptions{Name: DomainDeprecationWorkflowTypeName})
+	newWorker.RegisterActivityWithOptions(w.CheckActivePollersActivity, activity.RegisterOptions{Name: checkActivePollersActivity, EnableAutoHeartbeat: true})
 	newWorker.RegisterActivityWithOptions(w.DisableArchivalActivity, activity.RegisterOptions{Name: disableArchivalActivity, EnableAutoHeartbeat: true})
 	newWorker.RegisterActivityWithOptions(w.CheckOpenWorkflowsActivity, activity.RegisterOptions{Name: checkOpenWorkflowsActivity, EnableAutoHeartbeat: true})
 	newWorker.RegisterActivityWithOptions(w.DeprecateDomainActivity, activity.RegisterOptions{Name: deprecateDomainActivity, EnableAutoHeartbeat: true})

--- a/service/worker/domaindeprecation/workflow.go
+++ b/service/worker/domaindeprecation/workflow.go
@@ -38,6 +38,7 @@ const (
 	DomainDeprecationTaskListName     = "domain-deprecation-tasklist"
 	domainDeprecationBatchPrefix      = "domain-deprecation-batch"
 
+	checkActivePollersActivity = "checkActivePollers"
 	disableArchivalActivity    = "disableArchival"
 	deprecateDomainActivity    = "deprecateDomain"
 	checkOpenWorkflowsActivity = "checkOpenWorkflows"
@@ -61,6 +62,7 @@ var (
 		NonRetriableErrorReasons: []string{
 			ErrDomainDoesNotExistNonRetryable,
 			ErrAccessDeniedNonRetryable,
+			ErrActivePollersNonRetryable,
 		},
 	}
 
@@ -77,7 +79,19 @@ func (w *domainDeprecator) DomainDeprecationWorkflow(ctx workflow.Context, param
 	logger := workflow.GetLogger(ctx)
 	logger.Info("Starting domain deprecation workflow", zap.String("domain", params.DomainName))
 
-	// Step 1: Activity disables archival
+	// Step 1: Check for active pollers (skipped when Force is set)
+	if !params.Force {
+		err := workflow.ExecuteActivity(
+			workflow.WithActivityOptions(ctx, activityOptions),
+			w.CheckActivePollersActivity,
+			params,
+		).Get(ctx, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Step 2: Activity disables archival
 	err := workflow.ExecuteActivity(
 		workflow.WithActivityOptions(ctx, activityOptions),
 		w.DisableArchivalActivity,
@@ -87,7 +101,7 @@ func (w *domainDeprecator) DomainDeprecationWorkflow(ctx workflow.Context, param
 		return err
 	}
 
-	// Step 2: Deprecate a domain
+	// Step 3: Deprecate a domain
 	err = workflow.ExecuteActivity(
 		workflow.WithActivityOptions(ctx, activityOptions),
 		w.DeprecateDomainActivity,
@@ -97,7 +111,7 @@ func (w *domainDeprecator) DomainDeprecationWorkflow(ctx workflow.Context, param
 		return err
 	}
 
-	// Step 3: Start child batch workflow to terminate open workflows of a domain
+	// Step 4: Start child batch workflow to terminate open workflows of a domain
 	batchParams := batcher.BatchParams{
 		DomainName: params.DomainName,
 		Query:      "CloseTime = missing",

--- a/service/worker/domaindeprecation/workflow_test.go
+++ b/service/worker/domaindeprecation/workflow_test.go
@@ -22,11 +22,13 @@ package domaindeprecation
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-go/tally"
+	"go.uber.org/cadence"
 	"go.uber.org/cadence/activity"
 	"go.uber.org/cadence/testsuite"
 	"go.uber.org/cadence/workflow"
@@ -159,13 +161,14 @@ func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_CheckOpenWorkflows_Err
 }
 
 func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_ActivePollers_Error() {
-	mockErr := errors.New("domain has active pollers")
-	s.workflowEnv.OnActivity(checkActivePollersActivity, mock.Anything, defaultParams).Return(mockErr)
+	pollerErr := cadence.NewCustomError(ErrActivePollersNonRetryable,
+		fmt.Sprintf("domain %s has active pollers on task lists: %v, use Force to override", testDomain, []string{"tl1"}))
+	s.workflowEnv.OnActivity(checkActivePollersActivity, mock.Anything, defaultParams).Return(pollerErr)
 
 	s.workflowEnv.ExecuteWorkflow(DomainDeprecationWorkflowTypeName, defaultParams)
 	s.True(s.workflowEnv.IsWorkflowCompleted())
 	s.Error(s.workflowEnv.GetWorkflowError())
-	s.ErrorContains(s.workflowEnv.GetWorkflowError(), mockErr.Error())
+	s.ErrorContains(s.workflowEnv.GetWorkflowError(), ErrActivePollersNonRetryable)
 }
 
 func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_ActivePollers_SkippedWhenForced() {

--- a/service/worker/domaindeprecation/workflow_test.go
+++ b/service/worker/domaindeprecation/workflow_test.go
@@ -78,6 +78,7 @@ func (s *domainDeprecationWorkflowTestSuite) SetupTest() {
 	})
 
 	s.workflowEnv.RegisterWorkflowWithOptions(s.deprecator.DomainDeprecationWorkflow, workflow.RegisterOptions{Name: DomainDeprecationWorkflowTypeName})
+	s.workflowEnv.RegisterActivityWithOptions(s.deprecator.CheckActivePollersActivity, activity.RegisterOptions{Name: checkActivePollersActivity})
 	s.workflowEnv.RegisterActivityWithOptions(s.deprecator.DisableArchivalActivity, activity.RegisterOptions{Name: disableArchivalActivity})
 	s.workflowEnv.RegisterActivityWithOptions(s.deprecator.DeprecateDomainActivity, activity.RegisterOptions{Name: deprecateDomainActivity})
 	s.workflowEnv.RegisterActivityWithOptions(s.deprecator.CheckOpenWorkflowsActivity, activity.RegisterOptions{Name: checkOpenWorkflowsActivity})
@@ -88,6 +89,7 @@ func (s *domainDeprecationWorkflowTestSuite) TearDownTest() {
 }
 
 func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_Success() {
+	s.workflowEnv.OnActivity(checkActivePollersActivity, mock.Anything, defaultParams).Return(nil)
 	s.workflowEnv.OnActivity(disableArchivalActivity, mock.Anything, defaultParams).Return(nil)
 	s.workflowEnv.OnActivity(deprecateDomainActivity, mock.Anything, defaultParams).Return(nil)
 	s.workflowEnv.OnWorkflow(batcher.BatchWorkflowV2, mock.Anything, mock.Anything).Return(
@@ -104,6 +106,7 @@ func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_Success() {
 
 func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_Disable_Archival_Error() {
 	mockErr := errors.New("error")
+	s.workflowEnv.OnActivity(checkActivePollersActivity, mock.Anything, defaultParams).Return(nil)
 	s.workflowEnv.OnActivity(disableArchivalActivity, mock.Anything, defaultParams).Return(mockErr)
 	s.workflowEnv.ExecuteWorkflow(DomainDeprecationWorkflowTypeName, defaultParams)
 	s.True(s.workflowEnv.IsWorkflowCompleted())
@@ -113,6 +116,7 @@ func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_Disable_Archival_Error
 
 func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_Deprecate_Domain_Error() {
 	mockErr := errors.New("error")
+	s.workflowEnv.OnActivity(checkActivePollersActivity, mock.Anything, defaultParams).Return(nil)
 	s.workflowEnv.OnActivity(disableArchivalActivity, mock.Anything, defaultParams).Return(nil)
 	s.workflowEnv.OnActivity(deprecateDomainActivity, mock.Anything, defaultParams).Return(mockErr)
 	s.workflowEnv.ExecuteWorkflow(DomainDeprecationWorkflowTypeName, defaultParams)
@@ -123,6 +127,7 @@ func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_Deprecate_Domain_Error
 
 func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_BatchTerminate_ChildWorkflowError() {
 	mockErr := errors.New("batch workflow failed")
+	s.workflowEnv.OnActivity(checkActivePollersActivity, mock.Anything, defaultParams).Return(nil)
 	s.workflowEnv.OnActivity(disableArchivalActivity, mock.Anything, defaultParams).Return(nil)
 	s.workflowEnv.OnActivity(deprecateDomainActivity, mock.Anything, defaultParams).Return(nil)
 	s.workflowEnv.OnWorkflow(batcher.BatchWorkflowV2, mock.Anything, mock.Anything).Return(
@@ -136,6 +141,7 @@ func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_BatchTerminate_ChildWo
 
 func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_CheckOpenWorkflows_Error() {
 	mockErr := errors.New("error")
+	s.workflowEnv.OnActivity(checkActivePollersActivity, mock.Anything, defaultParams).Return(nil)
 	s.workflowEnv.OnActivity(disableArchivalActivity, mock.Anything, defaultParams).Return(nil)
 	s.workflowEnv.OnActivity(deprecateDomainActivity, mock.Anything, defaultParams).Return(nil)
 	s.workflowEnv.OnWorkflow(batcher.BatchWorkflowV2, mock.Anything, mock.Anything).Return(
@@ -150,4 +156,34 @@ func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_CheckOpenWorkflows_Err
 	s.True(s.workflowEnv.IsWorkflowCompleted())
 	s.Error(s.workflowEnv.GetWorkflowError())
 	s.ErrorContains(s.workflowEnv.GetWorkflowError(), mockErr.Error())
+}
+
+func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_ActivePollers_Error() {
+	mockErr := errors.New("domain has active pollers")
+	s.workflowEnv.OnActivity(checkActivePollersActivity, mock.Anything, defaultParams).Return(mockErr)
+
+	s.workflowEnv.ExecuteWorkflow(DomainDeprecationWorkflowTypeName, defaultParams)
+	s.True(s.workflowEnv.IsWorkflowCompleted())
+	s.Error(s.workflowEnv.GetWorkflowError())
+	s.ErrorContains(s.workflowEnv.GetWorkflowError(), mockErr.Error())
+}
+
+func (s *domainDeprecationWorkflowTestSuite) TestWorkflow_ActivePollers_SkippedWhenForced() {
+	forceParams := DomainDeprecationParams{
+		DomainName:    testDomain,
+		SecurityToken: "token",
+		Force:         true,
+	}
+	s.workflowEnv.OnActivity(disableArchivalActivity, mock.Anything, forceParams).Return(nil)
+	s.workflowEnv.OnActivity(deprecateDomainActivity, mock.Anything, forceParams).Return(nil)
+	s.workflowEnv.OnWorkflow(batcher.BatchWorkflowV2, mock.Anything, mock.Anything).Return(
+		batcher.HeartBeatDetails{
+			SuccessCount: 10,
+			ErrorCount:   0,
+		}, nil).Once()
+	s.workflowEnv.OnActivity(checkOpenWorkflowsActivity, mock.Anything, forceParams).Return(false, nil)
+
+	s.workflowEnv.ExecuteWorkflow(DomainDeprecationWorkflowTypeName, forceParams)
+	s.True(s.workflowEnv.IsWorkflowCompleted())
+	s.NoError(s.workflowEnv.GetWorkflowError())
 }

--- a/tools/cli/domain_commands.go
+++ b/tools/cli/domain_commands.go
@@ -458,6 +458,7 @@ func (d *domainCLIImpl) DeprecateDomain(c *cli.Context) error {
 	params := domaindeprecation.DomainDeprecationParams{
 		DomainName:    domainName,
 		SecurityToken: securityToken,
+		Force:         c.Bool(FlagForce),
 	}
 	input, err := json.Marshal(params)
 	if err != nil {

--- a/tools/cli/domain_utils.go
+++ b/tools/cli/domain_utils.go
@@ -236,7 +236,7 @@ var (
 		},
 		&cli.BoolFlag{
 			Name:  FlagForce,
-			Usage: "Deprecate domain even if it has active pollers.",
+			Usage: "Skip all safety checks and force domain deprecation. Use with caution.",
 		},
 	}
 

--- a/tools/cli/domain_utils.go
+++ b/tools/cli/domain_utils.go
@@ -236,7 +236,7 @@ var (
 		},
 		&cli.BoolFlag{
 			Name:  FlagForce,
-			Usage: "Deprecate domain regardless of domain history.",
+			Usage: "Deprecate domain even if it has active pollers.",
 		},
 	}
 


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Add check for active pollers on domain deprecation workflow. Fail if the domain has active pollers in all domain clusters (exclude cadence-scheduler tasklist). Provide force flag to deprecate domain with active pollers.

https://github.com/cadence-workflow/cadence/issues/8400

**Why?**
Deprecating a domain with active pollers can cause issues such as interruption of existing migration and polling errors. This change surface the existence of pollers during the deprecation of the domain and prevents it from happening. If the user wants to deprecate the domain with active pollers, they can still do it via force.

**How did you test it?**
go test -race -run TestDomainDeprecationWorkflowTestSuite/TestWorkflow_ActivePollers_Error ./service/worker/domaindeprecation/...
go test -race -run TestDomainDeprecationWorkflowTestSuite/TestWorkflow_ActivePollers_SkippedWhenForced ./service/worker/domaindeprecation/...
go test -race -run TestDomainDeprecationWorkflowTestSuite/TestWorkflow_Success ./service/worker/domaindeprecation/...
go test -race -run TestDomainDeprecationWorkflowTestSuite/TestWorkflow_Disable_Archival_Error ./service/worker/domaindeprecation/...
go test -race -run TestDomainDeprecationWorkflowTestSuite/TestWorkflow_Deprecate_Domain_Error ./service/worker/domaindeprecation/...
go test -race -run TestDomainDeprecationWorkflowTestSuite/TestWorkflow_BatchTerminate_ChildWorkflowError ./service/worker/domaindeprecation/...
go test -race -run TestDomainDeprecationWorkflowTestSuite/TestWorkflow_CheckOpenWorkflows_Error ./service/worker/domaindeprecation/...

**Potential risks**
This addresses the existing risks.

**Release notes**
Deprecate domain workflow now checks for active pollers and fails if the domain is still being polled.

**Documentation Changes**
N/A
